### PR TITLE
fix(security): scope trivy KSV-0037 to the infrastructure trees

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,7 +83,7 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (9) and trivy (163 in the local v0.72.0 reproduction): Kubernetes misconfiguration
+  # checkov (9) and trivy (110 in the local v0.73.0 reproduction): Kubernetes misconfiguration
   # in k8s/, which the section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -92,6 +92,16 @@ DISABLE_ERRORS_LINTERS:
   # (HelmRepository, HTTPRoute, PodDisruptionBudget) and against the LimitRange manifests
   # themselves. See .trivyignore.yaml for the reason and #2988 for the measurement. The residual is
   # real and still includes HIGH/CRITICAL RBAC breadth.
+  #
+  # It then went 157 -> 110 when KSV-0037 ("user resources should not be placed in kube-system")
+  # was scoped to the infrastructure trees — 47 findings, every one a cluster component that
+  # belongs in kube-system by construction (CNI, DNS, CSI, cloud-controller-manager and their
+  # namespace-local VPAs, PDBs and Gateway material). The check stays live for application trees;
+  # see .trivyignore.yaml for the disposition and the paired control that demonstrates the boundary.
+  #
+  # ⚠️ That 157 is NOT 163 minus a fix. 163 was measured on trivy v0.72.0 and 157 on v0.73.0 with
+  # no manifest change in between, so those 6 are a scanner rule-set difference, not backlog
+  # movement — exactly the drift this block warns about below. Only the 47 are this slice's work.
   #
   # KSV-0109's two HIGH findings are path-scoped false positives (#2990): one ConfigMap embeds
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
@@ -174,8 +184,8 @@ DISABLE_ERRORS_LINTERS:
   # exact commands this job runs, so a slice can show the number moved without a CI round trip.
   #
   # ⚠️ Read trivy's number from that script, NOT from the MegaLinter summary. MegaLinter reports
-  # this trivy scan as "1 non blocking error" while the local v0.72.0 scan actually fails 163 checks
-  # across 73 targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's
+  # this trivy scan as "1 non blocking error" while the local v0.73.0 scan actually fails 110 checks
+  # across 27 targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's
   # number is a genuine sum of "Failed checks:" and needs no such caveat.
   #
   # ⚠️ Both numbers above DRIFT without anyone touching this file — they moved between the slice

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -50,9 +50,21 @@ misconfigurations:
   #
   # So this is scoped to the infrastructure trees rather than skipped outright, and that boundary is
   # what keeps the control working: all 47 sit under an infrastructure path, while k8s/bases/apps/**
