### PR TITLE
fix(observability): read the CNPG alert webhook from a file, not the environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,6 +141,7 @@ jobs:
               - 'scripts/wait-for-platform-flux-revision.sh'
               - 'scripts/tests/test-opencost-usage-scraper.sh'
               - 'scripts/tests/test-crossplane-sync-exporter.sh'
+              - 'scripts/tests/test-cnpg-degraded-alert.sh'
               # Both halves, so editing the guard alone — or its test alone —
               # still runs the check that covers it.
               - 'scripts/dr-rebuild-supersession-guard.sh'
@@ -438,6 +439,15 @@ jobs:
         # reads exactly like a fleet with nothing wrong. Schema validation cannot
         # see any of it, so render the component contract instead.
         run: bash scripts/tests/test-crossplane-sync-exporter.sh
+
+      - name: 🩺 Validate the CNPG degraded-cluster alert
+        if: needs.changes.outputs.k8s == 'true'
+        # This CronJob is the only signal for a database degraded without
+        # crashlooping, and a broken check prints the same "none degraded" line
+        # as a healthy fleet. Run its real script against a stubbed API and
+        # delivery so both silent-zero guards and the credential's handling are
+        # pinned by behaviour rather than by schema.
+        run: bash scripts/tests/test-cnpg-degraded-alert.sh
 
       - name: 🧭 Validate the DR rebuild supersession gate
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -114,8 +114,22 @@ spec:
                   # (checkov CKV_K8S_35). An env value sits in
                   # /proc/self/environ for the pod's whole life and is
                   # inherited by every process the script starts; the file is
-                  # mounted 0400 and read once, here.
+                  # mounted 0440 (root:fsGroup, group-readable by this
+                  # container's own user) and read once, here.
                   WEBHOOK_URL=$(cat /etc/cnpg-degraded-alert/url)
+
+                  # The value becomes a curl CONFIG directive below, where a
+                  # newline starts a SECOND directive -- so an LF in the Secret
+                  # would let the config say `output = ...` or anything else
+                  # curl accepts. A valid URL cannot contain a control
+                  # character, so rejecting them costs nothing and turns a
+                  # malformed Secret into a loud failure instead of a silently
+                  # reconfigured request. Checked with `tr -d`, which needs no
+                  # locale or regex assumptions.
+                  if [ "$(printf '%s' "$WEBHOOK_URL" | tr -d '[:cntrl:]')" != "$WEBHOOK_URL" ]; then
+                    echo "ERROR: webhook URL contains control characters" >&2
+                    exit 1
+                  fi
 
                   # A non-2xx or unparseable response must NOT be reported as
                   # "no degraded clusters" — that is the silent-zero failure
@@ -133,7 +147,11 @@ spec:
                     echo "ERROR: kube API returned HTTP $code listing CNPG clusters" >&2
                     exit 1
                   fi
-                  if ! jq -e 'has("items")' /tmp/body >/dev/null; then
+                  # `has("items")` is satisfied by {"items":{}}, which then
+                  # counts zero clusters and reports a malformed API response as
+                  # a healthy one -- the silent zero this guard exists to stop.
+                  # Require the ARRAY, not merely the key.
+                  if ! jq -e '(.items | type) == "array"' /tmp/body >/dev/null; then
                     echo "ERROR: unexpected response shape from kube API" >&2
                     exit 1
                   fi
@@ -193,8 +211,10 @@ spec:
                   # syntax at all, so there is nothing here to get wrong; a
                   # quoted value would need backslash and double-quote escaped
                   # and would drag in a `sed` the rest of this script does not
-                  # use. URLs cannot contain a raw newline, and curl trims
-                  # surrounding whitespace, so this is total for the input.
+                  # use. curl trims surrounding whitespace, and the
+                  # control-character guard above has already rejected the one
+                  # input that could end this line early -- the guard is what
+                  # makes that total, not the shape of a well-formed URL.
                   printf 'url = %s\n' "$WEBHOOK_URL" |
                     curl -sf --max-time 15 \
                       --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -86,6 +86,14 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
+            # fsGroup is what makes the mounted webhook readable at all. Secret
+            # volume files are owned by root:root unless fsGroup is set, so a
+            # non-root container reading a mode-0400 file gets EACCES and this
+            # CronJob fails before its first API call -- silently removing the
+            # only degraded-CNPG alert. Setting fsGroup makes kubelet chown the
+            # volume to root:65532, which the group-readable mode below then
+            # opens to this container and nothing else.
+            fsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -222,14 +230,17 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
-            # 256 is 0400: readable only by the container's own user, rather
-            # than by anything else that lands in this pod. The Secret is the
+            # 288 is 0440: readable by root and by the pod's fsGroup (65532,
+            # set above), rather than by anything else that lands in this pod.
+            # It must carry the GROUP bit: kubelet owns secret-volume files
+            # root:fsGroup, never uid:fsGroup, so an owner-only 0400 is
+            # unreadable by the container's own non-root user. The Secret is the
             # one secret-cnpg-degraded-alert.yaml creates from the per-cluster
             # Flux substitution.
             #
