### PR TITLE
security(supply-chain): trust only commit-pinned shared publish workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,6 +136,12 @@ jobs:
               # Both halves, for the same reason as the guard above.
               - 'scripts/verify-published-evidence.sh'
               - 'scripts/tests/test-verify-published-evidence.sh'
+              # The pin guard itself runs unconditionally in the validate job, so
+              # only its TEST is selected here. Both halves are listed anyway: a PR
+              # that edits the guard must also run the test that pins its ablations,
+              # or a widened allow-list would ship with every check still green.
+              - 'scripts/guard-shared-publish-workflow-pin.sh'
+              - 'scripts/tests/test-shared-publish-workflow-pin-guard.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -423,6 +429,15 @@ jobs:
         # verdict in both rollout states and the wiring that reaches it — a gate
         # that runs after latest already moved has verified nothing that matters.
         run: bash scripts/tests/test-verify-published-evidence.sh
+
+      - name: 🔐 Validate the shared-publish-workflow pin guard
+        if: needs.changes.outputs.k8s == 'true'
+        # The guard fails by PASSING: a widened cosign matcher still verifies, so
+        # nothing else in CI notices. This pins the shapes it must reject — above
+        # all the SHA-or-tag alternation removed in #3022, which is the exact
+        # prior contents of all eight subjects and would otherwise revert in
+        # silence — plus the floor and the wiring that reaches it.
+        run: bash scripts/tests/test-shared-publish-workflow-pin-guard.sh
 
       - name: 📋 Validate Kubescape finding summary
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -17,13 +17,14 @@ spec:
     provider: cosign
     matchOIDCIdentity:
       # Keyless-signed by the shared publish-app workflow this app's cd.yaml
-      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
-      # so an artifact signed from a floating ref (e.g. @main) does not verify.
-      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
-      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # calls. The ref part accepts only a 40-hex commit SHA, so an artifact
+      # signed from any other ref — a floating @main, or a release tag — does
+      # not verify. Every caller of the shared publish workflows pins them by
+      # commit across its whole history, which is what makes the commit form
+      # sufficient on its own (#3022).
       # cosign's keyless attestation verification rejects MULTIPLE identity
       # entries outright ("unsupported: multiple identities are not supported at
       # this time"), so any future alternation must stay inside one subject
       # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/apps/doggy-countdown/oci-repository.yaml
+++ b/k8s/bases/apps/doggy-countdown/oci-repository.yaml
@@ -17,13 +17,14 @@ spec:
     provider: cosign
     matchOIDCIdentity:
       # Keyless-signed by the shared publish-app workflow this app's cd.yaml
-      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
-      # so an artifact signed from a floating ref (e.g. @main) does not verify.
-      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
-      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # calls. The ref part accepts only a 40-hex commit SHA, so an artifact
+      # signed from any other ref — a floating @main, or a release tag — does
+      # not verify. Every caller of the shared publish workflows pins them by
+      # commit across its whole history, which is what makes the commit form
+      # sufficient on its own (#3022).
       # cosign's keyless attestation verification rejects MULTIPLE identity
       # entries outright ("unsupported: multiple identities are not supported at
       # this time"), so any future alternation must stay inside one subject
       # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -29,13 +29,14 @@ spec:
       # subject is that workflow's path, NOT .github's own cd.yaml — same
       # convention as the publish-app.yaml-signed app artifacts.
       #
-      # The ref part accepts only a 40-hex commit SHA or a release tag, so an
-      # artifact signed from a floating ref (e.g. @main) does not verify.
-      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
-      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # The ref part accepts only a 40-hex commit SHA, so an artifact signed
+      # from any other ref — a floating @main, or a release tag — does not
+      # verify. Every caller of the shared publish workflows pins them by
+      # commit across its whole history, which is what makes the commit form
+      # sufficient on its own (#3022).
       # cosign's keyless attestation verification rejects MULTIPLE identity
       # entries outright ("unsupported: multiple identities are not supported at
       # this time"), so any future alternation must stay inside one subject
       # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -17,13 +17,14 @@ spec:
     provider: cosign
     matchOIDCIdentity:
       # Keyless-signed by the shared publish-app workflow this app's cd.yaml
-      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
-      # so an artifact signed from a floating ref (e.g. @main) does not verify.
-      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
-      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # calls. The ref part accepts only a 40-hex commit SHA, so an artifact
+      # signed from any other ref — a floating @main, or a release tag — does
+      # not verify. Every caller of the shared publish workflows pins them by
+      # commit across its whole history, which is what makes the commit form
+      # sufficient on its own (#3022).
       # cosign's keyless attestation verification rejects MULTIPLE identity
       # entries outright ("unsupported: multiple identities are not supported at
       # this time"), so any future alternation must stay inside one subject
       # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -110,7 +110,7 @@ spec:
       message: >-
         first-party app image is not signed by the publish-app release
         pipeline (keyless cosign, actions publish-app.yaml identity, pinned by
-        commit SHA or release tag)
+        commit SHA — a release tag is not accepted)
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)
         .filter(image, image.startsWith('ghcr.io/devantler-tech/provider-upjet-'))

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -57,10 +57,10 @@ spec:
       cosign:
         keyless:
           # publish-app.yaml lives in the actions monorepo. Callers pin that
