### PR TITLE
feat(observability): alert when a Crossplane managed resource stops reconciling

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/alertmanager/cilium-network-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/alertmanager/cilium-network-policy.yaml
@@ -29,6 +29,19 @@ spec:
         - ports:
             - port: "9093"
               protocol: TCP
+    # The crossplane-sync-alerter CronJob (observability) POSTs /api/v2/alerts so
+    # the crossplane-sync-exporter's series reaches Slack through this
+    # Alertmanager's catch-all route. Scoped to that one pod label rather than the
+    # whole observability namespace: everything else there is a scrape client and
+    # has no reason to inject alerts.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+            app: crossplane-sync-alerter
+      toPorts:
+        - ports:
+            - port: "9093"
+              protocol: TCP
   egress:
     # Post alert notifications to the Slack incoming-webhook. Pinned by FQDN
     # (not world:443) so a compromised pod cannot exfiltrate elsewhere — the same

--- a/k8s/providers/hetzner/infrastructure/controllers/alertmanager/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/alertmanager/helm-release.yaml
@@ -112,7 +112,12 @@ spec:
               # into the webhook URL); set here only for clarity in the UI.
               channel: "#platform-alerts"
               send_resolved: true
-              title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} on {{ .CommonLabels.host }}'
+              # `host` is guarded because it is a node-agent label, not a
+              # universal one: the crossplane-sync-alerter posts cluster-scoped
+              # alerts with no host, which would otherwise render a dangling
+              # "on " in the Slack title. A no-op for the node-agent alerts,
+              # which always carry it.
+              title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}{{ with .CommonLabels.host }} on {{ . }}{{ end }}'
               # Render every annotation the node-agent attaches (keys vary by
               # rule), one per line, for each grouped alert.
               text: |-

--- a/k8s/providers/hetzner/infrastructure/controllers/alertmanager/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/alertmanager/helm-release.yaml
@@ -112,12 +112,7 @@ spec:
               # into the webhook URL); set here only for clarity in the UI.
               channel: "#platform-alerts"
               send_resolved: true
