### PR TITLE
security(k8s): put the headlamp namespace under the user-namespace enforce ratchet

### DIFF
--- a/k8s/providers/hetzner/apps/headlamp/patches/enable-user-namespaces.yaml
+++ b/k8s/providers/hetzner/apps/headlamp/patches/enable-user-namespaces.yaml
@@ -1,0 +1,40 @@
+# Opt headlamp into the label-gated user-namespace rules (#1807, #2843).
+#
+# Headlamp carries this label for a different reason than the other five
+# namespaces, and the difference is the whole point of the change.
+#
+# Elsewhere the label drives the `add-user-namespaces` MUTATE rule, which
+# injects hostUsers: false through a +(hostUsers) conditional anchor. That
+# anchor cannot reach headlamp: its chart renders `hostUsers` from a
+# values.yaml default of true, so the field is authored rather than absent.
+# The value is set instead by the exact-target HelmRelease values patch in
+# ../../kustomization.yaml, and that patch remains what actually hardens the
+# workload. The mutate rule is a no-op here either way.
+#
+# What the label adds is the ENFORCE RATCHET — the `disallow-host-users`
+# validate rule in validate-host-restrictions.yaml, which is scoped by this
+# same label. Without it headlamp was the one user-namespaced workload whose
+# isolation rested on a single line of kustomize config: drop that values
+# patch in a chart bump, a bad conflict resolution or an overshooting revert,
+# and the chart default of true returns, admission accepts it, no policy
+# report is produced, and the namespace does not look wrong because it was
+# never labelled. With the label, that same regression is rejected at
+# admission instead.
+#
+# Safe to apply now: the pilot (#2651) is verified and closed, the running pod
+# already sets hostUsers: false explicitly and so passes =(hostUsers): false
+# unchanged, headlamp is the only workload in the namespace, and it holds no
+# CNPG pods, so the rules' cnpg.io/cluster exclude is moot here. Its Longhorn
+# PVC round trip — the plugin sidecar writes, the main container reads — is the
+# property the disposable userns-longhorn-smoke Job proved on this cluster
+# (#2619).
+#
+# Hetzner-only, like the others: this label lives in the Hetzner overlay so the
+# nested local Docker provider stays default-off.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlamp
+  labels:
+    pod-security.devantler.tech/user-namespaces: enabled

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -92,3 +92,6 @@ patches:
   - path: umami/patches/enable-user-namespaces.yaml
   - path: backstage/patches/enable-user-namespaces.yaml
   - path: crossview/patches/enable-user-namespaces.yaml
+  # Headlamp's label is the enforce ratchet only — the values patch above is
+  # what sets hostUsers, and the mutate rule cannot reach an authored value.
+  - path: headlamp/patches/enable-user-namespaces.yaml


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Headlamp is user-namespaced, but that isolation currently rests on a single line of config with
nothing behind it. If it is ever dropped — a chart bump, a bad conflict resolution, an overshooting
revert — Headlamp silently goes back onto the host user namespace: nothing is rejected, no report is
produced, and the namespace does not look wrong. Every other user-namespaced app already has a
guardrail that catches exactly this; Headlamp was the one it did not cover.

## What

Brings the `headlamp` namespace under that existing guardrail, so losing the setting is rejected
outright instead of passing quietly. The setting itself is unchanged — this only removes the silence
around losing it. The pilot this was waiting on (#2651) is verified and closed.

**Security floor:** a silent regression of Headlamp's user-namespace isolation becomes impossible —
it is refused at admission rather than reported nowhere.
**Everyday path:** unchanged. Nothing new to remember or run; the running pod already satisfies the
rule, Headlamp is the only workload in the namespace, and no other app is affected.

Fixes #2843
Part of #1807