-          # reusable workflow either by commit SHA or by release tag, so the
-          # ref alternation admits exactly those two forms and rejects a
-          # mutable ref such as @main — the same shape as the tenants' Flux
-          # OCIRepository verify blocks. Keep this to exactly ONE identity
+          # reusable workflow by commit SHA, so the ref admits that form alone
+          # and rejects everything else — a mutable ref such as @main, and a
+          # release tag — the same shape as the tenants' Flux OCIRepository
+          # verify blocks (#3022). Keep this to exactly ONE identity
           # entry: the IVPOL engine verifies cosign v3 bundles through
           # sigstore-go, which rejects more than one identity per verification
           # ("unsupported: multiple identities are not supported at this
@@ -71,7 +71,7 @@ spec:
           # form as an alternation inside this one regex.
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$
+              subjectRegExp: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$
     # Crossplane provider packages (provider-upjet-*): the crossplane-contrib
     # reusable publish workflow they use cannot sign, so each provider repo
     # attaches the keyless signature in its own publish-provider-package.yml

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -250,16 +250,19 @@ spec:
             provider: cosign
             matchOIDCIdentity:
               # Keyless-signed by the shared publish-app workflow this tenant's
-              # cd.yaml calls. The ref part accepts only a 40-hex commit SHA or a
-              # release tag, so an artifact signed from a floating ref (e.g. @main)
-              # does not verify. Consumers pin the workflow by SHA, so only the SHA
-              # branch is exercised today; the tag branch is kept so a tag-pinned
-              # caller also verifies. cosign's keyless attestation verification
+              # cd.yaml calls. The ref part accepts only a 40-hex commit SHA, so
+              # an artifact signed from any other ref — a floating @main, or a
+              # release tag — does not verify. Every caller of the shared publish
+              # workflows pins them by commit across its whole history, which is
+              # what makes the commit form sufficient on its own (#3022). A new
+              # tenant generated from this template inherits that requirement, so
+              # its cd.yaml must pin by commit too — the template's own default
+              # already does. cosign's keyless attestation verification
               # rejects MULTIPLE identity entries outright ("unsupported: multiple
               # identities are not supported at this time"), so any future
               # alternation must stay inside one subject regex.
               - issuer: '^https://token\.actions\.githubusercontent\.com$'
-                subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+                subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'
     # --- Flux Kustomization (one of two variants by `sops`) ---------------
     # The impersonating Kustomization that reconciles the tenant's own artifact
     # under its namespaced SA (bound to the `tenant-edit` role). Two variants because the SOPS `decryption`

--- a/k8s/providers/hetzner/apps/aws/oci-repository.yaml
+++ b/k8s/providers/hetzner/apps/aws/oci-repository.yaml
@@ -25,9 +25,10 @@ spec:
       # cd.yaml calls. Signing runs INSIDE that workflow, so the cosign OIDC
       # subject is that workflow's path, NOT aws's own cd.yaml.
       #
-      # The ref part accepts only a 40-hex commit SHA or a release tag, so an
-      # artifact signed from a floating ref (e.g. @main) does not verify.
-      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
-      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # The ref part accepts only a 40-hex commit SHA, so an artifact signed
+      # from any other ref — a floating @main, or a release tag — does not
+      # verify. Every caller of the shared publish workflows pins them by
+      # commit across its whole history, which is what makes the commit form
+      # sufficient on its own (#3022).
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@[0-9a-f]{40}$'

--- a/scripts/guard-shared-publish-workflow-pin.sh
+++ b/scripts/guard-shared-publish-workflow-pin.sh
@@ -42,6 +42,14 @@
 # actions SHA still matches `[0-9a-f]{40}`. Restricting to approved revisions needs a
 # generated allow-list and is tracked separately on #2818. This guard keeps the
 # property #2816 established from silently regressing.
+#
+# Note for whoever implements that allow-list: the check below matches the literal
+# PATTERN text `[0-9a-f]{40}`, because these subjects are regexes. A subject naming one
+# concrete commit — which is what a generated approved-revision list would emit — is
+# therefore REJECTED here today, despite being strictly narrower than what is accepted.
+# That is a limit of this check, not a judgement about the shape; extend the allow-list
+# deliberately when the generator lands, rather than reading the failure as a defect in
+# the generated output.
 
 set -euo pipefail
 

--- a/scripts/guard-shared-publish-workflow-pin.sh
+++ b/scripts/guard-shared-publish-workflow-pin.sh
@@ -3,17 +3,25 @@
 # publish workflow pins a FIXED revision, and never a moving ref.
 #
 # WHY THIS EXISTS (#2818)