-              # `host` is guarded because it is a node-agent label, not a
-              # universal one: the crossplane-sync-alerter posts cluster-scoped
-              # alerts with no host, which would otherwise render a dangling
-              # "on " in the Slack title. A no-op for the node-agent alerts,
-              # which always carry it.
-              title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}{{ with .CommonLabels.host }} on {{ . }}{{ end }}'
+              title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} on {{ .CommonLabels.host }}'
               # Render every annotation the node-agent attaches (keys vary by
               # rule), one per line, for each grouped alert.
               text: |-

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -1,0 +1,195 @@
+# Turns the crossplane-sync-exporter's series into an actual notification.
+#
+# The exporter (bases/infrastructure/coroot/components/crossplane-sync-exporter)
+# publishes `crossplane_managed_resource_condition` into Coroot's bundled
+# Prometheus, but NOTHING consumes it: Coroot CE alerts on its own built-in
+# application SLOs and has no rule engine for an arbitrary series, and there is no
+# prometheus-operator, so a `PrometheusRule` would be reconciled by nobody. The
+# defect the exporter exists to surface — a managed resource reporting Ready=True
+# while Synced=False, so Crossplane has silently stopped reconciling it — is
+# therefore visible only to someone who goes looking at a graph.
+#
+# This CronJob is the missing consumer. It queries Prometheus and POSTs to
+# Alertmanager's v2 API, which already fans out to Slack through its catch-all
+# route (controllers/alertmanager/helm-release.yaml). Alertmanager owns grouping,
+# repeat_interval and resolution, so this job stays a pure sensor: it re-asserts
+# what is wrong right now and lets Alertmanager decide what to say about it.
+#
+# WHY A CRONJOB AND NOT A RULE: identical reasoning to
+# cron-job-alert-autosuppressor.yaml — the schedule IS the loop. Alertmanager
+# expires an alert at `endsAt`, so an alert re-asserted every 5m with a 15m
+# `endsAt` self-resolves ~15m after the underlying condition clears, and a job
+# that fails or is never scheduled degrades to "the alert resolves", never to a
+# stuck-firing alert nobody can clear.
+#
+# LIVENESS IS PART OF THE ALERT, NOT AN AFTERTHOUGHT. A dead exporter and a
+# healthy fleet both produce zero `Synced=False` samples, so silence alone is not
+# evidence of health. The exporter's own scrape config deliberately preserves
+# `up{job="crossplane-sync-exporter"}` for this, so the job alerts separately when
+# the sensor itself is down or absent, and refuses to interpret an empty result as
+# good news.
+#
+# COVERAGE IS PARTIAL AND SAYS SO. The exporter currently describes only the
+# Repository kind (CustomResourceStateMetrics takes no wildcard), so this alert
+# covers exactly the kinds the exporter lists. That limit is stated in the alert
+# annotation itself rather than left for a reader to infer from a quiet channel.
+#
+# PROD-ONLY: Alertmanager and its Slack webhook are wired only in the hetzner
+# overlay, so this lives here, not in the base.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: crossplane-sync-alerter
+  namespace: observability
+spec:
+  # 5m: fast enough that a stuck resource surfaces well inside the 4h Slack
+  # repeat_interval, slow enough to stay far below Alertmanager's cost of
+  # re-notifying. Must stay comfortably under the 15m endsAt below.
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app: crossplane-sync-alerter
+        spec:
+          restartPolicy: Never
+          # HTTP-only to two in-cluster Services; no Kubernetes API access.
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: alerter
+              # curl + jq, digest-pinned (same image as the autosuppressor).
+              # observability is exempt from disallow-latest-tag.
+              image: docker.io/badouralix/curl-jq:latest@sha256:1e7c0284e24572ace7170df9fc91f15fd3b79ebf056d4dde17244d5d74bbfabc
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  PROM="http://coroot-prometheus.observability.svc.cluster.local:9090"
+                  AM="http://alertmanager.kubescape.svc.cluster.local:9093"
+                  RETRY="-sS --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused --max-time 30"
+
+                  # Alertmanager expires an alert at endsAt, so every alert this
+                  # job posts self-resolves unless a later run re-asserts it.
+                  # 15m = 3 missed runs; shorter would flap on one slow scrape.
+                  #
+                  # Formatted with jq's `todate`, NOT `date` arithmetic: the three
+                  # date implementations disagree on relative offsets (`-d '+15
+                  # minutes'` is GNU, `-v+15M` is BSD, and BusyBox -- what this
+                  # Alpine image actually ships -- accepts neither). Only `+%s` is
+                  # universal, so the offset is plain shell arithmetic and jq does
+                  # the RFC3339 formatting it is guaranteed to get right.
+                  ENDS=$(jq -nr --argjson t "$(date -u +%s)" '($t + 900) | todate')
+                  case "$ENDS" in
+                    ????-??-??T??:??:??Z) ;;
+                    *) echo "ERROR: could not compute endsAt (got '$ENDS')"; exit 1 ;;
+                  esac
+
+                  q() { curl $RETRY --get --data-urlencode "query=$1" "$PROM/api/v1/query"; }
+
+                  # ---- 1. Is the sensor alive? -------------------------------
+                  # `up` is exempt from the exporter's metric_relabel keep, so its
+                  # ABSENCE means no scrape has ever been delivered (component not
+                  # deployed, remote_write broken) and 0 means the scrape fails.
+                  # Both are sensor failures, and both must alert -- otherwise the
+                  # quiet that follows reads exactly like a healthy fleet.
+                  UP=$(q 'up{job="crossplane-sync-exporter"}')
+                  if [ "$(printf '%s' "$UP" | jq -r '.status')" != "success" ]; then
+                    echo "ERROR: Prometheus query failed"; exit 1
+                  fi
+                  up_n=$(printf '%s' "$UP" | jq -r '[.data.result[]] | length')
+                  up_ok=$(printf '%s' "$UP" | jq -r '[.data.result[] | select(.value[1] == "1")] | length')
+
+                  alerts='[]'
+                  add() { alerts=$(printf '%s' "$alerts" | jq -c --argjson a "$1" '. + [$a]'); }
+
+                  if [ "$up_n" -eq 0 ] || [ "$up_ok" -eq 0 ]; then
+                    reason=$([ "$up_n" -eq 0 ] && echo "no up series" || echo "scrape failing")
+                    add "$(jq -nc --arg e "$ENDS" --arg r "$reason" '{
+                      labels: {
+                        alertname: "CrossplaneSyncExporterDown",
+                        severity: "warning",
+                        namespace: "observability",
+                        job: "crossplane-sync-exporter"
+                      },
+                      annotations: {
+                        summary: "Crossplane sync exporter is not reporting (\($r))",
+                        description: "No usable crossplane_managed_resource_condition data, so a managed resource that has stopped reconciling would NOT alert. A broken exporter and a healthy fleet look identical from Slack, which is why this fires instead of staying quiet.",
+                        runbook: "Check the crossplane-sync-exporter deployment in the observability namespace and its remote_write to coroot-prometheus."
+                      },
+                      endsAt: $e
+                    }')"
+                    echo "sensor down: $reason"
+                  fi
+
+                  # ---- 2. Managed resources that stopped reconciling ---------
+                  # Synced=False is the signal; Ready is reported alongside it so
+                  # the notification carries the Ready=True/Synced=False pair that
+                  # makes this failure mode invisible in kubectl's usual columns.
+                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0')
+                  if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
+                    echo "ERROR: Prometheus query for stuck resources failed"; exit 1
+                  fi
+
+                  n_stuck=$(printf '%s' "$STUCK" | jq -r '[.data.result[]] | length')
+                  i=0
+                  while [ "$i" -lt "$n_stuck" ]; do
+                    m=$(printf '%s' "$STUCK" | jq -c --argjson i "$i" '.data.result[$i].metric')
+                    name=$(printf '%s' "$m" | jq -r '.name // "unknown"')
+                    ns=$(printf '%s' "$m" | jq -r '.namespace // ""')
+                    why=$(printf '%s' "$m" | jq -r '.reason // "unknown"')
+                    add "$(jq -nc --arg e "$ENDS" --arg name "$name" --arg ns "$ns" --arg why "$why" '{
+                      labels: ({
+                        alertname: "CrossplaneManagedResourceNotSynced",
+                        severity: "warning",
+                        resource: $name,
+                        reason: $why
+                      } + (if $ns == "" then {} else {namespace: $ns} end)),
+                      annotations: {
+                        summary: "Crossplane is no longer reconciling \($name)",
+                        description: "The managed resource reports Synced=False (reason: \($why)). Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Coverage note: the exporter describes only the managed kinds listed in its CustomResourceStateMetrics config, so other kinds are NOT watched by this alert.",
+                        runbook: "kubectl describe the resource and read its Synced condition message; a provider credential or API error is the usual cause."
+                      },
+                      endsAt: $e
+                    }')"
+                    echo "not synced: $name ($why)"
+                    i=$((i + 1))
+                  done
+
+                  # ---- 3. Post ------------------------------------------------
+                  n=$(printf '%s' "$alerts" | jq -r 'length')
+                  if [ "$n" -eq 0 ]; then
+                    echo "all watched managed resources are syncing; exporter healthy"
+                    exit 0
+                  fi
+                  curl $RETRY -X POST -H 'Content-Type: application/json' \
+                    -d "$alerts" "$AM/api/v2/alerts" >/dev/null \
+                    && echo "posted $n alert(s) to alertmanager"

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -128,11 +128,31 @@ spec:
                   up_n=$(printf '%s' "$UP" | jq -r '[.data.result[]] | length')
                   up_ok=$(printf '%s' "$UP" | jq -r '[.data.result[] | select(.value[1] == "1")] | length')
 
