### PR TITLE
security(k8s): run the userns-longhorn-smoke probe at a high UID

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,7 +83,7 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (15) and trivy (163 in the local v0.72.0 reproduction): Kubernetes misconfiguration
+  # checkov (10) and trivy (163 in the local v0.72.0 reproduction): Kubernetes misconfiguration
   # in k8s/, which the section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -97,21 +97,25 @@ DISABLE_ERRORS_LINTERS:
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
   # `external_secrets_replicas` count. Trivy matched those identifier strings, not credential data.
   #
-  # checkov's 15 are all `kubernetes` framework, and 4 of them are CKV_K8S_40, at exactly these
-  # sites: the two vault-backup jobs, the userns-longhorn-smoke probe, and the vault-config Job.
+  # checkov's 10 are all `kubernetes` framework, and 3 of them are CKV_K8S_40, at exactly these
+  # sites: the two vault-backup jobs and the vault-config Job.
   # Re-derive that list from the scan rather than adjusting a number here — every figure in this
   # block is a measurement, and the running arithmetic that used to track it went stale twice.
   #
-  # The first three carry scoped skips that were tried and withdrawn, because each named a per-site
-  # technical constraint that does not survive checking. The two vault-backup jobs claimed to share
-  # the vault-snapshots PVC with the OpenBao StatefulSet — but the live StatefulSet mounts
-  # `config`/`unseal-keys`/`tmp`/`home` plus claim templates `data`/`audit`, and never that PVC at
-  # all, so there is no shared ownership to preserve. The user-namespace probes claimed their UID was
-  # the measurement subject — but `/proc/self/uid_map` describes the pod's namespace and reads
-  # identically for every process in it regardless of UID, and `fsGroup` supplies volume access as a
-  # GID independent of `runAsUser`. #2904 carries the per-site remediation and the risk-acceptance
-  # question for those. It was written when there were four: the Headlamp mapping probe was the
-  # fourth, and #2959 removed that probe outright.
+  # The two vault-backup jobs carry no suppression: their scoped skip claimed to share the
+  # vault-snapshots PVC with the OpenBao StatefulSet, and the live StatefulSet mounts
+  # `config`/`unseal-keys`/`tmp`/`home` plus claim templates `data`/`audit`, never that PVC at all,
+  # so there is no shared ownership to preserve. They are two of the three `vault-snapshots`
+  # writers — the third is the dr-rebuild workflow's helper pod, which this check does not reach
+  # because it is not a committed Kubernetes manifest — and all three
+  # share one RWO PVC at `100:1000`, so they move together. That touches the DR restore path, so
+  # #2904 holds their remediation and the risk-acceptance question.
+  #
+  # The user-namespace probes are resolved rather than excepted, because the UID was never the
+  # measurement subject: `/proc/self/uid_map` describes the pod's namespace and reads identically
+  # for every process in it regardless of UID, and `fsGroup` supplies volume access as a GID
+  # independent of `runAsUser`. `userns-longhorn-smoke` therefore states 65532 and passes the
+  # check outright; #2959 removed the Headlamp mapping probe.
   #
   # The vault-config Job's UID is image-baked, so it wants a scoped skip naming that reason rather
   # than a raise: the openbao image carries `openbao:x:100:1000` in its own /etc/passwd, which is

--- a/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
+++ b/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
@@ -25,11 +25,28 @@ spec:
       restartPolicy: Never
       automountServiceAccountToken: false
       enableServiceLinks: false
+      # UID 65532 rather than a low one (checkov CKV_K8S_40, which passes from
+      # 10000 up). The busybox image declares no `User`, so it would run as root
+      # unedited, and it carries no /etc/passwd entry for the UID this runs
+      # under — the identity is unmapped either way and nothing in the image
+      # looks it up.
+      #
+      # The UID is not what this Job measures. Both containers assert on
+      # /proc/self/uid_map, which describes the pod's user namespace and reads
+      # identically for every process in it whatever UID that process has, so
+      # the `uid_host_start > 0` acceptance condition is untouched. `id -u`/
+      # `id -g` reach the sentinel only as text, and the round-trip assertions
+      # grep for the `init-user=`/`main-user=` keys, never their values.
+      #
+      # What makes /smoke writable is `fsGroup` == `runAsGroup`, not the UID:
+      # the kubelet chowns the Longhorn volume to that GID. The three move
+      # together for that reason — raising one alone would be the change that
+      # breaks this.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
@@ -62,8 +79,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 65532
+            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL
@@ -119,8 +136,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 65532
+            runAsGroup: 65532
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Kubernetes misconfiguration backlog (#2787) is what keeps checkov and trivy reporting-only
instead of gating, so every finding cleared is a step toward turning that gate back on. This clears
one of the ten checkov findings left.

It is the safe one to take unattended. #2904 splits the remaining `CKV_K8S_40` sites into the
production `vault-snapshots` writers — which share a volume, touch the disaster-recovery restore
path, and need a watched window — and this smoke probe, which is commented out of its kustomization
and does not deploy at all.

## What

The probe now runs under a high user ID, which is what the check asks for. Its actual subject is the
user-namespace mapping, not the identity it runs as, so the proof it performs is unchanged.

Measured with the repository's own reproduction script: checkov goes from 11 findings to 10, and the
passing count rises by one — so the finding is genuinely resolved, not hidden behind a suppression.
Two figures in the linter config had drifted from reality and are corrected, which that file asks
any change here to do.

No production workload changes.

Part of #2787
Part of #2904
