### PR TITLE
security(ci): detect MegaLinter scanner-version drift automatically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,10 @@ jobs:
               - '.trivyignore.yaml'
               - 'scripts/megalinter-scan-counts.sh'
               - 'scripts/tests/test-megalinter-scan-counts-ignorefile.sh'
+              # The version-drift guard reads its constants out of
+              # megalinter-scan-counts.sh, so the three move together.
+              - 'scripts/check-megalinter-version-drift.sh'
+              - 'scripts/tests/test-check-megalinter-version-drift.sh'
               # Both halves, so editing the guard alone — or its test alone —
               # still runs the check that covers it.
               - 'scripts/normalize-sarif-paths.sh'
@@ -321,6 +325,17 @@ jobs:
         # reproduction helper at its command boundary so a future argument
         # cleanup cannot silently turn every scoped disposition back on.
         run: bash scripts/tests/test-megalinter-scan-counts-ignorefile.sh
+
+      - name: 🔢 Validate scanner version-drift guard
+        if: needs.changes.outputs.k8s == 'true'
+        # Guards the guard, offline. The live comparison runs on main
+        # (validate-main.yaml) because it needs to read Actions logs, which a
+        # fork PR's token cannot do — gating PRs on it would fail closed on
+        # every fork. What is checked here is the parsing contract, whose
+        # dangerous direction is a log-format change reading as "no drift".
+        run: |
+          shellcheck scripts/check-megalinter-version-drift.sh
+          bash scripts/tests/test-check-megalinter-version-drift.sh
 
       - name: 🔐 Validate OpenBao OIDC admin role
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -242,3 +242,33 @@ jobs:
         run: |
           shellcheck scripts/summarize-sarif-findings.sh
           bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"
+
+  validate-scanner-versions:
+    name: 🔢 Validate Scanner Versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+      actions: read # read the mega-linter job log to learn the live versions
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🔢 Compare recorded scanner versions against the live MegaLinter run
+        # scripts/megalinter-scan-counts.sh reproduces CI's checkov and trivy
+        # counts, and #2787 reads those counts as backlog movement. Its
+        # equivalence holds only at the versions it records — and nothing in
+        # THIS repository selects them: the MegaLinter action is pinned in
+        # devantler-tech/actions, so the constants here go stale with no signal
+        # when that pin moves. A rule-set change then looks exactly like someone
+        # fixing findings.
+        #
+        # On main rather than on PRs for two reasons: reading Actions logs needs
+        # a token a fork PR does not have, and version drift is slow-moving, so
+        # per-PR is the wrong cadence. The offline parsing contract IS gated on
+        # PRs, in ci.yaml.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/check-megalinter-version-drift.sh

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -39,7 +39,16 @@ REPO="${GITHUB_REPOSITORY:-devantler-tech/platform}"
 MEGALINTER_JOB_MATCH='mega-linter'
 MAX_RUNS=40
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The org-managed workflow that runs mega-linter for this repository. Binding to it is a PROVENANCE
+# check, not decoration: the job is selected out of arbitrary recent runs, and a job's display name
+# is attacker-controllable — a pull request can add a workflow with a job called "mega-linter" that
+# prints three convincing `- Using [...]` lines. Matching the name alone would let that run supply
+# the versions, which could mask real drift or wedge main red.
+readonly MANAGED_WORKFLOW_PATH='.github/workflows/validate-go-project.yaml'
+
+# Overridable so the contract suite can exercise the provenance branch below against a synthetic
+# tree. Defaults to this script's own repository, which is what CI uses.
+REPO_ROOT="${DRIFT_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 readonly REPO_ROOT
 CONSTANTS_FILE="$REPO_ROOT/scripts/megalinter-scan-counts.sh"
 readonly CONSTANTS_FILE