+                  # A SCRAPEABLE exporter is not a working one. An RBAC denial, a
+                  # removed/renamed GVK, or a collector misconfiguration all leave
+                  # the HTTP endpoint healthy -- `up` stays 1 -- while the custom
+                  # resource collector emits no condition series at all. The stuck
+                  # query below then matches nothing and this job reports "all
+                  # watched managed resources are syncing": the exact silence the
+                  # alert exists to break, now with a green sensor in front of it.
+                  # So zero condition series is a sensor failure in its own right.
+                  COV=$(q 'count(crossplane_managed_resource_condition{condition="Synced"})')
+                  if [ "$(printf '%s' "$COV" | jq -r '.status')" != "success" ]; then
+                    echo "ERROR: Prometheus query for exporter coverage failed"; exit 1
+                  fi
+                  cov_n=$(printf '%s' "$COV" | jq -r '[.data.result[]] | length')
+
                   alerts='[]'
                   add() { alerts=$(printf '%s' "$alerts" | jq -c --argjson a "$1" '. + [$a]'); }
 
-                  if [ "$up_n" -eq 0 ] || [ "$up_ok" -eq 0 ]; then
-                    reason=$([ "$up_n" -eq 0 ] && echo "no up series" || echo "scrape failing")
+                  if [ "$up_n" -eq 0 ] || [ "$up_ok" -eq 0 ] || [ "$cov_n" -eq 0 ]; then
+                    if [ "$up_n" -eq 0 ]; then
+                      reason="no up series"
+                    elif [ "$up_ok" -eq 0 ]; then
+                      reason="scrape failing"
+                    else
+                      reason="scrape healthy but no condition series"
+                    fi
                     add "$(jq -nc --arg e "$ENDS" --arg r "$reason" '{
                       labels: {
                         alertname: "CrossplaneSyncExporterDown",
@@ -169,10 +189,14 @@ spec:
                   #      so min==0 means "at least one sample was 0" and matches a
                   #      recovered [0,1] series, while max==0 means "no sample was
                   #      ever 1", which is the property wanted.
-                  #   3. `count_over_time(...[3m] offset 12m) > 0` -- a sample
-                  #      existed 12-15m ago, so the window is COMPLETE. Without it
+                  #   3. `count_over_time(...[3m] offset 15m) > 0` -- a sample
+                  #      existed 15-18m ago, so the window is COMPLETE. Without it
                   #      a resource first observed 30s ago satisfies the history
-                  #      clause trivially and fires immediately.
+                  #      clause trivially and fires immediately. The offset must be
+                  #      15m, not 12m: at `offset 12m` the sub-window is 12-15m ago,
+                  #      so a series whose FIRST sample landed 12m ago qualifies and
+                  #      the alert fires after ~12m while its own text claims 15m of
+                  #      continuous failure. The offset anchors the claim.
                   #
                   # History is aggregated `by (name, namespace)` and joined `on
                   # (name, namespace)` because `reason` is part of the series
@@ -184,7 +208,7 @@ spec:
                   # samples and one missed scrape cannot suppress the alert.
                   # Worst-case detection latency is 15m of grace plus up to one
                   # 5m cron period; the failure this watches for persisted 22 days.
-                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 12m)) > 0)')
+                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 15m)) > 0)')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
                   fi

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -159,19 +159,32 @@ spec:
                   # sample is an ordinary reconciliation error, not a stuck
                   # resource -- firing on it pages on every provider API blip.
                   # `endsAt` cannot help: it expires an alert, it does not delay
