### PR TITLE
fix(coroot): grant the crossplane sync exporter the CRD read its discovery needs

### DIFF
--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
@@ -15,3 +15,22 @@ rules:
       - get
       - list
       - watch
+  # kube-state-metrics resolves the configured `groupVersionKind` through the
+  # CRD API before it can build a store for it, so the rule above is necessary
+  # but not sufficient: without this one the reflector retry-loops on a
+  # forbidden list and the exporter emits nothing while reporting itself ready.
+  #
+  # This reads CRD *definitions* — schemas — not the managed resources
+  # themselves, so it does not widen the access the comment above scopes:
+  # provider configuration lives in managed-resource specs, which stay pinned to
+  # the kinds listed in the first rule. `resourceNames` cannot narrow this
+  # further, because RBAC honours it only for get/update/delete/patch and the
+  # discovery path lists.
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -66,6 +66,73 @@ reject_text() {
   fi
 }
 
+# Collapse each `rules[]` entry into one canonical signature line:
+#
+#   apiGroups=[g1,g2] resources=[r1] verbs=[v1,v2]
+#
+# Line-at-a-time assertions cannot express what an RBAC rule actually MEANS. A
+# group, a resource and a verb set only grant anything when they sit in the SAME
+# entry, and independent `require_line` checks pass just as happily when they are
+# split across two rules — which grants something quite different from what the
+# assertions appear to say. Signatures make the grouping the thing being
+# asserted, so a split rule fails.
+#
+# Values within a key keep their document order; every rule here is written in
+# the canonical order kustomize emits, so this stays an exact comparison rather
+# than a set comparison that could mask a duplicated or reordered verb.
+rule_signatures() {
+  awk '
+    function flush() {
+      if (started) {
+        printf "apiGroups=[%s] resources=[%s] verbs=[%s]\n", groups, resources, verbs
+      }
+      groups = ""; resources = ""; verbs = ""; key = ""
+    }
+    function append(current, value) {
+      return current == "" ? value : current "," value
+    }
+
+    /^rules:[[:space:]]*$/ { in_rules = 1; next }
+    # Any other column-0 key ends the rules block.
+    /^[^[:space:]-]/ { if (in_rules) { flush(); started = 0; in_rules = 0 } }
+    !in_rules { next }
+
+    /^-[[:space:]]/ {
+      flush()
+      started = 1
+      sub(/^-[[:space:]]*/, "")
+    }
+    /^[[:space:]]*[a-zA-Z]+:[[:space:]]*$/ {
+      key = $0
+      gsub(/[[:space:]]|:/, "", key)
+      next
+    }
+    /^[[:space:]]*-[[:space:]]/ {
+      value = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (key == "apiGroups") { groups = append(groups, value) }
+      else if (key == "resources") { resources = append(resources, value) }
+      else if (key == "verbs") { verbs = append(verbs, value) }
+    }
+    END { flush() }
+  '
+}
+
+# Assert one whole rule, by signature. `require_line` on the signature stream is
+# deliberate: it is the same exact-whole-line comparison used everywhere else in
+# this file, now applied to a unit that carries meaning.
+require_rule() {
+  local cluster_role="$1"
+  local signature="$2"
+  local description="$3"
+
+  require_line \
+    "$(rule_signatures <<<"${cluster_role}")" \
+    "${signature}" \
+    "${description}"
+}
+
 extract_resource() {
   local kind="$1"
   local name="$2"
@@ -282,14 +349,10 @@ require_text \
 cluster_role="$(
   extract_resource ClusterRole crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter ClusterRole'
-require_line \
+require_rule \
   "${cluster_role}" \
-  '- repo.github.m.upbound.io' \
-  'the exporter must be limited to the managed-resource group it exports'
-require_line \
-  "${cluster_role}" \
-  '- repositories' \
-  'the exporter must be limited to the resource it exports'
+  'apiGroups=[repo.github.m.upbound.io] resources=[repositories] verbs=[get,list,watch]' \
+  'the exporter must hold exactly one read-only rule on the managed resource it exports'
 
 # The DISCOVERY half of the RBAC, and the reason this component shipped dead
 # (#3068). kube-state-metrics resolves a CustomResourceStateMetrics
@@ -309,14 +372,10 @@ require_line \
 # consistent with the scoping rationale on the rule above: managed-resource
 # access, where provider configuration actually lives, stays pinned to the
 # kinds listed there.
-require_line \
+require_rule \
   "${cluster_role}" \
-  '- apiextensions.k8s.io' \
-  'the exporter must be able to reach the CRD API its GVK discovery requires'
-require_line \
-  "${cluster_role}" \
-  '- customresourcedefinitions' \
-  'the exporter must be able to read the CRD definitions it resolves its GVK through'
+  'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[get,list,watch]' \
+  'the exporter must hold exactly one read-only rule granting the CRD read its GVK discovery requires'
 
 # A metrics exporter able to read every custom resource could also read provider
 # configuration it has no need for.

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -133,6 +133,38 @@ require_rule() {
     "${description}"
 }
 
+# The closed half of the contract: every rule present must be one of the rules
+# named here.
+#
+# `require_rule` only proves a signature is PRESENT, which is a one-directional
+# claim. A third entry granting get/list/watch on some unrelated resource — core
+# `configmaps`, say — satisfies both required-rule assertions, carries no
+# wildcard, and uses no mutating verb, so it passes every other check in this
+# file while quietly widening what the exporter can read.
+#
+# Least privilege is a statement about the WHOLE role, not about the rules
+# someone remembered to assert, so the allowed set has to be closed. This is
+# also what makes the "exactly one ... rule" wording on the assertions below
+# true rather than aspirational.
+reject_unexpected_rules() {
+  local cluster_role="$1"
+  shift
+
+  local actual expected_signature matched
+  while IFS= read -r actual; do
+    [ -z "${actual}" ] && continue
+    matched=0
+    for expected_signature in "$@"; do
+      if [ "${actual}" = "${expected_signature}" ]; then
+        matched=1
+        break
+      fi
+    done
+    [ "${matched}" -eq 1 ] ||
+      fail "the exporter must hold no RBAC rule beyond the two it needs (found: ${actual})"
+  done <<<"$(rule_signatures <<<"${cluster_role}")"
+}
+
 extract_resource() {
   local kind="$1"
   local name="$2"
@@ -376,6 +408,12 @@ require_rule \
   "${cluster_role}" \
   'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[get,list,watch]' \
   'the exporter must hold exactly one read-only rule granting the CRD read its GVK discovery requires'
+
+# Closes the set: the two rules above are the ONLY rules this role may carry.
+reject_unexpected_rules \
+  "${cluster_role}" \
+  'apiGroups=[repo.github.m.upbound.io] resources=[repositories] verbs=[get,list,watch]' \
+  'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[get,list,watch]'
 
 # A metrics exporter able to read every custom resource could also read provider
 # configuration it has no need for.

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -291,6 +291,33 @@ require_line \
   '- repositories' \
   'the exporter must be limited to the resource it exports'
 
+# The DISCOVERY half of the RBAC, and the reason this component shipped dead
+# (#3068). kube-state-metrics resolves a CustomResourceStateMetrics
+# `groupVersionKind` through the CRD API before it can build a store for it, so
+# the managed-resource grant above is necessary but NOT sufficient: without this
+# rule the reflector retry-loops on a forbidden list and the exporter emits zero
+# condition series while reporting itself 1/1 Ready.
+#
+# That is the same silent-sensor shape the rest of this contract guards, one
+# level down — an absent series is indistinguishable from a healthy fleet — and
+# nothing else in the pipeline catches it, because every assertion above passes
+# on a manifest whose exporter cannot read a single resource.
+#
+# `resourceNames` cannot narrow this: Kubernetes RBAC only honours it for
+# get/update/delete/patch, never for list or watch, and the discovery path
+# lists. Reading CRD *definitions* is schema access, which is what keeps this
+# consistent with the scoping rationale on the rule above: managed-resource
+# access, where provider configuration actually lives, stays pinned to the
+# kinds listed there.
+require_line \
+  "${cluster_role}" \
+  '- apiextensions.k8s.io' \
+  'the exporter must be able to reach the CRD API its GVK discovery requires'
+require_line \
+  "${cluster_role}" \
+  '- customresourcedefinitions' \
+  'the exporter must be able to read the CRD definitions it resolves its GVK through'
+
 # A metrics exporter able to read every custom resource could also read provider
 # configuration it has no need for.
 reject_text \

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -119,18 +119,37 @@ rule_signatures() {
   '
 }
 
-# Assert one whole rule, by signature. `require_line` on the signature stream is
-# deliberate: it is the same exact-whole-line comparison used everywhere else in
+# Assert one whole rule, by signature, and assert there is EXACTLY one of it.
+#
+# Counting rather than matching is what makes the "exactly one ... rule" wording
+# on the assertions below true. A presence check answers "at least one", so a
+# role carrying the same grant twice satisfies it, and `reject_unexpected_rules`
+# cannot catch that either: a duplicate is by definition a member of the allowed
+# set. The pair would then enforce "at least one of each, and no other KIND of
+# rule" while claiming to enforce "exactly one of each".
+#
+# The duplicate grants no additional Kubernetes permission — RBAC is a union, so
+# two identical rules authorise exactly what one does. It is asserted anyway
+# because a role that accumulated a duplicate is a role someone edited without
+# noticing what was already there, and that is the edit most likely to widen the
+# next grant by mistake.
+#
+# The comparison stays the exact trimmed-whole-line one used everywhere else in
 # this file, now applied to a unit that carries meaning.
 require_rule() {
   local cluster_role="$1"
   local signature="$2"
   local description="$3"
+  local line matches=0
 
-  require_line \
-    "$(rule_signatures <<<"${cluster_role}")" \
-    "${signature}" \
-    "${description}"
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ "${line}" = "${signature}" ] && matches=$((matches + 1))
+  done <<<"$(rule_signatures <<<"${cluster_role}")"
+
+  [ "${matches}" -eq 1 ] ||
+    fail "${description} (found ${matches} matching rules, expected exactly 1)"
 }
 
 # The closed half of the contract: every rule present must be one of the rules
@@ -143,9 +162,10 @@ require_rule() {
 # file while quietly widening what the exporter can read.
 #
 # Least privilege is a statement about the WHOLE role, not about the rules
-# someone remembered to assert, so the allowed set has to be closed. This is
-# also what makes the "exactly one ... rule" wording on the assertions below
-# true rather than aspirational.
+# someone remembered to assert, so the allowed set has to be closed. This closes
+# it in one direction only — no rule outside the allowed set — which is why
+# `require_rule` counts rather than merely matching: a duplicate of an allowed
+# rule is a member of the allowed set, so nothing here would reject it.
 reject_unexpected_rules() {
   local cluster_role="$1"
   shift

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -293,7 +293,48 @@ const (
 // Nothing granted to the aws/aws service account this validator exists to
 // protect is touched: the additions are in `observability`, and the exporter
 // cannot read any AWS-bearing resource.
-const expectedRenderedSurfaceSHA = "927693205f5fdf2c53d5ef92d5bcb3fa777d4a84910d24fe4501153bf82cf904"
+//
+// This value additionally covers granting that same exporter the CRD read its
+// discovery path requires (#3068). The component shipped unable to read
+// anything: kube-state-metrics resolves a CustomResourceStateMetrics
+// `groupVersionKind` through the CRD API before it can build a store for it, so
+// the repositories rule above is necessary but not sufficient, and without the
+// CRD read the reflector retry-loops on a forbidden list while the workload
+// reports itself Ready.
+//
+// Measured by rendering the production infrastructure root on the base commit
+// and on this change: the diff is EIGHT added lines and nothing else. No
+// document is removed, renamed, or otherwise altered, no resource enters or
+// leaves the surface, and the set difference in the removal direction is EMPTY.
+// The eight lines are one rule on the existing `crossplane-sync-exporter`
+// ClusterRole:
+//
+//	apiGroups: ["apiextensions.k8s.io"]
+//	resources: ["customresourcedefinitions"]
+//	verbs:     ["get", "list", "watch"]
+//
+// The grant reads CRD *definitions*, which carry schemas, not the managed
+// resources themselves — so the scoping rationale above is preserved intact:
+// managed-resource access, where provider configuration actually lives, stays
+// pinned to `repo.github.m.upbound.io/repositories`. It is read-only, and
+// `scripts/tests/test-crossplane-sync-exporter.sh` now pins this rule too, so
+// the discovery half can no longer go missing unobserved — which is exactly how
+// it went missing the first time, since that contract asserted the
+// managed-resource half alone.
+//
+// `resourceNames` cannot narrow it further: RBAC honours that field only for
+// get/update/delete/patch, never for list or watch, and the discovery path
+// lists.
+//
+// Nothing granted to the aws/aws service account is touched by this change
+// either. The rule is cluster-scoped because CRD definitions are, but it
+// confers no access to any AWS-bearing resource, identity, binding, policy
+// document or service account.
+//
+// The fingerprint was produced by two independent renderers that agree
+// exactly — the required CI job on the approved toolchain, and a local render —
+// which is what rules out a renderer-version artifact in the value.
+const expectedRenderedSurfaceSHA = "73b795b29997daff50837313bd74f2ee62e3cfacfef08bc80fe3cf1ca4fecc75"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Crossplane sync exporter shipped this morning and has been dead in production ever since. It reports itself healthy — 1/1 Ready — while publishing nothing at all, because its service account is refused one permission its startup path needs.

That is the exact failure the exporter was built to prevent, one level down: an absent metric and a healthy fleet look identical, so an alert built on this signal would sit permanently silent and read as "nothing is wrong".

## What

Grants the exporter read access to custom resource definitions, which is how it discovers the resource kind it was configured to watch. Managed-resource access is unchanged and still pinned to the single kind it exports; this adds schema discovery only, not data access.

The contract suite had pinned one half of this permission set and never the other, which is why a fully valid, fully green manifest could ship an exporter that could not read anything. That gap is now covered, so the same class of change cannot pass silently again.

Part of #3068