@@ -108,10 +117,46 @@ extract_one() {
 resolve_log() {
   command -v gh >/dev/null 2>&1 || die_unverifiable 'gh is not installed'
   local dest="$1" run_id job_id runs
+
+  # This repository must NOT define the managed workflow itself. If it ever does, the path stops
+  # being proof of org-managed provenance — an in-repo file could then be edited to emit whatever
+  # versions it likes. Fail closed and make a human look rather than silently trusting it.
+  if [ -f "$REPO_ROOT/$MANAGED_WORKFLOW_PATH" ]; then
+    die_unverifiable "$MANAGED_WORKFLOW_PATH now exists in this repository, so its runs no longer
+prove org-managed provenance. Re-establish how the mega-linter job is identified before trusting it."
+  fi
+
+  # `gh api` refuses a response containing terminal escape sequences unless allowed explicitly, and
+  # Actions logs always contain them — but the flag only exists on newer gh (present and required on
+  # 2.97.0; reported absent on 2.96.0). Probe for it rather than assuming either way: passing an
+  # unknown flag aborts, and omitting a needed one aborts too.
+  #
+  # Written as two literal calls rather than an argument array on purpose: under `set -u`, expanding
+  # an EMPTY array as "${arr[@]}" is an unbound-variable error on bash 3.2, which is what macOS
+  # ships. That aborted this function mid-run when the flag was absent.
+  # NOT `gh api --help | grep -q …`: under `pipefail`, `grep -q` exits on the first match and closes
+  # the pipe, gh dies of SIGPIPE, and the pipeline reports FAILURE — so the probe answers "absent"
+  # on a gh that has the flag. Measured here on 2.97.0. Capture the text, then match it.
+  local esc_supported=no help_text
+  help_text="$(gh api --help 2>&1 || true)"
+  case "$help_text" in
+    *--allow-escape-sequences*) esc_supported=yes ;;
+  esac
+
+  fetch_log() { # $1 job id, $2 destination
+    if [ "$esc_supported" = yes ]; then
+      gh api --allow-escape-sequences "repos/$REPO/actions/jobs/$1/logs" >"$2"
+    else
+      gh api "repos/$REPO/actions/jobs/$1/logs" >"$2"
+    fi
+  }
+
+  # Select by the managed workflow's PATH, not the run's display name, then by job name within it.
   runs="$(gh api "repos/$REPO/actions/runs?per_page=$MAX_RUNS" \
-    --jq '.workflow_runs[].id' 2>/dev/null)" ||
+    --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | .id" 2>/dev/null)" ||
     die_unverifiable "could not list recent runs for $REPO"
-  [ -n "$runs" ] || die_unverifiable "no recent workflow runs found for $REPO"
+  [ -n "$runs" ] ||
+    die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
 
   for run_id in $runs; do
     # A skipped job states no versions, so require one that actually executed.
@@ -121,8 +166,9 @@ resolve_log() {
             | select(.conclusion == \"success\" or .conclusion == \"failure\")
             | .id" 2>/dev/null | head -1)" || continue
     if [ -n "$job_id" ]; then
-      printf 'Reading mega-linter job %s (run %s) in %s\n' "$job_id" "$run_id" "$REPO" >&2
-      gh api --allow-escape-sequences "repos/$REPO/actions/jobs/$job_id/logs" >"$dest" 2>/dev/null ||
+      printf 'Reading mega-linter job %s (run %s of %s) in %s\n' \
+        "$job_id" "$run_id" "$MANAGED_WORKFLOW_PATH" "$REPO" >&2
+      fetch_log "$job_id" "$dest" ||
         die_unverifiable "could not download the log for job $job_id"
       return 0
     fi

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Fail when the scanner versions recorded in scripts/megalinter-scan-counts.sh no longer match the
+# ones MegaLinter actually runs in CI (#2853).
+#
+# WHY THIS EXISTS
+# megalinter-scan-counts.sh reproduces CI's checkov and trivy counts locally, and its equivalence is
+# EMPIRICAL — established against one CI run at three specific versions. Nothing in this repository
+# selects those versions: the MegaLinter action is pinned in devantler-tech/actions. When that pin
+# moves, the constants here go stale with no signal at all, and the helper's advisory note starts
+# misleading in both directions — claiming a mismatch that no longer exists, or staying silent on a
+# real one. A rule-set change between scanner versions looks exactly like backlog movement, which is
+# the one thing #2787 must be able to tell apart.
+#
+# WHY IT LIVES IN CI AND NOT IN THE HELPER
+# The helper's whole value is being an offline answer available before pushing. Deriving the live
+# versions costs an authenticated API call and log download, so folding it in would put the network
+# on the ordinary pre-push path. This runs in CI instead, where that cost is already paid.
+#
+# WHERE THE LIVE VERSIONS COME FROM
+# The "🧹 Lint - mega-linter" job log prints them itself:
+#   ghcr.io/oxsecurity/megalinter-go:v9.6.0
+#   - Using [checkov v3.3.2] https://megalinter.io/9.6.0/descriptors/repository_checkov
+#   - Using [trivy v0.71.2] https://megalinter.io/9.6.0/descriptors/repository_trivy
+#
+# FINDING THAT JOB IS THE AWKWARD PART, and the reason this walks runs instead of reading one:
+#   * The workflow that runs mega-linter ("✅ Validate Go Project") is NOT in this repository — it is
+#     org-managed, absent from the repo's workflow list, and its workflow id 404s. So this cannot be
+#     a job with `needs:` on it, and it cannot be located by workflow file either.
+#   * mega-linter is `skipped` on main. Measured 2026-08-09: skipped on all 25 most recent main
+#     commits, including ones that changed k8s/. Reading "the latest run on main" therefore finds a
+#     job that ran nothing and states no versions.
+# So: walk recent runs newest-first and take the first mega-linter job that actually executed.
+#
+# Exit codes: 0 in sync · 1 drift (act on it) · 2 could not verify (fail closed).
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-devantler-tech/platform}"
+MEGALINTER_JOB_MATCH='mega-linter'
+MAX_RUNS=40
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+CONSTANTS_FILE="$REPO_ROOT/scripts/megalinter-scan-counts.sh"
+readonly CONSTANTS_FILE
+CONSTANTS_REL='scripts/megalinter-scan-counts.sh'
+readonly CONSTANTS_REL
+
+log_file=''
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-file)
+      log_file="${2:?--log-file needs a path}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:?--repo needs owner/name}"
+      shift 2
+      ;;
+    -h | --help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+die_unverifiable() {
+  printf 'CANNOT VERIFY: %s\n' "$1" >&2
+  printf 'Failing closed: an unreadable log is not evidence that the versions still match.\n' >&2
+  exit 2
+}
+
+# Read a constant from the file that owns it, rather than keeping a second copy that can itself go
+# stale — the exact failure this guard exists to prevent.
+read_const() {
+  local name="$1" value
+  value="$(sed -n "s/^readonly $name='\([^']*\)'.*/\1/p" "$CONSTANTS_FILE")"
+  [ -n "$value" ] || die_unverifiable "could not read $name from $CONSTANTS_REL"
+  printf '%s' "$value"
+}
+
+# Extract exactly one version for a tool. Fails closed on absent OR conflicting matches: a log with
+# two different versions for one tool is not describing a single run, and silently taking one of
+# them would report a comparison that means nothing.
+#
+# The pattern is anchored per tool because the real log contains `- Using [trivy-sbom v0.71.2]`
+# directly beside `- Using [trivy v0.71.2]`; an unanchored match reads the sbom's version, which
+# tracks a different component and would drift independently.
+extract_one() {
+  local label="$1" pattern="$2" file="$3" found
+  found="$(grep -aoE "$pattern" "$file" | grep -aoE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' |
+    sort -u || true)"
+  if [ -z "$found" ]; then
+    die_unverifiable "could not find the $label version marker in the mega-linter log"
+  fi
+  if [ "$(printf '%s\n' "$found" | wc -l | tr -d ' ')" -ne 1 ]; then
+    printf 'CANNOT VERIFY: conflicting %s versions in one log: %s\n' \
+      "$label" "$(printf '%s' "$found" | tr '\n' ' ')" >&2
+    exit 2
+  fi
+  printf '%s' "$found"
+}
+
+resolve_log() {
+  command -v gh >/dev/null 2>&1 || die_unverifiable 'gh is not installed'
+  local dest="$1" run_id job_id runs
+  runs="$(gh api "repos/$REPO/actions/runs?per_page=$MAX_RUNS" \
+    --jq '.workflow_runs[].id' 2>/dev/null)" ||
+    die_unverifiable "could not list recent runs for $REPO"
+  [ -n "$runs" ] || die_unverifiable "no recent workflow runs found for $REPO"
+
+  for run_id in $runs; do
+    # A skipped job states no versions, so require one that actually executed.
+    job_id="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
+      --jq ".jobs[]
+            | select(.name | test(\"$MEGALINTER_JOB_MATCH\"))
+            | select(.conclusion == \"success\" or .conclusion == \"failure\")
+            | .id" 2>/dev/null | head -1)" || continue
+    if [ -n "$job_id" ]; then
+      printf 'Reading mega-linter job %s (run %s) in %s\n' "$job_id" "$run_id" "$REPO" >&2
+      gh api --allow-escape-sequences "repos/$REPO/actions/jobs/$job_id/logs" >"$dest" 2>/dev/null ||
+        die_unverifiable "could not download the log for job $job_id"
+      return 0
+    fi
+  done
+  die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job in the last $MAX_RUNS runs of $REPO"
+}
+
+ci_megalinter="$(read_const CI_MEGALINTER_VERSION)"
+ci_checkov="$(read_const CI_CHECKOV_VERSION)"
+ci_trivy="$(read_const CI_TRIVY_VERSION)"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+if [ -n "$log_file" ]; then
+  [ -r "$log_file" ] || die_unverifiable "log file not readable: $log_file"
+  cp "$log_file" "$scratch/job.log"
+else
+  resolve_log "$scratch/job.log"
+fi
+[ -s "$scratch/job.log" ] || die_unverifiable 'the mega-linter log is empty'
+
+live_megalinter="$(extract_one megalinter 'ghcr\.io/oxsecurity/megalinter[a-z-]*:v[0-9][^[:space:]"]*' "$scratch/job.log")"
+live_checkov="$(extract_one checkov '\[checkov v[0-9][^]]*\]' "$scratch/job.log")"
+live_trivy="$(extract_one trivy '\[trivy v[0-9][^]]*\]' "$scratch/job.log")"
+
+drifted=''
+compare() {
+  local label="$1" constant="$2" recorded="$3" live="$4"
+  if [ "$recorded" = "$live" ]; then
+    printf '  %-11s %-10s matches CI\n' "$label" "$recorded"
+  else
+    printf '  %-11s %-10s CI now runs %s   <-- DRIFT (%s)\n' "$label" "$recorded" "$live" "$constant"
+    drifted="$drifted $constant=$live"
+  fi
+}
+
+printf 'Recorded vs live MegaLinter scanner versions:\n'
+compare megalinter "CI_MEGALINTER_VERSION" "$ci_megalinter" "$live_megalinter"
+compare checkov "CI_CHECKOV_VERSION" "$ci_checkov" "$live_checkov"
+compare trivy "CI_TRIVY_VERSION" "$ci_trivy" "$live_trivy"
+
+if [ -n "$drifted" ]; then
+  cat >&2 <<EOF
+
+DRIFT: MegaLinter in CI no longer runs the versions $CONSTANTS_REL records.
+
+Why this fails the build rather than warning: a scanner rule-set change adds or retires findings, and
+that is indistinguishable from someone fixing or introducing them. Leaving the constants stale means
+the next #2787 slice cannot tell which it measured.
+
+To fix, set these in $CONSTANTS_REL:
+EOF
+  for pair in $drifted; do
+    printf "  readonly %s='%s'\n" "${pair%%=*}" "${pair##*=}" >&2
+  done
+  cat >&2 <<EOF
+
+Then re-measure the checkov baseline on the new version and record it on #2787 — the count may move
+for reasons that are not backlog progress. If CI_CHECKOV_FRAMEWORKS' per-framework baselines change
+too, update them in the same commit.
+EOF
+  exit 1
+fi
+
+printf '\nIn sync with MegaLinter %s.\n' "$live_megalinter"

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -151,14 +151,43 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
     fi
   }
 
+  # Succeeds only when the managed workflow is POSITIVELY absent at revision $1.
+  #
+  # The repository-level check above proves only that MAIN does not define it. A run's `.path` is
+  # the workflow's path IN THE REVISION THAT RAN, so a pull request that adds
+  # `.github/workflows/validate-go-project.yaml` on its own branch produces a run whose path matches
+  # the selector exactly while main stays clean — and its `mega-linter` job would then supply
+  # whatever versions it likes. Provenance therefore has to be established per candidate.
+  #
+  # The commit is resolved first because a 404 from the contents endpoint is ambiguous on its own:
+  # it means "no such file" OR "no such commit". With the commit known to resolve, the second 404
+  # can only mean the file is absent. Anything other than a clean 404 is not evidence of absence,
+  # so it returns non-zero and the candidate is skipped rather than trusted.
+  managed_path_absent_at() {
+    local sha="$1" resp status
+    gh api "repos/$REPO/commits/$sha" >/dev/null 2>&1 || return 1
+    resp="$(gh api -i "repos/$REPO/contents/$MANAGED_WORKFLOW_PATH?ref=$sha" 2>/dev/null || true)"
+    status="$(printf '%s\n' "$resp" | sed -n '1s|^HTTP/[0-9.]* \([0-9][0-9][0-9]\).*|\1|p')"
+    [ "$status" = 404 ]
+  }
+
   # Select by the managed workflow's PATH, not the run's display name, then by job name within it.
   runs="$(gh api "repos/$REPO/actions/runs?per_page=$MAX_RUNS" \
-    --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | .id" 2>/dev/null)" ||
+    --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha)\"" \
+    2>/dev/null)" ||
     die_unverifiable "could not list recent runs for $REPO"
   [ -n "$runs" ] ||
     die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
 
