### PR TITLE
perf(ci): skip the Flux fence when the GHCR bridge has nothing to write

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -232,6 +232,9 @@ sync_lease_result_file="${work_dir}/sync-lease-result.txt"
 sync_lease_lost_file="${work_dir}/sync-lease-lost"
 root_secret_state_file="${work_dir}/root-secret-state.json"
 root_secret_cas_patch_file="${work_dir}/root-secret-cas-patch.json"
+# resourceVersion the unfenced fast path made its decision against; empty until
+# the drift probe has observed one.
+probed_root_secret_version=""
 variables_secret_state_file="${work_dir}/variables-secret-state.json"
 variables_secret_cas_patch_file="${work_dir}/variables-secret-cas-patch.json"
 sync_lease_holder=""
@@ -406,7 +409,37 @@ ghcr_state_already_matches_git() {
     "${desired_revision}" \
     "${operator_image}" \
     "${targets_file}" >/dev/null 2>&1 || return 1
-  [[ ! -s "${targets_file}" ]]
+  [[ ! -s "${targets_file}" ]] || return 1
+
+  # Pin what the probe observed. The unfenced patch below is only sound while
+  # the cluster still looks the way it did here, so record the version the
+  # decision was made against rather than trusting that nothing moved.
+  probed_root_secret_version="$(jq -r '.metadata.resourceVersion // ""' \
+    "${probe_dir}/root-secret.json" 2>/dev/null)" || return 1
+  [[ -n "${probed_root_secret_version}" ]]
+}
+
+# The fast path patches root auth outside the fence, so the probe's conclusion
+# must still hold at the moment of the write. Re-read and require the exact
+# resourceVersion the probe decided on; anything else means a writer moved
+# under us and the run falls through to the fenced transaction, which is the
+# unchanged behaviour. The remaining read/write window is closed by
+# patch_secret_data_with_cas, whose own CAS test rejects a patch built from a
+# superseded read.
+root_secret_unchanged_since_probe() {
+  local recheck_file="${work_dir}/drift-probe/root-secret-recheck.json"
+  local current_version
+
+  [[ -n "${probed_root_secret_version}" ]] || return 1
+  kubectl \
+    --context "${KUBE_CONTEXT}" \
+    --namespace flux-system \
+    get secret ksail-registry-credentials \
+    -o json \
+    >"${recheck_file}" 2>/dev/null || return 1
+  current_version="$(jq -r '.metadata.resourceVersion // ""' \
+    "${recheck_file}" 2>/dev/null)" || return 1
+  [[ "${current_version}" == "${probed_root_secret_version}" ]]
 }
 
 # Emit bounded, printable output only from operations that cannot contain the
@@ -3824,7 +3857,8 @@ fi
 if ghcr_state_already_matches_git \
   "${pull_revision}" \
   "${KSAIL_OPERATOR_IMAGE}" \
-  "${FANOUT_NAMESPACES[@]}"; then
+  "${FANOUT_NAMESPACES[@]}" &&
+  root_secret_unchanged_since_probe; then
   patch_root_secret
   echo "✅ Every consumer, node proof and root credential already matched Git/SOPS; reasserted root Flux auth without fencing Flux."
   exit 0

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -328,6 +328,87 @@ verify_consumer_secret() {
   fi
 }
 
