### PR TITLE
fix(ci): name the node holding a residual GHCR drain fence

### DIFF
--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -27,7 +27,7 @@ report_residual_bridge_ownership() {
     | (.metadata.annotations[$owner_annotation] // "") as $owner
     | (.metadata.annotations[$recovery_annotation] // "") as $recovery
     | select($owner != "" or $recovery != "")
-    | "  node \(.metadata.name) (cordoned=\(.spec.unschedulable // false))"
+    | "  node \(.metadata.name) (cordoned=\(.spec.unschedulable == true))"
       + (if $owner == "" then ""
          else "\n    \($owner_annotation) = \($owner)" end)
       + (if $recovery == "" then ""

--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -7,6 +7,46 @@
 readonly GHCR_PULL_VERIFIED_REVISION_ANNOTATION="platform.devantler.tech/ghcr-pull-verified-revision-v2"
 readonly GHCR_PULL_VERIFIED_IMAGE_ANNOTATION="platform.devantler.tech/ghcr-pull-verified-image-v2"
 
+# Name the nodes that still hold a drain fence, so a refusal is actionable
+# without a live cluster query. A transaction killed before its EXIT trap
+# released the fence leaves the annotation behind and every later deploy then
+# refuses, which is correct but surfaces only as a bare
+# `jq: error (at …): residual GHCR bridge ownership`.
+#
+# This reports; it never releases. Releasing needs the pre-claim schedulability
+# the killed transaction did not record, so whether a node may be uncordoned is
+# a decision this function cannot make and must not imply.
+report_residual_bridge_ownership() {
+  local nodes_file="$1"
+  local held
+
+  held="$(jq -r \
+    --arg owner_annotation "platform.devantler.tech/ghcr-auth-drain-owner" \
+    --arg recovery_annotation "platform.devantler.tech/ghcr-auth-drain-recovery" '
+    .items[]
+    | (.metadata.annotations[$owner_annotation] // "") as $owner
+    | (.metadata.annotations[$recovery_annotation] // "") as $recovery
+    | select($owner != "" or $recovery != "")
+    | "  node \(.metadata.name) (cordoned=\(.spec.unschedulable // false))"
+      + (if $owner == "" then ""
+         else "\n    \($owner_annotation) = \($owner)" end)
+      + (if $recovery == "" then ""
+         else "\n    \($recovery_annotation) = \($recovery)" end)
+  ' "${nodes_file}" 2>/dev/null)" || return 0
+  [[ -n "${held}" ]] || return 0
+
+  {
+    printf 'Residual GHCR bridge ownership is held on:\n'
+    printf '%s\n' "${held}"
+    printf 'A previous transaction was killed before releasing its drain fence.\n'
+    printf 'Node selection fails closed until the annotation(s) above are removed:\n'
+    printf '  kubectl --context <ctx> annotate node <node> <annotation>-\n'
+    printf 'A cordoned node is left cordoned on purpose: the killed transaction\n'
+    printf 'recorded no pre-claim schedulability, so confirm the node should be\n'
+    printf 'schedulable before uncordoning it.\n'
+  } >&2
+}
+
 # Select nodes that have not completed the v2 proof for the incoming credential
 # revision or the exact image used for the registry pull. Credential-stale nodes
 # require a reboot because containerd loads registry auth only at process start;
@@ -51,6 +91,7 @@ select_talos_node_targets() {
       | @tsv
     end
   ' "${nodes_file}" >"${unsorted_targets}"; then
+    report_residual_bridge_ownership "${nodes_file}"
     rm -f "${unsorted_targets}"
     return 1
   fi

--- a/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
@@ -136,10 +136,90 @@ if declare -F select_talos_node_targets >/dev/null; then
   else
     fail "a changed image with current credentials selects image-only mode"
   fi
+
+  # A transaction killed before its EXIT trap released the drain fence leaves an
+  # owner annotation behind, and selection then refuses every later deploy. The
+  # refusal must name which node holds the fence: without it the only signal is
+  # a bare `jq: error (at …): residual GHCR bridge ownership`, and identifying
+  # the node costs a live cluster query while the delivery lane is down.
+  residual_nodes="${work_dir}/residual-nodes.json"
+  residual_targets="${work_dir}/residual-targets.tsv"
+  residual_stderr="${work_dir}/residual-stderr.log"
+  jq -n \
+    --arg revision "${DESIRED_REVISION}" \
+    --arg image "${DESIRED_IMAGE}" \
+    --arg revision_key "${GHCR_PULL_VERIFIED_REVISION_ANNOTATION:-}" \
+    --arg image_key "${GHCR_PULL_VERIFIED_IMAGE_ANNOTATION:-}" '
+    {
+      items: [
+        {
+          metadata: {
+            name: "prod-control-plane-2",
+            uid: "control-plane-2-uid",
+            labels: {"node-role.kubernetes.io/control-plane": ""},
+            annotations: {
+              ($revision_key): $revision,
+              ($image_key): $image,
+              "platform.devantler.tech/ghcr-auth-drain-owner":
+                "revision-prefix-4242-1337"
+            }
+          },
+          spec: {unschedulable: true},
+          status: {addresses: [
+            {type: "InternalIP", address: "10.0.0.2"}
+          ]}
+        },
+        {
+          metadata: {
+            name: "prod-worker-1",
+            uid: "worker-1-uid",
+            labels: {},
+            annotations: {
+              ($revision_key): $revision,
+              ($image_key): $image
+            }
+          },
+          status: {addresses: [
+            {type: "InternalIP", address: "10.0.0.4"}
+          ]}
+        }
+      ]
+    }
+  ' >"${residual_nodes}"
+
+  if select_talos_node_targets \
+    "${residual_nodes}" \
+    "${DESIRED_REVISION}" \
+    "${DESIRED_IMAGE}" \
+    "${residual_targets}" 2>"${residual_stderr}"; then
+    fail "residual bridge ownership still refuses node selection"
+  else
+    pass "residual bridge ownership still refuses node selection"
+  fi
+
+  if grep -Fq -- "prod-control-plane-2" "${residual_stderr}" &&
+    grep -Fq -- "platform.devantler.tech/ghcr-auth-drain-owner" \
+      "${residual_stderr}" &&
+    grep -Fq -- "revision-prefix-4242-1337" "${residual_stderr}"; then
+    pass "the residual-ownership refusal names the node, annotation and holder"
+  else
+    fail "the residual-ownership refusal names the node, annotation and holder"
+  fi
+
+  # A node that holds no fence must never be reported as holding one, or the
+  # operator clears the wrong node's annotation on a live cluster.
+  if grep -Fq -- "prod-worker-1" "${residual_stderr}"; then
+    fail "an unfenced node is not reported as holding a fence"
+  else
+    pass "an unfenced node is not reported as holding a fence"
+  fi
 else
   fail "legacy verification markers select reboot mode"
   fail "v2 post-reboot markers suppress an already-proved reboot"
   fail "a changed image with current credentials selects image-only mode"
+  fail "residual bridge ownership still refuses node selection"
+  fail "the residual-ownership refusal names the node, annotation and holder"
+  fail "an unfenced node is not reported as holding a fence"
 fi
 
 operation_log="${work_dir}/operations.log"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production delivery is wedged right now. A deploy that was killed part-way left its drain fence held on one control-plane node, and the bridge correctly refuses to touch any node while a fence is outstanding — so every subsequent deploy *and* its heal job fail closed.

The refusal was the problem, not the gate. It surfaced as a bare `jq: error (at …): residual GHCR bridge ownership`, naming no node, no holder and no remedy. Working out which node held the fence took a live cluster query, with the merge queue blocked the whole time.

## What

The refusal now says which node holds the fence, whether it is cordoned, which annotation and which holder, and the command to remove it.

The gate itself is unchanged — it still fails closed on the same condition — and the report is silent when no fence is held, so an unrelated failure prints nothing. It reports and never releases: a cordoned node stays cordoned, because the killed transaction recorded no pre-claim schedulability and this path cannot judge whether the node should be schedulable.

Part of #3065

> Related: #3034 adds a `--fences` report and updates three other refusals; this is the fourth one, which it does not cover and which is the one that fired here.
