### PR TITLE
fix(renovate): disable automerge for kubelet-serving-cert-approver releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -286,6 +286,16 @@
       "addLabels": [
         "vendored-manifest"
       ]
+    },
+    {
+      "description": "kubelet-serving-cert-approver ships only raw Kubernetes install manifests, so the custom-managed kustomize remote resource can change privileged controller/RBAC YAML in the prod infrastructure-controllers layer. Keep Renovate visibility, but require maintainer review for every release bump so the upstream manifest and local PDB selector are re-checked before deployment. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
+      "matchPackageNames": [
+        "alex1989hu/kubelet-serving-cert-approver"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "security/review-required"
+      ]
     }
   ],
   "ignorePaths": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -233,6 +233,12 @@
       "matchPackageNames": ["quay.io/kubevirt/**"],
       "automerge": false,
       "addLabels": ["vendored-manifest"]
+    },
+    {
+      "description": "kubelet-serving-cert-approver ships only raw Kubernetes install manifests, so the custom-managed kustomize remote resource can change privileged controller/RBAC YAML in the prod infrastructure-controllers layer. Keep Renovate visibility, but require maintainer review for every release bump so the upstream manifest and local PDB selector are re-checked before deployment. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
+      "matchPackageNames": ["alex1989hu/kubelet-serving-cert-approver"],
+      "automerge": false,
+      "addLabels": ["security/review-required"]
     }
   ],
   "ignorePaths": ["k8s/bases/infrastructure/cluster-policies/samples"]


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Motivation

The kubelet-serving-cert-approver dependency is a pinned upstream raw manifest containing privileged controller and RBAC resources. Its Renovate updates need manual inspection of the upstream manifest and the local PDB selector before production deployment.

## Change

Add a final package rule for alex1989hu/kubelet-serving-cert-approver that keeps update visibility but sets automerge to false and adds security/review-required. Its final position overrides the repository-wide major, minor, and patch automerge defaults.

## Review finding disposition

The prior P1 correctly identified that a label alone was not an auto-merge boundary at the old head. Current shared workflow behavior has since changed: Platform PR 3090 is a non-draft Renovate PR with automerge false and security/review-required; both auto-merge eligibility jobs completed successfully, while autoMergeRequest and mergeQueueEntry are both null. The package-specific Renovate setting is therefore now effective without adding a second label classifier.

## Verification

- RED: the exact package-rule assertion returned false against current main before the rebase.
- GREEN: the assertion returns true on ac4dd33de258a1cc099e2114f091a5cf454f8ed4.
- jq parsed the complete Renovate config successfully.
- git diff --check passed.
- Live positive precedent: Platform PR 3090 remains unarmed and unqueued with the same automerge-disabled review-required shape.