### PR TITLE
fix: update resource paths in kustomization files to point to apps

### DIFF
--- a/k8s/clusters/dev/apps/kustomization.yaml
+++ b/k8s/clusters/dev/apps/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../distributions/talos/infrastructure
+  - ../../../distributions/talos/apps/

--- a/k8s/clusters/local/apps/kustomization.yaml
+++ b/k8s/clusters/local/apps/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../distributions/kind/infrastructure
+  - ../../../distributions/kind/apps/

--- a/k8s/clusters/prod/apps/kustomization.yaml
+++ b/k8s/clusters/prod/apps/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../distributions/talos/infrastructure
+  - ../../../distributions/talos/apps/


### PR DESCRIPTION
Update resource paths in kustomization files to reference the apps directory instead of infrastructure.