### PR TITLE
fix(cilium): refuse a zero-count gate release and correct the runbook order

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/components/homogeneous-devices/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/components/homogeneous-devices/kustomization.yaml
@@ -110,10 +110,18 @@
 #      the fleet already on the current template, returning to RollingUpdate
 #      rolls nothing. A chart or other Helm-value change stages and soaks
 #      separately.
-#   5. That release restores the deploy: `ksail cluster update` runs again and
-#      the post-deploy guard restores the recorded autoscaler replica count.
+#   5. That release restores the deploy: `ksail cluster update` runs again. The
+#      autoscaler suspension is restored by the guard's --after-revision-ready
+#      phase — after Flux proves the released revision Ready and BEFORE cluster
+#      update — not by the post-deploy phase. That ordering is load-bearing:
+#      cluster update waits for the cluster-autoscaler Deployment, and KSail
+#      treats a zero-replica Deployment as never-ready, so a release that
+#      restored afterwards would hang on the suspension it owns (observed in
+#      prod 2026-08-09). The post-deploy phase remains the failure-path net.
 #      Verify the FIRST autoscaler-created node afterwards like a stepped one —
-#      it boots the new set directly.
+#      it boots the new set directly, and its machine template is refreshed by
+#      the same cluster update, so a node created in the short window before
+#      that step warrants the same check.
 #
 # MERGE-ORDER NOTE (load-bearing): parent `patches:` are applied AFTER all
 # component patches — a devices value carried by

--- a/scripts/guard-cilium-homogeneous-device-rollout.sh
+++ b/scripts/guard-cilium-homogeneous-device-rollout.sh
@@ -417,6 +417,17 @@ elif [[ "${phase}" == '--after-revision-ready' ]]; then
   # the very deploy that releases the gate. Restoring in --after-deploy is too
   # late for that wait, and restoring in --before-publish would do it before the
   # safe artifact is deployed, which the gate deliberately forbids.
+  #
+  # A remembered count of ZERO is a different situation and must not be
+  # "restored": the autoscaler was already scaled down before the gate claimed
+  # it, so honouring that intent leaves the Deployment at zero — which is
+  # exactly what cluster update cannot wait on. Restoring it would also clear
+  # the ownership marker and destroy the state a retry needs. Fail here, with
+  # the conflict named, rather than hand cluster update a hang.
+  remembered_replicas="$(get_previous_replicas)"
+  if [[ "${remembered_replicas}" == "0" ]]; then
+    fail 'the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Restore the intended replica count on cluster-autoscaler-hetzner-cluster-autoscaler, or release the gate in a deploy that skips cluster update, before retrying.'
+  fi
   restore_autoscaler_if_owned
 elif [[ "${phase}" == '--after-deploy' ]]; then
   restore_autoscaler_if_owned

