### PR TITLE
fix(cilium): update MTU configuration in HelmRelease

### DIFF
--- a/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -31,3 +31,4 @@ spec:
       hostRoot: /sys/fs/cgroup
     k8sServiceHost: localhost
     k8sServicePort: 7445
+    MTU: 1500

--- a/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -31,5 +31,5 @@ spec:
       hostRoot: /sys/fs/cgroup
     k8sServiceHost: localhost
     k8sServicePort: 7445
-    # TODO: Remove this when the following issue is fixed: https://github.com/cilium/cilium/issues/37529
+    # TODO: Remove MTU setting when the following issue is fixed: https://github.com/cilium/cilium/issues/37529
     MTU: 1500

--- a/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/distributions/talos/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -31,4 +31,5 @@ spec:
       hostRoot: /sys/fs/cgroup
     k8sServiceHost: localhost
     k8sServicePort: 7445
+    # TODO: Remove this when the following issue is fixed: https://github.com/cilium/cilium/issues/37529
     MTU: 1500


### PR DESCRIPTION
Set the MTU value to 1500 in the HelmRelease configuration to fix cloudflared tunnel quic connection