-# #2816 tightened these matchers from `@.+` to `@([0-9a-f]{40}|refs/tags/v.+)`, which
-# closed moving refs. Nothing keeps them closed: the property lives in eight separate
-# regex strings, hand-written, under three different key spellings, and a single one
-# widened back to `@.+` restores "trust any signer that can run this workflow from any
-# ref" while every other check in CI stays green. A widened matcher is not a broken
-# matcher — it verifies, it just verifies less — so no schema, no kubeconform pass and
-# no deploy will notice.
+# The accepted ref shape is a 40-hex commit and nothing else. The property lives in
+# eight separate regex strings, hand-written, under three different key spellings, and
+# a single one widened back to `@.+` restores "trust any signer that can run this
+# workflow from any ref" while every other check in CI stays green. A widened matcher
+# is not a broken matcher — it verifies, it just verifies less — so no schema, no
+# kubeconform pass and no deploy will notice.
 #
-# The ref is judged by an ALLOW-LIST — a 40-hex commit, or a tag under refs/tags/ —
-# because enumerating forbidden shapes only catches the regressions someone thought
-# of, and would wave through `@main` or `@v1`.
+# The ref is judged by an ALLOW-LIST — a 40-hex commit — because enumerating forbidden
+# shapes only catches the regressions someone thought of, and would wave through
+# `@main` or `@v1`.
+#
+# THE TAG ALTERNATIVE IS GONE, AND THIS GUARD IS WHAT KEEPS IT GONE (#3022).
+# A `refs/tags/v.+` alternative used to sit beside the commit form. It was removed once
+# it was confirmed unexercised: every artifact these subjects verify is signed by a
+# caller that pins the shared workflow by commit — measured across the complete history
+# of all six consumers and against the signing certificates of every readable artifact,
+# with zero tag-form signatures. Re-adding it would widen the trusted signer set for no
+# artifact that exists, so the allow-list below rejects it rather than merely
+# tolerating its absence.
 #
 # 🔴 THE ROOT SOURCE IS DELIBERATELY EXCLUDED, AND THAT IS THE WHOLE DESIGN.
 #
@@ -137,10 +145,13 @@ EOF
     # positively recognisable inverts that — an unfamiliar shape fails, and adding a
     # legitimately new one is a deliberate edit here rather than a silent widening.
     #
-    # Exactly two forms qualify: a 40-hex commit, and a tag under refs/tags/. The
-    # wildcard inside `refs/tags/v.+` widens the tag NAME, never the ref KIND, so it
-    # stays valid — which is why this is judged per alternative rather than on the
-    # whole string.
+    # Exactly one form qualifies: a 40-hex commit (#3022).
+    #
+    # An alternation is therefore always a widening now, but it is still parsed
+    # per alternative rather than rejected wholesale on sight — that way the error
+    # names the offending alternative instead of the whole string, and a future
+    # legitimately-added form is a deliberate edit to the allow-list below rather
+    # than a change to this parsing.
     # A grouped ref must be FULLY grouped. `(A|B)` is the shape this understands;
     # `(A)?B` is not, and stripping a leading paren from it would silently hand the
     # trailing `B` to the per-alternative check as part of A's text. Reject the
@@ -161,26 +172,15 @@ EOF
     esac
 
     while IFS= read -r alternative; do
-      # Match each alternative WHOLE, never by prefix.
+      # Match the alternative WHOLE (`-x`), never by prefix.
       #
-      # `refs/tags/*` as a shell glob accepts anything that merely STARTS with the
-      # tag prefix, so `(refs/tags/v.+)?refs/heads/.+$` — where the tag group is
-      # optional and a branch ref follows it — was accepted and the guard reported
-      # all eight subjects pinned. Reproduced against the real repository before
-      # this fix: exit 0 with a subject that permits `refs/heads/`.
-      #
-      # The tag form therefore allows only characters that widen the tag NAME. `/`
-      # is excluded because it is what lets a second ref kind be appended, and the
-      # grouping and alternation metacharacters are excluded because a matcher that
-      # needs them is not a plain tag pattern and must be reviewed here deliberately.
+      # A prefix match is what let `(refs/tags/v.+)?refs/heads/.+$` through when the
+      # tag form was still accepted: the group was optional and a branch ref followed
+      # it, yet the guard reported all eight subjects pinned. The commit form has no
+      # prefix hazard of its own, but the whole-line anchor is what guarantees that —
+      # `[0-9a-f]{40}` must be the entire alternative, so nothing can be appended to
+      # it.
       if printf '%s' "$alternative" | grep -qxE '\[0-9a-f\]\{40\}'; then
-        continue
-      fi
-      # NOTE the bracket expression's ordering: a backslash is LITERAL inside a
-      # POSIX bracket, so `\]` does not escape anything — it ends the class early.
-      # `]` must therefore come first and `-` last, which is what makes `[` and `]`
-      # members rather than delimiters.
-      if printf '%s' "$alternative" | grep -qxE 'refs/tags/[]A-Za-z0-9._*+{}[-]+'; then
         continue
       fi
       printf '%s: ref alternative %s does not pin a fixed revision (subject: %s)\n' \