-                  # one. So the query itself carries the gate, in two parts:
-                  #   min_over_time(...[15m]) == 0  -- NO sample in the window was
-                  #     1, i.e. the resource never synced across the whole window;
-                  #   count_over_time(...[3m] offset 12m) > 0  -- a sample existed
-                  #     12-15m ago, so the window is COMPLETE. Without this a
-                  #     resource first observed 30s ago satisfies min_over_time
-                  #     trivially and fires immediately, which is the same defect
-                  #     one layer down.
+                  # one. So the query itself carries the gate, in three parts:
+                  #
+                  #   1. `... == 0` -- the CURRENT sample is 0. Without this the
+                  #      history clauses alone can fire on a series whose newest
+                  #      sample is 1, i.e. one that has already recovered.
+                  #   2. `max_over_time(...[15m]) == 0` -- EVERY sample in the
+                  #      window was 0. It must be max, not min: the metric is 0/1,
+                  #      so min==0 means "at least one sample was 0" and matches a
+                  #      recovered [0,1] series, while max==0 means "no sample was
+                  #      ever 1", which is the property wanted.
+                  #   3. `count_over_time(...[3m] offset 12m) > 0` -- a sample
+                  #      existed 12-15m ago, so the window is COMPLETE. Without it
+                  #      a resource first observed 30s ago satisfies the history
+                  #      clause trivially and fires immediately.
+                  #
+                  # History is aggregated `by (name, namespace)` and joined `on
+                  # (name, namespace)` because `reason` is part of the series
+                  # identity: a resource that changes reason leaves an obsolete
+                  # all-zero series behind, which would keep satisfying the window
+                  # on its own labels long after the live series recovered.
+                  #
                   # Scrape interval is 1m, so the offset sub-window spans ~3
                   # samples and one missed scrape cannot suppress the alert.
                   # Worst-case detection latency is 15m of grace plus up to one
                   # 5m cron period; the failure this watches for persisted 22 days.