-  for run_id in $runs; do
+  local head_sha
+  while read -r run_id head_sha; do
+    [ -n "$run_id" ] || continue
+    if ! managed_path_absent_at "$head_sha"; then
+      printf 'Skipping run %s: %s is not provably absent at its revision %s, so that run is not\n' \
+        "$run_id" "$MANAGED_WORKFLOW_PATH" "$head_sha" >&2
+      printf '  org-managed and its log is not evidence of anything.\n' >&2
+      continue
+    fi
     # A skipped job states no versions, so require one that actually executed.
     job_id="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
       --jq ".jobs[]
@@ -172,8 +201,11 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
         die_unverifiable "could not download the log for job $job_id"
       return 0
     fi
-  done
-  die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job in the last $MAX_RUNS runs of $REPO"
+  done <<EOF
+$runs
+EOF
+  die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job from a provably org-managed run in the
+last $MAX_RUNS runs of $REPO"
 }
 
 ci_megalinter="$(read_const CI_MEGALINTER_VERSION)"

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -46,6 +46,17 @@ set -euo pipefail
 readonly CI_CHECKOV_VERSION='3.3.2'
 readonly CI_TRIVY_VERSION='0.71.2'
 
+# The MegaLinter release those two versions came from. It is not a local concept — nothing here runs
+# MegaLinter — but it is what makes the pair above checkable: MegaLinter bundles both scanners AND
+# the .checkov.yml this script deliberately drops, all inside one immutable image tag. So the image
+# version is the single provenance for every CI-side input this script models, and the only one of
+# them that a log states directly.
+#
+# Nothing in THIS repository selects it: the MegaLinter action is pinned in devantler-tech/actions,
+# so all three constants go stale here when that pin moves, silently and in both directions.
+# scripts/check-megalinter-version-drift.sh is the CI-side guard that catches it (#2853).
+readonly CI_MEGALINTER_VERSION='9.6.0'
+
 # The frameworks MegaLinter's checkov run reports, and their current contribution to the CI total.
 #
 # A missing framework is REPORTED, never refused, because the two causes are indistinguishable from
