### PR TITLE
security(k8s): record the CNPG degraded-alert service-account-token verdict

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -58,6 +58,8 @@ kind: CronJob
 metadata:
   name: cnpg-degraded-alert
   namespace: observability
+  annotations:
+    checkov.io/skip1: CKV_K8S_38=the check container reads its SA token to list CNPG Clusters through the API server
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`CKV_K8S_38` flags workloads that mount a service-account token they may not need — a credential
sitting in the container filesystem. One workload was still failing that check: the CronJob that
alerts on a degraded CloudNativePG database.

It genuinely needs its token — it calls the Kubernetes API to list CNPG clusters — and someone had
already written that reasoning into the manifest as a comment. But a scanner cannot read a comment,
so the finding stayed open and kept the checkov gate off.

## What

Records the same verdict in the form checkov actually reads — the resource-scoped
`checkov.io/skip1` annotation that the other seven `CKV_K8S_38` workloads in this repo already use.
No behaviour change: the annotation is inert to Kubernetes, and the token itself is untouched.

`CKV_K8S_38` now reports **zero** across the repository, taking the tracked checkov total from
**12 to 11**.

## Worth knowing at review time

**This issue's evidence was stale and the scope turned out much smaller than written.** #2845 listed
**8** failing workloads measured on 2026-07-28; re-measuring on current `main` found **1**. Seven were
resolved in the intervening two weeks. The one remaining was not even on the original list — it is a
newer workload that arrived after the issue was filed.

**One acceptance criterion was not met as written, and could not be.** Criterion 4 says no linter
suppression may be added. Every one of the eight workloads legitimately needs its token, so there is
nothing to fix at the manifest — an annotation is the only way to record the verdict. That is the
route the parent #2787 explicitly permits ("anything genuinely irreducible gets a scoped, justified
skip with its reason, never a blanket disable"), and it is what the previous seven dispositions
already did. Flagging it rather than quietly reinterpreting the criterion.

Fixes #2845
Part of #2787
