### PR TITLE
feat(weave-gitops): add Helm release and related resources

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,8 +1,8 @@
-# TODO: Test if domain can be *.local.platform.devantler.tech, or update to *.lan
 127.0.0.1 dex.platform.lan
 127.0.0.1 goldilocks.platform.lan
 127.0.0.1 nextcloud.platform.lan
 127.0.0.1 oauth2-proxy.platform.lan
 127.0.0.1 platform.lan
 127.0.0.1 traefik.platform.lan
+127.0.0.1 weave-gitops.platform.lan
 127.0.0.1 whoami.platform.lan

--- a/k8s/bases/apps/kustomization.yaml
+++ b/k8s/bases/apps/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - homepage/
   - nextcloud/
+  - weave-gitops/
   - whoami/

--- a/k8s/bases/apps/weave-gitops/cluster-user-auth-secret.yaml
+++ b/k8s/bases/apps/weave-gitops/cluster-user-auth-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-user-auth
+  namespace: flux-system
+type: Opaque
+stringData:
+  username: devantler
+  password: ${weave_gitops_admin_password:=admin}

--- a/k8s/bases/apps/weave-gitops/cluster-user-auth-secret.yaml
+++ b/k8s/bases/apps/weave-gitops/cluster-user-auth-secret.yaml
@@ -6,4 +6,5 @@ metadata:
 type: Opaque
 stringData:
   username: devantler
-  password: ${weave_gitops_admin_password:=admin}
+  # password: admin
+  password: ${weave_gitops_admin_password:=$2a$10$wdBwQCe9wNBK3EadbIZwPOoPZt6RnqjOZuwUZlFVsISEo5l8jiQbq}

--- a/k8s/bases/apps/weave-gitops/helm-release.yaml
+++ b/k8s/bases/apps/weave-gitops/helm-release.yaml
@@ -14,14 +14,16 @@ spec:
   interval: 1h0m0s
   # https://github.com/weaveworks/weave-gitops/blob/main/charts/gitops-server/values.yaml
   values:
+    annotations:
+      reloader.stakater.com/auto: "true"
     adminUser:
       create: true
       createSecret: false
       username: devantler
     ingress:
       enabled: true
-      annotations:
-        traefik.ingress.kubernetes.io/router.middlewares: traefik-forward-auth@kubernetescrd
+      # annotations:
+      #   traefik.ingress.kubernetes.io/router.middlewares: traefik-forward-auth@kubernetescrd
       hosts:
         - host: weave-gitops.${domain}
           paths:

--- a/k8s/bases/apps/weave-gitops/helm-release.yaml
+++ b/k8s/bases/apps/weave-gitops/helm-release.yaml
@@ -22,8 +22,8 @@ spec:
       username: devantler
     ingress:
       enabled: true
-      # annotations:
-      #   traefik.ingress.kubernetes.io/router.middlewares: traefik-forward-auth@kubernetescrd
+      annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-forward-auth@kubernetescrd
       hosts:
         - host: weave-gitops.${domain}
           paths:

--- a/k8s/bases/apps/weave-gitops/helm-release.yaml
+++ b/k8s/bases/apps/weave-gitops/helm-release.yaml
@@ -1,0 +1,29 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: weave-gitops
+  namespace: flux-system
+spec:
+  chart:
+    spec:
+      chart: weave-gitops
+      version: 4.0.36
+      sourceRef:
+        kind: HelmRepository
+        name: weave-gitops
+  interval: 1h0m0s
+  # https://github.com/weaveworks/weave-gitops/blob/main/charts/gitops-server/values.yaml
+  values:
+    adminUser:
+      create: true
+      createSecret: false
+      username: devantler
+    ingress:
+      enabled: true
+      annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: traefik-forward-auth@kubernetescrd
+      hosts:
+        - host: weave-gitops.${domain}
+          paths:
+            - path: /
+              pathType: ImplementationSpecific

--- a/k8s/bases/apps/weave-gitops/helm-repository.yaml
+++ b/k8s/bases/apps/weave-gitops/helm-repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: weave-gitops
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts

