### PR TITLE
fix(kyverno): apply admission resource override to container

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -103,12 +103,13 @@ spec:
       # (no eviction), and with replicas: 2 + the PDB a Recreate fallback or an OOM
       # only ever takes one replica, so the admission path stays up. Limit stays
       # far under auto-vpa's 6Gi maxAllowed ceiling.
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          memory: 1Gi
+      container:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

### Motivation
- The Kyverno Helm values previously set the resource sizing at `admissionController.resources`, which the chart does not apply to the admission-controller main container. 
- Image verification policies use `failurePolicy: Fail`, so an OOMed or unavailable Kyverno admission controller can cause a cluster-wide Pod CREATE denial-of-service and requires a correct static baseline to avoid fail-closed outages.

### Description
- Move the resource override into `admissionController.container.resources` in `k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml` so the chart applies the sizing to the admission-controller main container. 
- Preserve the intended sizing values (`requests.cpu: 100m`, `requests.memory: 256Mi`, `limits.memory: 1Gi`) and keep the existing `podSecurityContext` and `rbac` blocks unchanged. 

### Testing
- Ran an indentation-aware Python assertion that confirmed `values.admissionController.container.resources` exists and the obsolete `values.admissionController.resources` path is absent, and it succeeded. 
- Ran `python3 scripts/validate-naming.py` and `python3 scripts/validate-embedded-json.py`, and both checks succeeded. 
- Ran `git diff --check` and repository state checks which passed locally. 
- Attempted `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` but these could not be executed in this environment because `kubectl` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a69f8788832b888b0a298c1ab516)