--- a/scripts/tests/test-shared-publish-workflow-pin-guard.sh
+++ b/scripts/tests/test-shared-publish-workflow-pin-guard.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Behaviour and wiring tests for scripts/guard-shared-publish-workflow-pin.sh.
+#
+# The guard is the only thing standing between the shared-publish-workflow cosign
+# subjects and a silent widening: a widened matcher still verifies, so no schema,
+# kubeconform pass or deploy notices. That makes the guard's own failure modes the
+# interesting ones — it fails by passing, never by crashing.
+#
+# The behaviour half runs a COPY of the guard over a synthetic tree. The guard
+# derives its scan root from its own location (`dirname $BASH_SOURCE/..`) and greps
+# `.`, so placing the copy at <tmp>/scripts/ makes <tmp> the repository it sees.
+# That is the seam; without it every case would scan the real repository and the
+# ablations could not vary anything.
+#
+# The wiring half asserts the guard is actually reached. A guard no workflow calls
+# protects nothing, and this one is deliberately unconditional — not behind a paths
+# filter — because the subjects it covers live in four different trees.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly guard="${root_dir}/scripts/guard-shared-publish-workflow-pin.sh"
+
+# These subjects are cosign identity REGEXES, so the accepted ref is the pattern
+# `[0-9a-f]{40}` as literal text — not a concrete commit. A hand-written literal
+# SHA is a different thing (an approved-revision allow-list, #2818's option 2) and
+# the guard does not recognise it today.
+readonly SHA_PATTERN='[0-9a-f]{40}'
+
+pass_count=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+ok() {
+  pass_count=$((pass_count + 1))
+  printf 'ok — %s\n' "$1"
+}
+
+[ -f "${guard}" ] || fail "guard not found at ${guard}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+# build_tree <dir> <ref-for-subject-1> — writes eight subjects, the first carrying
+# the supplied ref and the remaining seven a plain 40-hex pin. One varying subject
+# is what isolates the ref check from the floor check.
+build_tree() {
+  local dir="$1" first_ref="$2" i
+  rm -rf "${dir}"
+  mkdir -p "${dir}/scripts" "${dir}/k8s"
+  cp "${guard}" "${dir}/scripts/guard-shared-publish-workflow-pin.sh"
+
+  printf 'spec:\n  verify:\n    matchOIDCIdentity:\n      - issuer: x\n        subject: '\''^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@%s$'\''\n' \
+    "${first_ref}" >"${dir}/k8s/subject-1.yaml"
+
+  for i in 2 3 4 5 6 7 8; do
+    printf 'spec:\n  verify:\n    matchOIDCIdentity:\n      - issuer: x\n        subject: '\''^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@%s$'\''\n' \
+      "${SHA_PATTERN}" >"${dir}/k8s/subject-${i}.yaml"
+  done
+}
+
+# run_tree <dir> — exit status of the guard as that tree's repository root.
+run_tree() {
+  local dir="$1" status=0
+  ( cd "${dir}" && bash "${dir}/scripts/guard-shared-publish-workflow-pin.sh" ) \
+    >"${dir}/stdout" 2>"${dir}/stderr" || status=$?
+  return "${status}"
+}
+
+# --- GREEN: the narrowed shape is what the guard accepts ---------------------
+
+tree="${work_dir}/green"
+build_tree "${tree}" "[0-9a-f]{40}"
+if run_tree "${tree}"; then
+  ok "eight SHA-only subjects pass"
+else
+  printf '%s\n' "$(cat "${tree}/stderr")" >&2
+  fail "eight SHA-only subjects should pass, guard rejected them"
+fi
+
+# --- RED: every widening must fire -------------------------------------------
+#
+# `([0-9a-f]{40}|refs/tags/v.+)` is the shape this change removed (#3022). It is
+# listed FIRST because it is the regression this test exists for: it is the exact
+# prior contents of all eight subjects, so a guard that still accepts it would let
+# the whole change revert silently while reporting a clean repository.
+
+assert_rejected() {
+  local label="$1" ref="$2" dir="${work_dir}/red-$3"
+  build_tree "${dir}" "${ref}"
+  if run_tree "${dir}"; then
+    fail "guard ACCEPTED ${label} (ref: ${ref}) — the widening is not enforced"
+  fi
+  grep -q 'does not pin\|not a fully grouped' "${dir}/stderr" \
+    || fail "guard rejected ${label} but not for the ref reason: $(head -1 "${dir}/stderr")"
+  ok "rejects ${label}"
+}
+
+assert_rejected "the pre-#3022 SHA-or-tag alternation" '([0-9a-f]{40}|refs/tags/v.+)' alternation
+assert_rejected "a bare tag ref"                       'refs/tags/v.+'                 tagonly
+assert_rejected "a tag ref with a literal version"     'refs/tags/v1.2.3'              tagliteral
+assert_rejected "a wildcard ref"                       '.+'                            wildcard
+assert_rejected "a branch ref"                         'refs/heads/main'               branchref
+assert_rejected "a bare moving ref"                    'main'                          bareref
+assert_rejected "a short commit"                       '0123456'                       shortsha
+assert_rejected "a partially grouped alternation"      '([0-9a-f]{40})?refs/heads/.+'   partialgroup
+
+# --- RED: the floor fails closed on a shrunken match set ---------------------
+#
+# An empty or reduced result from a filtered read is a claim about the FILTER. If
+# the subjects move to a key spelling the pattern does not know, the grep returns
+# less and the guard would otherwise report a clean repository having checked
+# nothing.
+
+tree="${work_dir}/red-floor"
+build_tree "${tree}" "[0-9a-f]{40}"
+rm "${tree}/k8s/subject-8.yaml"
+if run_tree "${tree}"; then
+  fail "guard passed with only seven subjects — the floor did not fail closed"
+fi
+grep -q 'expected at least' "${tree}/stderr" || fail "floor fired but with the wrong message"
+ok "fails closed when fewer subjects are found than expected"
+
+# --- RED: a reference discovered but not validated is reported ---------------
+#
+# A ninth consumer written in a form the strict pattern misses (a multiline
+# `subject: >-`, or a fourth key name) is invisible to validation while the eight
+# known subjects still satisfy the floor.
+
+tree="${work_dir}/red-unvalidated"
+build_tree "${tree}" "[0-9a-f]{40}"
+printf 'spec:\n  verify:\n    matchOIDCIdentity:\n      - issuer: x\n        someOtherKey: '\''^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@.+$'\''\n' \
+  >"${tree}/k8s/subject-9.yaml"
+if run_tree "${tree}"; then
+  fail "guard passed with an unvalidated shared-publish-workflow reference"
+fi
+grep -q 'did not validate' "${tree}/stderr" || fail "unvalidated-reference check fired with the wrong message"
+ok "reports a reference it discovered but could not validate"
+
+# --- The guard stays scoped: first-party tag signers are NOT its business ----
+#
+# ksail's own cd.yaml signs by release tag, legitimately and permanently. The
+# narrowed allow-list must not reach it — a guard that fires on the correct,
+# deployed configuration is one that gets switched off.
+
+tree="${work_dir}/scope"
+build_tree "${tree}" "[0-9a-f]{40}"
+printf 'spec:\n  attestors:\n    - cosign:\n        keyless:\n          identities:\n            - subjectRegExp: ^https://github\\.com/devantler-tech/ksail/\\.github/workflows/cd\\.yaml@refs/tags/v.+$\n' \
+  >"${tree}/k8s/ksail-signer.yaml"
+if run_tree "${tree}"; then
+  ok "ignores first-party tag signers outside the shared publish workflows"
+else
+  printf '%s\n' "$(cat "${tree}/stderr")" >&2
+  fail "guard fired on ksail's legitimate tag signer — it is out of scope"
+fi
+
+# --- Integration: the real repository satisfies the narrowed guard -----------
+
+if ( cd "${root_dir}" && bash "${guard}" >/dev/null 2>"${work_dir}/real.stderr" ); then
+  ok "the real repository passes the narrowed guard"
+else
+  printf '%s\n' "$(cat "${work_dir}/real.stderr")" >&2
+  fail "the real repository does not satisfy the narrowed guard"
+fi
+
+# Belt and braces: assert directly that no shared-publish subject still carries a
+# tag alternative, independently of the guard's own parsing. If the guard's
+# pattern ever stops matching these lines, the check above passes vacuously while
+# this one still sees the file contents.
+if grep -rnE 'workflows/publish-(app|manifests)\\?\.yaml@[^'\''"]*refs/tags' \
+  --include='*.yaml' "${root_dir}" >"${work_dir}/leftover" 2>/dev/null; then
+  printf '%s\n' "$(cat "${work_dir}/leftover")" >&2
+  fail "a shared-publish-workflow subject still accepts a tag ref"
+fi
+ok "no shared-publish-workflow subject accepts a tag ref"
+
+# --- Wiring: the guard is actually reached, in all three workflows -----------
+
+for wf in ci cd validate-main; do
+  file="${root_dir}/.github/workflows/${wf}.yaml"
+  [ -f "${file}" ] || fail "expected workflow ${file} to exist"
+  grep -q 'scripts/guard-shared-publish-workflow-pin\.sh' "${file}" \
+    || fail "${wf}.yaml does not invoke the guard — it would protect nothing there"
+  ok "${wf}.yaml invokes the guard"
+done
+
+# The guard must NOT sit behind a paths filter: its subjects live in k8s/, talos/
+# and the tenant RGD, so a PR touching only one of those trees must still run it.
+if grep -n -B4 'scripts/guard-shared-publish-workflow-pin\.sh' "${root_dir}/.github/workflows/ci.yaml" \
+  | grep -q "if:.*needs\.changes"; then
+  fail "the guard is gated on a paths filter in ci.yaml; it must run unconditionally"
+fi
+ok "the guard runs unconditionally in ci.yaml"
+
+printf '\n%d assertion(s) passed.\n' "${pass_count}"