--- a/k8s/bases/apps/weave-gitops/kustomization.yaml
+++ b/k8s/bases/apps/weave-gitops/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-user-auth-secret.yaml
+  - helm-release.yaml
+  - helm-repository.yaml

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -10,6 +10,7 @@ stringData:
     hcloud_token: ENC[AES256_GCM,data:0PCFWpWVHq2yODo1Owyjihj9qv/eckbWk4w8YVru+jG+p1mfgz5ipHHz+zUkv39v3pjUYvrPwRwJLJhMhY4ERQ==,iv:EndM1Zi8yo6AHokKMVjNiryLMx7oiKpND6UCtz/M4DI=,tag:aABKuGrrclZZKl4SvtjXAQ==,type:str]
     nextcloud_password: ENC[AES256_GCM,data:HBtHVLszEDg121lGyItNlmN5d9GNH4bVHx2ERY6c624ZBRLhzmZq1KI=,iv:/BZW3UtHQ8TKZ0OYeKKNrqSyhw84JAt3Ze6fNa1V3oQ=,tag:l2574z4qFvOXfehPrW4oBw==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:ju6ek+8TeEQWaHBgj88iTA6Ey7cvbeL3SdQykganKwdkk6GTsjj2VO/bKPs=,iv:me5/Zo90lBf0PEmVd//AfCF4RToj+dTvS2ayKZbVqbM=,tag:yKbBqNtnyD6lbtn5IUh5mg==,type:str]
+    weave_gitops_admin_password: ENC[AES256_GCM,data:ycx63XD++XXloHpVvt1rYlGcqoSDW89jN0DvHtyhYi9qtF2hJQsP7MY=,iv:h/GPG2JWliE+yjBq+/fH2WAZH1jNxZVRn62Hx1nJlG0=,tag:FmvIcMy/V041obU00WyniQ==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
@@ -21,7 +22,7 @@ sops:
             bit4OGl5QVBJV2tMYTA4SjJHN1VkWVkKuOtlVdLXYA/Xhij3RttbU8crRx3brSVu
             MUfT1wTTowU3AkI2mX5AXO3v4IVqYmo6CNn60PeKUzOGfJdDjjzfOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-15T23:32:46Z"
-    mac: ENC[AES256_GCM,data:G4Tg5gUjlBxxwDd2OiPclUDIWOuPMdSwxdjIQPWQRpHUCGXgAKAGo1qCPdk3lDFe28hbkUT3Dfgd/PMoqI+ZHJIfpidqVNZB5REiEAX8Bo6QxYMkQtid5eFPSQRe0O8Lh7tJNoWZaIvDoDbUHK/ZHmEiw/yz8TVQVb11MvXaftg=,iv:UMcxjuzt6NVuDAt/EJfKiqhZ8xQarTsTzgOuedUX970=,tag:cpbIKSY0DD7UZ+21wIIT+g==,type:str]
+    lastmodified: "2025-07-03T19:04:25Z"
+    mac: ENC[AES256_GCM,data:GJG1hhr14hkRK8DmBxfcM9j1B9hyAFnDKqNr2piFlpPMyxDJ7VGy85WumJTpzqoZ3MOXWu9vvs2nghvTSYMy26zOH1KPQs+HtVn3bglZZOWrjwpSHLuZPyfkIbvXFt2IfRWH95qwOMu/SO5Xwg9zoEaUQqD/GSRsfxpsCRcXzLM=,iv:dcasXAh3jW+TY2PKRjHW56QKxdNaKPY7v+QqPdrG+5o=,tag:VadPA5VPYVl1A6HXEW6Hjg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -10,7 +10,8 @@ stringData:
     hcloud_token: ENC[AES256_GCM,data:0PCFWpWVHq2yODo1Owyjihj9qv/eckbWk4w8YVru+jG+p1mfgz5ipHHz+zUkv39v3pjUYvrPwRwJLJhMhY4ERQ==,iv:EndM1Zi8yo6AHokKMVjNiryLMx7oiKpND6UCtz/M4DI=,tag:aABKuGrrclZZKl4SvtjXAQ==,type:str]
     nextcloud_password: ENC[AES256_GCM,data:HBtHVLszEDg121lGyItNlmN5d9GNH4bVHx2ERY6c624ZBRLhzmZq1KI=,iv:/BZW3UtHQ8TKZ0OYeKKNrqSyhw84JAt3Ze6fNa1V3oQ=,tag:l2574z4qFvOXfehPrW4oBw==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:ju6ek+8TeEQWaHBgj88iTA6Ey7cvbeL3SdQykganKwdkk6GTsjj2VO/bKPs=,iv:me5/Zo90lBf0PEmVd//AfCF4RToj+dTvS2ayKZbVqbM=,tag:yKbBqNtnyD6lbtn5IUh5mg==,type:str]
-    weave_gitops_admin_password: ENC[AES256_GCM,data:ycx63XD++XXloHpVvt1rYlGcqoSDW89jN0DvHtyhYi9qtF2hJQsP7MY=,iv:h/GPG2JWliE+yjBq+/fH2WAZH1jNxZVRn62Hx1nJlG0=,tag:FmvIcMy/V041obU00WyniQ==,type:str]
+    #ENC[AES256_GCM,data:g4PUHJjp98qINhXWr3rpG4MaKiMVwy45gsjwDHCxL29RV/8GYOPiP0RcpcSceVLwHGyGLfVSpF/MEbwNd9EGuhYN7PQR7xg=,iv:94SsxnrV7lMPmQatLQFUEM1ohm4XwZOGjhnsY2fvIW4=,tag:TwlTw3QzlyS5F7M01LFv6Q==,type:comment]
+    weave_gitops_admin_password: ENC[AES256_GCM,data:pofc5uF63r03uo1n3wfAMdcWB6ZB3Fv5PsC1OmmyIvfDiZc8ZWN1/i79gCDAJOX1rAmedZlTfiU6WmDm,iv:6SzXOW40Yt6KXwiN4hiK3bZ0ixN6g7HpqV9TMy2vbyc=,tag:dxtIKvWcT4vJ7wUkT0z8ug==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
@@ -22,7 +23,7 @@ sops:
             bit4OGl5QVBJV2tMYTA4SjJHN1VkWVkKuOtlVdLXYA/Xhij3RttbU8crRx3brSVu
             MUfT1wTTowU3AkI2mX5AXO3v4IVqYmo6CNn60PeKUzOGfJdDjjzfOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-03T19:04:25Z"
-    mac: ENC[AES256_GCM,data:GJG1hhr14hkRK8DmBxfcM9j1B9hyAFnDKqNr2piFlpPMyxDJ7VGy85WumJTpzqoZ3MOXWu9vvs2nghvTSYMy26zOH1KPQs+HtVn3bglZZOWrjwpSHLuZPyfkIbvXFt2IfRWH95qwOMu/SO5Xwg9zoEaUQqD/GSRsfxpsCRcXzLM=,iv:dcasXAh3jW+TY2PKRjHW56QKxdNaKPY7v+QqPdrG+5o=,tag:VadPA5VPYVl1A6HXEW6Hjg==,type:str]
+    lastmodified: "2025-07-03T19:26:42Z"
+    mac: ENC[AES256_GCM,data:e4n4VSoRDH49/Dr0aUMv8ghLXqJ5DPeSEOGcOF1RkWUqLnbaA7YQC+ZObD9ZdmAXZ1E1s3y8L7hf7e+0HzbZ02eIhROUqbOxOiYBt8IzEONlfvDQ/8NPWv85cGTts9UabQA3ya+WzGKgG4gM9otPXu2tWs/1Z9sNKd6PG9/MVBE=,iv:SXM1rrRaVugScQKWQlLQaD+kBmNTCfCEgmJskEYLV04=,tag:LCScYfO4I6qlanajxwScoQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/k8s/clusters/local/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/local/variables/variables-cluster-config-map.yaml
@@ -12,3 +12,4 @@ data:
   issuer_kind: ClusterIssuer
   issuer_name: selfsigned
   traefik_replicas: "1"
+

--- a/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
@@ -18,7 +18,7 @@ sops:
             OHBKalNlT09NYzdYc3RINUprL0ZqTW8KoTcrIHbkg3C3Gcq2GqMGiBE5j7QRXgjR
             Dksvvk875wmDUgBjK+4zwJtDwNFqi1w0ia4+rjpnwS2XkSiodwy6dQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-02T03:16:42Z"
-    mac: ENC[AES256_GCM,data:NSxnAd29zRiA3u7IWEwqPFFIfLffa8Q3FaPTIAQbcRPCvbvpa1BEXM5vb69/qqhMPBRkKnC9N09iR7j33bma4e2hSQktzgVtmykK78Tc2f67/H5z0OrqZAUHgaiyw/bo5nL8cnzQT6Jky426aQnti+5Z4aEc2Hw/1h5/2XI4U3w=,iv:aSSbiLAp8UyAWpbBpPNN/EcQHFpitF/lrNR6/seGhX8=,tag:icm7w27Zw/Rlfv+Uznf28Q==,type:str]
+    lastmodified: "2025-07-03T19:03:26Z"
+    mac: ENC[AES256_GCM,data:1hU+klVbvBZ9/Q5xMZH41dCuxO5Dj08j7hxuWWlTQlGtxubOx1TniLfQ56TVhKoUonP7QiJ3F2hmvSGowU2IsMzojLSN7dYnu+XbXP9KUlbAe3I3KXPSScEjmPLCumXgCCgCOhQVbWFeofYvtfnyLiAJ9ZR+gC23cXe0QBPcdkI=,iv:nNE+lJMCoIwSm4eqFkbkpHYOhOmUmfOVJuJrgM6PQsI=,tag:3HAi2YhY3f5Y+qGsj2Oktw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -10,6 +10,8 @@ stringData:
     hcloud_token: ENC[AES256_GCM,data:yhjuxpL/mVZ+yopyzXdncZXv0qzwaAs2Dad5ePoNqhP5wVhSu0aahbFAYXwGLXnI2A1KeF+ItrERVzXE0jOD3A==,iv:mD2ohoDGcti6z/d5WEXVDc+ftBKZOrxTlQykIWcaDcU=,tag:xq9p2FsdLEN+IOxbf73qxQ==,type:str]
     nextcloud_password: ENC[AES256_GCM,data:uszfQlZHrzgENY2LO6ky/2vlljJJHcW7AWPQtymqJLso/51NTtf0jhY=,iv:ihEBC/X0wuBM90wJjPMx/5gr0plYMfWEpHpLw22ZhDk=,tag:Wjv/Q+Xtp0VSF7PlPzRiJQ==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:OcnWJyQfQ6OUdHr5YxYe2CmOSw8w7q0rit8CCP6Z9QlXqy4q1Yne1Ck3rU4=,iv:aReO3UrPimKuFEwkKeU+QLdXzTBALRWcFpHlVb+Cp6w=,tag:rMtxdbigYrbSn0GnoVkCAQ==,type:str]
+    #ENC[AES256_GCM,data:KiyCFpvyXdmIk0jb9w7nfAIOLCk2JWPfg68xNcboBFClNj0lmjxLTDWih42X7UMdaNRQ3H5ojkcgUEbY7w4fr0fdKUnnsOU=,iv:a834SzeB+UFqJxekA/iSNvek8jmJBZXM8q/0iMyGYUg=,tag:SnLESVHsqBLEyFEKHm3T0g==,type:comment]
+    weave_gitops_admin_password: ENC[AES256_GCM,data:BJSql+q7Go1egYeBhS7bbDzxRD/3BU5sTjAxTVVNHnJik7q4Q6u6a5cNWmZNBlpIiI6ykMM5rv7oFeQM,iv:ZQ3Bk7H2keS8un/KTfJB0lYlvwK+NqkZzjuWcMy8d+8=,tag:JELMKmqWDJsl4fRBGVcl8A==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
@@ -21,7 +23,7 @@ sops:
             YTF5eFRrUGlvZkZGdmx5UzI3WWRvRTQKzSuBSfK89EvVDbT483Wgek2dZWWa2M2r
             qDk/Sua5xcRVPSG93fJPngVPSKeJK/HLArjDMbwueZrhCHx5mZIirA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-15T23:30:52Z"
-    mac: ENC[AES256_GCM,data:tGoL84ZDW2Q3EOo5QczWpQxwgminzThulCVtqQXpCqHZUWIQdebs2sAQQ/UvUmJHClMyMANSBh0yewiXX9T2St9ePmMWldaOcC0cFsIa0h952HJmxPuugsMRvFYvhlM1UQaIubbLe+CyyTyxz4h6ZdMlLDzn4jVisP4mPya0IGg=,iv:N661N6xj4Dyx1kKnHzl8wfG+eavBh1Q91LuoQEjpnl4=,tag:0QrE/FFn4U0KmzOdzCYkkg==,type:str]
+    lastmodified: "2025-07-03T19:28:32Z"
+    mac: ENC[AES256_GCM,data:OIVRunerhUPFjMfWDBqzwM9ZDZ1nIQVpW99Kv7F/Z+kmu0iD+u7sgwN/17B5I0nPihJ9IrlEnT7Bi8M/tehzEeZJKe27Pomq1QWZfNR7tC4UktFBCGOYSD3n+qctpJEdP0rXaLJFg9+t7JjGhKvIfQiD3EVGWZ4jMlLXT+jfq9M=,iv:Ofi1NK/2SL+b7BSgmVsbdWzVlpN3M3s/TuWoJarhDuc=,tag:mmMTGr2o0l3kzmMHXGOjrw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
Introduce a Helm release for Weave GitOps along with necessary Kubernetes resources, including a secret for authentication and a Kustomization file to manage the deployment.