-                  STUCK=$(q 'min_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m]) == 0 and count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 12m) > 0')
+                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 12m)) > 0)')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
                   fi

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -154,7 +154,24 @@ spec:
                   # Synced=False is the signal; Ready is reported alongside it so
                   # the notification carries the Ready=True/Synced=False pair that
                   # makes this failure mode invisible in kubectl's usual columns.
-                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0')
+                  #
+                  # GRACE WINDOW. Crossplane retries, so a single Synced=False
+                  # sample is an ordinary reconciliation error, not a stuck
+                  # resource -- firing on it pages on every provider API blip.
+                  # `endsAt` cannot help: it expires an alert, it does not delay
+                  # one. So the query itself carries the gate, in two parts:
+                  #   min_over_time(...[15m]) == 0  -- NO sample in the window was
+                  #     1, i.e. the resource never synced across the whole window;
+                  #   count_over_time(...[3m] offset 12m) > 0  -- a sample existed
+                  #     12-15m ago, so the window is COMPLETE. Without this a
+                  #     resource first observed 30s ago satisfies min_over_time
+                  #     trivially and fires immediately, which is the same defect
+                  #     one layer down.
+                  # Scrape interval is 1m, so the offset sub-window spans ~3
+                  # samples and one missed scrape cannot suppress the alert.
+                  # Worst-case detection latency is 15m of grace plus up to one
+                  # 5m cron period; the failure this watches for persisted 22 days.
+                  STUCK=$(q 'min_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m]) == 0 and count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 12m) > 0')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
                   fi
@@ -175,7 +192,7 @@ spec:
                       } + (if $ns == "" then {} else {namespace: $ns} end)),
                       annotations: {
                         summary: "Crossplane is no longer reconciling \($name)",
-                        description: "The managed resource reports Synced=False (reason: \($why)). Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Coverage note: the exporter describes only the managed kinds listed in its CustomResourceStateMetrics config, so other kinds are NOT watched by this alert.",
+                        description: "The managed resource has reported Synced=False continuously for at least 15 minutes (reason: \($why)), so this is not a transient retry. Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Coverage note: the exporter describes only the managed kinds listed in its CustomResourceStateMetrics config, so other kinds are NOT watched by this alert.",
                         runbook: "kubectl describe the resource and read its Synced condition message; a provider credential or API error is the usual cause."
                       },
                       endsAt: $e
@@ -190,6 +207,16 @@ spec:
                     echo "all watched managed resources are syncing; exporter healthy"
                     exit 0
                   fi
-                  curl $RETRY -X POST -H 'Content-Type: application/json' \
-                    -d "$alerts" "$AM/api/v2/alerts" >/dev/null \
-                    && echo "posted $n alert(s) to alertmanager"
+                  # --fail is what makes a rejected POST observable. Without it
+                  # curl exits 0 on 4xx/5xx, the job logs "posted" and succeeds,
+                  # and the alerts are silently dropped -- the quiet then reads
+                  # exactly like a healthy fleet, which is the failure mode this
+                  # whole CronJob exists to remove. It also lets --retry-all-errors
+                  # retry a 5xx instead of accepting it.
+                  if curl $RETRY --fail -X POST -H 'Content-Type: application/json' \
+                       -d "$alerts" "$AM/api/v2/alerts" >/dev/null; then
+                    echo "posted $n alert(s) to alertmanager"
+                  else
+                    echo "ERROR: alertmanager rejected the POST; $n alert(s) NOT delivered"
+                    exit 1
+                  fi

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -204,11 +204,32 @@ spec:
                   # all-zero series behind, which would keep satisfying the window
                   # on its own labels long after the live series recovered.
                   #
+                  #   4. `sum by (...) (count_over_time(...[15m])) >= 12` -- the window is
+                  #      COVERED, not merely bounded. `max_over_time` ignores
+                  #      absent samples rather than treating them as non-zero,
+                  #      so clauses 1-3 are all satisfied by one false sample at
+                  #      the start of the window, a long data gap, and one false
+                  #      sample now -- during which the resource may have
+                  #      recovered, or been deleted and recreated, entirely
+                  #      unobserved. The alert would then claim 15 minutes of
+                  #      continuous failure it never actually saw.
+                  #
                   # Scrape interval is 1m, so the offset sub-window spans ~3