--- a/scripts/tests/test-shared-publish-workflow-pin-guard.sh
+++ b/scripts/tests/test-shared-publish-workflow-pin-guard.sh
@@ -179,21 +179,52 @@ fi
 ok "no shared-publish-workflow subject accepts a tag ref"
 
 # --- Wiring: the guard is actually reached, in all three workflows -----------
+#
+# Match the STEP, never the string. `ci.yaml` names this guard twice — once as a
+# paths-filter entry and once as the step that runs it — so a substring test is
+# satisfied by the filter entry alone. Deleting the actual invocation would then
+# leave this file reporting every assertion green while no pull request executes
+# the guard at all: the exact vacuous pass this suite exists to prevent, and one
+# the filter entry added in this same change introduced.
+#
+# So ask the workflow's structure what it will RUN, via each job's steps, rather
+# than asking the file what text it contains.
+
+# guard_steps <workflow-file> — one line per step that invokes the guard,
+# formatted `<job>|<step-if>|<job-if>`. Empty output means nothing runs it.
+guard_steps() {
+  yq e -o=json '.jobs // {}' "$1" 2>/dev/null | jq -r '
+    to_entries[]
+    | .key as $job
+    | (.value.if // "") as $jobif
+    | (.value.steps // [])[]
+    | select((.run // "") | test("scripts/guard-shared-publish-workflow-pin\\.sh"))
+    | [$job, (.if // ""), $jobif] | join("|")
+  '
+}
 
 for wf in ci cd validate-main; do
   file="${root_dir}/.github/workflows/${wf}.yaml"
   [ -f "${file}" ] || fail "expected workflow ${file} to exist"
-  grep -q 'scripts/guard-shared-publish-workflow-pin\.sh' "${file}" ||
-    fail "${wf}.yaml does not invoke the guard — it would protect nothing there"
-  ok "${wf}.yaml invokes the guard"
+  steps="$(guard_steps "${file}")"
+  [ -n "${steps}" ] ||
+    fail "${wf}.yaml has no step whose run: invokes the guard — it would protect nothing there"
+  ok "${wf}.yaml runs the guard ($(printf '%s\n' "${steps}" | wc -l | tr -d ' ') step(s))"
 done
 
 # The guard must NOT sit behind a paths filter: its subjects live in k8s/, talos/
 # and the tenant RGD, so a PR touching only one of those trees must still run it.
-if grep -n -B4 'scripts/guard-shared-publish-workflow-pin\.sh' "${root_dir}/.github/workflows/ci.yaml" |
-  grep -q "if:.*needs\.changes"; then
-  fail "the guard is gated on a paths filter in ci.yaml; it must run unconditionally"
-fi
+# Check the step's own `if:` AND its job's — either one gates it.
+while IFS='|' read -r job stepif jobif; do
+  [ -n "${job}" ] || continue
+  case "${stepif}${jobif}" in
+    *needs.changes*)
+      fail "the guard is gated on a paths filter in ci.yaml (job ${job}: step-if='${stepif}' job-if='${jobif}'); it must run unconditionally"
+      ;;
+  esac
+done <<EOF
+$(guard_steps "${root_dir}/.github/workflows/ci.yaml")
+EOF
 ok "the guard runs unconditionally in ci.yaml"
 
 printf '\n%d assertion(s) passed.\n' "${pass_count}"

--- a/scripts/tests/test-shared-publish-workflow-pin-guard.sh
+++ b/scripts/tests/test-shared-publish-workflow-pin-guard.sh
@@ -66,7 +66,7 @@ build_tree() {
 # run_tree <dir> — exit status of the guard as that tree's repository root.
 run_tree() {
   local dir="$1" status=0
-  ( cd "${dir}" && bash "${dir}/scripts/guard-shared-publish-workflow-pin.sh" ) \
+  (cd "${dir}" && bash "${dir}/scripts/guard-shared-publish-workflow-pin.sh") \
     >"${dir}/stdout" 2>"${dir}/stderr" || status=$?
   return "${status}"
 }
@@ -95,19 +95,19 @@ assert_rejected() {
   if run_tree "${dir}"; then
     fail "guard ACCEPTED ${label} (ref: ${ref}) — the widening is not enforced"
   fi
-  grep -q 'does not pin\|not a fully grouped' "${dir}/stderr" \
-    || fail "guard rejected ${label} but not for the ref reason: $(head -1 "${dir}/stderr")"
+  grep -q 'does not pin\|not a fully grouped' "${dir}/stderr" ||
+    fail "guard rejected ${label} but not for the ref reason: $(head -1 "${dir}/stderr")"
   ok "rejects ${label}"
 }
 
 assert_rejected "the pre-#3022 SHA-or-tag alternation" '([0-9a-f]{40}|refs/tags/v.+)' alternation
-assert_rejected "a bare tag ref"                       'refs/tags/v.+'                 tagonly
-assert_rejected "a tag ref with a literal version"     'refs/tags/v1.2.3'              tagliteral
-assert_rejected "a wildcard ref"                       '.+'                            wildcard
-assert_rejected "a branch ref"                         'refs/heads/main'               branchref
-assert_rejected "a bare moving ref"                    'main'                          bareref
-assert_rejected "a short commit"                       '0123456'                       shortsha
-assert_rejected "a partially grouped alternation"      '([0-9a-f]{40})?refs/heads/.+'   partialgroup
+assert_rejected "a bare tag ref" 'refs/tags/v.+' tagonly
+assert_rejected "a tag ref with a literal version" 'refs/tags/v1.2.3' tagliteral
+assert_rejected "a wildcard ref" '.+' wildcard
+assert_rejected "a branch ref" 'refs/heads/main' branchref
+assert_rejected "a bare moving ref" 'main' bareref
+assert_rejected "a short commit" '0123456' shortsha
+assert_rejected "a partially grouped alternation" '([0-9a-f]{40})?refs/heads/.+' partialgroup
 
 # --- RED: the floor fails closed on a shrunken match set ---------------------
 #
@@ -160,7 +160,7 @@ fi
 
 # --- Integration: the real repository satisfies the narrowed guard -----------
 
-if ( cd "${root_dir}" && bash "${guard}" >/dev/null 2>"${work_dir}/real.stderr" ); then
+if (cd "${root_dir}" && bash "${guard}" >/dev/null 2>"${work_dir}/real.stderr"); then
   ok "the real repository passes the narrowed guard"
 else
   printf '%s\n' "$(cat "${work_dir}/real.stderr")" >&2
@@ -183,15 +183,15 @@ ok "no shared-publish-workflow subject accepts a tag ref"
 for wf in ci cd validate-main; do
   file="${root_dir}/.github/workflows/${wf}.yaml"
   [ -f "${file}" ] || fail "expected workflow ${file} to exist"
-  grep -q 'scripts/guard-shared-publish-workflow-pin\.sh' "${file}" \
-    || fail "${wf}.yaml does not invoke the guard — it would protect nothing there"
+  grep -q 'scripts/guard-shared-publish-workflow-pin\.sh' "${file}" ||
+    fail "${wf}.yaml does not invoke the guard — it would protect nothing there"
   ok "${wf}.yaml invokes the guard"
 done
 
 # The guard must NOT sit behind a paths filter: its subjects live in k8s/, talos/
 # and the tenant RGD, so a PR touching only one of those trees must still run it.
-if grep -n -B4 'scripts/guard-shared-publish-workflow-pin\.sh' "${root_dir}/.github/workflows/ci.yaml" \
-  | grep -q "if:.*needs\.changes"; then
+if grep -n -B4 'scripts/guard-shared-publish-workflow-pin\.sh' "${root_dir}/.github/workflows/ci.yaml" |
+  grep -q "if:.*needs\.changes"; then
   fail "the guard is gated on a paths filter in ci.yaml; it must run unconditionally"
 fi
 ok "the guard runs unconditionally in ci.yaml"

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -269,7 +269,33 @@ const (
 //
 // The fingerprint itself was read from the required job's own output on the
 // approved renderer, because the local toolchain is refused as unapproved.
-const expectedRenderedSurfaceSHA = "94b0082679234b6c6c2ddf7f655f5445e3022ba486c8cb3e86826d5b2730a896"
+//
+// This value covers removing the `refs/tags/v.+` signer alternative from the
+// shared-publish-workflow cosign matchers (#3022). Measured against main
+// cd47606c by rendering all five roots from both trees: 515 documents on both
+// sides, membership IDENTICAL — set difference in BOTH directions over
+// apiVersion|kind|namespace|name returned zero, so nothing was added, removed
+// or renamed. Exactly SEVEN lines move in the whole production render, and
+// every one of them is a cosign subject matcher losing its tag alternative:
+//
+//	source.toolkit.fluxcd.io/v1  OCIRepository  {wedding-app, ascoachingogvaner,
+//	                                             doggy-countdown, github-config, aws}
+//	kro.run/v1alpha1             ResourceGraphDefinition  tenant.kro.run
+//	policies.kyverno.io/v1alpha1 ImageValidatingPolicy    verify-app-images
+//
+//	  @([0-9a-f]{40}|refs/tags/v.+)  ->  @[0-9a-f]{40}
+//
+// It is strictly a tightening: every subject the new matcher accepts, the old
+// one already accepted. No grant-bearing object moved — those seven lines are
+// the ENTIRE delta across the surface, so every Role / ClusterRole /
+// RoleBinding / ClusterRoleBinding / ServiceAccount document is byte-identical,
+// as is every `aws`-bearing line. Nothing granted to the aws/aws service
+// account this validator exists to protect is touched.
+//
+// (The eighth narrowed subject lives in talos/cluster/verify-first-party-images
+// .yaml, which is Talos machine config rather than a Kubernetes manifest and so
+// is outside this rendered surface entirely.)
+const expectedRenderedSurfaceSHA = "4d54629149b43fc6aa43004353fc92e3f1f95e154bcb750bf6b2b70fb4848e49"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.
@@ -323,7 +349,7 @@ var expectedRenderedHashes = map[resourceIdentity]string{
 	{apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding", name: "oidc-cluster-reader"}:                               "7d896404f02d6418c289065d73f9ad79345217d76c8d89eadca2c06e6066b487",
 	{apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding", name: "oidc-view"}:                                         "4d07ba3a995cfc139351b4227739efeba9348777f7fe47ac69b87d08e70bd45f",
 	{apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding", name: "opencost-usage-scraper"}:                            "4b28e1da280a7940a1cb4d538bc31ede1b5d272c17189a81afeae48acbb8b7a0",
-	{apiVersion: "kro.run/v1alpha1", kind: "ResourceGraphDefinition", name: "tenant.kro.run"}:                                           "a4ab25489f2548aec728d4706aff02246d4669538b0f577c57bef132051910b6",
+	{apiVersion: "kro.run/v1alpha1", kind: "ResourceGraphDefinition", name: "tenant.kro.run"}:                                           "e23c61eb872c6aafaceed74e400479d034ee636735880d6b4a6de338cd0c32a9",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "ascoachingogvaner", name: "ascoachingogvaner"}:    "89ea0484e37b691594b7a72be2ca2de285697818bf88a5b37b4fa8a9161c54fa",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "aws", name: "aws"}:                                "7bde9c682a81b752bdf9d2b14ce69ca1690008a39f2562d4887f8200447dea71",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "flux-system", name: "apps"}:                       "1a2ecb3104630c44466d846159ee68ff6a98888887c02ecd0278782793dead4a",

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -17,8 +17,8 @@
 #      its default branch (that workflow is workflow_dispatch-only).
 #   3. the app images (wedding-app, ascoachingogvaner, …) are signed by the
 #      shared publish-app.yaml workflow in devantler-tech/actions, pinned by
-#      commit SHA or release tag — the SAME form their Flux OCIRepository verify
-#      blocks and the verify-app-images ImageValidatingPolicy pin.
+#      commit SHA — the SAME form their Flux OCIRepository verify blocks and the
+#      verify-app-images ImageValidatingPolicy pin (#3022).
 # Talos evaluates rules in order, first match wins, so the two specific rules
 # MUST precede the ghcr.io/devantler-tech/* catch-all.
 #
@@ -68,11 +68,11 @@ rules:
       issuer: https://token.actions.githubusercontent.com
       subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/heads/main$
   # First-party APP images signed by the shared publish-app.yaml workflow in
-  # devantler-tech/actions. Callers pin that reusable workflow either by commit
-  # SHA or by release tag, so the ref alternation admits exactly those two forms
-  # and rejects a mutable ref such as @main. Same shape as the apps' Flux
+  # devantler-tech/actions. Callers pin that reusable workflow by commit SHA, so
+  # the ref admits that form alone and rejects everything else — a mutable ref
+  # such as @main, and a release tag (#3022). Same shape as the apps' Flux
   # OCIRepository verify blocks and the verify-app-images ImageValidatingPolicy.
   - image: ghcr.io/devantler-tech/*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$
+      subjectRegex: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Every cosign matcher that trusts a shared `devantler-tech/actions` publish workflow accepted two ref
shapes: a commit, **or any release tag**. The tag half was speculative width — it widened the set of
signers we trust without covering a single artifact that actually exists. Anything signed under it
would verify, and nothing we ship is signed that way.

It was left in place because removing it wrongly is the expensive direction: an artifact that *had*
been tag-signed would silently stop verifying, which surfaces as a tenant that no longer reconciles
or an app that no longer admits — not as a failed build. So it needed evidence, not a grep.

That evidence is now in, from two independent directions, and both say the same thing:

- **What actually signed our artifacts** — 63 published versions across four packages, read from
  their signing certificates. Every one commit-form. None tag-form.
- **What our repositories have ever asked for** — the complete history of all six consumers, 30
  revisions that call a shared publish workflow. Every one pins by commit. None by tag, ever.

## What

Removes the tag alternative from all eight matchers, so only a commit-pinned workflow is trusted.

Also closes the way back: the guard added in #3021 would still have accepted the old two-form shape,
so a future edit could have restored it with every check green. It now rejects it — and gains its
first test, which it never had. The test pins the exact prior shape as a case that must fail, so this
change cannot quietly revert.

**Everything currently deployed is accounted for.** Three of the five referenced artifacts were read
directly from their signing certificates. The other two — `wedding-app` and `ascoachingogvaner`, whose
packages are private — were pinned by resolving each deployed version back to the commit that
published it and reading that commit's `cd.yaml`: both pin the shared workflow by commit. The cosign
subject is GitHub's `job_workflow_ref`, i.e. the ref the caller used, so those artifacts cannot carry
a tag-form identity. That mechanism is confirmed rather than assumed — `doggy-countdown`'s image and
manifests from one run carry the caller's exact pinned commit. The evidence is in a comment below.

What is left inferential is narrow: older tags still sitting in those two private registries that the
`>=1.0.0` semver range could re-select if a newer one were deleted. The full-history scan covers that
case (30 of 30 caller revisions commit-pinned, none tag-pinned, ever), but it is inference rather than
a certificate read, so it is called out rather than buried.

The image-wide matchers are where a mistake would hurt most — over-constraining that same attestor
denied wedding-app at admission for hours on 2026-07-04 — so that is the part most worth a second
look. Exactly three running images fall under it: `wedding-app`, `ascoachingogvaner` and
`doggy-countdown`. `ksail` and `provider-upjet-unifi` have their own attestors and are untouched.

No behaviour changes for anything currently deployed: every artifact in the registry already
verifies under the narrowed form.

Fixes #3022


