### PR TITLE
fix(cloudflared): update to QUIC protocol and custom MTU

### DIFF
--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -26,7 +26,6 @@ spec:
               - op: replace
                 path: /spec/template/spec/containers/0/command
                 value:
-                  - cloudflared
                   - tunnel
                   - --no-autoupdate
                   - --metrics

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -16,18 +16,18 @@ spec:
         kind: HelmRepository
         name: cloudflared
   # TODO: Remove when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
-  # postRenderers:
-  #   - kustomize:
-  #       patches:
-  #         - target:
-  #             kind: Deployment
-  #             name: cloudflared-cloudflare-tunnel-remote
-  #           patch: |
-  #             - op: add
-  #               path: /spec/template/spec/containers/0/env/-
-  #               value:
-  #                 name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-  #                 value: "1230"
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: cloudflared-cloudflare-tunnel-remote
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: TUNNEL_DISABLE_QUIC_PMTU
+                  value: "true"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -34,13 +34,13 @@ spec:
                 - op: add
                   path: /spec/template/spec/containers/0/env/-
                   value:
-                    name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                    value: "1230"
+                    name: TUNNEL_DISABLE_QUIC_PMTU
+                    value: "true"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:
       tunnel_token: ${cloudflared_tunnel_token}
     image:
-      repository: ghcr.io/nobles5e/cloudflared/cloudflared
+      # repository: ghcr.io/nobles5e/cloudflared/cloudflared
       pullPolicy: Always
-      tag: latest
+      # tag: latest

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -31,11 +31,11 @@ spec:
                   - --no-autoupdate
                   - --metrics
                   - 0.0.0.0:2000
-              - op: add
-                path: /spec/template/spec/containers/0/env/-
-                value:
-                  name: TUNNEL_DISABLE_QUIC_PMTU
-                  value: true
+            # - op: add
+            #   path: /spec/template/spec/containers/0/env/-
+            #   value:
+            #     name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
+            #     value: "1230"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: TUNNEL_DISABLE_QUIC_PMTU
-                  value: "true"
+                  value: true
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -17,23 +17,26 @@ spec:
         name: cloudflared
   # TODO: Remove postRenderers when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
   postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: cloudflared-cloudflare-tunnel-remote
-            patch: |
-              - op: add
-                path: /spec/template/spec/containers/0/env/-
-                value:
-                  name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "1250"
+     - kustomize:
+         patches:
+           - target:
+               kind: Deployment
+               name: cloudflared-cloudflare-tunnel-remote
+             patch: |
+               - op: replace
+                 path: /spec/template/spec/containers/0/command
+                 value:
+                   - cloudflared
+                   - tunnel
+                   - --protocol
+                   - http2
+                   - --no-autoupdate
+                   - --metrics
+                   - 0.0.0.0:2000
+                   - run
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
-    cloudflare:
-      tunnel_token: ${cloudflared_tunnel_token}
-    image:
-      pullPolicy: Always
-      # TODO: Remove custom image when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
-      repository: ghcr.io/nobles5e/cloudflared/cloudflared
-      tag: latest
+     cloudflare:
+       tunnel_token: ${cloudflared_tunnel_token}
+     image:
+       pullPolicy: Always

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "1230"
+                  value: "800"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -16,26 +16,18 @@ spec:
         kind: HelmRepository
         name: cloudflared
   # TODO: Remove when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: cloudflared-cloudflare-tunnel-remote
-            patch: |
-              - op: replace
-                path: /spec/template/spec/containers/0/command
-                value:
-                  - cloudflared
-                  - tunnel
-                  - --no-autoupdate
-                  - --metrics
-                  - 0.0.0.0:2000
-            # - op: add
-            #   path: /spec/template/spec/containers/0/env/-
-            #   value:
-            #     name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-            #     value: "1230"
+  # postRenderers:
+  #   - kustomize:
+  #       patches:
+  #         - target:
+  #             kind: Deployment
+  #             name: cloudflared-cloudflare-tunnel-remote
+  #           patch: |
+  #             - op: add
+  #               path: /spec/template/spec/containers/0/env/-
+  #               value:
+  #                 name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
+  #                 value: "1230"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -31,11 +31,11 @@ spec:
                   - --no-autoupdate
                   - --metrics
                   - 0.0.0.0:2000
-                - op: add
-                  path: /spec/template/spec/containers/0/env/-
-                  value:
-                    name: TUNNEL_DISABLE_QUIC_PMTU
-                    value: "true"
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: TUNNEL_DISABLE_QUIC_PMTU
+                  value: "true"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cloudflared
-  # TODO: Remove when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
+  # TODO: Remove postRendererswhen Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
   postRenderers:
     - kustomize:
         patches:
@@ -33,6 +33,7 @@ spec:
     cloudflare:
       tunnel_token: ${cloudflared_tunnel_token}
     image:
-      repository: ghcr.io/nobles5e/cloudflared/cloudflared
       pullPolicy: Always
+      # TODO: Remove custom image when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
+      repository: ghcr.io/nobles5e/cloudflared/cloudflared
       tag: latest

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "1200"
+                  value: "1500"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -26,13 +26,13 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/env/-
                 value:
-                  name: TUNNEL_DISABLE_QUIC_PMTU
-                  value: "true"
+                  name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
+                  value: "1230"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:
       tunnel_token: ${cloudflared_tunnel_token}
     image:
-      # repository: ghcr.io/nobles5e/cloudflared/cloudflared
+      repository: ghcr.io/nobles5e/cloudflared/cloudflared
       pullPolicy: Always
-      # tag: latest
+      tag: latest

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -28,16 +28,21 @@ spec:
                 value:
                   - cloudflared
                   - tunnel
-                  - --protocol
-                  - http2
                   - --no-autoupdate
                   - --metrics
                   - 0.0.0.0:2000
                   - run
+              - op: replace
+                path: /spec/template/spec/containers/0/env
+                value:
+                  - name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
+                    value: "1230"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:
       tunnel_token: ${cloudflared_tunnel_token}
     image:
+      repository: ghcr.io/nobles5e/cloudflared/cloudflared
       pullPolicy: Always
+      tag: latest
 

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -31,11 +31,10 @@ spec:
                   - --no-autoupdate
                   - --metrics
                   - 0.0.0.0:2000
-                  - run
-              - op: replace
-                path: /spec/template/spec/containers/0/env
-                value:
-                  - name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
+                - op: add
+                  path: /spec/template/spec/containers/0/env/-
+                  value:
+                    name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
                     value: "1230"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
@@ -45,4 +44,3 @@ spec:
       repository: ghcr.io/nobles5e/cloudflared/cloudflared
       pullPolicy: Always
       tag: latest
-

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "800"
+                  value: "1200"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -26,6 +26,7 @@ spec:
               - op: replace
                 path: /spec/template/spec/containers/0/command
                 value:
+                  - cloudflared
                   - tunnel
                   - --no-autoupdate
                   - --metrics

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "1500"
+                  value: "1300"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cloudflared
-  # TODO: Remove postRendererswhen Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
+  # TODO: Remove postRenderers when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
   postRenderers:
     - kustomize:
         patches:

--- a/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/distributions/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
                 path: /spec/template/spec/containers/0/env/-
                 value:
                   name: CLOUDFLARED_QUIC_INITIAL_PACKET_SIZE
-                  value: "1300"
+                  value: "1250"
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
   values:
     cloudflare:


### PR DESCRIPTION
Update cloudflared configuration to utilize the QUIC protocol and set a custom MTU, ensuring compatibility with Talos KubeSpan and Cilium CNI.