### PR TITLE
security(kubescape): except the operator-bundle RBAC the CI scan actually sees

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/delete-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/delete-rbac.yaml
@@ -21,6 +21,21 @@
 # apply (the exception no-ops while it is absent). Keep this list reconciled
 # against a fresh scan (it can only be re-verified live once the scanner mount
 # fix lands — see the kubescape HelmRelease postRenderer / helm-charts#862).
+#
+# TWO OBJECT POPULATIONS, and an entry only suppresses in the one it names.
+# The cluster-scoped/namespaced entries below were derived from a LIVE cluster
+# scan, so they name the bindings the operators create at runtime (`cdi-sa`,
+# `kubevirt-apiserver`, `kubevirt-controller`, …). The CI gate runs
+# `ksail workload scan` over the RENDERED MANIFESTS, where those runtime
+# bindings do not exist at all — what exists there is each operator bundle's
+# OWN RBAC (`cdi-operator`, `kubevirt-operator`). So a live-derived name is
+# inert in CI and vice versa, and the two sets have to be listed separately.
+# The bundle-RBAC block at the end of each group is the manifest-visible half.
+# Ablated 2026-08-11 (ksail 7.178.20, `--framework nsa,mitre`): without that
+# block C-0007 reports 4 failing resources and this CR suppresses none of them;
+# with it, 0. The same asymmetry explains why exec-into-container-rbac.yaml
+# appears to work — of its seven entries only `kubevirt-operator` is
+# manifest-visible, and that one object is the entire C-0002 delta.
 apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
@@ -99,6 +114,17 @@ spec:
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
         name: reloader-reloader-role-binding             # config/secret change reloader
+      # --- cluster-scoped, MANIFEST-visible: vendored operator-bundle RBAC ---
+      # The CDI and KubeVirt bundles ship their own operator ClusterRoleBindings,
+      # and those are what the CI manifest scan sees (the runtime bindings above
+      # are not rendered anywhere). Both operators delete the resources they own
+      # — CRDs, deployments, services — as part of ordinary lifecycle management.
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: cdi-operator                               # CDI operator bundle
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: kubevirt-operator                          # KubeVirt (virt-operator) bundle
       # --- namespaced: RoleBinding -> Role/ClusterRole (7) ---
       - apiGroup: rbac.authorization.k8s.io
         kind: RoleBinding
@@ -123,3 +149,10 @@ spec:
       - apiGroup: rbac.authorization.k8s.io
         kind: RoleBinding
         name: wedding-app                                # tenant deployer SA (edit)
+      # --- namespaced, MANIFEST-visible: vendored operator-bundle RBAC ---
+      - apiGroup: rbac.authorization.k8s.io
+        kind: RoleBinding
+        name: cdi-operator                               # cdi namespace
+      - apiGroup: rbac.authorization.k8s.io
+        kind: RoleBinding
+        name: kubevirt-operator-rolebinding              # kubevirt namespace

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -327,6 +327,20 @@ data:
           {
             "designatorType": "Attributes",
             "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^cdi-operator$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^kubevirt-operator$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
               "kind": "^RoleBinding$",
               "name": "^ascoachingogvaner$"
             }
@@ -371,6 +385,20 @@ data:
             "attributes": {
               "kind": "^RoleBinding$",
               "name": "^wedding-app$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^RoleBinding$",
+              "name": "^cdi-operator$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^RoleBinding$",
+              "name": "^kubevirt-operator-rolebinding$"
             }
           }
         ],


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

One of the platform's Kubescape exceptions has never worked. C-0007 ("roles with delete
capabilities") has a dedicated exception listing 26 infrastructure bindings that legitimately need
delete permission — and it suppresses **none** of them. The findings it was written to cover have
been failing the posture gate the whole time.

The cause is that the exception describes a different set of objects than the gate looks at. Its
names came from a scan of the **running cluster**, so they are the bindings the CDI and KubeVirt
operators create once installed. The CI gate scans the **rendered manifests**, where those runtime
bindings do not exist yet; what fails there is each vendored operator bundle's own RBAC, which the
exception never mentioned. Neither list was wrong — they are two different populations, and nobody
had noticed the exception only ever named one of them.

This also explains a long-standing puzzle tracked on #2823: the same asymmetry is why the
neighbouring exec-into-container exception *appears* to work. Only one of its seven entries is
visible to the manifest scan, and that single object is its entire effect.

## What

Adds the four operator-bundle objects the gate actually flags, and records the two-population
distinction in the file so the next person does not re-derive it from scratch.

Measured before and after (ksail 7.178.20, both gated frameworks): C-0007 goes from **4 failing
resources to 0**, and the overall compliance score from **97 to 98**. The generated Headlamp mirror
is regenerated by its own generator, not hand-edited.

The gate's threshold is deliberately left alone. It is a regression floor, the score is known to
differ between macOS and the CI runner, and re-baselining it needs a CI-measured number — a separate
change from this one.

Part of #2823