-                  # samples and one missed scrape cannot suppress the alert.
+                  # samples and one missed scrape cannot suppress the alert, and
+                  # a full 15m window holds ~15 samples. The coverage floor of 12
+                  # is that budget minus 3, so up to three missed scrapes are
+                  # still tolerated while a multi-minute blind spot is not.
+                  #
+                  # It must aggregate with `sum by`, NOT the `count by` the other
+                  # clauses use. `count_over_time` yields one value PER SERIES, so
+                  # `count by` would count the group's SERIES (1, or 2 during a
+                  # reason change) rather than its samples -- `1 >= 12` is false
+                  # for every resource, which silently disables this alert
+                  # entirely. Measured against prod: `count by` matched 0 of 20
+                  # resources, `sum by` 20 of 20 at exactly 15 samples each.
                   # Worst-case detection latency is 15m of grace plus up to one
                   # 5m cron period; the failure this watches for persisted 22 days.
-                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 15m)) > 0)')
+                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[3m] offset 15m)) > 0) and on (name, namespace) (sum by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced"}[15m])) >= 12)')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
                   fi
@@ -220,14 +241,29 @@ spec:
                     name=$(printf '%s' "$m" | jq -r '.name // "unknown"')
                     ns=$(printf '%s' "$m" | jq -r '.namespace // ""')
                     why=$(printf '%s' "$m" | jq -r '.reason // "unknown"')
+                    # `reason` is deliberately NOT a label. Alertmanager keys the
+                    # identity of an alert on its label set, so a resource that
+                    # stays unsynced while Crossplane changes the reason would fire
+                    # a SECOND alert under a new fingerprint while the first stayed
+                    # active until its endsAt -- one broken resource, repeated Slack
+                    # notifications. The history query already joins on
+                    # (name, namespace) without reason for the same underlying
+                    # cause, so keeping it out of the identity makes the two agree.
+                    # The current reason still reaches the reader as an annotation,
+                    # which updates in place instead of forking.
+                    #
+                    # NOTE: this comment lives OUT here rather than inside the jq
+                    # program below. That program is a single-quoted shell string,
+                    # so an apostrophe in a comment inside it closes the quote and
+                    # breaks the whole script.
                     add "$(jq -nc --arg e "$ENDS" --arg name "$name" --arg ns "$ns" --arg why "$why" '{
                       labels: ({
                         alertname: "CrossplaneManagedResourceNotSynced",
                         severity: "warning",
-                        resource: $name,
-                        reason: $why
+                        resource: $name
                       } + (if $ns == "" then {} else {namespace: $ns} end)),
                       annotations: {
+                        reason: $why,
                         summary: "Crossplane is no longer reconciling \($name)",
                         description: "The managed resource has reported Synced=False continuously for at least 15 minutes (reason: \($why)), so this is not a transient retry. Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Coverage note: the exporter describes only the managed kinds listed in its CustomResourceStateMetrics config, so other kinds are NOT watched by this alert.",
                         runbook: "kubectl describe the resource and read its Synced condition message; a provider credential or API error is the usual cause."

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -53,6 +53,10 @@ resources:
   # Coroot has no declarative per-alert exemption. See the file header for the
   # exemption list + why each is by-design.
   - coroot/cron-job-alert-autosuppressor.yaml
+  # Prod-only: turns the crossplane-sync-exporter's series into a Slack
+  # notification via Alertmanager, which nothing else consumes. See the file
+  # header for why this is a CronJob rather than a PrometheusRule.
+  - coroot/cron-job-crossplane-sync-alerter.yaml
   # Prod-only: the CloudNativePG datastore + backup wiring that lets the Coroot
   # SERVER run HA (replicas: 2 — set in the coroot-patch below). The operator
   # only honours replicas > 1 when spec.postgres is set, so this Postgres is the


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

We already measure when Crossplane silently stops reconciling a managed resource — the resource keeps reporting `Ready=True` while `Synced=False`, so it drifts from Git while looking healthy in `kubectl`. But nothing was listening: the exporter's data went into Prometheus and stayed there, visible only to someone who happened to open a graph. Drift could persist indefinitely without anyone knowing.

## What

A scheduled job now reads that data and raises a Slack alert through the existing Alertmanager route, so a stuck resource reaches a human within minutes.

It also alerts when the exporter itself goes quiet. A broken sensor and a healthy fleet look identical from Slack, and treating silence as good news is how this class of problem stays hidden.

Coverage is partial by design and the alert says so in its own text — the exporter currently watches one resource kind, so the notification never implies more assurance than it has.

Fixes #2820