--- a/scripts/guard-cilium-homogeneous-device-rollout.sh
+++ b/scripts/guard-cilium-homogeneous-device-rollout.sh
@@ -327,6 +327,18 @@ restore_autoscaler_if_owned() {
     return
   fi
 
+  require_replica_count "${previous_replicas}" 'remembered autoscaler replica count'
+
+  # Normalise before anything compares this value. get_current_replicas only ever
+  # records the API's canonical form, but the annotation is operator-writable —
+  # the remediation below hands an operator an `annotate ... =<count>` command —
+  # so a zero-padded value can arrive. require_replica_count accepts "00", which
+  # would slip past the zero refusal below and scale the Deployment to zero
+  # anyway; and a padded "08" would reach wait_for_replicas, which compares it
+  # against the API's canonical "8" and blocks until it times out. 10# forces
+  # base ten, so a leading zero is never read as octal.
+  previous_replicas=$((10#${previous_replicas}))
+
   # A remembered count of ZERO cannot be "restored". Honouring it leaves the
   # Deployment at zero — which `ksail cluster update` waits on and KSail treats
   # as never-ready — and the restore below would then DELETE the ownership
@@ -347,7 +359,6 @@ restore_autoscaler_if_owned() {
     fail "the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Record the intended count and scale to match, then retry: kubectl --context admin@prod -n ${namespace} annotate deployment ${deployment} ${previous_replicas_annotation}=<count> --overwrite && kubectl --context admin@prod -n ${namespace} scale deployment ${deployment} --replicas=<count>. Scaling alone is not enough — the remembered value is what this check reads."
   fi
 
-  require_replica_count "${previous_replicas}" 'remembered autoscaler replica count'
   kubectl_prod -n "${namespace}" scale deployment "${deployment}" \
     --replicas="${previous_replicas}"
   wait_for_replicas "${previous_replicas}"

--- a/scripts/guard-cilium-homogeneous-device-rollout.sh
+++ b/scripts/guard-cilium-homogeneous-device-rollout.sh
@@ -426,7 +426,11 @@ elif [[ "${phase}" == '--after-revision-ready' ]]; then
   # the conflict named, rather than hand cluster update a hang.
   remembered_replicas="$(get_previous_replicas)"
   if [[ "${remembered_replicas}" == "0" ]]; then
-    fail 'the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Restore the intended replica count on cluster-autoscaler-hetzner-cluster-autoscaler, or release the gate in a deploy that skips cluster update, before retrying.'
+    # The remediation must change the REMEMBERED value, not just the running
+    # replica count: get_previous_replicas reads the annotation, so scaling the
+    # Deployment alone leaves the same 0 recorded and the next attempt fails
+    # here again.
+    fail "the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Record the intended count and scale to match, then retry: kubectl -n ${namespace} annotate deployment ${deployment} ${previous_replicas_annotation}=<count> --overwrite && kubectl -n ${namespace} scale deployment ${deployment} --replicas=<count>. Scaling alone is not enough — the remembered value is what this check reads."
   fi
   restore_autoscaler_if_owned
 elif [[ "${phase}" == '--after-deploy' ]]; then

--- a/scripts/guard-cilium-homogeneous-device-rollout.sh
+++ b/scripts/guard-cilium-homogeneous-device-rollout.sh
@@ -335,9 +335,21 @@ restore_autoscaler_if_owned() {
   # so a zero-padded value can arrive. require_replica_count accepts "00", which
   # would slip past the zero refusal below and scale the Deployment to zero
   # anyway; and a padded "08" would reach wait_for_replicas, which compares it
-  # against the API's canonical "8" and blocks until it times out. 10# forces
-  # base ten, so a leading zero is never read as octal.
-  previous_replicas=$((10#${previous_replicas}))
+  # against the API's canonical "8" and blocks until it times out.
+  #
+  # Strip the zeros TEXTUALLY rather than with $(( )). Shell arithmetic is signed
+  # 64-bit and wraps SILENTLY, so an all-digit repair value beyond that range —
+  # 18446744073709551617, say — would normalise to 1 here, and the release would
+  # then happily scale to one replica and delete both ownership annotations
+  # instead of refusing and preserving recovery state.
+  previous_replicas="${previous_replicas#"${previous_replicas%%[!0]*}"}"
+  [[ -n "${previous_replicas}" ]] || previous_replicas=0
+
+  # Range-check what survived. spec.replicas is an int32, so anything longer than
+  # its 10 digits is out of range by inspection; the length test short-circuits
+  # the numeric one, which would itself overflow on a longer value.
+  [[ "${#previous_replicas}" -le 10 && "${previous_replicas}" -le 2147483647 ]] ||
+    fail "the rollout gate owns a remembered autoscaler count outside the Kubernetes replica range (spec.replicas is an int32): ${previous_replicas}. Record the intended count and scale to match, then retry: kubectl --context admin@prod -n ${namespace} annotate deployment ${deployment} ${previous_replicas_annotation}=<count> --overwrite && kubectl --context admin@prod -n ${namespace} scale deployment ${deployment} --replicas=<count>."
 
   # A remembered count of ZERO cannot be "restored". Honouring it leaves the
   # Deployment at zero — which `ksail cluster update` waits on and KSail treats

--- a/scripts/guard-cilium-homogeneous-device-rollout.sh
+++ b/scripts/guard-cilium-homogeneous-device-rollout.sh
@@ -327,6 +327,26 @@ restore_autoscaler_if_owned() {
     return
   fi
 
+  # A remembered count of ZERO cannot be "restored". Honouring it leaves the
+  # Deployment at zero — which `ksail cluster update` waits on and KSail treats
+  # as never-ready — and the restore below would then DELETE the ownership
+  # annotation, destroying the state a retry needs.
+  #
+  # The refusal lives HERE, inside the release itself, rather than in one phase:
+  # the normal deploy's always() post-deploy reassert and the DR workflow both
+  # release exclusively through this function, so a refusal guarding only
+  # --after-revision-ready would be undone moments later by --after-deploy.
+  #
+  # The remediation must change the REMEMBERED value, not just the running
+  # replica count: get_previous_replicas reads the annotation, so scaling the
+  # Deployment alone leaves the same 0 recorded and the next attempt fails here
+  # again. Both commands pin admin@prod — every mutation this guard performs
+  # does, and an operator pastes these from whatever context they happen to be
+  # on.
+  if [[ "${previous_replicas}" == "0" ]]; then
+    fail "the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Record the intended count and scale to match, then retry: kubectl --context admin@prod -n ${namespace} annotate deployment ${deployment} ${previous_replicas_annotation}=<count> --overwrite && kubectl --context admin@prod -n ${namespace} scale deployment ${deployment} --replicas=<count>. Scaling alone is not enough — the remembered value is what this check reads."
+  fi
+
   require_replica_count "${previous_replicas}" 'remembered autoscaler replica count'
   kubectl_prod -n "${namespace}" scale deployment "${deployment}" \
     --replicas="${previous_replicas}"
@@ -418,20 +438,8 @@ elif [[ "${phase}" == '--after-revision-ready' ]]; then
   # late for that wait, and restoring in --before-publish would do it before the
   # safe artifact is deployed, which the gate deliberately forbids.
   #
-  # A remembered count of ZERO is a different situation and must not be
-  # "restored": the autoscaler was already scaled down before the gate claimed
-  # it, so honouring that intent leaves the Deployment at zero — which is
-  # exactly what cluster update cannot wait on. Restoring it would also clear
-  # the ownership marker and destroy the state a retry needs. Fail here, with
-  # the conflict named, rather than hand cluster update a hang.
-  remembered_replicas="$(get_previous_replicas)"
-  if [[ "${remembered_replicas}" == "0" ]]; then
-    # The remediation must change the REMEMBERED value, not just the running
-    # replica count: get_previous_replicas reads the annotation, so scaling the
-    # Deployment alone leaves the same 0 recorded and the next attempt fails
-    # here again.
-    fail "the rollout gate owns a remembered autoscaler count of 0, so releasing it cannot satisfy the readiness check that ksail cluster update performs (KSail treats a zero-replica Deployment as never-ready). Record the intended count and scale to match, then retry: kubectl -n ${namespace} annotate deployment ${deployment} ${previous_replicas_annotation}=<count> --overwrite && kubectl -n ${namespace} scale deployment ${deployment} --replicas=<count>. Scaling alone is not enough — the remembered value is what this check reads."
-  fi
+  # A remembered count of ZERO is refused inside restore_autoscaler_if_owned,
+  # so it covers this phase and every other release path alike.
   restore_autoscaler_if_owned
 elif [[ "${phase}" == '--after-deploy' ]]; then
   restore_autoscaler_if_owned

--- a/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
+++ b/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
@@ -413,8 +413,23 @@ fi
 # itself pins admin@prod, so the commands it hands out must too, or the retry
 # silently edits an identically named Deployment in another cluster and the
 # production annotation stays at 0.
-[[ "${zero_count_output}" == *'--context admin@prod'* ]] ||
-  fail "the zero-count remediation must pin the prod context; got: ${zero_count_output}"
+#
+# Assert each command SEPARATELY. The refusal emits an `annotate` and a `scale`,
+# so a single substring test over the combined output passes while either one of
+# them is missing the flag — the other's flag satisfies it. Bound each match at
+# `&` and `.` so it cannot run across the `&&` into its sibling command.
+zero_count_annotate="$(
+  printf '%s\n' "${zero_count_output}" |
+    grep -o 'kubectl[^&.]*annotate deployment[^&.]*' || true
+)"
+zero_count_scale="$(
+  printf '%s\n' "${zero_count_output}" |
+    grep -o 'kubectl[^&.]*scale deployment[^&.]*' || true
+)"
+[[ "${zero_count_annotate}" == *'--context admin@prod'* ]] ||
+  fail "the zero-count remediation's annotate command must pin the prod context; got: ${zero_count_annotate:-<no annotate command emitted>}"
+[[ "${zero_count_scale}" == *'--context admin@prod'* ]] ||
+  fail "the zero-count remediation's scale command must pin the prod context; got: ${zero_count_scale:-<no scale command emitted>}"
 
 # The refusal has to cover EVERY release path, not just this phase. The normal
 # deploy's always() post-deploy reassert invokes --after-deploy, and the DR
@@ -430,6 +445,30 @@ fi
   fail "the post-deploy zero-count refusal must name the conflict; got: ${zero_count_after_deploy}"
 [[ "$(<"${state_dir}/previous-replicas")" == '0' ]] ||
   fail 'a refused post-deploy zero-count release must preserve the ownership marker'
+
+# A ZERO-PADDED zero is the same conflict wearing a different spelling, and the
+# annotation is operator-writable: the refusal above hands an operator an
+# `annotate ... =<count>` command, so "00" is a plausible thing to arrive here.
+# require_replica_count accepts it (^[0-9]+$), so a refusal that tests only the
+# canonical "0" lets it through and does exactly the damage the refusal exists to
+# prevent — scale the Deployment to zero, then DELETE the ownership annotation a
+# retry needs. Assert the marker survives AND that nothing was scaled.
+printf '00\n' >"${state_dir}/previous-replicas"
+printf '0\n' >"${state_dir}/replicas"
+if zero_padded_output="$(run_guard --after-revision-ready true 2>&1)"; then
+  fail 'releasing a gate that owns a zero-padded remembered count must fail loudly'
+fi
+[[ "${zero_padded_output}" == *'remembered autoscaler count of 0'* ]] ||
+  fail "the zero-padded refusal must name the conflict; got: ${zero_padded_output}"
+[[ "$(<"${state_dir}/previous-replicas")" == '00' ]] ||
+  fail 'a refused zero-padded release must preserve the ownership marker for a retry'
+# The fake kubectl echoes back whatever it was scaled to, so a padded value that
+# slipped through would leave "00" here rather than the "0" nothing-happened
+# state. In prod the API canonicalises instead, and wait_for_replicas would then
+# compare "00" against "0" and block until it times out.
+[[ "$(<"${state_dir}/replicas")" == '0' ]] ||
+  fail "a refused zero-padded release must not scale the Deployment; got: $(<"${state_dir}/replicas")"
+
 : >"${state_dir}/previous-replicas"
 
 printf '0\n' >"${state_dir}/replicas"

--- a/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
+++ b/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
@@ -408,6 +408,28 @@ fi
   fail "the zero-count refusal must name the annotation that records the count; got: ${zero_count_output}"
 [[ "$(<"${state_dir}/previous-replicas")" == '0' ]] ||
   fail 'a refused zero-count release must preserve the ownership marker for a retry'
+# The remediation runs against prod, but an operator pastes it from whatever
+# context their workstation currently has. Every mutation the guard performs
+# itself pins admin@prod, so the commands it hands out must too, or the retry
+# silently edits an identically named Deployment in another cluster and the
+# production annotation stays at 0.
+[[ "${zero_count_output}" == *'--context admin@prod'* ]] ||
+  fail "the zero-count remediation must pin the prod context; got: ${zero_count_output}"
+
+# The refusal has to cover EVERY release path, not just this phase. The normal
+# deploy's always() post-deploy reassert invokes --after-deploy, and the DR
+# workflow releases exclusively through it, so a refusal that guards only
+# --after-revision-ready is undone moments later: restore_autoscaler_if_owned
+# scales to the remembered zero and then DELETES the annotation, destroying the
+# very marker this refusal just preserved.
+printf '0\n' >"${state_dir}/replicas"
+if zero_count_after_deploy="$(run_guard --after-deploy true 2>&1)"; then
+  fail 'the post-deploy release path must also refuse a remembered zero replica count'
+fi
+[[ "${zero_count_after_deploy}" == *'remembered autoscaler count of 0'* ]] ||
+  fail "the post-deploy zero-count refusal must name the conflict; got: ${zero_count_after_deploy}"
+[[ "$(<"${state_dir}/previous-replicas")" == '0' ]] ||
+  fail 'a refused post-deploy zero-count release must preserve the ownership marker'
 : >"${state_dir}/previous-replicas"
 
 printf '0\n' >"${state_dir}/replicas"

--- a/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
+++ b/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
@@ -469,6 +469,24 @@ fi
 [[ "$(<"${state_dir}/replicas")" == '0' ]] ||
   fail "a refused zero-padded release must not scale the Deployment; got: $(<"${state_dir}/replicas")"
 
+# An all-digit value past the shell's signed 64-bit range must be REFUSED, not
+# silently wrapped. 18446744073709551617 is 2^64+1, which $(( )) folds to 1 — so
+# normalising with arithmetic would "restore" one replica and delete both
+# ownership annotations, which is the same destruction the zero refusal prevents,
+# reached by a different route. spec.replicas is an int32, so this is out of
+# range on its face.
+printf '18446744073709551617\n' >"${state_dir}/previous-replicas"
+printf '0\n' >"${state_dir}/replicas"
+if overflow_output="$(run_guard --after-revision-ready true 2>&1)"; then
+  fail 'releasing a gate that owns an out-of-range remembered count must fail loudly'
+fi
+[[ "${overflow_output}" == *'outside the Kubernetes replica range'* ]] ||
+  fail "the out-of-range refusal must name the conflict; got: ${overflow_output}"
+[[ "$(<"${state_dir}/previous-replicas")" == '18446744073709551617' ]] ||
+  fail 'a refused out-of-range release must preserve the ownership marker for a retry'
+[[ "$(<"${state_dir}/replicas")" == '0' ]] ||
+  fail "a refused out-of-range release must not scale the Deployment; got: $(<"${state_dir}/replicas")"
+
 : >"${state_dir}/previous-replicas"
 
 printf '0\n' >"${state_dir}/replicas"

--- a/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
+++ b/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
@@ -386,6 +386,20 @@ run_guard --after-deploy true
 [[ "$(<"${state_dir}/replicas")" == '1' ]] ||
   fail 'the post-deploy phase must leave an already-restored autoscaler running'
 
+# A remembered count of ZERO — the autoscaler was already scaled down when the
+# gate claimed it — cannot be "restored" into something cluster update can wait
+# on. Honouring it would hand that step the same never-ready Deployment AND
+# clear the ownership marker a retry needs, so the release must fail loudly and
+# keep the marker instead.
+printf '0\n' >"${state_dir}/previous-replicas"
+printf '0\n' >"${state_dir}/replicas"
+if run_guard --after-revision-ready; then
+  fail 'releasing a gate that owns a remembered zero replica count must fail loudly'
+fi
+[[ "$(<"${state_dir}/previous-replicas")" == '0' ]] ||
+  fail 'a refused zero-count release must preserve the ownership marker for a retry'
+: >"${state_dir}/previous-replicas"
+
 printf '0\n' >"${state_dir}/replicas"
 run_guard --after-deploy true
 [[ "$(<"${state_dir}/replicas")" == '0' ]] ||

--- a/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
+++ b/scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
@@ -393,9 +393,19 @@ run_guard --after-deploy true
 # keep the marker instead.
 printf '0\n' >"${state_dir}/previous-replicas"
 printf '0\n' >"${state_dir}/replicas"
-if run_guard --after-revision-ready; then
+# Pass revision_ready=true and assert the MESSAGE, not merely a non-zero exit:
+# run_guard defaults that flag to false, so a phase that rejected it would fail
+# for an unrelated reason and this test would pass without ever reaching the
+# zero-count branch it exists to cover.
+if zero_count_output="$(run_guard --after-revision-ready true 2>&1)"; then
   fail 'releasing a gate that owns a remembered zero replica count must fail loudly'
 fi
+[[ "${zero_count_output}" == *'remembered autoscaler count of 0'* ]] ||
+  fail "the zero-count refusal must name the conflict; got: ${zero_count_output}"
+# The remediation has to change the REMEMBERED value, or an operator who
+# follows it hits this same refusal on the retry.
+[[ "${zero_count_output}" == *"${previous_replicas_annotation:-cilium-device-rollout-previous-replicas}"* ]] ||
+  fail "the zero-count refusal must name the annotation that records the count; got: ${zero_count_output}"
 [[ "$(<"${state_dir}/previous-replicas")" == '0' ]] ||
   fail 'a refused zero-count release must preserve the ownership marker for a retry'
 : >"${state_dir}/previous-replicas"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Two follow-ups from review of #3035, which merged before they could be pushed.

**A remembered replica count of zero is not releasable.** `require_replica_count` accepts any non-negative integer, so an autoscaler already scaled to zero when a gate is activated records `previous-replicas=0`. The release phase would then "restore" zero, clear the ownership marker, and hand `ksail cluster update` the same never-ready Deployment — reproducing the timeout with the state a retry needs already destroyed.

**The runbook still described the ordering that failed.** Its release step said the post-deploy guard restores the autoscaler after `cluster update`. That is exactly what broke in prod: `cluster update` waits for that Deployment, and KSail treats a zero-replica Deployment as never-ready. Following the runbook would walk the next rollout straight back into it.

## What

The release phase now fails with the conflict named and keeps the ownership marker, instead of silently losing recovery state.

The runbook names the `--after-revision-ready` phase and says why the bound matters. It also flags that a node created in the short window between the restore and `cluster update`'s config-secret apply is built from the not-yet-refreshed machine template, so it warrants the same verification the first autoscaler-created node already gets.

Comment and guard changes only — the rendered controllers root is byte-identical, so the approved authorization surface fingerprint is untouched.

Part of #3028