+# Compare one Secret data key against the expected Docker config without ever
+# printing the credential. Any read, decode or shape failure counts as drift, so
+# an unreadable cluster can never be mistaken for a matching one.
+secret_data_key_matches_expected() {
+  local namespace="$1" name="$2" key="$3" state_file="$4"
+  local decoded_file="${state_file%.json}-decoded.json"
+  local normalized_file="${state_file%.json}-normalized.json"
+
+  kubectl \
+    --context "${KUBE_CONTEXT}" \
+    --namespace "${namespace}" \
+    get secret "${name}" \
+    -o json \
+    >"${state_file}" 2>/dev/null || return 1
+  jq -er --arg key "${key}" '.data[$key] | @base64d' \
+    "${state_file}" >"${decoded_file}" 2>/dev/null || return 1
+  jq -S -c . "${decoded_file}" >"${normalized_file}" 2>/dev/null || return 1
+  cmp -s "${expected_normalized}" "${normalized_file}"
+}
+
+# Read-only drift probe, so a deploy with nothing to repair does not pay for the
+# repair machinery.
+#
+# The transaction below fences Flux to mutate safely: it pauses the parent and
+# child policy reconciliations and RESTARTS kustomize-controller, because Flux
+# documents that suspending does not stop an execution that already started.
+# That fence is correct when something is being written. It is also the dominant
+# cost of a deploy that writes nothing — measured 2026-08-09, the post-`cluster
+# update` reassert took 62 s of a 276 s deploy while reporting "(no change)" on
+# both Secrets, and the script runs twice per deploy (platform#3039).
+#
+# So prove first, with reads only, that every endpoint the transaction would
+# write already matches Git/SOPS. FAIL CLOSED: any drift, any read error, or any
+# residual bridge ownership returns non-zero and falls through to the unchanged
+# transaction. A false "matches" is the dangerous direction, so every check must
+# pass affirmatively — nothing here is skipped on error.
+#
+# This deliberately covers MORE than --check-only, which returns after proving
+# the SOPS credential can pull from GHCR *on the runner*. That says nothing
+# about cluster state, so it would pass straight over the partial machine-config
+# write this reassert exists to repair.
+ghcr_state_already_matches_git() {
+  local desired_revision="$1" operator_image="$2"
+  shift 2
+  local namespace
+  local probe_dir="${work_dir}/drift-probe"
+  local nodes_file="${probe_dir}/nodes.json"
+  local targets_file="${probe_dir}/targets.tsv"
+
+  mkdir -p "${probe_dir}" || return 1
+
+  # Root Flux auth, and the variables-base payload the whole fan-out derives
+  # from. Both carry the same credential under different keys.
+  secret_data_key_matches_expected \
+    flux-system ksail-registry-credentials '.dockerconfigjson' \
+    "${probe_dir}/root-secret.json" || return 1
+  secret_data_key_matches_expected \
+    flux-system variables-base 'ghcr_dockerconfigjson' \
+    "${probe_dir}/variables-base.json" || return 1
+
+  # Every materialised tenant/Kyverno consumer.
+  for namespace in "$@"; do
+    verify_consumer_secret "${namespace}" >/dev/null 2>&1 || return 1
+  done
+
+  # Every node's v2 proof. select_talos_node_targets is side-effect free and
+  # FAILS on residual GHCR bridge ownership — a recovery state that must never
+  # take the fast path — so its failure correctly falls through.
+  kubectl \
+    --context "${KUBE_CONTEXT}" \
+    get nodes \
+    --output json \
+    >"${nodes_file}" 2>/dev/null || return 1
+  select_talos_node_targets \
+    "${nodes_file}" \
+    "${desired_revision}" \
+    "${operator_image}" \
+    "${targets_file}" >/dev/null 2>&1 || return 1
+  [[ ! -s "${targets_file}" ]]
+}
+
 # Emit bounded, printable output only from operations that cannot contain the
 # registry credential. Prefix each line so it cannot become a workflow command.
 emit_safe_operation_output() {
@@ -3732,6 +3813,20 @@ if [[ "${fanout_complete}" != "true" ]]; then
   patch_variables_base
   patch_root_secret
   echo "✅ Staged the Git/SOPS credential and refreshed root Flux auth; the first reconcile will complete the missing downstream fan-out."
+  exit 0
+fi
+
+# Nothing to write means nothing to fence. Root auth is still reasserted from
+# Git/SOPS, so the documented "reasserts root auth on every run" property holds;
+# what is skipped is only the Flux pause and kustomize-controller restart that
+# exist to make a MUTATION safe. The probe proved the root Secret already
+# matches, so this patch is the same no-op the fenced path performs today.
+if ghcr_state_already_matches_git \
+  "${pull_revision}" \
+  "${KSAIL_OPERATOR_IMAGE}" \
+  "${FANOUT_NAMESPACES[@]}"; then
+  patch_root_secret
+  echo "✅ Every consumer, node proof and root credential already matched Git/SOPS; reasserted root Flux auth without fencing Flux."
   exit 0
 fi
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1825,6 +1825,18 @@ func fakeKubectlGetRootSecret() int {
 		"FAKE_SYNC_LEASE_LOST_AFTER_ROOT_SECRET_GET",
 		"sync-lease-lost-after-root-secret-get",
 	)
+	// Move the Secret once, immediately after the drift probe has read it. This
+	// is the only way to exercise the window between an unfenced probe and the
+	// patch it authorises: a concurrent writer that lands after the decision was
+	// made but before it was acted on.
+	if os.Getenv("FAKE_ROOT_SECRET_MOVES_AFTER_PROBE") == "true" &&
+		!markerExists("root-secret-moved-after-probe") {
+		touchMarker("root-secret-moved-after-probe")
+		setMarkerContent(
+			"root-secret-resource-version",
+			incrementDecimal(defaultString(markerContent("root-secret-resource-version"), "20")),
+		)
+	}
 	return 0
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -2047,9 +2047,9 @@ func fakeKubectlGetConsumerSecret(namespace string) int {
 	encoded := ""
 	if mismatch {
 		encoded = base64.StdEncoding.EncodeToString([]byte(`{"auths":{}}`))
-	} else {
+	} else if capture := os.Getenv("VARIABLES_PATCH_CAPTURE"); pathExists(capture) {
 		var patch map[string]any
-		if err := json.Unmarshal([]byte(mustReadCommandFile(os.Getenv("VARIABLES_PATCH_CAPTURE"))), &patch); err != nil {
+		if err := json.Unmarshal([]byte(mustReadCommandFile(capture)), &patch); err != nil {
 			return commandFailure(91, "parse variables-base patch: %v", err)
 		}
 		data, _ := patch["data"].(map[string]any)
@@ -2057,6 +2057,14 @@ func fakeKubectlGetConsumerSecret(namespace string) int {
 		if variablesPatchCount >= 3 {
 			removeMarker(revertedMarker)
 		}
+	} else {
+		// No variables-base patch in THIS run. The materialised consumer Secret
+		// is cluster state, not a per-run artifact: it persists across deploys
+		// and reflects whatever variables-base currently holds. The per-run
+		// capture is cleared between runs, so without this the fixture could not
+		// express an already-converged cluster — a second invocation would read
+		// an absent file and look like drift no matter what the cluster held.
+		encoded = markerContent("variables-secret-value")
 	}
 	fmt.Println(encodeJSON(map[string]any{
 		"data": map[string]any{".dockerconfigjson": encoded},

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
@@ -92,3 +92,27 @@ func TestReassertWithPartiallyAppliedNodeConfigStillFences(t *testing.T) {
 		t.Error("root patch missing after the fenced transaction")
 	}
 }
+
+// CodeRabbit raised this on #3041 and it is a real window: the probe reads the
+// root Secret, then the fast path patches it OUTSIDE the fence. A writer that
+// lands in between would have its change overwritten by a decision made against
+// a cluster that no longer exists. The fast path therefore pins the observed
+// resourceVersion, and anything else falls through to the fenced transaction.
+func TestRootSecretMovingAfterTheProbeFallsBackToTheFence(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	current := map[string]string{"FAKE_TALOS_NODES_CURRENT": "true"}
+
+	requireSuccessResult(t, f.runHelper(validConfig(), nil, current))
+	afterStage := fluxControllerRestartCount(t, f)
+
+	result := f.runHelperPreservingClusterState(validConfig(), nil, map[string]string{
+		"FAKE_TALOS_NODES_CURRENT":           "true",
+		"FAKE_ROOT_SECRET_MOVES_AFTER_PROBE": "true",
+	})
+	requireSuccessResult(t, result)
+
+	if after := fluxControllerRestartCount(t, f); after == afterStage {
+		t.Errorf("root Secret moved after the probe but the run still took the unfenced fast path (count stayed %q)", afterStage)
+	}
+}

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
@@ -1,0 +1,76 @@
+package refreshfluxghcrauth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The bridge fences Flux before it mutates: it pauses the parent and child
+// policy reconciliations and restarts kustomize-controller, because Flux
+// documents that suspending does not stop an execution that already started.
+// That fence is the dominant cost of a deploy which writes nothing, and the
+// script runs twice per deploy (platform#3039).
+//
+// These two tests pin BOTH directions, which is the whole safety property: the
+// fence is skipped only when a read-only probe proves every endpoint already
+// matches Git/SOPS, and it is still taken the moment anything drifts.
+
+func fluxControllerRestartCount(t *testing.T, f *fixture) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(f.syncStateDir, "flux-controller-restart-count"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read kustomize-controller restart count: %v", err)
+	}
+	return string(content)
+}
+
+func TestFullyCurrentClusterSkipsTheFluxFence(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{"FAKE_TALOS_NODES_CURRENT": "true"})
+	requireSuccessResult(t, result)
+
+	if restarts := fluxControllerRestartCount(t, f); restarts != "" {
+		t.Errorf("a cluster with nothing to write still restarted kustomize-controller (count %q)", restarts)
+	}
+	if pathExists(f.talosLog) {
+		t.Error("a cluster with nothing to write still reached the Talos API")
+	}
+	// Root auth is still reasserted from Git/SOPS. Skipping the fence must not
+	// weaken the documented "reasserts root auth on every run" property — only
+	// the machinery that exists to make a MUTATION safe is skipped.
+	if !pathExists(f.patchCapture) {
+		t.Error("fast path skipped the root Flux auth reassert")
+	}
+	requireNotContains(t, result.stdout+result.stderr, "fixture-secret-token")
+}
+
+// The escalation case, and the reason `--check-only` could not have been reused
+// for this: it returns after proving the SOPS credential pulls from GHCR on the
+// runner, which stays true while a node's machine config is only partly
+// applied. Here the credential revision matches but the verified image does
+// not — exactly that partial state — so the probe must refuse the fast path and
+// the full fenced transaction must run.
+func TestPartiallyAppliedNodeConfigStillTakesTheFluxFence(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_TALOS_NODES_CURRENT":  "true",
+		"FAKE_TALOS_VERIFIED_IMAGE": "ghcr.io/devantler-tech/ksail:v7.166.0",
+	})
+	requireSuccessResult(t, result)
+
+	if restarts := fluxControllerRestartCount(t, f); restarts == "" {
+		t.Error("drifted node proof took the fast path; the fenced transaction never ran")
+	}
+	if !pathExists(f.talosLog) {
+		t.Error("drifted node proof never reached the Talos API")
+	}
+	if !pathExists(f.patchCapture) {
+		t.Error("root patch missing after the fenced transaction")
+	}
+}

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_fast_path_test.go
@@ -9,12 +9,16 @@ import (
 // The bridge fences Flux before it mutates: it pauses the parent and child
 // policy reconciliations and restarts kustomize-controller, because Flux
 // documents that suspending does not stop an execution that already started.
-// That fence is the dominant cost of a deploy which writes nothing, and the
-// script runs twice per deploy (platform#3039).
+// That fence is correct whenever something is written, and it is the dominant
+// cost of a deploy that writes nothing — the script runs twice per deploy, and
+// the second invocation measured 62 s of a 276 s deploy while reporting no
+// change on both Secrets (platform#3039).
 //
-// These two tests pin BOTH directions, which is the whole safety property: the
-// fence is skipped only when a read-only probe proves every endpoint already
-// matches Git/SOPS, and it is still taken the moment anything drifts.
+// Both tests run the script TWICE against preserved cluster state, which is the
+// production shape: the deploy stages before publishing and reasserts after
+// `ksail cluster update`. They pin both directions of the safety property — the
+// fence is skipped only once a read-only probe proves every endpoint already
+// matches Git/SOPS, and is still taken the moment anything drifts.
 
 func fluxControllerRestartCount(t *testing.T, f *fixture) string {
 	t.Helper()
@@ -28,17 +32,25 @@ func fluxControllerRestartCount(t *testing.T, f *fixture) string {
 	return string(content)
 }
 
-func TestFullyCurrentClusterSkipsTheFluxFence(t *testing.T) {
+func TestReassertOverAConvergedClusterSkipsTheFluxFence(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	result := f.runHelper(validConfig(), nil, map[string]string{"FAKE_TALOS_NODES_CURRENT": "true"})
+	current := map[string]string{"FAKE_TALOS_NODES_CURRENT": "true"}
+
+	requireSuccessResult(t, f.runHelper(validConfig(), nil, current))
+	afterStage := fluxControllerRestartCount(t, f)
+	if afterStage == "" {
+		t.Fatal("the converging run did not fence Flux; the fixture is not exercising the mutation path")
+	}
+
+	result := f.runHelperPreservingClusterState(validConfig(), nil, current)
 	requireSuccessResult(t, result)
 
-	if restarts := fluxControllerRestartCount(t, f); restarts != "" {
-		t.Errorf("a cluster with nothing to write still restarted kustomize-controller (count %q)", restarts)
+	if after := fluxControllerRestartCount(t, f); after != afterStage {
+		t.Errorf("reassert over a converged cluster restarted kustomize-controller again (%q -> %q)", afterStage, after)
 	}
 	if pathExists(f.talosLog) {
-		t.Error("a cluster with nothing to write still reached the Talos API")
+		t.Error("reassert over a converged cluster reached the Talos API")
 	}
 	// Root auth is still reasserted from Git/SOPS. Skipping the fence must not
 	// weaken the documented "reasserts root auth on every run" property — only
@@ -49,23 +61,29 @@ func TestFullyCurrentClusterSkipsTheFluxFence(t *testing.T) {
 	requireNotContains(t, result.stdout+result.stderr, "fixture-secret-token")
 }
 
-// The escalation case, and the reason `--check-only` could not have been reused
-// for this: it returns after proving the SOPS credential pulls from GHCR on the
+// The escalation case, and the reason `--check-only` could not be reused for
+// this: it returns after proving the SOPS credential pulls from GHCR on the
 // runner, which stays true while a node's machine config is only partly
 // applied. Here the credential revision matches but the verified image does
 // not — exactly that partial state — so the probe must refuse the fast path and
 // the full fenced transaction must run.
-func TestPartiallyAppliedNodeConfigStillTakesTheFluxFence(t *testing.T) {
+func TestReassertWithPartiallyAppliedNodeConfigStillFences(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
-	result := f.runHelper(validConfig(), nil, map[string]string{
+
+	requireSuccessResult(t, f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_TALOS_NODES_CURRENT": "true",
+	}))
+	afterStage := fluxControllerRestartCount(t, f)
+
+	result := f.runHelperPreservingClusterState(validConfig(), nil, map[string]string{
 		"FAKE_TALOS_NODES_CURRENT":  "true",
 		"FAKE_TALOS_VERIFIED_IMAGE": "ghcr.io/devantler-tech/ksail:v7.166.0",
 	})
 	requireSuccessResult(t, result)
 
-	if restarts := fluxControllerRestartCount(t, f); restarts == "" {
-		t.Error("drifted node proof took the fast path; the fenced transaction never ran")
+	if after := fluxControllerRestartCount(t, f); after == afterStage {
+		t.Errorf("drifted node proof took the fast path; the fenced transaction never ran (count stayed %q)", afterStage)
 	}
 	if !pathExists(f.talosLog) {
 		t.Error("drifted node proof never reached the Talos API")


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The GHCR auth bridge fences Flux before it mutates — it pauses policy reconciliation and **restarts `kustomize-controller`**, because suspending does not stop an already-started execution. It takes that fence on every run, including runs that write nothing, and it runs twice per deploy. Measured while the Cilium gate was suppressing `cluster update`: stage 67 s + reassert 62 s of a 276 s deploy, both reporting `(no change)`.

## What

A read-only probe runs first and skips the fence when the cluster already matches Git/SOPS — root Secret, `variables-base`, every consumer secret, and every node proof. Root auth is still reasserted, pinned to the `resourceVersion` the probe decided against, so a concurrent writer sends the run down the fenced path instead. It **fails closed**: any drift, read error, or residual bridge ownership falls through to today’s transaction unchanged.

## ⚠️ Scope — read this before expecting a big number

This removes ~60 s and one GitOps-engine restart per invocation. It is **not** the reason deploys are slow right now, and it should not be merged in the belief that it is.

Since the rollout gate was released (#3035, 20:00Z) every deploy runs `ksail cluster update` again, and **every deploy now rolling-reboots all seven nodes**: 64 min, 36.5 min, 52 min for the three most recent, against 4.4–5.7 min while the gate was suppressing that step. Isolated inside a single run — the same script runs on both sides of `cluster update`, so the run contains its own control:

| Step | root Secret | nodes rebooted |
|---|---|---|
| `🔑 Stage` — **before** `cluster update` | `patched (no change)` | **0** |
| `🔑 Reassert` — **after** `cluster update` | `patched` (changed) | **7** |

`ksail cluster update` invalidates every node’s proof, so the reassert rebuilds it the expensive way. That is **#3042**, it is worth ~45–60 min per merge, and it needs a design decision. This PR is the ~60 s slice around it and lands independently.

Fixes #3039