### PR TITLE
fix(nextcloud): add ingress annotations for homepage integration

### DIFF
--- a/k8s/bases/apps/nextcloud/helm-release.yaml
+++ b/k8s/bases/apps/nextcloud/helm-release.yaml
@@ -23,6 +23,14 @@ spec:
     replicaCount: ${nextcloud_replicas:=1}
     ingress:
       enabled: true
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: Nextcloud
+        gethomepage.dev/description: File storage and collaboration platform.
+        gethomepage.dev/group: Apps
+        gethomepage.dev/icon: nextcloud
+        gethomepage.dev/app: nextcloud
+        gethomepage.dev/pod-selector: app.kubernetes.io/name=nextcloud
     service:
       annotations:
         traefik.ingress.kubernetes.io/service.sticky.cookie: "true"


### PR DESCRIPTION
Add ingress annotations to enable Nextcloud integration on the homepage, providing essential metadata for better visibility and organization.