### PR TITLE
fix(config): update domain in cluster config maps to include platform

### DIFF
--- a/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
@@ -5,6 +5,6 @@ metadata:
   name: variables-cluster
   namespace: flux-system
 data:
-  domain: dev.devantler.tech
+  domain: dev.platform.devantler.tech
   github_app_client_id: Iv23liZ8GHRgpx32Em2y
   traefik_service_type: ClusterIP

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -5,6 +5,6 @@ metadata:
   name: variables-cluster
   namespace: flux-system
 data:
-  domain: devantler.tech
+  domain: platform.devantler.tech
   github_app_client_id: Iv23liZ8GHRgpx32Em2y
   traefik_service_type: ClusterIP


### PR DESCRIPTION
Update the domain entries in the cluster configuration maps to reflect the new platform structure.