### PR TITLE
feat(kubescape): support complementary namespace exception scopes

### DIFF
--- a/scripts/generate-kubescape-exceptions/main.go
+++ b/scripts/generate-kubescape-exceptions/main.go
@@ -12,9 +12,9 @@
 //
 // Fail-closed by design: any CR shape this converter does not recognise (an
 // unknown spec.match key, a posture action other than `ignore`, a
-// namespaceSelector that isn't the `kubernetes.io/metadata.name In [...]`
-// expression) aborts with a non-zero exit instead of silently dropping or
-// widening an exception.
+// namespaceSelector that isn't a `kubernetes.io/metadata.name In [...]` or
+// `NotIn [...]` expression) aborts with a non-zero exit instead of silently
+// dropping or widening an exception.
 //
 // Usage, from the repository root:
 //
@@ -193,6 +193,82 @@ func asMapSlice(raw any, path, name, field string) ([]map[string]any, error) {
 	return entries, nil
 }
 
+type namespacePrefix struct {
+	terminal bool
+	children map[rune]*namespacePrefix
+}
+
+// escapeRegexClassRune uses the small character-class escape vocabulary shared
+// by both Go/OPA's RE2 implementation and JavaScript RegExp. The latter matters
+// because the generated Headlamp fallback evaluates the same designators in the
+// browser; RE2-only hex-brace escapes would make its entire exception group
+// unparsable.
+func escapeRegexClassRune(r rune) string {
+	switch r {
+	case '\\', '-', ']', '^':
+		return "\\" + string(r)
+	default:
+		return string(r)
+	}
+}
+
+// namespaceNotInPattern renders the complement of a finite set without regex
+// lookarounds. Kubescape and OPA use RE2, which deliberately does not support
+// negative lookahead, so a direct `^(?!excluded$).+$` cannot be consumed by the
+// actual exception engines. The prefix tree instead emits one alternative for
+// every first point at which a non-empty namespace differs from an exclusion,
+// plus extensions of an excluded name.
+func namespaceNotInPattern(values []string) string {
+	root := &namespacePrefix{children: map[rune]*namespacePrefix{}}
+
+	for _, value := range values {
+		node := root
+		for _, r := range value {
+			child := node.children[r]
+			if child == nil {
+				child = &namespacePrefix{children: map[rune]*namespacePrefix{}}
+				node.children[r] = child
+			}
+			node = child
+		}
+		node.terminal = true
+	}
+
+	var alternatives []string
+	var walk func(*namespacePrefix, string)
+	walk = func(node *namespacePrefix, prefix string) {
+		if prefix != "" && !node.terminal {
+			alternatives = append(alternatives, regexp.QuoteMeta(prefix))
+		}
+
+		if len(node.children) == 0 {
+			alternatives = append(alternatives, regexp.QuoteMeta(prefix)+".+")
+			return
+		}
+
+		children := make([]rune, 0, len(node.children))
+		for r := range node.children {
+			children = append(children, r)
+		}
+		sort.Slice(children, func(i, j int) bool { return children[i] < children[j] })
+
+		var excludedNext strings.Builder
+		for _, r := range children {
+			excludedNext.WriteString(escapeRegexClassRune(r))
+		}
+		alternatives = append(alternatives,
+			regexp.QuoteMeta(prefix)+"[^"+excludedNext.String()+"].*")
+
+		for _, r := range children {
+			walk(node.children[r], prefix+string(r))
+		}
+	}
+
+	walk(root, "")
+
+	return "^(" + strings.Join(alternatives, "|") + ")$"
+}
+
 // convertNamespaceSelector maps a namespaceSelector to one namespace-regex designator.
 func convertNamespaceSelector(selector map[string]any, path, name string) ([]designator, error) {
 	if unknown := unknownKeys(selector, "matchExpressions"); len(unknown) > 0 {
@@ -209,8 +285,11 @@ func convertNamespaceSelector(selector map[string]any, path, name string) ([]des
 	}
 
 	expr := expressions[0]
-	if expr["key"] != namespaceNameKey || expr["operator"] != "In" {
-		return nil, cseErrorf(path, name, "only `%s In [...]` matchExpressions are supported", namespaceNameKey)
+	operator, operatorOK := expr["operator"].(string)
+	if expr["key"] != namespaceNameKey || !operatorOK || (operator != "In" && operator != "NotIn") {
+		return nil, cseErrorf(path, name,
+			"only `%s In [...]` or `%s NotIn [...]` matchExpressions are supported",
+			namespaceNameKey, namespaceNameKey)
 	}
 
 	rawValues, ok := expr["values"].([]any)
@@ -218,6 +297,7 @@ func convertNamespaceSelector(selector map[string]any, path, name string) ([]des
 		return nil, cseErrorf(path, name, "namespaceSelector matchExpression has no values")
 	}
 
+	values := make([]string, 0, len(rawValues))
 	quoted := make([]string, 0, len(rawValues))
 
 	for _, rawValue := range rawValues {
@@ -226,10 +306,14 @@ func convertNamespaceSelector(selector map[string]any, path, name string) ([]des
 			return nil, cseErrorf(path, name, "namespaceSelector values must be strings, got %v", rawValue)
 		}
 
+		values = append(values, value)
 		quoted = append(quoted, regexp.QuoteMeta(value))
 	}
 
 	pattern := "^(" + strings.Join(quoted, "|") + ")$"
+	if operator == "NotIn" {
+		pattern = namespaceNotInPattern(values)
+	}
 
 	return []designator{{
 		DesignatorType: designatorTypeAttr,

--- a/scripts/generate-kubescape-exceptions/main_test.go
+++ b/scripts/generate-kubescape-exceptions/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -110,6 +111,56 @@ spec:
 	got := policies[0].Resources[0].Attributes["namespace"]
 	if got != "^(kube-system|cilium-secrets)$" {
 		t.Errorf("namespace = %q, want ^(kube-system|cilium-secrets)$", got)
+	}
+}
+
+// TestGenerateNamespaceSelectorNotIn verifies a complementary selector keeps
+// newly introduced namespaces covered while rejecting only the declared
+// exclusions. It exercises the generated designator rather than its source
+// spelling because Kubescape consumes the regex behavior.
+func TestGenerateNamespaceSelectorNotIn(t *testing.T) {
+	dir := writeCSE(t, `
+kind: ClusterSecurityException
+metadata:
+  name: mutation-enabled-namespaces
+spec:
+  posture:
+    - controlID: C-0013
+      action: ignore
+  match:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: [kube-system, cilium-secrets, edge.test]
+`)
+
+	policies, err := generate(dir)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	pattern := policies[0].Resources[0].Attributes["namespace"]
+	matcher, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("compile generated namespace pattern %q: %v", pattern, err)
+	}
+
+	tests := map[string]bool{
+		"":                    false,
+		"kube-system":         false,
+		"cilium-secrets":      false,
+		"edge.test":           false,
+		"edgeXtest":           true,
+		"kube-syste":          true,
+		"kube-system-extra":   true,
+		"new-tenant-namespace": true,
+	}
+
+	for namespace, want := range tests {
+		if got := matcher.MatchString(namespace); got != want {
+			t.Errorf("namespace %q matched = %t, want %t (pattern %q)", namespace, got, want, pattern)
+		}
 	}
 }
 
@@ -435,7 +486,7 @@ spec:
   posture: [{controlID: C-0002, action: ignore}]
   match:
     namespaceSelector:
-      matchExpressions: [{key: kubernetes.io/metadata.name, operator: NotIn, values: [x]}]
+      matchExpressions: [{key: kubernetes.io/metadata.name, operator: Exists, values: [x]}]
 `,
 			want: "matchExpressions are supported",
 		},

--- a/scripts/generate-kubescape-exceptions/main_test.go
+++ b/scripts/generate-kubescape-exceptions/main_test.go
@@ -147,13 +147,13 @@ spec:
 	}
 
 	tests := map[string]bool{
-		"":                    false,
-		"kube-system":         false,
-		"cilium-secrets":      false,
-		"edge.test":           false,
-		"edgeXtest":           true,
-		"kube-syste":          true,
-		"kube-system-extra":   true,
+		"":                     false,
+		"kube-system":          false,
+		"cilium-secrets":       false,
+		"edge.test":            false,
+		"edgeXtest":            true,
+		"kube-syste":           true,
+		"kube-system-extra":    true,
 		"new-tenant-namespace": true,
 	}
 
@@ -489,6 +489,18 @@ spec:
       matchExpressions: [{key: kubernetes.io/metadata.name, operator: Exists, values: [x]}]
 `,
 			want: "matchExpressions are supported",
+		},
+		"NotIn requires exclusions": {
+			body: `
+kind: ClusterSecurityException
+metadata: {name: empty-not-in}
+spec:
+  posture: [{controlID: C-0002, action: ignore}]
+  match:
+    namespaceSelector:
+      matchExpressions: [{key: kubernetes.io/metadata.name, operator: NotIn, values: []}]
+`,
+			want: "matchExpression has no values",
 		},
 		"empty posture": {
 			body: `


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- accept the standard `NotIn` operator for namespace-name `ClusterSecurityException` selectors
- compile the finite exclusion set into an anchored complement regex without unsupported negative lookahead
- keep one regex valid in both the Go/OPA RE2 consumers and Headlamp's JavaScript `RegExp` fallback
- preserve existing `In` output and fail closed on unsupported operators or an empty exclusion set

## Why

Parent #2824 needs to scope `pod-security-mutations` to every namespace except the mutation policy's exclusions. A positive namespace inventory is brittle: every newly onboarded namespace would fail CI until someone updated the exception. Kubernetes already models the durable scope as `NotIn`, but the offline CI and Headlamp generator could not preserve it.

This lands the generator capability only. No committed exception uses `NotIn` yet, so deployment behavior is unchanged. Parent #2824 can activate it after the three measured C-0055 workloads in #3064 are remediated.

## Verification

- TDD red: the new behavior test failed on current `main` because `NotIn` was rejected
- `go test ./scripts/generate-kubescape-exceptions -count=1`
- `go test ./...` (passed with network access after the sandbox correctly failed to fetch a pinned public Kustomize resource)
- `go vet ./scripts/generate-kubescape-exceptions`
- generated-pattern probe in macOS JavaScriptCore: 8/8 excluded, unseen, prefix, extension, empty, and metacharacter cases matched the hand-derived outcomes
- `git diff --check`

Fixes #3083
Part of #2824
