### PR TITLE
fix(unifi): suspend Flux Kustomization for unsigned UniFi Git source

### DIFF
--- a/k8s/providers/hetzner/apps/unifi/flux-kustomization.yaml
+++ b/k8s/providers/hetzner/apps/unifi/flux-kustomization.yaml
@@ -15,6 +15,11 @@ metadata:
   annotations:
     ksail.devantler.tech/reconcile-exclude: "true"
 spec:
+  # SECURITY: this external Git source drives write-scoped UniFi Crossplane
+  # managed resources through the Cloud Connector credential. Keep automatic
+  # reconciliation paused until the source is pinned or signature-verified so a
+  # compromised moving branch cannot use Crossplane as a confused deputy.
+  suspend: true
   interval: 1m
   timeout: 5m
   retryInterval: 2m


### PR DESCRIPTION
### Motivation
- Prevent a compromised moving Git branch from using Crossplane + a write-scoped UniFi Cloud Connector credential to perform network writes by pausing automatic reconciliation until the external source is pinned or signature-verified.

### Description
- Add an inline security note and set `suspend: true` in `k8s/providers/hetzner/apps/unifi/flux-kustomization.yaml` so Flux will not automatically reconcile the unsigned `devantler-tech/unifi` source while a safe pin/signature workflow is arranged.

### Testing
- Ran `python3 scripts/validate-naming.py` (passed), a YAML parse/assertion via `ruby -e 'require "yaml"; ...'` (passed), and `git diff --check` (passed); `ksail workload validate` and `kubectl kustomize`/`kubectl apply --dry-run=client` could not be executed in this environment because `ksail` and `kubectl` were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a528abf5a34832bbbf53552eafe4960)