### PR TITLE
fix(coredns): disposition required DNS bind capability

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,7 +83,7 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (9) and trivy (110 in the local v0.73.0 reproduction): Kubernetes misconfiguration
+  # checkov (8) and trivy (108 in the local v0.73.0 reproduction): Kubernetes misconfiguration
   # in k8s/, which the section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -107,7 +107,7 @@ DISABLE_ERRORS_LINTERS:
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
   # `external_secrets_replicas` count. Trivy matched those identifier strings, not credential data.
   #
-  # checkov's 9 are all `kubernetes` framework, and 2 of them are CKV_K8S_40, at exactly these
+  # checkov's 8 are all `kubernetes` framework, and 2 of them are CKV_K8S_40, at exactly these
   # sites: the two vault-backup jobs.
   # Re-derive that list from the scan rather than adjusting a number here — every figure in this
   # block is a measurement, and the running arithmetic that used to track it went stale twice.
@@ -184,7 +184,7 @@ DISABLE_ERRORS_LINTERS:
   # exact commands this job runs, so a slice can show the number moved without a CI round trip.
   #
   # ⚠️ Read trivy's number from that script, NOT from the MegaLinter summary. MegaLinter reports
-  # this trivy scan as "1 non blocking error" while the local v0.73.0 scan actually fails 110 checks
+  # this trivy scan as "1 non blocking error" while the local v0.73.0 scan actually fails 108 checks
   # across 27 targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's
   # number is a genuine sum of "Failed checks:" and needs no such caveat.
   #

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -88,3 +88,21 @@ misconfigurations:
     statement: >-
       external_secrets_replicas is a public controller replica count; Trivy matches the word
       secrets in the key name, not secret material.
+
+  # CoreDNS must bind UDP/TCP port 53 while running as the pinned image's non-root 65532 identity.
+  # The binary carries the required file capability, so the container adds only
+  # NET_BIND_SERVICE to its bounding set after dropping every other capability. These dispositions
+  # are path-scoped so the controls continue to report any other workload that adds a capability
+  # or binds a privileged port.
+  - id: KSV-0022
+    paths:
+      - k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+    statement: >-
+      CoreDNS requires only NET_BIND_SERVICE in its bounding set to serve cluster DNS on port 53;
+      the container drops every other capability and runs as non-root UID/GID 65532.
+  - id: KSV-0117
+    paths:
+      - k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+    statement: >-
+      Port 53 is the required DNS service port; the pinned CoreDNS binary carries the file
+      capability needed to bind it while the container runs as non-root UID/GID 65532.

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -13,6 +13,10 @@ metadata:
     # cluster DNS by watching Services, Endpoints and Pods through the API
     # server. Without the token CoreDNS cannot resolve any in-cluster name.
     checkov.io/skip1: CKV_K8S_38=CoreDNS resolves cluster DNS by watching Services/Endpoints via the API server
+    # CoreDNS must serve cluster DNS on port 53. The pinned non-root image's
+    # binary carries the file capability, so the container needs only this one
+    # capability in its bounding set and drops every other capability below.
+    checkov.io/skip2: CKV_K8S_25=CoreDNS requires only NET_BIND_SERVICE in its bounding set to serve DNS on port 53
 spec:
   progressDeadlineSeconds: 600
   replicas: 2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- record why the non-root CoreDNS process needs only NET_BIND_SERVICE in its capability bounding set to serve UDP/TCP port 53
- scope Checkov CKV_K8S_25 to the CoreDNS Deployment resource
- scope Trivy KSV-0022 and KSV-0117 to that exact file while keeping both controls active everywhere else
- refresh the measured scanner backlog from Checkov 9 / Trivy 110 to 8 / 108

Fixes #3061
Part of #2787

## Validation

- scripts/megalinter-scan-counts.sh: Checkov 8 failing checks, Trivy 108 misconfigurations, 0 vulnerabilities
- direct Trivy scan without the ignore file: KSV-0022 and KSV-0117 still report on CoreDNS
- scripts/tests/test-megalinter-scan-counts-ignorefile.sh
- ksail workload validate (exit 0; the unrelated flux-operator OCI chart returned 403 and KSail validated that resource without its Helm render)
- ksail --config ksail.prod.yaml workload validate (115 kustomizations and 564 YAML files validated)