-            # Written in DECIMAL deliberately. An unquoted `0400` is read as
-            # octal 256 by Kubernetes' own parser (sigs.k8s.io/yaml, which is
-            # YAML 1.1) and as decimal 400 — mode 0620 — by every YAML 1.2
+            # Written in DECIMAL deliberately. An unquoted `0440` is read as
+            # octal 288 by Kubernetes' own parser (sigs.k8s.io/yaml, which is
+            # YAML 1.1) and as decimal 440 — mode 0670 — by every YAML 1.2
             # reader, yq and kyaml included. The two disagree silently and
             # nothing validates the difference, so the literal that means the
             # same thing to both is the only safe one. `defaultMode: 420` on
@@ -237,4 +248,4 @@ spec:
             - name: webhook
               secret:
                 secretName: cnpg-degraded-alert-webhook
-                defaultMode: 256
+                defaultMode: 288

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -94,11 +94,6 @@ spec:
               env:
                 - name: GRACE_SECONDS
                   value: "900"
-                - name: WEBHOOK_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: cnpg-degraded-alert-webhook
-                      key: url
               command:
                 - /bin/sh
                 - -c
@@ -106,6 +101,13 @@ spec:
                   set -eu
                   API=https://kubernetes.default.svc
                   SA=/var/run/secrets/kubernetes.io/serviceaccount
+
+                  # Read from the mounted Secret rather than an env var
+                  # (checkov CKV_K8S_35). An env value sits in
+                  # /proc/self/environ for the pod's whole life and is
+                  # inherited by every process the script starts; the file is
+                  # mounted 0400 and read once, here.
+                  WEBHOOK_URL=$(cat /etc/cnpg-degraded-alert/url)
 
                   # A non-2xx or unparseable response must NOT be reported as
                   # "no degraded clusters" — that is the silent-zero failure
@@ -171,11 +173,26 @@ spec:
                   # POST fails. Swallowing that would record a successful run
                   # having sent nothing: the same silent-zero failure the API
                   # read above is guarded against, at the other end of the check.
-                  curl -sf --max-time 15 \
-                    --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
-                    -H 'Content-Type: application/json' \
-                    --data @/tmp/payload.json \
-                    "$WEBHOOK_URL"
+                  #
+                  # The URL reaches curl on stdin as a config file rather than
+                  # as an argument. An argv copy is readable from
+                  # /proc/<pid>/cmdline for the life of the request, so passing
+                  # it positionally would relocate the exposure CKV_K8S_35
+                  # names instead of removing it.
+                  #
+                  # The value is UNQUOTED on purpose. curl reads an unquoted
+                  # config value as everything to end of line, with no escape
+                  # syntax at all, so there is nothing here to get wrong; a
+                  # quoted value would need backslash and double-quote escaped
+                  # and would drag in a `sed` the rest of this script does not
+                  # use. URLs cannot contain a raw newline, and curl trims
+                  # surrounding whitespace, so this is total for the input.
+                  printf 'url = %s\n' "$WEBHOOK_URL" |
+                    curl -sf --max-time 15 \
+                      --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
+                      -H 'Content-Type: application/json' \
+                      --data @/tmp/payload.json \
+                      --config -
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -190,6 +207,9 @@ spec:
                 # scratch dir for the API response and the webhook payload.
                 - name: tmp
                   mountPath: /tmp
+                - name: webhook
+                  mountPath: /etc/cnpg-degraded-alert
+                  readOnly: true
               resources:
                 requests:
                   cpu: 5m
@@ -202,3 +222,19 @@ spec:
           volumes:
             - name: tmp
               emptyDir: {}
+            # 256 is 0400: readable only by the container's own user, rather
+            # than by anything else that lands in this pod. The Secret is the
+            # one secret-cnpg-degraded-alert.yaml creates from the per-cluster
+            # Flux substitution.
+            #
+            # Written in DECIMAL deliberately. An unquoted `0400` is read as
+            # octal 256 by Kubernetes' own parser (sigs.k8s.io/yaml, which is
+            # YAML 1.1) and as decimal 400 — mode 0620 — by every YAML 1.2
+            # reader, yq and kyaml included. The two disagree silently and
+            # nothing validates the difference, so the literal that means the
+            # same thing to both is the only safe one. `defaultMode: 420` on
+            # the coredns Deployment is the same convention.
+            - name: webhook
+              secret:
+                secretName: cnpg-degraded-alert-webhook
+                defaultMode: 256

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -125,7 +125,15 @@ pass "webhook URL is never passed to curl in argv"
 # and a stubbed curl, so what is asserted is what the container would really do.
 # ---------------------------------------------------------------------------
 
