### PR TITLE
fix(ci): name what blocked the image-verification handoff quiesce wait

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -3232,7 +3232,7 @@ report_flux_policy_handoff_blockers() {
       --namespace "${dependency_namespace}" \
       get "${FLUX_KUSTOMIZATION_RESOURCE}" \
       "${dependency_name}" \
-      -o json >"${flux_policy_blocker_state_file}" 2>/dev/null; then
+      -o json </dev/null >"${flux_policy_blocker_state_file}" 2>/dev/null; then
       flux_policy_report_conditions \
         "${flux_policy_blocker_state_file}" \
         "kustomization/${dependency_name} (dependency)"

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -215,6 +215,8 @@ flux_policy_parent_state_file="${work_dir}/flux-policy-parent-state.json"
 flux_policy_parent_patch_file="${work_dir}/flux-policy-parent-patch.json"
 flux_policy_parent_result_file="${work_dir}/flux-policy-parent-result.txt"
 flux_policy_fences_state_file="${work_dir}/flux-policy-fences-state.json"
+flux_policy_blocker_names_file="${work_dir}/flux-policy-blocker-names.txt"
+flux_policy_blocker_state_file="${work_dir}/flux-policy-blocker-state.json"
 flux_controller_deployment_state_file="${work_dir}/flux-controller-deployment-state.json"
 flux_controller_restart_patch_file="${work_dir}/flux-controller-restart-patch.json"
 flux_controller_result_file="${work_dir}/flux-controller-result.txt"
@@ -3174,6 +3176,73 @@ flux_policy_handoff_is_quiescent() {
   ' "${flux_policy_handoff_state_file}" >/dev/null
 }
 
+# Print the conditions that explain a Kustomization's reconciliation state.
+# Diagnostic output only: an unreadable or unparseable state file prints
+# nothing and still succeeds.
+flux_policy_report_conditions() {
+  local state_file="$1" label="$2"
+
+  [[ -s "${state_file}" ]] || return 0
+  jq -r --arg label "${label}" '
+    [.status.conditions[]?
+      | select(.type == "Reconciling" or .type == "Ready" or .type == "Healthy")
+      | "\($label): \(.type)=\(.status) \(.reason // "-"): "
+        + ((.message // "-") | gsub("\\s+"; " "))]
+    | if length == 0 then ["\($label): reported no status conditions"] else . end
+    | .[]
+  ' "${state_file}" 2>/dev/null || true
+}
+
+# Explain a failed quiesce wait. The blocking condition is already in the state
+# file that wait just read, and when the owner is held up by a dependency the
+# cause is one read further out. Without this the failure names image
+# verification while the real blocker is an unrelated workload, which is what
+# makes the merge-queue eviction it causes read as "some PR failed CI".
+#
+# Strictly best-effort: this runs on the production credential path, so a
+# diagnostic must never change the outcome it is describing.
+report_flux_policy_handoff_blockers() {
+  local dependency dependency_name dependency_namespace
+
+  flux_policy_report_conditions \
+    "${flux_policy_handoff_state_file}" \
+    "kustomization/${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}"
+
+  # Read the dependencies the owner itself declares rather than parsing them
+  # out of a controller-authored message.
+  jq -r '
+    if any(.status.conditions[]?;
+      .type == "Ready" and .reason == "DependencyNotReady")
+    then
+      .metadata.namespace as $namespace
+      | .spec.dependsOn[]?
+      | "\(.namespace // $namespace)/\(.name)"
+    else empty end
+  ' "${flux_policy_handoff_state_file}" \
+    2>/dev/null >"${flux_policy_blocker_names_file}" || return 0
+
+  while IFS= read -r dependency; do
+    dependency_namespace="${dependency%%/*}"
+    dependency_name="${dependency##*/}"
+    [[ -n "${dependency_namespace}" && -n "${dependency_name}" &&
+      "${dependency}" == "${dependency_namespace}/${dependency_name}" ]] ||
+      continue
+    if kubectl \
+      --context "${KUBE_CONTEXT}" \
+      --namespace "${dependency_namespace}" \
+      get "${FLUX_KUSTOMIZATION_RESOURCE}" \
+      "${dependency_name}" \
+      -o json >"${flux_policy_blocker_state_file}" 2>/dev/null; then
+      flux_policy_report_conditions \
+        "${flux_policy_blocker_state_file}" \
+        "kustomization/${dependency_name} (dependency)"
+    else
+      echo "Could not read dependency ${dependency} while explaining the image-verification policy handoff quiesce timeout."
+    fi
+  done <"${flux_policy_blocker_names_file}"
+  return 0
+}
+
 read_flux_policy_fences() {
   if ! kubectl \
     --context "${KUBE_CONTEXT}" \
@@ -3417,6 +3486,7 @@ pause_flux_policy_handoff() {
     fi
     if ((attempt == SYNC_ATTEMPTS)); then
       echo "::error::The Flux image-verification policy owner did not quiesce before the image-verification policy handoff."
+      report_flux_policy_handoff_blockers || true
       return 1
     fi
     sleep "${SYNC_INTERVAL}"

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -213,13 +213,30 @@ func fakeFluxPolicyChildObject() map[string]any {
 	if os.Getenv("FAKE_FLUX_POLICY_HANDOFF_NO_ANNOTATIONS") != "true" || owner != "" {
 		metadata["annotations"] = annotations
 	}
-	conditions := []any{
-		map[string]any{
-			"type":   "Ready",
-			"status": "True",
-			"reason": "ReconciliationSucceeded",
-		},
+	readyCondition := map[string]any{
+		"type":   "Ready",
+		"status": "True",
+		"reason": "ReconciliationSucceeded",
 	}
+	spec := map[string]any{"suspend": suspended}
+	if unhealthy := os.Getenv("FAKE_FLUX_POLICY_CHILD_UNHEALTHY"); unhealthy != "" {
+		readyCondition = map[string]any{
+			"type":    "Ready",
+			"status":  "False",
+			"reason":  "HealthCheckFailed",
+			"message": unhealthy,
+		}
+	}
+	if dependency := os.Getenv("FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY"); dependency != "" {
+		readyCondition = map[string]any{
+			"type":    "Ready",
+			"status":  "False",
+			"reason":  "DependencyNotReady",
+			"message": fmt.Sprintf("dependency 'flux-system/%s' is not ready", dependency),
+		}
+		spec["dependsOn"] = []any{map[string]any{"name": dependency}}
+	}
+	conditions := []any{readyCondition}
 	reconciling := os.Getenv("FAKE_FLUX_POLICY_RECONCILING") == "true"
 	if suspended && os.Getenv("FAKE_FLUX_POLICY_RECONCILING_AFTER_PAUSE") == "true" {
 		reconciling = true
@@ -241,30 +258,15 @@ func fakeFluxPolicyChildObject() map[string]any {
 		}
 	}
 	if reconciling {
-		conditions = append(conditions, map[string]any{
-			"type":    "Reconciling",
-			"status":  "True",
-			"reason":  defaultString(os.Getenv("FAKE_FLUX_POLICY_RECONCILING_REASON"), "Progressing"),
-			"message": os.Getenv("FAKE_FLUX_POLICY_RECONCILING_MESSAGE"),
-		})
-	}
-	spec := map[string]any{"suspend": suspended}
-	if unhealthy := os.Getenv("FAKE_FLUX_POLICY_CHILD_UNHEALTHY"); unhealthy != "" {
-		conditions[0] = map[string]any{
-			"type":    "Ready",
-			"status":  "False",
-			"reason":  "HealthCheckFailed",
-			"message": unhealthy,
+		reconcilingCondition := map[string]any{
+			"type":   "Reconciling",
+			"status": "True",
+			"reason": defaultString(os.Getenv("FAKE_FLUX_POLICY_RECONCILING_REASON"), "Progressing"),
 		}
-	}
-	if dependency := os.Getenv("FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY"); dependency != "" {
-		conditions[0] = map[string]any{
-			"type":    "Ready",
-			"status":  "False",
-			"reason":  "DependencyNotReady",
-			"message": fmt.Sprintf("dependency 'flux-system/%s' is not ready", dependency),
+		if message := os.Getenv("FAKE_FLUX_POLICY_RECONCILING_MESSAGE"); message != "" {
+			reconcilingCondition["message"] = message
 		}
-		spec["dependsOn"] = []any{map[string]any{"name": dependency}}
+		conditions = append(conditions, reconcilingCondition)
 	}
 	return map[string]any{
 		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -135,6 +135,15 @@ func fakeKubectlGetFluxPolicyKustomization(args []string, namespace string) int 
 	if name == "flux-system" {
 		return fakeKubectlGetFluxPolicyParent(args, namespace)
 	}
+	if namespace == "flux-system" &&
+		name == os.Getenv("FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY") &&
+		name != "" {
+		if os.Getenv("FAKE_FLUX_POLICY_DEPENDENCY_READ_FAILS") == "true" {
+			return commandFailure(1, "Error from server (NotFound): kustomizations.kustomize.toolkit.fluxcd.io %q not found", name)
+		}
+		fmt.Println(encodeJSON(fakeFluxPolicyDependencyObject(name)))
+		return 0
+	}
 	if namespace != "flux-system" ||
 		name != "infrastructure" ||
 		(!containsArg(args, "-o") && !containsArg(args, "--output")) {
@@ -142,6 +151,37 @@ func fakeKubectlGetFluxPolicyKustomization(args []string, namespace string) int 
 	}
 	fmt.Println(encodeJSON(fakeFluxPolicyChildObject()))
 	return 0
+}
+
+// fakeFluxPolicyDependencyObject models a Kustomization the handoff owner
+// depends on, still reconciling with the message that names the real blocker.
+func fakeFluxPolicyDependencyObject(name string) map[string]any {
+	return map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "flux-system",
+			"uid":       name + "-kustomization-uid",
+		},
+		"spec": map[string]any{"suspend": false},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":    "Reconciling",
+					"status":  "True",
+					"reason":  "ProgressingWithRetry",
+					"message": os.Getenv("FAKE_FLUX_POLICY_DEPENDENCY_BLOCKING_MESSAGE"),
+				},
+				map[string]any{
+					"type":    "Ready",
+					"status":  "False",
+					"reason":  "HealthCheckFailed",
+					"message": os.Getenv("FAKE_FLUX_POLICY_DEPENDENCY_BLOCKING_MESSAGE"),
+				},
+			},
+		},
+	}
 }
 
 func fakeFluxPolicyChildObject() map[string]any {
@@ -202,18 +242,35 @@ func fakeFluxPolicyChildObject() map[string]any {
 	}
 	if reconciling {
 		conditions = append(conditions, map[string]any{
-			"type":   "Reconciling",
-			"status": "True",
-			"reason": "Progressing",
+			"type":    "Reconciling",
+			"status":  "True",
+			"reason":  defaultString(os.Getenv("FAKE_FLUX_POLICY_RECONCILING_REASON"), "Progressing"),
+			"message": os.Getenv("FAKE_FLUX_POLICY_RECONCILING_MESSAGE"),
 		})
+	}
+	spec := map[string]any{"suspend": suspended}
+	if unhealthy := os.Getenv("FAKE_FLUX_POLICY_CHILD_UNHEALTHY"); unhealthy != "" {
+		conditions[0] = map[string]any{
+			"type":    "Ready",
+			"status":  "False",
+			"reason":  "HealthCheckFailed",
+			"message": unhealthy,
+		}
+	}
+	if dependency := os.Getenv("FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY"); dependency != "" {
+		conditions[0] = map[string]any{
+			"type":    "Ready",
+			"status":  "False",
+			"reason":  "DependencyNotReady",
+			"message": fmt.Sprintf("dependency 'flux-system/%s' is not ready", dependency),
+		}
+		spec["dependsOn"] = []any{map[string]any{"name": dependency}}
 	}
 	return map[string]any{
 		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
 		"kind":       "Kustomization",
 		"metadata":   metadata,
-		"spec": map[string]any{
-			"suspend": suspended,
-		},
+		"spec":       spec,
 		"status": map[string]any{
 			"observedGeneration": 13,
 			"conditions":         conditions,

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -739,6 +739,73 @@ func TestFluxChildReconciliationBlocksBeforePolicyHandoffAcquisition(t *testing.
 	requireLine(t, operations, "flux-policy-parent-resume:flux-system")
 }
 
+func TestHandoffQuiesceTimeoutNamesTheBlockingCondition(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_FLUX_POLICY_RECONCILING":         "true",
+		"FAKE_FLUX_POLICY_RECONCILING_REASON":  "ProgressingWithRetry",
+		"FAKE_FLUX_POLICY_RECONCILING_MESSAGE": "Running health checks for revision latest@sha256:fixture",
+		"FAKE_FLUX_POLICY_CHILD_UNHEALTHY":     "timeout waiting for: [Cluster/observability/coroot-db status: 'InProgress']",
+	})
+	requireFailureResult(t, result)
+	output := result.stdout + result.stderr
+	requireContains(t, output, "did not quiesce before the image-verification policy handoff")
+	requireContains(t, output, "ProgressingWithRetry")
+	requireContains(t, output, "Cluster/observability/coroot-db")
+}
+
+func TestHandoffQuiesceTimeoutNamesTheUnreadyDependency(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_FLUX_POLICY_RECONCILING":                 "true",
+		"FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY":  "infrastructure-controllers",
+		"FAKE_FLUX_POLICY_DEPENDENCY_BLOCKING_MESSAGE": "Running health checks for revision latest@sha256:fixture with a timeout of 25m0s",
+	})
+	requireFailureResult(t, result)
+	output := result.stdout + result.stderr
+	requireContains(t, output, "did not quiesce before the image-verification policy handoff")
+	requireContains(t, output, "infrastructure-controllers")
+	requireContains(t, output, "with a timeout of 25m0s")
+}
+
+func TestHandoffQuiesceDiagnosticCannotChangeTheOutcome(t *testing.T) {
+	t.Parallel()
+	blocked := newFixture(t)
+	blockedResult := blocked.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_FLUX_POLICY_RECONCILING": "true",
+	})
+	broken := newFixture(t)
+	brokenResult := broken.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_FLUX_POLICY_RECONCILING":                "true",
+		"FAKE_FLUX_POLICY_CHILD_DEPENDENCY_NOT_READY": "infrastructure-controllers",
+		"FAKE_FLUX_POLICY_DEPENDENCY_READ_FAILS":      "true",
+	})
+	requireFailureResult(t, brokenResult)
+	requireContains(
+		t,
+		brokenResult.stdout+brokenResult.stderr,
+		"did not quiesce before the image-verification policy handoff",
+	)
+	// Prove the dependency read was actually attempted and swallowed, so this
+	// stays an ablation of the diagnostic rather than of the code path.
+	requireContains(
+		t,
+		brokenResult.stdout+brokenResult.stderr,
+		"Could not read dependency flux-system/infrastructure-controllers",
+	)
+	if brokenResult.exitCode != blockedResult.exitCode {
+		t.Fatalf(
+			"an unreadable dependency changed the handoff failure exit status: got %d, want %d",
+			brokenResult.exitCode,
+			blockedResult.exitCode,
+		)
+	}
+	requireLine(t, readLines(broken.operationLog), "flux-policy-parent-resume:flux-system")
+	requireNoLine(t, readLines(broken.operationLog), "flux-policy-pause:infrastructure")
+}
+
 func TestFluxChildQuiescesBeforePolicyHandoffAcquisition(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

When a production deploy cannot take the image-verification policy handoff, it says only that the owner "did not quiesce" — and stops there. It names the step that gave up, not what it was waiting for. In both times this has happened the real blocker was somewhere else entirely: an un-stepped CNI rollout in one case, a degraded observability database in the other. Each time, working that out meant a live walk across four resources on the production cluster, while the message pointed at image verification and GHCR credentials — subsystems that were working fine.

That misdirection is expensive in a specific way: this failure evicts every PR from the merge queue, so it looks like "some PR failed CI" rather than a platform fault.

### What this changes

The failure now also reports the conditions the wait had already read — why the owner is still reconciling, and, when it is held up by something it depends on, that dependency's own blocking condition. The existing one-line error stays exactly as it is; the detail is added underneath.

The diagnostic is strictly best-effort: it runs on the production credential path, so it can never change the outcome it is describing.

Fixes #3002
