### PR TITLE
fix(k8s): remove kubeadmConfigPatches for kubelet certificate rotation on kind

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -4,33 +4,9 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: local
 nodes:
   - role: control-plane
-    kubeadmConfigPatches:
-      - |
-        kind: InitConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            rotate-certificates: "true"
   - role: worker
-    kubeadmConfigPatches:
-      - |
-        kind: JoinConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            rotate-certificates: "true"
   - role: worker
-    kubeadmConfigPatches:
-      - |
-        kind: JoinConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            rotate-certificates: "true"
   - role: worker
-    kubeadmConfigPatches:
-      - |
-        kind: JoinConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            rotate-certificates: "true"
 networking:
   disableDefaultCNI: true
 containerdConfigPatches:


### PR DESCRIPTION
Eliminate unnecessary kubeadmConfigPatches related to kubelet certificate rotation in the kind configuration.