-work_root="$(mktemp -d)"
+# Anchored under /tmp deliberately, rather than a bare `mktemp -d`.
+#
+# The patched script below rewrites `/tmp/` to point inside this sandbox, so the
+# sandbox's OWN path has to be able to collide with that rule — otherwise the
+# collision, and the guard that detects it, are both inert. A bare `mktemp -d`
+# returns /var/folders/… on macOS and /tmp/… on Linux, so the ordering bug this
+# guards against passed every local run and failed only in CI. Anchoring here
+# makes the local run reproduce the CI condition.
+work_root="$(mktemp -d /tmp/tmp.XXXXXXXXXX)"
 trap 'rm -rf "${work_root}"' EXIT
 
 # Build one scenario sandbox: a fake serviceaccount dir, a webhook file, a
@@ -200,10 +208,22 @@ run_scenario() {
     # is byte-identical to what the container runs.
     printf 'SA_OVERRIDE=%q\n' "${dir}/sa"
     printf 'WEBHOOK_OVERRIDE=%q\n' "${dir}/webhook/url"
+    # ORDER IS LOAD-BEARING: the `/tmp/` rewrite must run FIRST.
+    #
+    # `${dir}` is itself under `/tmp/` (mktemp -d), so running it last would
+    # re-match the sandbox path the webhook rule had just introduced and double
+    # it: `/etc/cnpg-degraded-alert/url` -> `${dir}/webhook/url` -> then the
+    # leading `/tmp/` of THAT becomes `${dir}/tmp/`, yielding
+    # `${dir}/tmp/${dir#/}/webhook/url`. Reversing the order leaves the webhook
+    # rule's output untouched because `/tmp/` has already been rewritten.
+    #
+    # This reproduces only where mktemp returns a path under /tmp — Linux CI,
+    # not macOS, where it returns /var/folders/… — so it passes locally and
+    # fails in CI.
     printf '%s\n' "${script_body}" |
       sed -e 's#^\( *\)SA=/var/run/secrets/kubernetes.io/serviceaccount$#\1SA="$SA_OVERRIDE"#' \
-        -e 's#/etc/cnpg-degraded-alert/url#'"${dir}"'/webhook/url#g' \
-        -e 's#/tmp/#'"${dir}"'/tmp/#g'
+        -e 's#/tmp/#'"${dir}"'/tmp/#g' \
+        -e 's#/etc/cnpg-degraded-alert/url#'"${dir}"'/webhook/url#g'
   } >"${patched}"
 
   # Prove the redirection actually applied. Without this the sed could silently
