### PR TITLE
fix(observability): stop Flux substitution eating the CNPG alert's grace period

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -60,6 +60,17 @@ metadata:
   namespace: observability
   annotations:
     checkov.io/skip1: CKV_K8S_38=the check container reads its SA token to list CNPG Clusters through the API server
+    # `${GRACE_SECONDS}` in the script below is the container's own env var, NOT
+    # a Flux post-build variable. The infrastructure-controllers Kustomization
+    # runs substituteFrom, so Flux's envsubst expanded it to the empty string and
+    # the deployed script read `jq --argjson grace ""`, which exits 1 with
+    # "invalid JSON text passed to --argjson". That is why this CronJob had
+    # NEVER succeeded (`status.lastSuccessfulTime` was unset) — the degraded-CNPG
+    # check has been dead since it was created. This resource needs no Flux
+    # substitution, so opt it out — same pattern as the actual-budget seed
+    # ConfigMap's JS template literals and the KRO ResourceGraphDefinitions'
+    # CEL expressions.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The alert that watches for a degraded CloudNativePG database has **never worked**. It has been failing every 30 minutes since it was created, and `lastSuccessfulTime` on the CronJob was never set.

That surfaced today: two databases (`wedding-db` and `coroot-db`) sat degraded at 2 of 3 replicas, and this check said nothing. The problem reached Slack only as a Flux reconciliation error naming a Kustomization — which is exactly the slow, indirect path this check was built to replace.

### What this changes

Flux was silently blanking the alert's grace-period setting. The script reads a value from the container's own environment, but Flux also treats that same syntax as one of its own variables and substituted it away to nothing, leaving the job with an unparseable command that exited immediately.

The fix opts this one resource out of Flux substitution — the same approach already used for the Actual Budget seed script and the KRO resource definitions, both of which contain similar syntax that Flux must leave alone.

Verified against the live cluster rather than from documentation: the already-opted-out resource keeps its variables intact in the deployed object, while every job without the opt-out has had all of its variables stripped.

I checked whether other manifests have the same latent problem — they do not. This was the only one.

Part of #3093

### Scope note

This restores the detector. It does **not** fix today's underlying database degradation, which is a separate Longhorn storage fault on one node — that root cause and its remediation are in #3093.
