### PR TITLE
fix(github): restrict OCIRepository cosign subject to protected release tags

### DIFF
--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -33,8 +33,10 @@ spec:
       # subjects are accepted via ONE regex-alternated entry — cosign's keyless
       # attestation verification rejects MULTIPLE identity entries outright
       # ("unsupported: multiple identities are not supported at this time"), so
-      # the transition must be expressed inside a single subject regex. Narrow
-      # the alternation to actions-only once the first actions-signed artifact
-      # has been published and verified.
+      # the transition must be expressed inside a single subject regex. Accept only
+      # protected release-tag invocations of the reusable signer; do not allow
+      # arbitrary branch or pull-request refs to publish higher-semver GitHub
+      # org-management artifacts. Narrow the alternation to actions-only once
+      # the first actions-signed artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-manifests\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-manifests\.yaml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'


### PR DESCRIPTION
### Motivation
- Prevent a supply-chain escalation where the `github-config` OCI artifact source would accept artifacts signed by the shared `publish-manifests` reusable workflow at arbitrary refs, allowing non-protected branch/PR signatures to be trusted. 
- The `github-config` app runs with namespace-scoped permissions to create/update Crossplane GitHub managed resources and `ExternalSecret`s, so an attacker-published artifact could mutate the org if the signer policy is too broad.

### Description
- Tightened the cosign OIDC subject check in `k8s/bases/apps/github-config/oci-repository.yaml` so the `matchOIDCIdentity.subject` requires `@refs/tags/vX.Y.Z` release-tag subjects instead of allowing `@.+`, rejecting branch and pull-request refs. 
- Kept the temporary repository-name alternation `(reusable-workflows|actions)` to preserve the planned signer repo transition while still enforcing tag-only acceptance. 
- Added clarifying comment text explaining the rationale and the narrower acceptance rule.

### Testing
- Ran a local regex smoke test (`python3` snippet) that confirmed `refs/tags/v1.2.3` matches and branch/PR subjects do not, and the test succeeded. 
- Ran `git diff --check` to ensure no whitespace/errors and it succeeded. 
- Ran `python3 scripts/validate-naming.py` and it succeeded against repository naming rules. 
- `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` could not be executed in this environment because `kubectl` is not installed, so full kustomize render validation was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52acebb2b0832ba49a008c8ab883ac)