@@ -65,6 +76,24 @@ readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:15 secrets:0 github_
 # is a ceiling rather than a zero check — refusing on any parsing error would refuse on the current,
 # CI-matching state. Anything above the ceiling is local-only and breaks comparability.
 readonly CI_CHECKOV_PARSING_ERRORS=1
+
+# TWO RESIDUAL DRIFT RISKS, REVIEWED AND ACCEPTED (#2853). Recorded here rather than fixed, because
+# in both cases the fix costs more than the failure it prevents. Revisit if either assumption moves.
+#
+#   Parsing-error IDENTITY, not just count. The check above compares a count, so one file becoming
+#   parsable while another stops would net to zero and pass. Detecting that needs per-file parse
+#   errors, which --compact suppresses — so closing it means dropping --compact and parsing full
+#   output, a large rewrite of every count path here. Accepted because the blast radius is small and
+#   self-limiting: the swap would have to happen between two runs, and any findings hidden behind the
+#   newly-unparsable file still surface in CI, which does not use this script. The count remains a
+#   ceiling, so the common direction — a NEW parse error appearing — is still caught.
+#
+#   Trivy's vulnerability DATABASE revision moves independently of the CLI version, so
+#   check-megalinter-version-drift.sh cannot pin it. No effect today: this repository reports 0
+#   vulnerabilities, and the misconfiguration counts that #2787 tracks come from built-in policies
+#   rather than the DB. Accepted on that basis, and the reason the two categories are reported
+#   SEPARATELY below is to keep it visible — a vulnerability count that moves without a code change
+#   is the signal that this assumption has expired.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly REPO_ROOT
@@ -271,7 +300,7 @@ report_version() {
   fi
 }
 
