### PR TITLE
fix(ci): date the gate-suppression control fixture relative to today

### DIFF
--- a/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
+++ b/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
@@ -272,12 +272,18 @@ ok
 
 # Control for the fixture: with exactly one marker the same path succeeds, so the
 # assertion above is about duplication and not about the fixture being unreadable.
-printf '  # %s 2026-07-26\n' "${activation_marker}" >"${fixture_kustomization}"
+#
+# The date is RELATIVE, like every other date in this file. An absolute one was a
+# time bomb: this control asserts exit 0, so once the hard-coded date aged past
+# fail_after_days the reporter correctly failed and took every pull request in the
+# repository with it. The duplicate case above can keep its absolute dates because
+# it asserts FAILURE — it fails closed on the duplication before age matters.
+printf '  # %s %s\n' "${activation_marker}" "${inside}" >"${fixture_kustomization}"
 : >"${tmp}/summary"
 CILIUM_ROLLOUT_GATE_ACTIVE=true PLATFORM_ROOT="${fixture_root}" \
   GITHUB_STEP_SUMMARY="${tmp}/summary" "${report_script}" >"${tmp}/out" 2>&1 ||
   fail 'a single marker read from PLATFORM_ROOT must succeed'
-grep -Fq '2026-07-26' "${tmp}/summary" ||
+grep -Fq "${inside}" "${tmp}/summary" ||
   fail 'the fixture summary must carry the declared date'
 ok
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

**Every pull request in this repository started failing CI a few hours ago**, and nothing was
committed to cause it — the failure arrives purely with the calendar.

A test fixture for the Cilium rollout-gate reporter hard-coded `2026-07-26` as the date of a
suppression marker, then asserted the reporter exits cleanly for it. Today is exactly 14 days later,
which is the reporter's hard-fail bound. So the reporter did the right thing and failed, the
assertion that expected success failed with it, and `🧪 Validate Manifests` went red for everyone.

The last green PR run was 21:36Z yesterday; the first failure was the first run after midnight UTC.

## What

Dates that fixture relative to today, which is what every other date assertion in the same file
already does. The duplicate-marker case above it keeps its absolute dates on purpose — it asserts
*failure*, and fails closed on the duplication before age is ever evaluated.

Verified the control still has teeth rather than passing vacuously: feeding it an out-of-bound date
again makes it fail at exactly that assertion. Full suite 30 passed / 0 failed.

## What this does NOT fix — please read

This unblocks CI. It does **not** resolve the underlying gate, and deliberately does not try to.

**The real activation marker carries the same `2026-07-26` date and the gate is active**, so the live
Cilium rollout gate has also reached its 14-day bound. Talos machine-config sync has now been
suppressed for two weeks, and prod deploys will fail on it. That needs a decision only you can make —
stepping the remaining Cilium agents onto the current DaemonSet revision, or rolling the component
back — and it is not something I can safely do from here. Raising the bound is explicitly not a
resolution, so I have not touched it. Filed separately as #3028.

Part of #3028 (this is the CI half; the gate itself is that issue).
