### PR TITLE
fix(talos): restrict provider image signing refs

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -85,7 +85,7 @@ spec:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
   validations:
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -61,7 +61,7 @@ rules:
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
   # First-party APP images signed by the shared publish-app.yaml workflow.
   # publish-app.yaml moved from devantler-tech/reusable-workflows into
   # devantler-tech/actions (actions#425): images published after the move


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

### Motivation

- The Talos `ImageVerificationConfig` rule for `ghcr.io/devantler-tech/provider-upjet-*` was accepting signatures from any GitHub ref (`@.+`), which permits non-release refs (branches/PRs/tags) to be trusted and therefore risks running provider images signed from unprotected refs. 
- Admission-time attestation (Kyverno `verify-app-images`) needed the same protected-ref constraint so node-level pull verification and cluster admission policy remain consistent.

### Description

- Tighten the Talos provider rule in `talos/cluster/verify-first-party-images.yaml` by changing the `subjectRegex` for `provider-upjet-*` signatures from `@.+$` to `@refs/tags/v[0-9].+` so only release-style tag refs are accepted. 
- Apply the same protected-release `subjectRegExp` change to the Kyverno attestor in `k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml` so admission validation and node pull verification match. 
- The change preserves the existing ordering and attestor semantics (first-match-wins) and is intentionally minimal to reduce risk while closing the trust surface.

### Testing

- A Python regex smoke test confirmed that `refs/tags/v0.1.0` matches the new pattern and branch/PR/non-`v*` tag refs do not. 
- `python scripts/validate-naming.py` completed successfully and `git diff --check` reported no problems. 
- `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` could not be executed in this environment because `kubectl` is not installed here, so CI's static manifest validation (`ksail workload validate` / Kubescape scan) will still run on the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a528fe2bb6c832b9d174ed6fe4b4be3)