-printf 'Scanner versions:\n'
+printf 'Scanner versions (CI runs them from MegaLinter %s):\n' "$CI_MEGALINTER_VERSION"
 if [ "$scanner" != trivy ]; then
   require_tool checkov 'brew install checkov'
   report_version checkov "$CI_CHECKOV_VERSION" "$(checkov --version 2>/dev/null | tr -d '[:space:]')"

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -158,6 +158,122 @@ else
   printf 'ok: control — without the in-repo copy the provenance check does not fire\n'
 fi
 
+# ---- PROVENANCE, PER CANDIDATE RUN -------------------------------------------------------------
+# The case above only proves MAIN does not define the managed workflow. A run's `.path` is the
+# workflow's path IN THE REVISION THAT RAN, so a pull request that adds a file at that same path
+# produces a run matching the selector exactly while main stays clean — and its `mega-linter` job
+# can then print any versions it likes. Provenance must therefore be re-checked at each candidate's
+# own revision.
+#
+# These cases drive the live selection path (no --log-file) through a `gh` stand-in that emits what
+# the real command would after its own --jq filtering.
+cat >"$scratch/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *--help*) printf -- '--allow-escape-sequences\n' ;;
+  *actions/jobs/*/logs*)
+    job="${args##*actions/jobs/}"
+    job="${job%%/logs*}"
+    cat "$GH_STUB_LOGDIR/$job.log" ;;
+  *actions/runs/*/jobs*)
+    run="${args##*actions/runs/}"
+    run="${run%%/jobs*}"
+    printf 'job%s\n' "$run" ;;
+  *actions/runs*per_page*) cat "$GH_STUB_RUNS" ;;
+  *contents/.github/workflows/validate-go-project.yaml*)
+    sha="${args##*ref=}"
+    if grep -qxF -- "$sha" "$GH_STUB_TAINTED"; then
+      printf 'HTTP/2.0 200 OK\n'
+    else
+      printf 'HTTP/2.0 404 Not Found\n'
+    fi ;;
+  *commits/*)
+    sha="${args##*commits/}"
+    if grep -qxF -- "$sha" "$GH_STUB_UNRESOLVABLE"; then exit 1; fi
+    printf 'resolved\n' ;;
+  *) printf 'unexpected gh call: %s\n' "$args" >&2; exit 99 ;;
+esac
+STUB
+chmod +x "$scratch/bin/gh"
+mkdir -p "$scratch/logs"
+export GH_STUB_LOGDIR="$scratch/logs"
+export GH_STUB_RUNS="$scratch/runs.txt"
+export GH_STUB_TAINTED="$scratch/tainted.txt"
+export GH_STUB_UNRESOLVABLE="$scratch/unresolvable.txt"
+: >"$scratch/unresolvable.txt"
+
+tainted_sha='deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+genuine_sha='cafebabecafebabecafebabecafebabecafebabe'
+
+# Run 111 is attacker-controlled: its revision defines the managed workflow, and its log states
+# versions that do NOT match the constants — so trusting it is visible as drift.
+make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
+make_log "$ci_megalinter" "$ci_checkov" "$ci_trivy" "$scratch/logs/job222.log"
+printf '%s\n' "$tainted_sha" >"$scratch/tainted.txt"
+
+run_live() {
+  out="$(DRIFT_REPO_ROOT="$scratch/fakerepo" PATH="$scratch/bin:$PATH" "$script" 2>&1)" && rc=0 || rc=$?
+}
+
+# A tainted run as the ONLY candidate must never have its log consumed.
+printf '111 %s\n' "$tainted_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 2 ]; then
+  printf 'FAIL: tainted-only candidate — expected exit 2, got %d (its log was trusted)\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$out" | grep -qF 'CANNOT VERIFY'; then
+  printf 'FAIL: tainted-only candidate — exit 2 but not a fail-closed refusal\n%s\n' "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a run whose own revision defines the managed workflow is not trusted\n'
+fi
+
+# Negative control: the SAME candidate, now untainted, must be consumed and read as in sync. Without
+# this the assertion above would pass for any unrelated refusal.
+: >"$scratch/tainted.txt"
+cp "$scratch/logs/job222.log" "$scratch/logs/job111.log"
+run_live
+if [ "$rc" -ne 0 ]; then
+  printf 'FAIL: control — an untainted candidate should be consumed, got exit %d\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: control — an untainted candidate is still consumed\n'
+fi
+
+# Discrimination: the newest candidate is tainted, the next is genuine. The guard must SKIP the
+# first and use the second. Consuming the first reports drift (exit 1) and aborting on it fails
+# closed (exit 2), so only skipping-and-continuing yields exit 0.
+make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
+printf '%s\n' "$tainted_sha" >"$scratch/tainted.txt"
+printf '111 %s\n222 %s\n' "$tainted_sha" "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 0 ]; then
+  printf 'FAIL: discrimination — expected exit 0 from the genuine run, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a tainted candidate is skipped and a later genuine one is used\n'
+fi
+
+# A revision that does not resolve is not evidence of absence. The contents endpoint answers 404
+# for "no such file" AND for "no such commit", so without resolving the commit first an
+# unresolvable revision would read as provably clean and its log would be trusted.
+printf '%s\n' "$genuine_sha" >"$scratch/unresolvable.txt"
+: >"$scratch/tainted.txt"
+make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job222.log"
+printf '222 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 2 ]; then
+  printf 'FAIL: unresolvable revision — expected exit 2, got %d (its log was trusted)\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a candidate whose revision does not resolve is not trusted\n'
+fi
+: >"$scratch/unresolvable.txt"
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -119,6 +119,45 @@ grep -q 'trivy-sbom v9.9.9' "$scratch/no-tv.log" ||
 } >"$scratch/dup.log"
 expect 'conflicting versions for one tool fail closed' 2 "$scratch/dup.log" 'conflicting'
 
+# ---- PROVENANCE: the managed workflow must not be definable inside this repository -------------
+# The live path picks a job out of arbitrary recent runs, so it binds to the org-managed workflow's
+# PATH. That binding is only proof of provenance while this repository does not define a workflow at
+# that same path — if it ever does, the file could be edited to emit any versions it likes. The
+# guard must then refuse rather than trust it.
+#
+# Uses a synthetic tree via DRIFT_REPO_ROOT, and a PATH-shadowed `gh` that fails if called: reaching
+# the network here would mean the provenance check ran too late to protect anything.
+mkdir -p "$scratch/fakerepo/.github/workflows" "$scratch/bin" "$scratch/fakerepo/scripts"
+cp "$repo_root/scripts/megalinter-scan-counts.sh" "$scratch/fakerepo/scripts/"
+printf 'name: impostor\n' >"$scratch/fakerepo/.github/workflows/validate-go-project.yaml"
+printf '#!/usr/bin/env bash\necho "gh must not be reached before the provenance check" >&2\nexit 99\n' \
+  >"$scratch/bin/gh"
+chmod +x "$scratch/bin/gh"
+
+out="$(DRIFT_REPO_ROOT="$scratch/fakerepo" PATH="$scratch/bin:$PATH" "$script" 2>&1)" && rc=0 || rc=$?
+if [ "$rc" -ne 2 ]; then
+  printf 'FAIL: in-repo managed workflow — expected exit 2, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$out" | grep -qF 'no longer'; then
+  printf 'FAIL: in-repo managed workflow — exit 2 but message did not explain provenance\n%s\n' \
+    "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: an in-repo copy of the managed workflow fails closed\n'
+fi
+
+# Negative control for the case above: with the impostor workflow REMOVED, the same synthetic tree
+# must get PAST the provenance check and reach gh (which is stubbed to fail loudly). Without this,
+# the assertion above would pass just as well if the guard refused for some unrelated reason.
+rm "$scratch/fakerepo/.github/workflows/validate-go-project.yaml"
+out="$(DRIFT_REPO_ROOT="$scratch/fakerepo" PATH="$scratch/bin:$PATH" "$script" 2>&1)" && rc=0 || rc=$?
+if printf '%s' "$out" | grep -qF 'no longer'; then
+  printf 'FAIL: provenance refusal fired with no in-repo workflow present\n%s\n' "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: control — without the in-repo copy the provenance check does not fire\n'
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/check-megalinter-version-drift.sh.
+#
+# Every case runs against a FIXTURE log via --log-file, so the suite is offline and does not depend
+# on a live MegaLinter run existing.
+#
+# The fixture is built from the real thing: the four marker lines below are copied verbatim from the
+# "🧹 Lint - mega-linter" job of platform run 31337531893, including the trivy-sbom line, which is
+# present in every real log and is the reason the trivy matcher has to be anchored.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/check-megalinter-version-drift.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+
+# Read the recorded constants from the helper that owns them, so this suite keeps testing the real
+# contract after a legitimate version bump instead of pinning a second copy that goes stale.
+read_const() {
+  sed -n "s/^readonly $1='\([^']*\)'.*/\1/p" "$repo_root/scripts/megalinter-scan-counts.sh"
+}
+ci_megalinter="$(read_const CI_MEGALINTER_VERSION)"
+ci_checkov="$(read_const CI_CHECKOV_VERSION)"
+ci_trivy="$(read_const CI_TRIVY_VERSION)"
+
+for name in ci_megalinter ci_checkov ci_trivy; do
+  if [ -z "${!name}" ]; then
+    printf 'FAIL: could not read %s from scripts/megalinter-scan-counts.sh\n' "$name" >&2
+    exit 1
+  fi
+done
+
+# Build a log fixture. Args: megalinter, checkov, trivy version (empty string omits that marker).
+make_log() {
+  local ml="$1" ck="$2" tv="$3" out="$4"
+  {
+    printf '2026-08-09T21:42:59Z ##[group]Pull down action image\n'
+    [ -n "$ml" ] && printf "2026-08-09T21:42:59Z ghcr.io/oxsecurity/megalinter-go:v%s\n" "$ml"
+    printf '2026-08-09T21:48:50Z - Using [actionlint v1.7.12] https://megalinter.io/x\n'
+    [ -n "$ck" ] && printf '2026-08-09T21:48:50Z - Using [checkov v%s] https://megalinter.io/x\n' "$ck"
+    [ -n "$tv" ] && printf '2026-08-09T21:48:50Z - Using [trivy v%s] https://megalinter.io/x\n' "$tv"
+    # Always present in a real log, and one character away from the trivy marker.
+    printf '2026-08-09T21:48:50Z - Using [trivy-sbom v9.9.9] https://megalinter.io/x\n'
+    printf '2026-08-09T21:48:57Z done\n'
+  } >"$out"
+}
+
+expect() {
+  local desc="$1" want_rc="$2" logfile="$3" want_msg="${4-}"
+  local out rc=0
+  out="$("$script" --log-file "$logfile" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    printf 'FAIL: %s — expected exit %d, got %d\n%s\n' "$desc" "$want_rc" "$rc" "$out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$want_msg" ] && ! printf '%s' "$out" | grep -qF "$want_msg"; then
+    printf 'FAIL: %s — exit %d correct but message lacked %q\n%s\n' "$desc" "$rc" "$want_msg" "$out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok: %s\n' "$desc"
+}
+
+# ---- GREEN: a log matching every recorded constant --------------------------------------------
+make_log "$ci_megalinter" "$ci_checkov" "$ci_trivy" "$scratch/match.log"
+expect 'matching versions pass' 0 "$scratch/match.log"
+
+# ---- RED: each version drifts INDEPENDENTLY ----------------------------------------------------
+# Asserted one at a time so a matcher that reads the wrong line cannot pass by coincidence: each
+# case leaves the other two markers correct, so only the named tool can be responsible.
+make_log '9.99.0' "$ci_checkov" "$ci_trivy" "$scratch/ml.log"
+expect 'megalinter drift is caught' 1 "$scratch/ml.log" 'CI_MEGALINTER_VERSION'
+
+make_log "$ci_megalinter" '3.99.9' "$ci_trivy" "$scratch/ck.log"
+expect 'checkov drift is caught' 1 "$scratch/ck.log" 'CI_CHECKOV_VERSION'
+
+make_log "$ci_megalinter" "$ci_checkov" '0.99.9' "$scratch/tv.log"
+expect 'trivy drift is caught' 1 "$scratch/tv.log" 'CI_TRIVY_VERSION'
+
+# The failure message has to name the file to edit, or the check is a puzzle rather than a signal.
+expect 'failure names the file to edit' 1 "$scratch/ck.log" 'scripts/megalinter-scan-counts.sh'
+
+# ---- FAIL-CLOSED: an unreadable log must never read as "no drift" ------------------------------
+# This is the important direction. A MegaLinter log-format change removes the markers; if that were
+# reported as success, the guard would go quietly dead at exactly the moment it stopped working.
+make_log '' "$ci_checkov" "$ci_trivy" "$scratch/no-ml.log"
+expect 'absent megalinter marker fails closed' 2 "$scratch/no-ml.log" 'could not find'
+
+make_log "$ci_megalinter" '' "$ci_trivy" "$scratch/no-ck.log"
+expect 'absent checkov marker fails closed' 2 "$scratch/no-ck.log" 'could not find'
+
+make_log "$ci_megalinter" "$ci_checkov" '' "$scratch/no-tv.log"
+expect 'absent trivy marker fails closed' 2 "$scratch/no-tv.log" 'could not find'
+
+: >"$scratch/empty.log"
+expect 'empty log fails closed' 2 "$scratch/empty.log"
+
+expect 'missing log file fails closed' 2 "$scratch/does-not-exist.log"
+
+# ---- The trivy matcher must not be satisfied by trivy-sbom -------------------------------------
+# trivy-sbom carries its own version and sits directly beside the trivy line in every real log. A
+# substring matcher reads 9.9.9 from it; with the real trivy marker absent the run must fail closed
+# rather than compare against the sbom's version.
+grep -q 'trivy-sbom v9.9.9' "$scratch/no-tv.log" ||
+  { printf 'FAIL: fixture lost its trivy-sbom decoy line\n' >&2; failures=$((failures + 1)); }
+
+# ---- Ambiguity is not resolved silently --------------------------------------------------------
+# Two different versions for one tool means the log is not describing a single run.
+{
+  cat "$scratch/match.log"
+  printf '2026-08-09T21:48:51Z - Using [checkov v3.0.0] https://megalinter.io/x\n'
+} >"$scratch/dup.log"
+expect 'conflicting versions for one tool fail closed' 2 "$scratch/dup.log" 'conflicting'
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\nmegalinter version-drift guard contract OK\n'

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -106,7 +106,10 @@ expect 'missing log file fails closed' 2 "$scratch/does-not-exist.log"
 # substring matcher reads 9.9.9 from it; with the real trivy marker absent the run must fail closed
 # rather than compare against the sbom's version.
 grep -q 'trivy-sbom v9.9.9' "$scratch/no-tv.log" ||
