### PR TITLE
fix(unifi): prevent pruning managed network resources

### DIFF
--- a/docs/unifi-management.md
+++ b/docs/unifi-management.md
@@ -110,10 +110,14 @@ no annotation; Crossplane creates it. See the tenant repo's
 [`docs/runbook.md`](https://github.com/devantler-tech/unifi/blob/main/docs/runbook.md)
 for the full procedure and how to find a live object's `_id`.
 
-> **Deletion:** the Managed Resources use the default `deletionPolicy: Delete`, and
-> the tenant's Flux `Kustomization` has `prune: true` — removing a resource from the
-> repo deletes the live object. Set `deletionPolicy: Orphan` on a resource if it must
-> survive removal from Git.
+> **Deletion:** the Platform Flux `Kustomization` deliberately has `prune: false`,
+> and its `unifi` ServiceAccount has no `delete` permission. Removing a resource
+> from the tenant repository therefore leaves both the Managed Resource and the
+> live UniFi object in place. Retirement is an explicit, reviewed Platform
+> operation: choose `deletionPolicy: Delete` to remove the backing object or
+> `deletionPolicy: Orphan` to preserve it, wait for that policy to reconcile, then
+> delete the Managed Resource with a platform-operator identity and verify the
+> intended live-object outcome. There is no Git-removal-only deletion path.
 
 ## Validation notes (confirm on the live cluster)
 

--- a/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
@@ -45,18 +45,6 @@ spec:
                 - flux-system
               names:
                 - flux-system
-          # The UniFi reconciler applies Crossplane Managed Resources whose
-          # default deletion policy cascades to live network objects. It keeps
-          # every other reliability field, but deliberately disables pruning;
-          # its ServiceAccount also lacks delete authority and its external
-          # source is pinned to an immutable commit by the EKS authorization
-          # validator. Keep this exception exact so no other Kustomization can
-          # bypass the portfolio-wide garbage-collection default.
-          - resources:
-              namespaces:
-                - unifi
-              names:
-                - unifi
       validate:
         message: >-
           Flux Kustomization must set the recommended reliability fields:

--- a/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
@@ -45,6 +45,18 @@ spec:
                 - flux-system
               names:
                 - flux-system
+          # The UniFi reconciler applies Crossplane Managed Resources whose
+          # default deletion policy cascades to live network objects. It keeps
+          # every other reliability field, but deliberately disables pruning;
+          # its ServiceAccount also lacks delete authority and its external
+          # source is pinned to an immutable commit by the EKS authorization
+          # validator. Keep this exception exact so no other Kustomization can
+          # bypass the portfolio-wide garbage-collection default.
+          - resources:
+              namespaces:
+                - unifi
+              names:
+                - unifi
       validate:
         message: >-
           Flux Kustomization must set the recommended reliability fields:

--- a/k8s/providers/hetzner/apps/unifi/flux-kustomization.yaml
+++ b/k8s/providers/hetzner/apps/unifi/flux-kustomization.yaml
@@ -19,13 +19,12 @@ spec:
   timeout: 5m
   retryInterval: 2m
   path: ./
-  prune: true
+  # Do not prune Crossplane managed resources sourced from the separate
+  # devantler-tech/unifi repository. A source compromise or accidental removal
+  # there must not cause Flux to delete the Kubernetes managed resource and let
+  # Crossplane cascade-delete the backing live UniFi object.
+  prune: false
   wait: true
-  # No force: these are Crossplane managed resources with the default
-  # deletionPolicy: Delete, so a force delete/recreate on immutable-field drift
-  # would cascade into deleting the backing UniFi object. Handle a genuine
-  # immutable conflict per-resource with the
-  # kustomize.toolkit.fluxcd.io/force: enabled annotation instead.
   serviceAccountName: unifi
   sourceRef:
     kind: GitRepository

--- a/k8s/providers/hetzner/apps/unifi/git-repository.yaml
+++ b/k8s/providers/hetzner/apps/unifi/git-repository.yaml
@@ -5,8 +5,11 @@ metadata:
   namespace: unifi
 spec:
   interval: 5m
-  # devantler-tech/unifi is public — no auth needed. It holds NO secrets; the
-  # UniFi API credentials come from OpenBao (see credentials-external-secret.yaml).
+  # devantler-tech/unifi is public — no credential is needed. It holds NO
+  # secrets; the UniFi API credentials come from OpenBao (see
+  # external-secret.yaml). Pin the full commit so a source-repository compromise
+  # cannot change resources already authorized for patch/update without a
+  # separately reviewed Platform change.
   url: https://github.com/devantler-tech/unifi
   ref:
-    branch: main
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98

--- a/k8s/providers/hetzner/apps/unifi/role.yaml
+++ b/k8s/providers/hetzner/apps/unifi/role.yaml
@@ -1,6 +1,6 @@
 ---
 # Least-privilege RBAC for the unifi app's ServiceAccount: a dedicated namespaced
-# Role granting full verbs over the namespaced provider-upjet-unifi
+# Role granting apply verbs over the namespaced provider-upjet-unifi
 # managed-resource API groups, and only within the unifi namespace. The app's
 # Flux Kustomization applies the Managed Resources from devantler-tech/unifi AS
 # this SA, so it needs no more than this — the ProviderConfig + credential
@@ -34,4 +34,3 @@ rules:
       - create
       - update
       - patch
-      - delete

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -143,6 +143,25 @@ components:
   - ../../../bases/components/helmrelease-drift-detection
   - ../../../bases/components/helmrelease-flux-defaults
 patches:
+  # UniFi exists only on Hetzner and applies Crossplane Managed Resources whose
+  # default deletion policy cascades to live network objects. Keep its deliberate
+  # non-pruning exception in this provider overlay so the shared admission policy
+  # remains strict for every other environment. The authorization validator pins
+  # the rendered exception set and the reconciler's immutable source/delete bounds.
+  - target:
+      group: kyverno.io
+      version: v1
+      kind: ClusterPolicy
+      name: enforce-flux-best-practices
+    patch: |
+      - op: add
+        path: /spec/rules/0/exclude/any/-
+        value:
+          resources:
+            namespaces:
+              - unifi
+            names:
+              - unifi
   # gateway-patch self-identifies (Gateway/platform/kube-system), so a path is
   # enough — no explicit target, matching the coroot patch below.
   - path: patches/attach-hcloud-load-balancer.yaml

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -389,7 +389,30 @@ const (
 // changes, including the Umami Namespace, whose identical rendered form merely
 // moves between two already-scanned ownership layers. The validator reported
 // no per-resource mismatch; only this aggregate fingerprint moved.
-const expectedRenderedSurfaceSHA = "83763a582a9daac9d8555695165489dd86613504099717bfd95b340e396c5f14"
+//
+// This value additionally covers the UniFi source containment repair in #2707,
+// measured after rebasing the PR onto exact main 57ca1dbe. Four of the five
+// authorization roots are byte-identical across main and this change:
+// infrastructure, infrastructure/controllers, prod/bootstrap, and prod. The
+// complete apps render has identical membership and exactly THREE changed
+// fields across three existing documents:
+//
+//	rbac.authorization.k8s.io/v1    Role           unifi/unifi-managed-resources
+//	  verbs: delete                                        (removed)
+//	kustomize.toolkit.fluxcd.io/v1  Kustomization  unifi/unifi
+//	  prune: true -> false
+//	source.toolkit.fluxcd.io/v1      GitRepository  unifi/unifi
+//	  ref.branch: main -> ref.commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+//
+// The first two changes remove deletion paths. The third replaces a moving
+// branch with one full immutable commit from the expected repository, so a
+// source-repository compromise cannot alter resources that retain patch/update
+// authority without a separately reviewed Platform change. The semantic
+// validatePinnedUnifiSource control and its negative tests reject branches,
+// tags/mixed selectors, abbreviated hashes, substitutions, and alternate URLs
+// before the aggregate hash is considered. No identity, binding, resource kind,
+// or remaining verb moved.
+const expectedRenderedSurfaceSHA = "1c4c1986a7b891b184d70a19bec6a85f33c0ea4c0ac174b26501000e38582cd1"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.
@@ -410,6 +433,8 @@ var exactPinnedHelmChartVersion = regexp.MustCompile(
 		`(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`,
 )
 
+var exactGitCommit = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
 // commandExecutor makes the renderer orchestration independently testable
 // without weakening the production command and deadline contract.
 type commandExecutor func(context.Context, string, ...string) ([]byte, error)
@@ -427,6 +452,36 @@ type resourceIdentity struct {
 type resourceType struct {
 	apiVersion string
 	kind       string
+}
+
+// validatePinnedUnifiSource keeps the external repository from moving without
+// a reviewed Platform change. This source retains patch/update authority over
+// live UniFi managed resources, so a branch, tag, abbreviated hash, alternate
+// repository, or mixed selector is not an acceptable provenance boundary.
+func validatePinnedUnifiSource(document map[string]any, identity resourceIdentity) error {
+	wantIdentity := resourceIdentity{
+		apiVersion: "source.toolkit.fluxcd.io/v1",
+		kind:       "GitRepository",
+		namespace:  "unifi",
+		name:       "unifi",
+	}
+	if identity != wantIdentity {
+		return nil
+	}
+
+	spec, ok := document["spec"].(map[string]any)
+	if !ok || spec["url"] != "https://github.com/devantler-tech/unifi" {
+		return errors.New("unifi GitRepository must use the trusted devantler-tech/unifi source")
+	}
+	ref, ok := spec["ref"].(map[string]any)
+	if !ok || len(ref) != 1 {
+		return errors.New("unifi GitRepository must pin exactly one full immutable commit")
+	}
+	commit, ok := ref["commit"].(string)
+	if !ok || !exactGitCommit.MatchString(commit) {
+		return errors.New("unifi GitRepository must pin exactly one full immutable commit")
+	}
+	return nil
 }
 
 // expectedRenderedHashes preserves object-specific diagnostics for the core
@@ -451,7 +506,7 @@ var expectedRenderedHashes = map[resourceIdentity]string{
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "flux-system", name: "infrastructure"}:             "d1bc403b6458bd22cf967bd570e24718341cbd584f58e7f0069aaffe1e187945",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "flux-system", name: "infrastructure-controllers"}: "9d9b62d3221442d6355d16a34d31c198619fb3b3728df960fd67222a531ece7b",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "github-config", name: "github-config"}:            "8e9f72b0f4f982d050aff0b97d246c68b538cbc397cdd45d031c95cfae981e7c",
-	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "unifi", name: "unifi"}:                            "47c63f6a762caeacf257ddd32cbbeb3f3568eeea0e258ec006621579114731ff",
+	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "unifi", name: "unifi"}:                            "33a579299700de2467631854bac4982d3e14caa3bad8cbcd2613ac180b30af32",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "wedding-app", name: "wedding-app"}:                "8af27d4845565c57b9ebc618f186669f18ada89e070cf4e6514924717a2532f8",
 }
 
