### PR TITLE
ci(cd): restrict manual prod deploys to main

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   deploy-prod:
     name: 🚀 Deploy to Production
+    # workflow_dispatch lets an operator choose a ref. Only deploy from main
+    # so prod secrets never flow into branch-controlled workflow/action code.
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: prod
     permissions:
@@ -30,6 +33,7 @@ jobs:
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: refs/heads/main
           persist-credentials: false
 
       - name: 🚀 Deploy to Production


### PR DESCRIPTION
### Motivation
- Prevent `workflow_dispatch` runs from selecting arbitrary branch refs and executing branch-controlled local composite actions with production secrets by ensuring manual deploys only run from `refs/heads/main`.

### Description
- Add a job-level guard `if: ${{ github.ref == 'refs/heads/main' }}` and pin the checkout to `ref: refs/heads/main` in `.github/workflows/cd.yaml` so the local `./.github/actions/deploy-prod` composite action is always executed from `main`.

### Testing
- Ran a quick YAML load-check via a Ruby script that validated the new `if` guard and pinned checkout and it succeeded.
- Ran `git diff --check` to ensure no whitespace or diff issues and it succeeded.
- An attempted Python/YAML-based check could not run due to a missing `PyYAML` dependency, and `actionlint` was not available in the environment, so those additional static checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a7f400bc832b851cb078d0beb22a)