### PR TITLE
feat(middlewares): add headers middleware and update forward-auth configuration

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -37,3 +37,6 @@ spec:
       enabled: true
       hosts:
         - oauth2-proxy.${domain}
+      annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-headers@kubernetescrd
+

--- a/k8s/bases/infrastructure/controllers/traefik/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/traefik/helm-release.yaml
@@ -30,6 +30,7 @@ spec:
             scheme: https
     service:
       type: ${traefik_service_type:=LoadBalancer}
+
     ingressRoute:
       dashboard:
         enabled: true

--- a/k8s/bases/infrastructure/middlewares/forward-auth/forward-auth.yaml
+++ b/k8s/bases/infrastructure/middlewares/forward-auth/forward-auth.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   forwardAuth:
     address: https://oauth2-proxy.${domain}/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-Access-Token
+      - Authorization

--- a/k8s/bases/infrastructure/middlewares/forward-auth/headers.yaml
+++ b/k8s/bases/infrastructure/middlewares/forward-auth/headers.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: headers
+  namespace: traefik
+spec:
+  headers:
+    sslRedirect: true
+    stsSeconds: 315360000
+    browserXssFilter: true
+    contentTypeNosniff: true
+    forceSTSHeader: true
+    sslHost: ${domain}
+    stsIncludeSubdomains: true
+    stsPreload: true
+    frameDeny: true

--- a/k8s/bases/infrastructure/middlewares/forward-auth/kustomization.yaml
+++ b/k8s/bases/infrastructure/middlewares/forward-auth/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - forward-auth.yaml
+  - headers.yaml


### PR DESCRIPTION
Introduce a new headers middleware for Traefik and update the forward-auth configuration to include trust for forwarded headers and additional response headers.

- Fixes https://github.com/devantler-tech/platform/issues/1022