@@ -1369,6 +1424,9 @@ func validateRendered(rendered []byte) error {
 	substitutionProblems := make([]error, 0)
 	for _, document := range documents {
 		identity := identityOf(document)
+		if sourceErr := validatePinnedUnifiSource(document, identity); sourceErr != nil {
+			problems = append(problems, sourceErr)
+		}
 		isAuthorizationCapable := isAuthorizationCapableDocument(document, identity)
 		hasAuthorizationSubstitution := isAuthorizationCapable &&
 			containsFluxSubstitution(document) &&

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -402,7 +402,7 @@ const (
 //	kustomize.toolkit.fluxcd.io/v1  Kustomization  unifi/unifi
 //	  prune: true -> false
 //	source.toolkit.fluxcd.io/v1      GitRepository  unifi/unifi
-//	  ref.branch: main -> ref.commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+//	  ref.branch: main -> one full 40-hex ref.commit pin
 //
 // The first two changes remove deletion paths. The third replaces a moving
 // branch with one full immutable commit from the expected repository, so a

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -391,11 +391,11 @@ const (
 // no per-resource mismatch; only this aggregate fingerprint moved.
 //
 // This value additionally covers the UniFi source containment repair in #2707,
-// measured after rebasing the PR onto exact main 57ca1dbe. Four of the five
+// measured after rebasing the PR onto exact main 57ca1dbe. Three of the five
 // authorization roots are byte-identical across main and this change:
-// infrastructure, infrastructure/controllers, prod/bootstrap, and prod. The
-// complete apps render has identical membership and exactly THREE changed
-// fields across three existing documents:
+// infrastructure/controllers, prod/bootstrap, and prod. The complete apps
+// render has identical membership and exactly THREE changed fields across
+// three existing documents:
 //
 //	rbac.authorization.k8s.io/v1    Role           unifi/unifi-managed-resources
 //	  verbs: delete                                        (removed)
@@ -410,8 +410,11 @@ const (
 // authority without a separately reviewed Platform change. The semantic
 // validatePinnedUnifiSource control and its negative tests reject branches,
 // tags/mixed selectors, abbreviated hashes, substitutions, and alternate URLs
-// before the aggregate hash is considered. No identity, binding, resource kind,
-// or remaining verb moved.
+// before the aggregate hash is considered. The infrastructure render changes
+// exactly one existing ClusterPolicy by adding the exact unifi/unifi admission
+// exception needed to admit prune:false; validateUnifiPruneExemption pins that
+// rule's complete exception set to flux-system/flux-system and unifi/unifi.
+// No identity, binding, resource kind, or remaining verb moved.
 const expectedRenderedSurfaceSHA = "1c4c1986a7b891b184d70a19bec6a85f33c0ea4c0ac174b26501000e38582cd1"
 
 // authorizationOverlayPaths lists every independently reconciled production
@@ -482,6 +485,74 @@ func validatePinnedUnifiSource(document map[string]any, identity resourceIdentit
 		return errors.New("unifi GitRepository must pin exactly one full immutable commit")
 	}
 	return nil
+}
+
+// validateUnifiPruneExemption keeps the deliberate non-pruning reconciler
+// deployable while requiring the admission-policy exception to remain scoped
+// to exactly one namespaced Kustomization.
+func validateUnifiPruneExemption(document map[string]any, identity resourceIdentity) error {
+	wantIdentity := resourceIdentity{
+		apiVersion: "kyverno.io/v1",
+		kind:       "ClusterPolicy",
+		name:       "enforce-flux-best-practices",
+	}
+	if identity != wantIdentity {
+		return nil
+	}
+
+	exactSingleton := func(value any, want string) bool {
+		values, ok := value.([]any)
+		return ok && len(values) == 1 && values[0] == want
+	}
+	spec, ok := document["spec"].(map[string]any)
+	if !ok {
+		return errors.New("enforce-flux-best-practices must exempt only unifi/unifi from prune enforcement")
+	}
+	rules, ok := spec["rules"].([]any)
+	if !ok {
+		return errors.New("enforce-flux-best-practices must exempt only unifi/unifi from prune enforcement")
+	}
+	for _, ruleValue := range rules {
+		rule, ok := ruleValue.(map[string]any)
+		if !ok || rule["name"] != "kustomization-recommended-settings" {
+			continue
+		}
+		exclude, ok := rule["exclude"].(map[string]any)
+		if !ok {
+			break
+		}
+		exclusions, ok := exclude["any"].([]any)
+		if !ok {
+			break
+		}
+		seenFluxSystem := false
+		seenUnifi := false
+		for _, exclusionValue := range exclusions {
+			exclusion, ok := exclusionValue.(map[string]any)
+			if !ok {
+				break
+			}
+			resources, ok := exclusion["resources"].(map[string]any)
+			if !ok {
+				break
+			}
+			switch {
+			case exactSingleton(resources["namespaces"], "flux-system") &&
+				exactSingleton(resources["names"], "flux-system") && !seenFluxSystem:
+				seenFluxSystem = true
+			case exactSingleton(resources["namespaces"], "unifi") &&
+				exactSingleton(resources["names"], "unifi") && !seenUnifi:
+				seenUnifi = true
+			default:
+				return errors.New("enforce-flux-best-practices must exempt only unifi/unifi from prune enforcement")
+			}
+		}
+		if seenFluxSystem && seenUnifi && len(exclusions) == 2 {
+			return nil
+		}
+		break
+	}
+	return errors.New("enforce-flux-best-practices must exempt only unifi/unifi from prune enforcement")
 }
 
 // expectedRenderedHashes preserves object-specific diagnostics for the core
@@ -1426,6 +1497,9 @@ func validateRendered(rendered []byte) error {
 		identity := identityOf(document)
 		if sourceErr := validatePinnedUnifiSource(document, identity); sourceErr != nil {
 			problems = append(problems, sourceErr)
+		}
+		if exemptionErr := validateUnifiPruneExemption(document, identity); exemptionErr != nil {
+			problems = append(problems, exemptionErr)
 		}
 		isAuthorizationCapable := isAuthorizationCapableDocument(document, identity)
 		hasAuthorizationSubstitution := isAuthorizationCapable &&

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -164,6 +164,118 @@ spec:
 	}
 }
 
+// TestValidatePinnedUnifiSource rejects every source shape that can move
+// without a reviewed Platform change. The unifi Kustomization keeps patch and
+// update authority over live managed resources, so its external Git source
+// must be both the expected repository and one full immutable commit.
+func TestValidatePinnedUnifiSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  string
+		wantError bool
+	}{
+		{
+			name: "exact trusted commit",
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: unifi
+  namespace: unifi
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+`,
+		},
+		{
+			name:      "mutable branch",
+			wantError: true,
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: unifi
+  namespace: unifi
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    branch: main
+`,
+		},
+		{
+			name:      "abbreviated commit",
+			wantError: true,
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: unifi
+  namespace: unifi
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    commit: 7b17f7e
+`,
+		},
+		{
+			name:      "mutable branch beside commit",
+			wantError: true,
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: unifi
+  namespace: unifi
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    branch: main
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+`,
+		},
+		{
+			name:      "different repository",
+			wantError: true,
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: unifi
+  namespace: unifi
+spec:
+  url: https://github.com/attacker/unifi
+  ref:
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+`,
+		},
+		{
+			name: "unrelated source",
+			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: other
+  namespace: other
+spec:
+  url: https://example.com/other
+  ref:
+    branch: main
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documents, err := decodeDocuments([]byte(tt.manifest))
+			if err != nil || len(documents) != 1 {
+				t.Fatalf("decode source: documents=%d error=%v", len(documents), err)
+			}
+			err = validatePinnedUnifiSource(documents[0], identityOf(documents[0]))
+			if tt.wantError && err == nil {
+				t.Fatal("validatePinnedUnifiSource() error = nil, want rejection")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("validatePinnedUnifiSource() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 // TestValidateRenderedRejectsIndirectAuthorizationResources covers controllers.
 func TestValidateRenderedRejectsIndirectAuthorizationResources(t *testing.T) {
 	tests := []struct {

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -249,6 +249,96 @@ func TestValidatePinnedUnifiSource(t *testing.T) {
 	}
 }
 
+// TestValidateUnifiPruneExemption pins the admission exception that makes the
+// non-pruning UniFi reconciler deployable without weakening the default rule
+// for any other Flux Kustomization.
+func TestValidateUnifiPruneExemption(t *testing.T) {
+	targetIdentity := resourceIdentity{
+		apiVersion: "kyverno.io/v1",
+		kind:       "ClusterPolicy",
+		name:       "enforce-flux-best-practices",
+	}
+	policy := func(exclusions ...any) map[string]any {
+		return map[string]any{
+			"spec": map[string]any{
+				"rules": []any{
+					map[string]any{
+						"name":    "kustomization-recommended-settings",
+						"exclude": map[string]any{"any": exclusions},
+					},
+				},
+			},
+		}
+	}
+	resourceExclusion := func(namespace, name string) map[string]any {
+		return map[string]any{
+			"resources": map[string]any{
+				"namespaces": []any{namespace},
+				"names":      []any{name},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		identity  resourceIdentity
+		document  map[string]any
+		wantError bool
+	}{
+		{
+			name:     "exact narrow exemption",
+			identity: targetIdentity,
+			document: policy(
+				resourceExclusion("flux-system", "flux-system"),
+				resourceExclusion("unifi", "unifi"),
+			),
+		},
+		{
+			name:      "missing exemption",
+			identity:  targetIdentity,
+			document:  policy(resourceExclusion("flux-system", "flux-system")),
+			wantError: true,
+		},
+		{
+			name:      "namespace wildcard is not narrow",
+			identity:  targetIdentity,
+			document:  policy(resourceExclusion("*", "unifi")),
+			wantError: true,
+		},
+		{
+			name:     "additional broad exemption is rejected",
+			identity: targetIdentity,
+			document: policy(
+				resourceExclusion("flux-system", "flux-system"),
+				resourceExclusion("unifi", "unifi"),
+				resourceExclusion("*", "*"),
+			),
+			wantError: true,
+		},
+		{
+			name: "unrelated policy",
+			identity: resourceIdentity{
+				apiVersion: "kyverno.io/v1",
+				kind:       "ClusterPolicy",
+				name:       "other",
+			},
+			document: policy(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUnifiPruneExemption(tt.document, tt.identity)
+			if tt.wantError && err == nil {
+				t.Fatal("validateUnifiPruneExemption() error = nil, want rejection")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("validateUnifiPruneExemption() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 // TestValidateRenderedRejectsIndirectAuthorizationResources covers controllers.
 func TestValidateRenderedRejectsIndirectAuthorizationResources(t *testing.T) {
 	tests := []struct {

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -169,103 +169,78 @@ spec:
 // update authority over live managed resources, so its external Git source
 // must be both the expected repository and one full immutable commit.
 func TestValidatePinnedUnifiSource(t *testing.T) {
+	const (
+		trustedURL   = "https://github.com/devantler-tech/unifi"
+		pinnedCommit = "7b17f7e33ef507c24c395b884a433c62b92ace98"
+	)
+	targetIdentity := resourceIdentity{
+		apiVersion: "source.toolkit.fluxcd.io/v1",
+		kind:       "GitRepository",
+		namespace:  "unifi",
+		name:       "unifi",
+	}
+	source := func(url string, ref map[string]any) map[string]any {
+		return map[string]any{
+			"spec": map[string]any{
+				"url": url,
+				"ref": ref,
+			},
+		}
+	}
+
 	tests := []struct {
 		name      string
-		manifest  string
+		identity  resourceIdentity
+		document  map[string]any
 		wantError bool
 	}{
 		{
-			name: "exact trusted commit",
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: unifi
-  namespace: unifi
-spec:
-  url: https://github.com/devantler-tech/unifi
-  ref:
-    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
-`,
+			name:     "exact trusted commit",
+			identity: targetIdentity,
+			document: source(trustedURL, map[string]any{"commit": pinnedCommit}),
 		},
 		{
 			name:      "mutable branch",
+			identity:  targetIdentity,
+			document:  source(trustedURL, map[string]any{"branch": "main"}),
 			wantError: true,
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: unifi
-  namespace: unifi
-spec:
-  url: https://github.com/devantler-tech/unifi
-  ref:
-    branch: main
-`,
 		},
 		{
 			name:      "abbreviated commit",
+			identity:  targetIdentity,
+			document:  source(trustedURL, map[string]any{"commit": "7b17f7e"}),
 			wantError: true,
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: unifi
-  namespace: unifi
-spec:
-  url: https://github.com/devantler-tech/unifi
-  ref:
-    commit: 7b17f7e
-`,
 		},
 		{
-			name:      "mutable branch beside commit",
+			name:     "mutable branch beside commit",
+			identity: targetIdentity,
+			document: source(trustedURL, map[string]any{
+				"branch": "main",
+				"commit": pinnedCommit,
+			}),
 			wantError: true,
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: unifi
-  namespace: unifi
-spec:
-  url: https://github.com/devantler-tech/unifi
-  ref:
-    branch: main
-    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
-`,
 		},
 		{
 			name:      "different repository",
+			identity:  targetIdentity,
+			document:  source("https://github.com/attacker/unifi", map[string]any{"commit": pinnedCommit}),
 			wantError: true,
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: unifi
-  namespace: unifi
-spec:
-  url: https://github.com/attacker/unifi
-  ref:
-    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
-`,
 		},
 		{
 			name: "unrelated source",
-			manifest: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: other
-  namespace: other
-spec:
-  url: https://example.com/other
-  ref:
-    branch: main
-`,
+			identity: resourceIdentity{
+				apiVersion: "source.toolkit.fluxcd.io/v1",
+				kind:       "GitRepository",
+				namespace:  "other",
+				name:       "other",
+			},
+			document: source("https://example.com/other", map[string]any{"branch": "main"}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			documents, err := decodeDocuments([]byte(tt.manifest))
-			if err != nil || len(documents) != 1 {
-				t.Fatalf("decode source: documents=%d error=%v", len(documents), err)
-			}
-			err = validatePinnedUnifiSource(documents[0], identityOf(documents[0]))
+			err := validatePinnedUnifiSource(tt.document, tt.identity)
 			if tt.wantError && err == nil {
 				t.Fatal("validatePinnedUnifiSource() error = nil, want rejection")
 			}

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -339,6 +339,63 @@ func TestValidateUnifiPruneExemption(t *testing.T) {
 	}
 }
 
+// TestUnifiPruneExemptionIsHetznerScoped keeps the production-only safety
+// exception out of the shared infrastructure base while proving that the
+// Hetzner render still carries the exact admission shape the app needs.
+func TestUnifiPruneExemptionIsHetznerScoped(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	basePath := filepath.Join(
+		repoRoot,
+		"k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml",
+	)
+	baseContents, err := os.ReadFile(basePath) //nolint:gosec // Explicit repository path.
+	if err != nil {
+		t.Fatalf("read shared Flux policy: %v", err)
+	}
+	baseDocuments, err := decodeDocuments(baseContents)
+	if err != nil {
+		t.Fatalf("decode shared Flux policy: %v", err)
+	}
+	if got, want := len(baseDocuments), 1; got != want {
+		t.Fatalf("shared Flux policy documents = %d, want %d", got, want)
+	}
+	if err := validateUnifiPruneExemption(baseDocuments[0], identityOf(baseDocuments[0])); err == nil {
+		t.Fatal("shared Flux policy unexpectedly exempts unifi/unifi")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rendererCommandTimeout)
+	defer cancel()
+	rendered, err := commandOutput(
+		ctx,
+		"kubectl",
+		"kustomize",
+		filepath.Join(repoRoot, infrastructureOverlayPath),
+	)
+	if err != nil {
+		t.Fatalf("render Hetzner infrastructure: %v", err)
+	}
+	renderedDocuments, err := decodeDocuments(rendered)
+	if err != nil {
+		t.Fatalf("decode Hetzner infrastructure: %v", err)
+	}
+	found := false
+	for _, document := range renderedDocuments {
+		identity := identityOf(document)
+		if identity.apiVersion != "kyverno.io/v1" ||
+			identity.kind != "ClusterPolicy" ||
+			identity.name != "enforce-flux-best-practices" {
+			continue
+		}
+		found = true
+		if err := validateUnifiPruneExemption(document, identity); err != nil {
+			t.Fatalf("validate rendered Hetzner exception: %v", err)
+		}
+	}
+	if !found {
+		t.Fatal("Hetzner infrastructure render omitted enforce-flux-best-practices")
+	}
+}
+
 // TestValidateRenderedRejectsIndirectAuthorizationResources covers controllers.
 func TestValidateRenderedRejectsIndirectAuthorizationResources(t *testing.T) {
 	tests := []struct {

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -169,10 +169,8 @@ spec:
 // update authority over live managed resources, so its external Git source
 // must be both the expected repository and one full immutable commit.
 func TestValidatePinnedUnifiSource(t *testing.T) {
-	const (
-		trustedURL   = "https://github.com/devantler-tech/unifi"
-		pinnedCommit = "7b17f7e33ef507c24c395b884a433c62b92ace98"
-	)
+	const trustedURL = "https://github.com/devantler-tech/unifi"
+	pinnedCommit := strings.Repeat("a", 40)
 	targetIdentity := resourceIdentity{
 		apiVersion: "source.toolkit.fluxcd.io/v1",
 		kind:       "GitRepository",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The UniFi Flux Kustomization consumed a moving external Git branch while retaining create/update/patch authority over live Crossplane managed resources. Disabling prune and removing RBAC delete prevents disappearance-driven deletion, while an immutable source pin prevents a compromised source branch from rewriting routes or DNS.

### Description

- Set `prune: false` and remove the `delete` verb from the UniFi reconciler Role.
- Pin `https://github.com/devantler-tech/unifi` to full commit `7b17f7e33ef507c24c395b884a433c62b92ace98`; advancing the source now requires a separately reviewed Platform change.
- Add `validatePinnedUnifiSource` to reject a mutable branch, mixed selector, abbreviated commit, or alternate source URL.
- Add the exact `unifi/unifi` exception required by the enforcing Flux best-practices ClusterPolicy through the Hetzner infrastructure overlay; the shared base retains only `flux-system/flux-system`.
- Validate both boundaries: the rendered Hetzner rule contains exactly the two permitted exceptions, while the shared source policy contains no UniFi exemption.
- Update the UniFi deletion runbook to describe the explicit platform-operator retirement path and its Delete-versus-Orphan choice.
- Add direct negative-control coverage for mutable/untrusted sources and widened, missing, or wrongly layered policy exceptions.

### Security boundary

The complete apps render retains identical resource membership and changes exactly three fields: remove Role verb `delete`, set Kustomization `prune: false`, and replace `ref.branch: main` with the full commit pin. The Hetzner infrastructure render changes exactly one existing ClusterPolicy by adding the exact `unifi/unifi` exclusion. The Docker infrastructure render retains only `flux-system/flux-system`. The controllers, production bootstrap, and production roots are byte-identical to exact base `57ca1dbeda272f4569b41d563a9fc3702997cc2d`.

### Testing

- `go test ./scripts/validate-eks-ci-role-policy`
- `go test ./...`
- Exact `kubectl kustomize` comparison of all five production roots against the base above
- Structural comparison of Hetzner and Docker infrastructure policy exclusions
- `python3 scripts/validate-naming.py`
- `git diff --check`

Two local KSail remote-schema validations were canceled after remaining silent beyond their diagnostic window; the hosted manifest and policy checks are authoritative for this head.

All 26 hosted checks pass on exact head `7c07688de0e998553fc50ccf723f28de74279dbd`. Codex reviewed that head with no major issues, and CodeRabbit confirmed its provider-scope finding is addressed.