### PR TITLE
fix(ci): stop a cancelled deploy from taking a GHCR lease it cannot release

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -307,8 +307,17 @@ runs:
       # only after the publish, signing, attestation, post-publish auth check,
       # and Flux reconcile all succeeded. Never mutate auth as cleanup for a
       # failed delivery.
+      # Runs on failure but NOT on cancellation. This step takes the
+      # `ghcr-auth-refresh` Lease, which has no automatic expiry takeover
+      # because Talos writes cannot be fenced — a non-empty holder needs
+      # explicit human recovery. Under `always()` a cancelled job still
+      # entered here, then the runner force-killed it when the
+      # post-cancellation grace expired, so the release never landed and every
+      # later deploy failed to acquire the Lease. A merge-queue eviction
+      # cancels this job routinely. The next deploy's staging step performs
+      # this same reassertion with a full time budget.
       if: >-
-        always() &&
+        !cancelled() &&
         steps.verify_flux_ghcr_auth_after_push.outcome == 'success' &&
         steps.reconcile.outcome == 'success'
       shell: bash

--- a/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
@@ -259,11 +259,79 @@ func TestDeployActionConsumerStagingPrecedesPublishAndIsReassertedAfterUpdate(t 
 	requireNotContains(t, action[firstRefresh:push], "--check-only")
 	requireContains(t, action[postPushRefresh:reconcile], "run: ./scripts/refresh-flux-ghcr-auth.sh --check-only")
 	finalRefreshStep := action[finalRefresh:]
-	requireContains(t, finalRefreshStep, "always() &&")
+	requireContains(t, finalRefreshStep, "!cancelled() &&")
 	requireContains(t, finalRefreshStep, "steps.verify_flux_ghcr_auth_after_push.outcome == 'success'")
 	requireContains(t, finalRefreshStep, "steps.reconcile.outcome == 'success'")
 	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 3 {
 		t.Errorf("refresh helper references = %d, want 3", count)
+	}
+}
+
+// splitCompositeSteps returns one string per step of a composite action, each
+// beginning at its own "- name:" line.
+func splitCompositeSteps(document string) []string {
+	const marker = "\n    - name:"
+	parts := strings.Split(document, marker)
+	if len(parts) < 2 {
+		return nil
+	}
+	steps := make([]string, 0, len(parts)-1)
+	for _, part := range parts[1:] {
+		steps = append(steps, strings.TrimPrefix(marker, "\n")+part)
+	}
+	return steps
+}
+
+// stepDirectives drops comment lines, so a rationale that merely mentions a
+// condition is never mistaken for the condition itself.
+func stepDirectives(step string) string {
+	lines := strings.Split(step, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// A step running the refresh helper without --check-only acquires the
+// `ghcr-auth-refresh` Lease, which by design has no automatic expiry takeover:
+// Talos machine-config writes expose no fencing token, so a non-empty holder
+// always requires explicit human recovery. `always()` also runs after the job
+// is cancelled, and a cancelled job is force-killed once the runner's
+// post-cancellation grace expires — the EXIT trap's release never lands, and
+// every later deploy then fails to acquire the Lease. A merge-queue eviction
+// cancels this job routinely, so no lease-acquiring step may remain reachable
+// after cancellation.
+func TestDeployStepsThatTakeTheSyncLeaseNeverRunAfterCancellation(t *testing.T) {
+	action := readRepositoryFile(t, ".github/actions/deploy-prod/action.yml")
+
+	steps := splitCompositeSteps(action)
+	if len(steps) == 0 {
+		t.Fatal("expected the deploy action to contain composite steps")
+	}
+
+	inspected := 0
+	for _, step := range steps {
+		if !strings.Contains(step, "scripts/refresh-flux-ghcr-auth.sh") {
+			continue
+		}
+		if strings.Contains(step, "--check-only") {
+			// Read-only: exits before acquire_sync_lease, so it holds nothing.
+			continue
+		}
+		inspected++
+		if strings.Contains(stepDirectives(step), "always()") {
+			t.Errorf(
+				"step acquires the GHCR sync Lease under always(); a cancelled job is killed before cleanup releases it, wedging every later deploy:\n%s",
+				step,
+			)
+		}
+	}
+	if inspected != 2 {
+		t.Fatalf("lease-acquiring deploy steps inspected = %d, want 2", inspected)
 	}
 }
 


### PR DESCRIPTION
## Why

Prod CD has been failing every run with:

> Another GHCR synchronization transaction holds the synchronization lease; automatic expiry takeover is disabled because Talos writes cannot be fenced.

A merge-queue deploy was evicted (cancelled) on 2026-08-09. Its post-cancellation cleanup step still started, took the deploy lease, and was then force-killed when the runner's grace window ran out — leaving the lease held by a dead process. That lease deliberately has no automatic takeover, so **every deploy after it fails, permanently, until a human clears it.** Merge-queue evictions are routine here, so this is reachable in normal operation rather than a freak event.

## What

The cleanup step now runs on failure but **not** on cancellation. Its real purpose — repairing auth when `cluster update` fails part-way — is unchanged; only the cancelled path is dropped, and that path could never finish inside the grace window anyway. The next deploy performs the same reassertion with a full time budget.

Also adds a contract test asserting that **no** step which takes the lease is reachable after cancellation, so this cannot regress into any future step. The sibling step in `dr-rebuild.yaml` already used this condition — this brings the deploy action in line with it.

> ⚠️ This stops the pipeline re-wedging itself. It does **not** clear the lease currently stuck in prod, and CD is separately still blocked by the Cilium rollout gate (#3028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)