### PR TITLE
fix(kustomization): add testkube resource to kustomization.yaml

### DIFF
--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - cilium/
   - dex/
   - reloader/
+  - testkube/
   - traefik/


### PR DESCRIPTION
Include the testkube resource in the kustomization.yaml file to ensure proper deployment configuration.