### PR TITLE
fix(apps): restrict public Umami routes

### DIFF
--- a/k8s/bases/apps/umami/canary.yaml
+++ b/k8s/bases/apps/umami/canary.yaml
@@ -39,6 +39,18 @@ spec:
     gatewayRefs:
       - name: platform
         namespace: kube-system
+    # Only expose Umami's public collection endpoints at the edge. The admin UI
+    # and login API must not be reachable from the internet because Umami creates
+    # a built-in admin/umami account before our in-cluster provisioning CronJob
+    # can rotate it. Keeping the public HTTPRoute collector-only removes that
+    # first-boot takeover race while preserving tracking. If the dashboard needs
+    # browser access later, add a separate SSO-protected route instead of widening
+    # this Flagger-owned route.
+    match:
+      - uri:
+          prefix: /api/send
+      - uri:
+          prefix: /script.js
     # Tile metadata for the Homepage dashboard. Flagger copies spec.service.apex
     # annotations/labels onto the HTTPRoute it generates (pkg/router/gateway_api.go),
     # so the gethomepage.dev/* annotations the hand-written route used to carry are

--- a/k8s/bases/apps/umami/canary.yaml
+++ b/k8s/bases/apps/umami/canary.yaml
@@ -54,15 +54,20 @@ spec:
     # Tile metadata for the Homepage dashboard. Flagger copies spec.service.apex
     # annotations/labels onto the HTTPRoute it generates (pkg/router/gateway_api.go),
     # so the gethomepage.dev/* annotations the hand-written route used to carry are
-    # reproduced here — Umami reappears under the Analytics group, discovered the
-    # same way as every other app. pod-selector keys on app.kubernetes.io/instance
+    # reproduced here. pod-selector keys on app.kubernetes.io/instance
     # (NOT /name): Flagger's default --selector-labels (app,name,
     # app.kubernetes.io/name) rewrites app.kubernetes.io/name to
     # "umami-umami-primary" on the primary Deployment, while leaving
     # app.kubernetes.io/instance=umami intact on the running pods.
+    #
+    # The tile is disabled because this route serves only the collection
+    # endpoints above — https://analytics.${domain}/ has no match and would give
+    # the reader a dead link. The remaining annotations are kept so re-enabling
+    # is a one-line change once the SSO-protected dashboard route exists
+    # (devantler-tech/platform#3134).
     apex:
       annotations:
-        gethomepage.dev/enabled: "true"
+        gethomepage.dev/enabled: "false"
         gethomepage.dev/name: Umami
         gethomepage.dev/description: Privacy-first web analytics.
         gethomepage.dev/group: Analytics


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

### Motivation
- Prevent a first-boot race where the Umami admin UI/login is reachable publicly while an in-cluster Job/cron rotates the default `admin/umami` password, which could allow an attacker to seize the admin account.

### Description
- Restrict the Flagger-owned public route for Umami so the gateway only exposes collector endpoints (`/api/send` and `/script.js`) and does not forward admin or login endpoints to the internet, by adding a `match:` block to `k8s/bases/apps/umami/canary.yaml`.

### Testing
- Parsed the modified YAML with `ruby -e 'require "yaml"; YAML.load_file("k8s/bases/apps/umami/canary.yaml"); puts "yaml ok"'` (succeeded).
- Ran `git diff --check` (no whitespace or diff errors), `python scripts/validate-naming.py` (naming rules OK), and `python scripts/validate-embedded-json.py` (embedded JSON blobs parse OK); all succeeded.
- Could not run `ksail workload validate`, `ksail --config ksail.prod.yaml workload validate`, or `kubectl kustomize` because `ksail`/`kubectl` are not installed in the execution environment (these remain recommended pre-merge static validations to run in CI or locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52ccd86190832b9a7593f3113ceb5e)