-  { printf 'FAIL: fixture lost its trivy-sbom decoy line\n' >&2; failures=$((failures + 1)); }
+  {
+    printf 'FAIL: fixture lost its trivy-sbom decoy line\n' >&2
+    failures=$((failures + 1))
+  }
 
 # ---- Ambiguity is not resolved silently --------------------------------------------------------
 # Two different versions for one tool means the log is not describing a single run.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`scripts/megalinter-scan-counts.sh` is how every slice of #2787 proves the scanner backlog moved. It reproduces CI's checkov and trivy counts locally — but only at the three versions it hard-codes, and **nothing in this repository selects those versions**. The MegaLinter action is pinned in `devantler-tech/actions`, so when that pin moves the constants here go stale silently, in both directions.

That matters because a scanner rule-set change adds or retires findings, which looks *identical* to someone fixing them. It has already cost real work: the last three measurement comments on #2787 each had to caveat their numbers against a version gap, and one reported a baseline it could not confirm.

## What

Records the MegaLinter release those versions came from, and adds a guard that compares all three against what the live mega-linter job actually ran. On drift it fails and prints the exact lines to change.

The live comparison runs on push-to-main. Only the offline parsing contract gates PRs — reading Actions logs needs a token a fork PR does not have, so gating PRs on it would fail closed on every fork.

It fails **closed**: an absent or conflicting version marker exits "cannot verify" rather than "no drift", so a MegaLinter log-format change cannot retire the guard quietly.

Also records the reviewed dispositions for the two residual risks #2853 deliberately left open (parsing-error identity, trivy's vulnerability-DB revision) as accepted, each with the signal that would expire that acceptance.

## Security floor / DevEx cost

- **Floor:** a stale measurement baseline can no longer be mistaken for backlog progress on the two scanners that are currently the *only* static checks catching a committed `privileged: true` or a missing resource limit in `k8s/`.
- **Everyday path:** unchanged — the pre-push helper stays fully offline and gained one provenance line of output. No new local tool, no new step before pushing.

Fixes #2853
Part of #2787