### PR TITLE
fix: remove timeout configuration from connection in ksail.yaml

### DIFF
--- a/ksail.yaml
+++ b/ksail.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   connection:
     context: kind-local
-    timeout: 10m
   project:
     kustomizationPath: k8s/clusters/local
     deploymentTool: Flux


### PR DESCRIPTION
Eliminate the timeout configuration from the connection settings in ksail.yaml to streamline the connection process.