-  # and the tenant trees stay covered. A user application given `namespace: kube-system` is still
-  # reported — verified with a temporary app manifest, which fails this check with the entry below
-  # in place.
+  # and k8s/clusters/** stay covered. A user application given `namespace: kube-system` is still
+  # reported — verified with a paired control, two copies of one manifest: the copy under
+  # k8s/bases/apps/ FAILS this check with this entry in place, and the copy under
+  # k8s/bases/infrastructure/ is excepted. Same bytes, different path, so the boundary is what
+  # decides rather than the file contents.
+  #
+  # ⚠️ This exception does NOT decide anything about tenant workloads, and it would be wrong to read
+  # it as covering them. Tenants are generated from the KRO ResourceGraphDefinitions under
+  # k8s/bases/infrastructure/resource-graph-definitions/, which are inside the scoped path — but
+  # trivy reports ZERO misconfigurations on those two resource-graph-definition.yaml files with or
+  # without this entry, because it does not evaluate the resource templates nested inside an RGD.
+  # Their generated workloads are therefore outside this scanner's reach either way; that is a
+  # pre-existing coverage gap tracked in #3055, not something this scoping introduces. Every
+  # template in them targets `${tenantNamespace.metadata.name}` today — the only kube-system
+  # references are RBAC grants naming the shared Gateway, not workload placement.
   - id: KSV-0037
     paths:
       - k8s/bases/infrastructure/**

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -29,6 +29,39 @@ misconfigurations:
       LimitRange is namespace-scoped but this check evaluates each file independently, including
       resources that cannot carry a LimitRange and the LimitRange manifests themselves.
 
+  # KSV-0037 "user resources should not be placed in kube-system namespace" — 47 of trivy's 157
+  # findings on this tree (30%), all MEDIUM.
+  #
+  # The control protects a real property: kube-system carries elevated trust, so an APPLICATION
+  # does not belong there. Every one of the 47 is instead a cluster component that belongs in
+  # kube-system by construction, and the firing set says so — 17 VerticalPodAutoscaler,
+  # 12 HelmRelease, 5 PodDisruptionBudget, 5 HelmRepository, 2 HTTPRoute, 2 Gateway, 1 LimitRange,
+  # 1 Deployment, 1 CiliumNetworkPolicy, 1 Certificate. Their subjects are the CNI (cilium,
+  # cilium-operator, cilium-envoy, hubble-relay, hubble-ui), DNS (coredns), the Hetzner CSI and
+  # cloud-controller-manager, metrics-server, snapshot-controller, cluster-autoscaler, descheduler,
+  # spire and tetragon.
+  #
+  # Most of the set is not merely conventional but structurally forced: a VerticalPodAutoscaler's
+  # targetRef and a PodDisruptionBudget's selector are both namespace-local, so an autoscaler or
+  # budget for a kube-system workload cannot itself live anywhere else. The LimitRange IS the
+  # kube-system namespace's own default limit range, and the Certificate is the TLS material for the
+  # Gateway in the same namespace. The single Deployment is CoreDNS — the canonical kube-system
+  # component.
+  #
+  # So this is scoped to the infrastructure trees rather than skipped outright, and that boundary is
+  # what keeps the control working: all 47 sit under an infrastructure path, while k8s/bases/apps/**
+  # and the tenant trees stay covered. A user application given `namespace: kube-system` is still
+  # reported — verified with a temporary app manifest, which fails this check with the entry below
+  # in place.
+  - id: KSV-0037
+    paths:
+      - k8s/bases/infrastructure/**
+      - k8s/providers/*/infrastructure/**
+    statement: >-
+      These are cluster infrastructure components that belong in kube-system by construction — CNI,
+      DNS, CSI, cloud-controller-manager and their namespace-local VerticalPodAutoscalers,
+      PodDisruptionBudgets and Gateway material. Application trees remain covered by this check.
+
   # KSV-0109 matches identifier text rather than secret material at both sites below. Keep the
   # dispositions separate so each path carries the reason that was checked against its content.
   - id: KSV-0109


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The security scanners on `k8s/` still report on every pull request without failing the build, while
a backlog is worked off. The largest remaining group was one check firing 47 times — 30% of trivy's
findings on the tree — on cluster components that are exactly where they should be.

Left as noise, it buries the findings that matter. The residual on this tree still includes
HIGH/CRITICAL RBAC breadth, and that is much harder to see behind 47 reports about CoreDNS and the
CNI living in `kube-system`.

## What

Scopes that one check to the infrastructure trees, with the reasoning recorded next to it, and
corrects the recorded scanner figures the config asks each slice to re-measure.

The check itself protects something real — an application does not belong in `kube-system` — so it
is **scoped, not switched off**. It stays live for application trees, and a user workload placed in
`kube-system` is still reported. That boundary was verified rather than assumed, with two copies of
one manifest: the copy under the apps tree fails the check, the copy under the infrastructure tree
is excepted. Same bytes, different path.

Measured with the repository's own counts script: trivy **157 → 110** across 27 targets. checkov is
unchanged at 9.

Two honesty notes, both carried into the config rather than left in this description:

- The previously recorded figure was 163, measured on an older scanner version. 157 is the current
  version on unchanged manifests, so those 6 are scanner rule-set drift rather than progress. Only
  the 47 are this change's work.
- Self-review caught a wrong claim in my own first draft, that tenant trees stay covered. They are
  not covered, and not because of this change: tenants are generated from `ResourceGraphDefinition`
  templates that no static scanner descends into, measured at zero findings with and without this
  entry. Filed separately as #3055 and stated plainly in the comment instead of implied.

Part of #2787