@@ -213,6 +233,12 @@ run_scenario() {
     fail "serviceaccount path redirection did not apply; the script's SA line changed shape"
   grep -q "${dir}/webhook/url" "${patched}" ||
     fail "webhook path redirection did not apply; the script no longer reads /etc/cnpg-degraded-alert/url"
+  # The check above is a SUBSTRING match, so the doubled path `${dir}/tmp/${dir#/}/webhook/url`
+  # satisfies it — that is exactly how the ordering bug reached CI. Assert the
+  # sandbox root appears at most once per line to catch any future rule that
+  # rewrites another rule's output.
+  ! grep -q -- "${dir}.*${dir}" "${patched}" ||
+    fail "a redirection rewrote another rule's output; the sandbox path is doubled in the patched script"
 
   (
     cd "${dir}"

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -66,7 +66,6 @@ pod_path='.spec.jobTemplate.spec.template.spec'
 
 env_block="$(yq eval "${container_path}.env" "${manifest}")"
 script_body="$(yq eval "${container_path}.command[2]" "${manifest}")"
-volume_mounts="$(yq eval "${container_path}.volumeMounts" "${manifest}")"
 volumes="$(yq eval "${pod_path}.volumes" "${manifest}")"
 
 [ -n "${script_body}" ] && [ "${script_body}" != "null" ] ||
@@ -220,6 +219,7 @@ run_scenario() {
     # This reproduces only where mktemp returns a path under /tmp — Linux CI,
     # not macOS, where it returns /var/folders/… — so it passes locally and
     # fails in CI.
+    # shellcheck disable=SC2016  # `$SA_OVERRIDE` is emitted INTO the patched script; the shell here must not expand it.
     printf '%s\n' "${script_body}" |
       sed -e 's#^\( *\)SA=/var/run/secrets/kubernetes.io/serviceaccount$#\1SA="$SA_OVERRIDE"#' \
         -e 's#/tmp/#'"${dir}"'/tmp/#g' \
@@ -229,6 +229,7 @@ run_scenario() {
   # Prove the redirection actually applied. Without this the sed could silently
   # match nothing and every scenario would exercise real in-cluster paths,
   # failing identically for the wrong reason.
+  # shellcheck disable=SC2016  # matching the LITERAL `$SA_OVERRIDE` the sed above wrote into the file.
   grep -q 'SA="\$SA_OVERRIDE"' "${patched}" ||
     fail "serviceaccount path redirection did not apply; the script's SA line changed shape"
   grep -q "${dir}/webhook/url" "${patched}" ||
@@ -253,7 +254,7 @@ deliveries() {
 
 # A cluster degraded well past any grace period.
 old_stamp="$(date -u -r 0 +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d @0 +%Y-%m-%dT%H:%M:%SZ)"
-readonly degraded_body="$(
+degraded_body="$(
   jq -n --arg ts "${old_stamp}" '{
     items: [{
       metadata: { namespace: "umami", name: "umami-db" },
@@ -265,7 +266,8 @@ readonly degraded_body="$(
     }]
   }'
 )"
-readonly healthy_body="$(
+readonly degraded_body
+healthy_body="$(
   jq -n --arg ts "${old_stamp}" '{
     items: [{
       metadata: { namespace: "umami", name: "umami-db" },
@@ -277,6 +279,7 @@ readonly healthy_body="$(
     }]
   }'
 )"
+readonly healthy_body
 
 # Scenario 1 — degraded cluster, real webhook: exactly one delivery, and the URL
 # reaches curl through its stdin config rather than its argv.

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+
+# Contract for the cnpg-degraded-alert CronJob (#2787).
+#
+# This CronJob is the ONLY signal for a CloudNativePG cluster that is degraded
+# without crashlooping — a pod that stays Running, never Ready, with zero
+# restarts, which no Coroot inspection covers. It had no test at all, so every
+# behaviour its own manifest comment calls load-bearing was pinned by nothing.
+#
+# Two classes are asserted here, and they fail in opposite directions:
+#
+#   SILENT-ZERO. A broken check and a healthy fleet both print "none degraded".
+#   The script guards that with an HTTP-code check, a response-shape check and a
+#   deliberate absence of `|| true` on the delivery. Each of those is a line
+#   someone could remove while every schema validation stayed green, so each is
+#   pinned by a scenario that removes it and expects the run to FAIL.
+#
+#   CREDENTIAL EXPOSURE. checkov CKV_K8S_35 flags the webhook arriving as an
+#   environment variable. The remediation is only real if the value reaches the
+#   script from a mounted file AND does not reappear in curl's argv, so both are
+#   asserted — a fix that moves the secret from `/proc/self/environ` to
+#   `/proc/<pid>/cmdline` has relocated the exposure, not removed it.
+#
+# The script is extracted from the rendered manifest rather than copied here, so
+# this cannot drift into testing a stale transcription of it.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly manifest="${root_dir}/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml"
+readonly ci_workflow="${root_dir}/.github/workflows/ci.yaml"
+
+# Deliberately NOT a hooks.slack.com-shaped literal. GitHub push protection
+# matches that shape and blocks the push on a synthetic value just as it would
+# on a live one — correctly, since it cannot tell them apart. The script only
+# special-cases the example.invalid placeholder, so any other host exercises the
+# delivery path exactly the same way. `.invalid` is RFC 2606 reserved, so this
+# can never resolve even if a stub were missed.
+readonly REAL_WEBHOOK='https://hooks.test.invalid/delivery-target'
+readonly PLACEHOLDER_WEBHOOK='https://example.invalid/no-slack-configured'
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok — %s\n' "$1"
+}
+
+for tool in yq jq; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    printf '::error::%s is required to run this contract test.\n' "${tool}" >&2
+    exit 64
+  }
+done
+[ -f "${manifest}" ] || fail "manifest not found: ${manifest} (run from the repository root)"
+
+# ---------------------------------------------------------------------------
+# Structural assertions on the rendered container.
+# ---------------------------------------------------------------------------
+
+container_path='.spec.jobTemplate.spec.template.spec.containers[0]'
+pod_path='.spec.jobTemplate.spec.template.spec'
+
+env_block="$(yq eval "${container_path}.env" "${manifest}")"
+script_body="$(yq eval "${container_path}.command[2]" "${manifest}")"
+volume_mounts="$(yq eval "${container_path}.volumeMounts" "${manifest}")"
+volumes="$(yq eval "${pod_path}.volumes" "${manifest}")"
+
+[ -n "${script_body}" ] && [ "${script_body}" != "null" ] ||
+  fail "could not extract the container script from ${manifest}"
+
+# CKV_K8S_35. `secretKeyRef` anywhere in this container's env is the finding.
+if grep -q 'secretKeyRef' <<<"${env_block}"; then
+  fail "CKV_K8S_35: container env still carries a secretKeyRef; the webhook must arrive as a mounted file"
+fi
+pass "no secretKeyRef in the container environment"
+
+# The secret has to actually reach the pod, or the check above is satisfied by
+# simply deleting the credential. Assert the volume and its mount exist and name
+# the same Secret the manifest's own secret-cnpg-degraded-alert.yaml creates.
+grep -q 'cnpg-degraded-alert-webhook' <<<"${volumes}" ||
+  fail "no volume sourced from the cnpg-degraded-alert-webhook Secret"
+pass "webhook Secret is mounted as a volume"
+
+webhook_mount_path="$(yq eval \
+  "${container_path}.volumeMounts[] | select(.name == \"webhook\") | .mountPath" "${manifest}")"
+[ -n "${webhook_mount_path}" ] && [ "${webhook_mount_path}" != "null" ] ||
+  fail "the webhook volume is not mounted into the container"
+grep -q 'readOnly: true' <<<"$(yq eval \
+  "${container_path}.volumeMounts[] | select(.name == \"webhook\")" "${manifest}")" ||
+  fail "the webhook mount must be readOnly"
+pass "webhook mount is present and readOnly at ${webhook_mount_path}"
+
+# A mounted credential that every process in the pod can read is only half the
+# control. defaultMode pins it to the container's own user.
+default_mode="$(yq eval \
+  "${pod_path}.volumes[] | select(.name == \"webhook\") | .secret.defaultMode" "${manifest}")"
+[ "${default_mode}" = "256" ] ||
+  fail "expected the webhook volume defaultMode 0400 (256 decimal), got: ${default_mode}"
+pass "webhook volume is mounted 0400"
+
+# The relocation trap: the URL must not be handed to curl as an argument, or it
+# is simply exposed through /proc/<pid>/cmdline instead of /proc/self/environ.
+#
+# Checked as two LINE-anchored patterns rather than one expression spanning the
+# whole invocation. grep is line-oriented, and this curl call is written across
+# five continuation lines, so a `curl.*"$WEBHOOK_URL"` pattern matches nothing
+# whatever the script says — it passes identically on a fixed and a reverted
+# manifest. That vacuous form was caught by ablating this very assertion.
+if grep -Eq '^[[:space:]]*"\$\{?WEBHOOK_URL\}?"[[:space:]]*$' <<<"${script_body}"; then
+  fail "the webhook URL is a bare curl continuation argument; it would appear in /proc/<pid>/cmdline"
+fi
+if grep -Eq 'curl.*"\$\{?WEBHOOK_URL\}?"' <<<"${script_body}"; then
+  fail "the webhook URL is passed to curl as an argument; it would appear in /proc/<pid>/cmdline"
+fi
+grep -Fq -- '--config -' <<<"${script_body}" ||
+  fail "the delivery does not read its URL from a stdin config; the URL must not travel in argv"
+pass "webhook URL is never passed to curl in argv"
+
+# ---------------------------------------------------------------------------
+# Behavioural scenarios. The extracted script runs against a stubbed kube API
+# and a stubbed curl, so what is asserted is what the container would really do.
+# ---------------------------------------------------------------------------
+
+work_root="$(mktemp -d)"
+trap 'rm -rf "${work_root}"' EXIT
+
+# Build one scenario sandbox: a fake serviceaccount dir, a webhook file, a
+# stubbed curl that serves a canned kube API response and records deliveries.
+#
+# The stub distinguishes the two curl calls the script makes the same way curl
+# itself does — the API read asks for an output file with -o, the delivery does
+# not — so neither has to be matched on its URL.
+setup_scenario() {
+  local name="$1" api_code="$2" api_body="$3" webhook="$4"
+  local dir="${work_root}/${name}"
+
+  mkdir -p "${dir}/bin" "${dir}/sa" "${dir}/webhook" "${dir}/tmp"
+  printf 'fake-ca' >"${dir}/sa/ca.crt"
+  printf 'fake-token' >"${dir}/sa/token"
+  printf '%s' "${webhook}" >"${dir}/webhook/url"
+  printf '%s' "${api_body}" >"${dir}/api-body.json"
+  printf '%s' "${api_code}" >"${dir}/api-code"
+
+  cat >"${dir}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+# Stub curl. Distinguishes the kube API read (-o <file>) from the Slack
+# delivery, records every invocation, and never touches the network.
+set -uo pipefail
+dir="${SCENARIO_DIR}"
+printf '%s\n' "$*" >>"${dir}/curl-argv.log"
+
+out_file=""
+prev=""
+for arg in "$@"; do
+  [ "${prev}" = "-o" ] && out_file="${arg}"
+  prev="${arg}"
+done
+
+if [ -n "${out_file}" ]; then
+  cat "${dir}/api-body.json" >"${out_file}"
+  printf '%s' "$(cat "${dir}/api-code")"
+  code="$(cat "${dir}/api-code")"
+  # -f is not in play for the API read; the script inspects the printed code.
+  exit 0
+fi
+
+# Delivery. Record the config curl was handed on stdin plus the payload, so the
+# test can assert the URL travelled out-of-band and the body is well-formed.
+cat >>"${dir}/curl-stdin.log"
+for arg in "$@"; do
+  case "${arg}" in
+    @*) cp "${arg#@}" "${dir}/delivered-payload.json" 2>/dev/null || true ;;
+  esac
+done
+printf 'delivered\n' >>"${dir}/deliveries.log"
+exit "${STUB_DELIVERY_EXIT:-0}"
+STUB
+  chmod +x "${dir}/bin/curl"
+  printf '%s' "${dir}"
+}
+
+# Run the extracted script inside a scenario sandbox.
+#
+# The script hard-codes the in-cluster serviceaccount path and the kube API
+# host, so both are redirected here rather than edited into a copy: a test that
+# rewrites the script is no longer testing the script.
+run_scenario() {
+  local dir="$1" grace="${2:-900}"
+  local patched="${dir}/script.sh"
+
+  {
+    printf '%s\n' 'set -eu'
+    printf 'GRACE_SECONDS=%s\n' "${grace}"
+    printf 'export SCENARIO_DIR=%q\n' "${dir}"
+    # Redirect the two in-cluster absolute paths at the top, so the body below
+    # is byte-identical to what the container runs.
+    printf 'SA_OVERRIDE=%q\n' "${dir}/sa"
+    printf 'WEBHOOK_OVERRIDE=%q\n' "${dir}/webhook/url"
+    printf '%s\n' "${script_body}" |
+      sed -e 's#^\( *\)SA=/var/run/secrets/kubernetes.io/serviceaccount$#\1SA="$SA_OVERRIDE"#' \
+        -e 's#/etc/cnpg-degraded-alert/url#'"${dir}"'/webhook/url#g' \
+        -e 's#/tmp/#'"${dir}"'/tmp/#g'
+  } >"${patched}"
+
+  # Prove the redirection actually applied. Without this the sed could silently
+  # match nothing and every scenario would exercise real in-cluster paths,
+  # failing identically for the wrong reason.
+  grep -q 'SA="\$SA_OVERRIDE"' "${patched}" ||
+    fail "serviceaccount path redirection did not apply; the script's SA line changed shape"
+  grep -q "${dir}/webhook/url" "${patched}" ||
+    fail "webhook path redirection did not apply; the script no longer reads /etc/cnpg-degraded-alert/url"
+
+  (
+    cd "${dir}"
+    PATH="${dir}/bin:${PATH}" SCENARIO_DIR="${dir}" bash "${patched}" >"${dir}/stdout.log" 2>"${dir}/stderr.log"
+  )
+}
+
+deliveries() {
+  local dir="$1"
+  [ -f "${dir}/deliveries.log" ] && wc -l <"${dir}/deliveries.log" | tr -d ' ' || printf '0'
+}
+
+# A cluster degraded well past any grace period.
+old_stamp="$(date -u -r 0 +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d @0 +%Y-%m-%dT%H:%M:%SZ)"
+readonly degraded_body="$(
+  jq -n --arg ts "${old_stamp}" '{
+    items: [{
+      metadata: { namespace: "umami", name: "umami-db" },
+      spec: { instances: 3 },
+      status: {
+        readyInstances: 2,
+        conditions: [{ type: "Ready", status: "True", lastTransitionTime: $ts }]
+      }
+    }]
+  }'
+)"
+readonly healthy_body="$(
+  jq -n --arg ts "${old_stamp}" '{
+    items: [{
+      metadata: { namespace: "umami", name: "umami-db" },
+      spec: { instances: 3 },
+      status: {
+        readyInstances: 3,
+        conditions: [{ type: "Ready", status: "True", lastTransitionTime: $ts }]
+      }
+    }]
+  }'
+)"
+
+# Scenario 1 — degraded cluster, real webhook: exactly one delivery, and the URL
+# reaches curl through its stdin config rather than its argv.
+dir="$(setup_scenario delivers 200 "${degraded_body}" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'delivers': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "1" ] ||
+  fail "scenario 'delivers': expected exactly 1 delivery, got $(deliveries "${dir}")"
+grep -Fq "${REAL_WEBHOOK}" "${dir}/curl-stdin.log" ||
+  fail "scenario 'delivers': the webhook URL never reached curl's stdin config"
+if grep -Fq "${REAL_WEBHOOK}" "${dir}/curl-argv.log"; then
+  fail "scenario 'delivers': the webhook URL appeared in curl's argv"
+fi
+jq -e '.text | test("umami/umami-db")' "${dir}/delivered-payload.json" >/dev/null ||
+  fail "scenario 'delivers': payload does not name the degraded cluster"
+jq -e '.text | test("2/3 instances ready")' "${dir}/delivered-payload.json" >/dev/null ||
+  fail "scenario 'delivers': payload does not carry the ready/desired counts"
+pass "a degraded cluster delivers exactly one alert, with the URL out of argv"
+
+# Scenario 2 — the reserved placeholder host stays inert, so local and CI runs
+# are quiet by design without swallowing a real delivery failure.
+dir="$(setup_scenario placeholder 200 "${degraded_body}" "${PLACEHOLDER_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'placeholder': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'placeholder': expected no delivery against example.invalid"
+grep -q 'No Slack webhook configured' "${dir}/stdout.log" ||
+  fail "scenario 'placeholder': the skip was not reported"
+pass "the example.invalid placeholder stays inert"
+
+# Scenario 3 — a healthy fleet is quiet, and says how many it checked.
+dir="$(setup_scenario healthy 200 "${healthy_body}" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'healthy': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'healthy': a healthy fleet must not alert"
+grep -q 'Checked 1 CNPG cluster' "${dir}/stdout.log" ||
+  fail "scenario 'healthy': the checked count was not reported"
+pass "a healthy fleet is quiet and reports what it checked"
+
+# Scenario 4 — SILENT-ZERO. A 500 from the kube API must fail the Job, never
+# read as "nothing degraded".
+dir="$(setup_scenario api_error 500 '{}' "${REAL_WEBHOOK}")"
+if run_scenario "${dir}"; then
+  fail "scenario 'api_error': a 500 from the kube API was reported as success"
+fi
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'api_error': delivered an alert despite a failed API read"
+grep -q 'kube API returned HTTP 500' "${dir}/stderr.log" ||
+  fail "scenario 'api_error': the failure was not reported to stderr"
+pass "a failing kube API read fails the Job instead of reading as healthy"
+
+# Scenario 5 — SILENT-ZERO, second shape. A 200 whose body is not the expected
+# list shape must also fail rather than count zero items.
+dir="$(setup_scenario bad_shape 200 '{"unexpected":true}' "${REAL_WEBHOOK}")"
+if run_scenario "${dir}"; then
+  fail "scenario 'bad_shape': an unparseable API response was reported as success"
+fi
+grep -q 'unexpected response shape' "${dir}/stderr.log" ||
+  fail "scenario 'bad_shape': the shape guard did not report"
+pass "an unexpected API response shape fails the Job"
+
+# Scenario 6 — a CRD-less cluster is a supported state, not a failure.
+dir="$(setup_scenario no_crd 404 '{}' "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'no_crd': a 404 should exit 0"
+[ "$(deliveries "${dir}")" = "0" ] || fail "scenario 'no_crd': alerted with no CNPG CRD installed"
+pass "a cluster without the CNPG CRD exits cleanly"
+
+# Scenario 7 — SILENT-ZERO, delivery end. A webhook POST that fails must fail
+# the Job; recording a successful run having sent nothing is the whole failure
+# this check exists to avoid.
+dir="$(setup_scenario delivery_fails 200 "${degraded_body}" "${REAL_WEBHOOK}")"
+if STUB_DELIVERY_EXIT=22 run_scenario "${dir}"; then
+  fail "scenario 'delivery_fails': a failed webhook POST was reported as a successful run"
+fi
+pass "a failed webhook delivery fails the Job"
+
+# Scenario 8 — a cluster degraded only INSIDE the grace period stays quiet, so
+# a rolling restart or a scale-up does not page.
+dir="$(setup_scenario within_grace 200 "$(
+  jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{
+    items: [{
+      metadata: { namespace: "umami", name: "umami-db" },
+      spec: { instances: 3 },
+      status: {
+        readyInstances: 2,
+        conditions: [{ type: "Ready", status: "True", lastTransitionTime: $ts }]
+      }
+    }]
+  }'
+)" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'within_grace': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'within_grace': alerted on a cluster still inside its grace period"
+pass "a cluster still inside the grace period does not page"
+
+# ---------------------------------------------------------------------------
+# Wiring. A contract nothing runs protects nothing.
+# ---------------------------------------------------------------------------
+
+grep -Fq "scripts/tests/test-cnpg-degraded-alert.sh" "${ci_workflow}" ||
+  fail "this test is not referenced from ${ci_workflow}"
+grep -Fq "bash scripts/tests/test-cnpg-degraded-alert.sh" "${ci_workflow}" ||
+  fail "this test is listed in the paths filter but never executed by a CI step"
+pass "the contract is wired into CI and executed"
+
+printf '\nAll cnpg-degraded-alert contract assertions passed.\n'

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -94,12 +94,24 @@ grep -q 'readOnly: true' <<<"$(yq eval \
 pass "webhook mount is present and readOnly at ${webhook_mount_path}"
 
 # A mounted credential that every process in the pod can read is only half the
-# control. defaultMode pins it to the container's own user.
+# control. defaultMode narrows it to root and the pod's fsGroup.
+#
+# These two assertions are ONE invariant and must stay together: kubelet owns
+# secret-volume files root:fsGroup, never uid:fsGroup, so the mode has to carry
+# the GROUP bit and fsGroup has to name the container's group. Pinning the mode
+# alone is what let an owner-only 0400 ship against a non-root container with no
+# fsGroup -- a combination that reads as maximally strict and actually denies the
+# container its own credential, failing the CronJob before its first API call.
 default_mode="$(yq eval \
   "${pod_path}.volumes[] | select(.name == \"webhook\") | .secret.defaultMode" "${manifest}")"
-[ "${default_mode}" = "256" ] ||
-  fail "expected the webhook volume defaultMode 0400 (256 decimal), got: ${default_mode}"
-pass "webhook volume is mounted 0400"
+[ "${default_mode}" = "288" ] ||
+  fail "expected the webhook volume defaultMode 0440 (288 decimal), got: ${default_mode}"
+
+fs_group="$(yq eval "${pod_path}.securityContext.fsGroup" "${manifest}")"
+run_as_user="$(yq eval "${pod_path}.securityContext.runAsUser" "${manifest}")"
+[ "${fs_group}" = "${run_as_user}" ] ||
+  fail "fsGroup (${fs_group}) must match runAsUser (${run_as_user}), or the mounted webhook is unreadable"
+pass "webhook volume is mounted 0440 and readable by fsGroup ${fs_group}"
 
 # The relocation trap: the URL must not be handed to curl as an argument, or it
 # is simply exposed through /proc/<pid>/cmdline instead of /proc/self/environ.

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -351,6 +351,38 @@ grep -q 'unexpected response shape' "${dir}/stderr.log" ||
   fail "scenario 'bad_shape': the shape guard did not report"
 pass "an unexpected API response shape fails the Job"
 
+# Scenario 5b — SILENT-ZERO, third shape. `has("items")` is satisfied by a
+# non-array `items`, which then counts zero clusters and reports a malformed
+# response as a healthy one. The guard must require the ARRAY, not the key.
+dir="$(setup_scenario items_not_array 200 '{"items":{}}' "${REAL_WEBHOOK}")"
+if run_scenario "${dir}"; then
+  fail "scenario 'items_not_array': a non-array items was reported as success"
+fi
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'items_not_array': delivered an alert on a malformed response"
+grep -q 'unexpected response shape' "${dir}/stderr.log" ||
+  fail "scenario 'items_not_array': the shape guard did not report"
+pass "an items value that is not an array fails the Job"
+
+# Scenario 5c — CURL CONFIG INJECTION. The URL is handed to curl as a config
+# directive, where a newline begins a SECOND directive. A Secret carrying an LF
+# could therefore append arbitrary curl configuration (`output = ...` and the
+# rest) to a request this script believes it fully controls. The value must be
+# rejected before the config is built, and nothing may be delivered.
+injected="${REAL_WEBHOOK}
+output = ${work_root}/injected-output"
+dir="$(setup_scenario url_control_chars 200 '{"items":[]}' "${injected}")"
+if run_scenario "${dir}"; then
+  fail "scenario 'url_control_chars': an LF in the webhook URL was accepted"
+fi
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'url_control_chars': delivered despite a malformed webhook URL"
+[ ! -e "${work_root}/injected-output" ] ||
+  fail "scenario 'url_control_chars': the injected curl directive took effect"
+grep -q 'control characters' "${dir}/stderr.log" ||
+  fail "scenario 'url_control_chars': the control-character guard did not report"
+pass "a webhook URL carrying a control character fails before any delivery"
+
 # Scenario 6 — a CRD-less cluster is a supported state, not a failure.
 dir="$(setup_scenario no_crd 404 '{}' "${REAL_WEBHOOK}")"
 run_scenario "${dir}" || fail "scenario 'no_crd': a 404 should exit 0"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The CNPG degraded-cluster alert is the only signal we have for a database that is
degraded without crashlooping. Its Slack webhook was handed to the job as an
environment variable, which means the credential sat readable for the pod's whole
life and was inherited by every process the job started. It is a scanner finding
we have been carrying rather than a live incident.

That job also had no test at all, so the guards its own comments call load-bearing —
the ones that stop a broken check from reporting "nothing is wrong" — were held in
place by nothing.

## What

The webhook is now mounted as a read-only file and read once, so it never enters
the environment. Delivery hands the URL to curl privately rather than on its
command line, so the fix removes the exposure instead of moving it somewhere else.

Adds the job's first test. It runs the real script against a stubbed cluster and a
stubbed delivery, covering eight scenarios including the two "fail loudly rather
than look healthy" guards. Every assertion was checked by breaking the thing it
protects and confirming it fails.

Scanner backlog: 8 findings down to 7, with the passing count up by one — the check
now passes here rather than the scan having lost sight of it.

Part of #2787