### PR TITLE
feat(security): assert the node image verifier can enforce at all

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,11 @@ jobs:
               - 'scripts/tests/test-restrict-tenant-secret-stores.sh'
               - 'scripts/tests/test-kyverno-admission-vpa.sh'
               - 'scripts/tests/kyverno-admission-vpa-rules.yaml'
+              # The image-verifier liveness checker and its test are one
+              # contract: the checker's whole value is failing loudly, so a
+              # change to either must re-run both.
+              - 'scripts/validate-image-verifier-liveness.sh'
+              - 'scripts/tests/test-validate-image-verifier-liveness.sh'
               - 'scripts/generate-kubescape-exceptions/**'
               - 'scripts/kubescape-backlog-bridge/**'
               # The updater and its annotation helper are one fail-closed
@@ -398,6 +403,17 @@ jobs:
         # regress the Hetzner WireGuard settings. Bash plus the kubectl bundled
         # on the GitHub-hosted runner; no cluster or secrets required.
         run: bash scripts/tests/test-cilium-bandwidth-manager-component.sh
+
+      - name: 🔏 Validate image-verifier liveness checker
+        if: needs.changes.outputs.k8s == 'true'
+        # The checker asserts that containerd's image-verifier can enforce AT
+        # ALL (#2856). It runs here, inside the required job, rather than in its
+        # own workflow: a check that gates nothing is advisory, and this one
+        # guards a control whose failure mode is silence. Fakes talosctl and
+        # kubectl from fixtures — no cluster, no secrets.
+        run: |
+          shellcheck scripts/validate-image-verifier-liveness.sh scripts/tests/test-validate-image-verifier-liveness.sh
+          bash scripts/tests/test-validate-image-verifier-liveness.sh
 
       - name: 🔐 Validate Cilium mutual-auth policy scope
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -67,15 +67,22 @@ jobs:
       - name: ⚙️ Setup talosctl
         shell: bash
         env:
-          TALOS_VERSION: "1.13.6"
+          # Keep in step with spec.cluster.talos.version in ksail.prod.yaml, the
+          # same pin the deploy composite, CI and the DR workflow carry. A client
+          # older than the cluster can start failing before it inspects a single
+          # node, which would read as a fleet-wide fault rather than a stale pin.
+          # renovate: datasource=github-releases depName=siderolabs/talos extractVersion=^v(?<version>.+)$
+          TALOS_VERSION: "1.13.7"
           # SHA-256 of talosctl-linux-amd64 for the TALOS_VERSION above, from
           # that release's sha256sum.txt. UPDATE BOTH TOGETHER — a version bump
           # that leaves this stale fails the step, which is the intended
           # direction: this job installs a binary with sudo and then points it
           # at production with restored cluster credentials, so an unverified
           # download is a privileged one. The version alone pins the URL, not
-          # the bytes it serves.
-          TALOSCTL_SHA256: "540c5e7cb0d3fa3a9b2e1c717ced212727b73bcaf0cf9cf9ba2472ec381041d4"
+          # the bytes it serves. That includes a Renovate bump of the line above:
+          # it cannot know the new digest, so the step fails loudly until a human
+          # updates this value rather than installing unverified bytes.
+          TALOSCTL_SHA256: "97d08e5584e56114659f131e95e227910d1f3b427d26360dca2af3ed821b71f8"
         run: |
           set -euo pipefail
           curl -fsSL "https://github.com/siderolabs/talos/releases/download/v${TALOS_VERSION}/talosctl-linux-amd64" -o /tmp/talosctl

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -1,0 +1,95 @@
+name: Validate Image Verifier Liveness
+
+# Assert that node-level image verification can enforce AT ALL.
+#
+# The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml
+# were correct, active, and evaluating NOTHING for weeks, because containerd's
+# image-verifier plugin had no bin_dir and no verifier binary — a state
+# containerd documents as permitting every pull (devantler-tech/platform#2856).
+# Nothing in CI could see it: the rules were present, the node config matched the
+# repository, and every check was green.
+#
+# This runs on a cadence rather than on a PR because the condition it watches is
+# not introduced by a diff. It drifts with the node image, the Talos version, and
+# the schematic — none of which this repository's PR events observe. A
+# path-filtered PR check would have caught none of #2856.
+#
+# EXPECTED TO FAIL until #3101 installs the verifier. That is the point: the
+# signal should be red while the control is inert, not silent.
+
+on:
+  schedule:
+    - cron: "30 6 * * *" # daily, offset from the midnight policy sync
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/validate-image-verifier-liveness.sh
+      - scripts/tests/test-validate-image-verifier-liveness.sh
+      - .github/workflows/validate-image-verifier-liveness.yaml
+
+permissions: {}
+
+concurrency:
+  # Read-only against prod, so it does not share the deploy lock — but two
+  # copies of it racing each other buys nothing.
+  group: validate-image-verifier-liveness
+  cancel-in-progress: true
+
+jobs:
+  validate-image-verifier-liveness:
+    name: 🔏 Validate Image Verifier Liveness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 🧪 Test the checker itself
+        # The checker's whole value is noticing a silent condition, so a
+        # regression in it is silent too. Its own tests need no cluster and no
+        # secrets, so they run first and fail fast.
+        shell: bash
+        run: ./scripts/tests/test-validate-image-verifier-liveness.sh
+
+      - name: ⚙️ Setup talosctl
+        shell: bash
+        env:
+          TALOS_VERSION: "1.13.6"
+        run: |
+          curl -fsSL "https://github.com/siderolabs/talos/releases/download/v${TALOS_VERSION}/talosctl-linux-amd64" -o /tmp/talosctl
+          sudo install /tmp/talosctl /usr/local/bin/talosctl
+          talosctl version --client
+
+      - name: 🔑 Restore kubeconfig
+        shell: bash
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          mkdir -p ~/.kube
+          umask 077
+          printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: 🔑 Restore talosconfig
+        shell: bash
+        env:
+          TALOS_CONFIG: ${{ secrets.TALOS_CONFIG }}
+        run: |
+          mkdir -p ~/.talos
+          umask 077
+          printf '%s' "${TALOS_CONFIG}" > ~/.talos/config
+          chmod 600 ~/.talos/config
+
+      - name: 🔏 Assert every node can enforce image verification
+        shell: bash
+        env:
+          # Pinned for the same reason the deploy composite pins it: the
+          # restored kubeconfig's current-context is not guaranteed to be prod,
+          # and a check that silently read another cluster would report a
+          # healthy fleet that is not the one being gated.
+          KUBECTL_CONTEXT: admin@prod
+        run: ./scripts/validate-image-verifier-liveness.sh

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -78,8 +78,18 @@ jobs:
         shell: bash
         env:
           TALOS_VERSION: "1.13.6"
+          # SHA-256 of talosctl-linux-amd64 for the TALOS_VERSION above, from
+          # that release's sha256sum.txt. UPDATE BOTH TOGETHER — a version bump
+          # that leaves this stale fails the step, which is the intended
+          # direction: this job installs a binary with sudo and then points it
+          # at production with restored cluster credentials, so an unverified
+          # download is a privileged one. The version alone pins the URL, not
+          # the bytes it serves.
+          TALOSCTL_SHA256: "540c5e7cb0d3fa3a9b2e1c717ced212727b73bcaf0cf9cf9ba2472ec381041d4"
         run: |
+          set -euo pipefail
           curl -fsSL "https://github.com/siderolabs/talos/releases/download/v${TALOS_VERSION}/talosctl-linux-amd64" -o /tmp/talosctl
+          echo "${TALOSCTL_SHA256}  /tmp/talosctl" | sha256sum --check --strict -
           sudo install /tmp/talosctl /usr/local/bin/talosctl
           talosctl version --client
 

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -21,15 +21,13 @@ name: Validate Image Verifier Liveness
 # signal, and activation becomes one reversible line in #3101.
 #
 # The checker's OWN tests need no cluster and no secrets, so they gate every PR
-# that touches the checker. That split is the point: a regression in a checker
-# whose job is noticing a silent condition would itself be silent.
+# that touches the checker. They live in ci.yaml's `validate` job, which
+# `CI - Required Checks` depends on, so they actually block a merge — a test
+# that only reports is advisory, and a regression in a checker whose job is
+# noticing a silent condition would itself be silent. This workflow therefore
+# carries only the on-demand fleet check.
 
 on:
-  pull_request:
-    paths:
-      - scripts/validate-image-verifier-liveness.sh
-      - scripts/tests/test-validate-image-verifier-liveness.sh
-      - .github/workflows/validate-image-verifier-liveness.yaml
   workflow_dispatch:
 
 permissions: {}
@@ -39,28 +37,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: 🧪 Test Image Verifier Liveness Checker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # checkout repository
-    steps:
-      - name: 📑 Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: 🧪 Test the checker itself
-        shell: bash
-        run: ./scripts/tests/test-validate-image-verifier-liveness.sh
-
   validate-image-verifier-liveness:
     name: 🔏 Validate Image Verifier Liveness
-    needs: test
-    # A pull request has no business reading prod, and fork PRs cannot hold the
-    # cluster secrets. Removing this condition is what activation means.
-    if: github.event_name == 'workflow_dispatch'
+    # Dormancy is now the TRIGGER SET, not a job condition: `workflow_dispatch`
+    # is the only event, so there is no PR or schedule path to guard against.
+    # Adding the daily `schedule:` is what activation means (#3101).
     runs-on: ubuntu-latest
+    # KUBE_CONFIG and TALOS_CONFIG are `prod` ENVIRONMENT secrets, not repository
+    # secrets — every other consumer (ci.yaml's deploy jobs, cd.yaml, dr-rebuild)
+    # declares this for the same reason. Without it GitHub resolves both to the
+    # empty string, the restore steps write empty configs, and the check cannot
+    # reach a single node. It would fail as an infrastructure error rather than
+    # passing falsely, but a control that can never run is the same class of
+    # problem as the one this whole PR exists to detect.
+    environment: prod
     permissions:
       contents: read # checkout repository
     concurrency:

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -9,36 +9,38 @@ name: Validate Image Verifier Liveness
 # Nothing in CI could see it: the rules were present, the node config matched the
 # repository, and every check was green.
 #
-# This runs on a cadence rather than on a PR because the condition it watches is
-# not introduced by a diff. It drifts with the node image, the Talos version, and
-# the schematic — none of which this repository's PR events observe. A
-# path-filtered PR check would have caught none of #2856.
+# The fleet check is DORMANT: it runs only on demand (`workflow_dispatch`), and
+# #3101 turns on its daily cadence as part of installing the verifier.
 #
-# EXPECTED TO FAIL until #3101 installs the verifier. That is the point: the
-# signal should be red while the control is inert, not silent.
+# The verifier is absent fleet-wide today, so the check reports RED on every
+# node. That verdict is correct and is tracked on #3101 — it is not news any
+# individual run needs to act on. Publishing it daily on `main` would spend the
+# repository's CI-red channel, which means "something broke, fix it now", on a
+# known open issue that the tracker already states. Landing the checker dormant
+# keeps the capability reviewable and runnable on demand without burning that
+# signal, and activation becomes one reversible line in #3101.
+#
+# The checker's OWN tests need no cluster and no secrets, so they gate every PR
+# that touches the checker. That split is the point: a regression in a checker
+# whose job is noticing a silent condition would itself be silent.
 
 on:
-  schedule:
-    - cron: "30 6 * * *" # daily, offset from the midnight policy sync
-  workflow_dispatch:
-  push:
-    branches: [main]
+  pull_request:
     paths:
       - scripts/validate-image-verifier-liveness.sh
       - scripts/tests/test-validate-image-verifier-liveness.sh
       - .github/workflows/validate-image-verifier-liveness.yaml
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  # Read-only against prod, so it does not share the deploy lock — but two
-  # copies of it racing each other buys nothing.
-  group: validate-image-verifier-liveness
+  group: validate-image-verifier-liveness-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate-image-verifier-liveness:
-    name: 🔏 Validate Image Verifier Liveness
+  test:
+    name: 🧪 Test Image Verifier Liveness Checker
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -49,11 +51,28 @@ jobs:
           persist-credentials: false
 
       - name: 🧪 Test the checker itself
-        # The checker's whole value is noticing a silent condition, so a
-        # regression in it is silent too. Its own tests need no cluster and no
-        # secrets, so they run first and fail fast.
         shell: bash
         run: ./scripts/tests/test-validate-image-verifier-liveness.sh
+
+  validate-image-verifier-liveness:
+    name: 🔏 Validate Image Verifier Liveness
+    needs: test
+    # A pull request has no business reading prod, and fork PRs cannot hold the
+    # cluster secrets. Removing this condition is what activation means.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    concurrency:
+      # Read-only against prod, so it does not share the deploy lock — but two
+      # copies of it racing each other buys nothing.
+      group: validate-image-verifier-liveness-fleet
+      cancel-in-progress: true
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: ⚙️ Setup talosctl
         shell: bash

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -93,11 +93,25 @@ while [[ "$#" -gt 0 ]]; do
       # An unreachable node fails everything, exactly as the real client does
       # when it cannot talk to the API.
       [[ -d "${FIXTURES}/${node}" ]] || { printf 'error connecting to %s\n' "${node}" >&2; exit 1; }
-      # `ls /` is the reachability probe: the node answered, so it succeeds.
-      [[ "${path}" == '/' ]] && exit 0
       listing="${FIXTURES}/${node}/dirs/${path//\//_}"
       content="${FIXTURES}/${node}/files/${path//\//_}"
+      # The node drops out mid-check: its config files still probe and read, but
+      # every OTHER `ls` now fails — including the `/` reachability probe. That
+      # ordering is the point: the check gets past the config and only then finds
+      # the node gone, which is the path a start-of-run probe cannot cover.
+      if [[ -f "${FIXTURES}/${node}/lsfail_all" && ! -f "${content}" ]]; then
+        printf 'error connecting to %s\n' "${node}" >&2
+        exit 1
+      fi
+      # `ls /` is the reachability probe: the node answered, so it succeeds.
+      [[ "${path}" == '/' ]] && exit 0
       if [[ -f "${listing}" ]]; then
+        # A node that answers the short-form existence probe and then fails the
+        # long-form listing: the directory was there, the node stopped talking.
+        if [[ "${long}" -eq 1 && -f "${FIXTURES}/${node}/lsfail" ]]; then
+          printf 'error connecting to %s\n' "${node}" >&2
+          exit 1
+        fi
         [[ "${long}" -eq 1 ]] && cat "${listing}"
         exit 0
       fi
@@ -412,7 +426,7 @@ run_script >/dev/null 2>&1 || true
 refute_text "$(cat "${fixtures}/kubectl-args")" '--context' 'case 11: passed an empty --context when KUBECTL_CONTEXT was unset'
 
 # ===========================================================================
-# Case 12 — a bin_dir holding ONLY a SUBDIRECTORY must FAIL. A directory's mode
+# Case 16 — a bin_dir holding ONLY a SUBDIRECTORY must FAIL. A directory's mode
 # string ('drwxr-xr-x') contains an 'x', so a check that counts any entry with
 # an 'x' reports this node as enforcing. containerd executes files in bin_dir
 # and does not descend, so such a node permits every pull — a fail-open in the
@@ -427,9 +441,9 @@ ${listing_header}
 EOF
 
 if output="$(run_script TALOS_NODES=dironly 2>&1)"; then
-  fail 'case 12: a bin_dir holding only a subdirectory MUST fail — directories are not verifier binaries'
+  fail 'case 16: a bin_dir holding only a subdirectory MUST fail — directories are not verifier binaries'
 fi
-require_text "${output}" 'holds no executable' 'case 12: names the condition that failed'
+require_text "${output}" 'holds no executable' 'case 16: names the condition that failed'
 
 # ...while an executable SYMLINK in bin_dir still counts: a verifier installed
 # via a symlink into bin_dir is executed exactly like a regular file.
@@ -441,22 +455,35 @@ ${listing_header}
 EOF
 
 output="$(run_script TALOS_NODES=symlink 2>&1)" ||
-  fail 'case 12: an executable symlink in bin_dir must count as a verifier'
-require_text "${output}" 'holds 1 executable' 'case 12: counted the symlinked verifier'
+  fail 'case 16: an executable symlink in bin_dir must count as a verifier'
+require_text "${output}" 'holds 1 executable' 'case 16: counted the symlinked verifier'
 
 # ===========================================================================
 # Case 13 — an empty entry in the node list is a USAGE error (exit 2), not a
 # node to skip. Skipping it would check fewer nodes than asked for and still
 # exit 0: a clean report on a fleet the check never looked at.
 # ===========================================================================
-if output="$(run_script TALOS_NODES=good,,good 2>&1)"; then
-  fail 'case 13: an interior empty node entry must not succeed'
-fi
-status=0
-run_script TALOS_NODES=good,,good >/dev/null 2>&1 || status=$?
-[[ "${status}" -eq 2 ]] ||
-  fail "case 13: an empty node entry must exit 2 (usage), got ${status}"
-require_text "${output}" 'empty entry' 'case 13: names the malformed list'
+# A trailing comma is the case a post-split scan structurally cannot catch:
+# `read -a` discards the trailing empty field, so 'good,' splits to exactly one
+# element and looks perfectly well-formed. Leading and doubled commas are here
+# for the same reason — the check is on the raw string, so all three share a
+# code path and all three are pinned.
+for malformed in 'good,,good' 'good,' ',good' 'good,,'; do
+  status=0
+  output="$(run_script "TALOS_NODES=${malformed}" 2>&1)" || status=$?
+  [[ "${status}" -ne 0 ]] ||
+    fail "case 13: malformed node list '${malformed}' must not succeed"
+  [[ "${status}" -eq 2 ]] ||
+    fail "case 13: malformed node list '${malformed}' must exit 2 (usage), got ${status}"
+  require_text "${output}" 'empty entry' "case 13: names the malformed list for '${malformed}'"
+  refute_text "${output}" 'can enforce image verification.' \
+    "case 13: reported a verdict for the malformed list '${malformed}'"
+done
+
+# The well-formed list must still work — otherwise the guard above could be
+# rejecting everything and every assertion here would still pass.
+run_script TALOS_NODES=good,good >/dev/null 2>&1 ||
+  fail 'case 13: a well-formed comma-separated list must still be accepted'
 
 # ===========================================================================
 # Case 14 — a bin_dir belonging to a DIFFERENT plugin must not count.
@@ -509,5 +536,89 @@ if [[ "${status}" -ne 2 ]]; then
 fi
 require_text "${output}" 'cannot reach node unreachable' 'case 15: names the unreachable node'
 refute_text "${output}" 'can enforce image verification.' 'case 15: reported a verdict for a node it never checked'
+
+# ===========================================================================
+# Case 17 — a node that stops answering AFTER its config was read is an
+# infrastructure error, not a verdict.
+#
+# `talosctl ls -l` on a bin_dir already proven to exist can still fail. awk over
+# empty input prints 0 quite happily, so discarding that status turns an
+# unreachable node into a confident "holds no executable" FAIL — the checker
+# blaming the cluster for a runner-side fault, at exit code 1 where a human
+# reads "the fleet is unprotected" rather than "the check did not run".
+# ===========================================================================
+write_node vanishing
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/vanishing/files/_etc_cri_conf.d_cri.toml"
+# `ls <dir>` succeeds (the existence probe) because a listing fixture exists,
+# but it is EMPTY, so `ls -l` on it produces no rows...
+write_dir vanishing /opt/containerd/image-verifier/bin </dev/null
+# ...and this makes the long-form listing fail outright, which is the real
+# shape: the directory was there a moment ago and the node is now unresponsive.
+printf 'FAIL_LS_LONG\n' >"${fixtures}/vanishing/lsfail"
+
+status=0
+output="$(run_script TALOS_NODES=vanishing 2>&1)" || status=$?
+if [[ "${status}" -eq 1 ]]; then
+  fail 'case 17: a failed listing on an existing bin_dir must not be reported as "holds no executable"'
+fi
+[[ "${status}" -eq 2 ]] ||
+  fail "case 17: a failed listing must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'could not list' 'case 17: names the listing failure'
+refute_text "${output}" 'can enforce image verification.' 'case 17: reported a verdict it could not reach'
+
+# ===========================================================================
+# Case 19 — a node that drops out between the config read and the bin_dir probe
+# is an infrastructure error, not "the directory does not exist".
+#
+# `directory_exists` sees the same failed `ls` either way. Reporting the
+# unreachable case as a verdict blames the cluster for a runner-side fault, and
+# a start-of-run reachability probe cannot cover it — the node was answering
+# when the run began.
+# ===========================================================================
+write_node dropout
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/dropout/files/_etc_cri_conf.d_cri.toml"
+printf 'DROPPED\n' >"${fixtures}/dropout/lsfail_all"
+
+status=0
+output="$(run_script TALOS_NODES=dropout 2>&1)" || status=$?
+if [[ "${status}" -eq 1 ]]; then
+  fail 'case 19: an unreachable node must not be reported as "bin_dir does not exist"'
+fi
+[[ "${status}" -eq 2 ]] ||
+  fail "case 19: a mid-check dropout must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'cannot reach node dropout' 'case 19: names the unreachable node'
+refute_text "${output}" 'does not exist' 'case 19: blamed the cluster for a runner-side fault'
+
+# ===========================================================================
+# Case 18 — PARTIAL node discovery must abort, never pass on the prefix.
+#
+# kubectl can return a valid node followed by one whose addresses are missing,
+# so jq emits an address and THEN fails. Run through a process substitution,
+# `fail_infra` exits only that subshell: the loop keeps the addresses already
+# emitted, and if those happen to be healthy the script exits 0 having silently
+# dropped the rest of the fleet. That is the fail-open this whole script exists
+# to detect, arriving through the enumeration rather than the verdict.
+# ===========================================================================
+# kubectl SUCCEEDS here — that is the whole point. The failure has to come from
+# jq, midway through valid output: the first node yields an address, the second
+# has no `status.addresses` at all, so jq errors on it AFTER writing "good" to
+# stdout. A fake that simply exits non-zero would abort discovery at the kubectl
+# step and never exercise the partial-output path (it did, and the ablation
+# caught it).
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[{"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},{"status":{}}]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+status=0
+output="$(run_script 2>&1)" || status=$?
+if [[ "${status}" -eq 0 ]]; then
+  fail 'case 18: partial node discovery MUST NOT exit 0 — the rest of the fleet was never enumerated'
+fi
+[[ "${status}" -eq 2 ]] ||
+  fail "case 18: partial discovery must exit 2 (infrastructure), got ${status}"
+refute_text "${output}" 'can enforce image verification.' 'case 18: reported a fleet it only partly enumerated'
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -126,8 +126,13 @@ run_script() {
     "$@" bash "${script}"
 }
 
-# --- The credential that must never appear in output. -----------------------
-readonly canary='ghp_TESTCANARYVALUEmustNeverBePrinted0001'
+# --- The credential value that must never appear in output. -----------------
+# Deliberately NOT shaped like a real token. The property under test is "no
+# config content reaches stdout", which any distinctive sentinel proves — while
+# a realistic `ghp_`-shaped literal is itself a finding for the secret scanners
+# this repository gates on (betterleaks/secretlint/trufflehog report 0 on this
+# tree, and a test fixture is not a good reason to spend that).
+readonly canary='CANARY-registry-auth-value-must-never-be-printed'
 
 verifier_config() {
   local bin_dir="$1"

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -759,4 +759,68 @@ rm -f "${fixtures}/probeerror/lserror_etc_cri_conf.d_cri.toml"
 run_script TALOS_NODES=probeerror >/dev/null 2>&1 ||
   fail 'case 21: the same node must pass once the probe error is gone'
 
+# ===========================================================================
+# Case 23 — two nodes publishing the SAME InternalIP must not pass.
+#
+# The flattening emits that address once per node, so both passes inspect the
+# SAME machine while the other node is never looked at — and since the machine
+# they both reach is healthy, the run reports a green fleet with a node it never
+# touched. Distinct from case 22: there the node contributes NO address, here it
+# contributes a duplicate one, so a "did every node yield an address?" check
+# passes and only a uniqueness check catches it.
+#
+# `scripts/refresh-flux-ghcr-auth.sh`'s `validate_talos_node_inventory` refuses
+# the same shape before it mutates anything; this mirrors that rule.
+# ===========================================================================
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[
+  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-stale"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}}
+]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -ne 0 ]] ||
+  fail 'case 23: two nodes sharing one InternalIP MUST NOT yield exit 0 — one was never inspected'
+[[ "${status}" -eq 2 ]] ||
+  fail "case 23: a duplicate InternalIP must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'prod-worker-stale' 'case 23: names the nodes sharing an address'
+refute_text "${output}" 'can enforce image verification.' \
+  'case 23: reported a verdict for a fleet where one node was never inspected'
+
+# A node carrying TWO InternalIPs is the same ambiguity from the other side:
+# which one talosctl would reach is unspecified, so it is refused rather than
+# guessed.
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[
+  {"metadata":{"name":"prod-worker-dual"},"status":{"addresses":[{"type":"InternalIP","address":"good"},{"type":"InternalIP","address":"empty"}]}}
+]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 23: a node with two InternalIPs must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'prod-worker-dual' 'case 23: names the node carrying two addresses'
+
+# Control: distinct addresses across distinct nodes still pass, so the
+# uniqueness rule is not simply rejecting every multi-node fleet.
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[
+  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"onlysystem"}]}}
+]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+run_script >/dev/null 2>&1 ||
+  fail 'case 23: a fleet of distinct nodes with distinct InternalIPs must still be accepted'
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -368,4 +368,51 @@ grep -Fq -- '--context admin@prod' "${fixtures}/kubectl-args" ||
 run_script >/dev/null 2>&1 || true
 refute_text "$(cat "${fixtures}/kubectl-args")" '--context' 'case 11: passed an empty --context when KUBECTL_CONTEXT was unset'
 
+# ===========================================================================
+# Case 12 — a bin_dir holding ONLY a SUBDIRECTORY must FAIL. A directory's mode
+# string ('drwxr-xr-x') contains an 'x', so a check that counts any entry with
+# an 'x' reports this node as enforcing. containerd executes files in bin_dir
+# and does not descend, so such a node permits every pull — a fail-open in the
+# dangerous direction, and the exact class #2856 was.
+# ===========================================================================
+write_node dironly
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/dironly/files/_etc_cri_conf.d_cri.toml"
+write_dir dironly /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   plugins
+EOF
+
+if output="$(run_script TALOS_NODES=dironly 2>&1)"; then
+  fail 'case 12: a bin_dir holding only a subdirectory MUST fail — directories are not verifier binaries'
+fi
+require_text "${output}" 'holds no executable' 'case 12: names the condition that failed'
+
+# ...while an executable SYMLINK in bin_dir still counts: a verifier installed
+# via a symlink into bin_dir is executed exactly like a regular file.
+write_node symlink
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/symlink/files/_etc_cri_conf.d_cri.toml"
+write_dir symlink /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   lrwxrwxrwx   0     0     31        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+output="$(run_script TALOS_NODES=symlink 2>&1)" ||
+  fail 'case 12: an executable symlink in bin_dir must count as a verifier'
+require_text "${output}" 'holds 1 executable' 'case 12: counted the symlinked verifier'
+
+# ===========================================================================
+# Case 13 — an empty entry in the node list is a USAGE error (exit 2), not a
+# node to skip. Skipping it would check fewer nodes than asked for and still
+# exit 0: a clean report on a fleet the check never looked at.
+# ===========================================================================
+if output="$(run_script TALOS_NODES=good,,good 2>&1)"; then
+  fail 'case 13: an interior empty node entry must not succeed'
+fi
+status=0
+run_script TALOS_NODES=good,,good >/dev/null 2>&1 || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 13: an empty node entry must exit 2 (usage), got ${status}"
+require_text "${output}" 'empty entry' 'case 13: names the malformed list'
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -103,6 +103,14 @@ while [[ "$#" -gt 0 ]]; do
         printf 'error connecting to %s\n' "${node}" >&2
         exit 1
       fi
+      # A path that fails for a reason OTHER than being absent: the real client
+      # emits an RPC error here, not an lstat one. Kept distinct from the
+      # no-fixture case below so a transient fault can be told apart from a
+      # config the node genuinely does not ship.
+      if [[ -f "${FIXTURES}/${node}/lserror${path//\//_}" ]]; then
+        printf 'rpc error: code = Unavailable desc = connection error\n' >&2
+        exit 1
+      fi
       # `ls /` is the reachability probe: the node answered, so it succeeds.
       [[ "${path}" == '/' ]] && exit 0
       if [[ -f "${listing}" ]]; then
@@ -620,5 +628,135 @@ fi
 [[ "${status}" -eq 2 ]] ||
   fail "case 18: partial discovery must exit 2 (infrastructure), got ${status}"
 refute_text "${output}" 'can enforce image verification.' 'case 18: reported a fleet it only partly enumerated'
+
+# ===========================================================================
+# Case 19 — a discovered node with NO InternalIP must not be silently dropped.
+#
+# Distinct from case 18, and the distinction is the whole point: there the node
+# has no `status.addresses` at all, so jq ERRORS and discovery already fails
+# closed. Here the array is present and perfectly valid — it just holds only a
+# Hostname and an ExternalIP. jq's `select(.type == "InternalIP")` matches
+# nothing, emits nothing, and SUCCEEDS. The node vanishes from the fleet while
+# every other node reports OK, so the script prints a confident green verdict
+# for a fleet it never fully enumerated: the same fail-open shape the script
+# exists to detect, arriving through enumeration rather than the verdict.
+# ===========================================================================
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[
+  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-2"},{"type":"ExternalIP","address":"203.0.113.7"}]}}
+]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -ne 0 ]] ||
+  fail 'case 19: a node with no InternalIP MUST NOT yield exit 0 — it was never checked'
+[[ "${status}" -eq 2 ]] ||
+  fail "case 19: a node with no InternalIP must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'prod-worker-2' 'case 19: names the node that has no InternalIP'
+refute_text "${output}" 'can enforce image verification.' \
+  'case 19: reported a verdict for a fleet that was only partly enumerated'
+
+# The healthy-fleet control: without it, a discover_nodes that rejected EVERY
+# node would pass every assertion above.
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' '{"items":[
+  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-1"},{"type":"InternalIP","address":"good"}]}}
+]}'
+exit 0
+FAKE
+chmod +x "${fake_bin}/kubectl"
+run_script >/dev/null 2>&1 ||
+  fail 'case 19: a fleet whose nodes all have an InternalIP must still be accepted'
+
+# ===========================================================================
+# Case 20 — an explicitly EMPTY node list is a usage error, not a fallback.
+#
+# `--nodes "$TALOS_NODES"` with the variable unset expands to an empty string.
+# Treating that as "no list was given" silently switches to cluster discovery,
+# so the check reports a green verdict for a DIFFERENT fleet than the caller
+# asked for — and the explicit addresses are usually explicit precisely because
+# the current kube context is not the fleet in question.
+#
+# Discovery is wired to a healthy node here on purpose: if the fallback fires,
+# the script exits 0 and the assertion below is what catches it.
+# ===========================================================================
+run_script_with_args() {
+  env PATH="${fake_bin}:${PATH}" FIXTURES="${fixtures}" \
+    TALOSCTL="${fake_bin}/talosctl" KUBECTL="${fake_bin}/kubectl" \
+    bash "${script}" "$@"
+}
+
+status=0
+output="$(run_script_with_args --nodes '' 2>&1)" || status=$?
+[[ "${status}" -ne 0 ]] ||
+  fail 'case 20: --nodes "" must not silently fall back to cluster discovery'
+[[ "${status}" -eq 2 ]] ||
+  fail "case 20: --nodes '' must exit 2 (usage), got ${status}"
+refute_text "${output}" 'can enforce image verification.' \
+  'case 20: reported a verdict for a fleet the caller never asked for'
+
+# Same for the environment form, which is how CI passes the list.
+status=0
+output="$(run_script TALOS_NODES= 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 20: TALOS_NODES set-but-empty must exit 2 (usage), got ${status}"
+
+# Controls: an explicit non-empty list still works, and a genuinely UNSET
+# TALOS_NODES must still reach discovery — otherwise the guard above would be
+# rejecting the discovery path outright and case 7 would be the only thing
+# keeping it honest.
+run_script_with_args --nodes good >/dev/null 2>&1 ||
+  fail 'case 20: an explicit non-empty --nodes must still be accepted'
+run_script >/dev/null 2>&1 ||
+  fail 'case 20: an unset TALOS_NODES must still fall through to discovery'
+
+# ===========================================================================
+# Case 21 — a config probe that fails for a reason OTHER than "absent" is an
+# infrastructure error, never a config to skip.
+#
+# `talosctl ls <config>` failing is ambiguous: the file may not be there, or the
+# node may have hiccuped. Only the first is a verdict. Treating both as "this
+# node does not ship that config" means a transient fault silently removes one
+# containerd from the check — and if the OTHER containerd is wired up,
+# `configs_present` stays nonzero and the node passes while one of its two image
+# paths was never inspected.
+#
+# The system containerd here is deliberately HEALTHY: that is what makes the
+# skip invisible without this case.
+# ===========================================================================
+write_node probeerror
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/probeerror/files/_etc_containerd_config.toml"
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/probeerror/files/_etc_cri_conf.d_cri.toml"
+write_dir probeerror /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.9   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+# The CRI config probe fails with an RPC error rather than an lstat one. The
+# node itself still answers `ls /`, so a reachability probe cannot catch this.
+printf 'PROBE_ERROR\n' >"${fixtures}/probeerror/lserror_etc_cri_conf.d_cri.toml"
+
+status=0
+output="$(run_script TALOS_NODES=probeerror 2>&1)" || status=$?
+[[ "${status}" -ne 0 ]] ||
+  fail 'case 21: a config probe error MUST NOT be skipped into a green verdict'
+[[ "${status}" -eq 2 ]] ||
+  fail "case 21: a config probe error must exit 2 (infrastructure), got ${status}"
+require_text "${output}" '/etc/cri/conf.d/cri.toml' 'case 21: names the config it could not probe'
+refute_text "${output}" 'can enforce image verification.' \
+  'case 21: reported a verdict for a node whose containerd was never inspected'
+refute_text "${output}" "${canary}" 'case 21: probe error must not carry config contents'
+
+# Control: with the probe error removed the same node passes, so the assertions
+# above are pinning the probe failure and not some unrelated defect in the
+# fixture.
+rm -f "${fixtures}/probeerror/lserror_etc_cri_conf.d_cri.toml"
+run_script TALOS_NODES=probeerror >/dev/null 2>&1 ||
+  fail 'case 21: the same node must pass once the probe error is gone'
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# Pin the behaviour of scripts/validate-image-verifier-liveness.sh.
+#
+# WHY THIS EXISTS. The script's whole job is to notice a condition that looks
+# identical to health from every other angle: ImageVerificationConfig rules
+# present and correct, node config matching the repository, CI green — and no
+# verifier binary, so containerd permits every pull (devantler-tech/platform#2856).
+# A regression here is silent by construction: the script would exit 0 and the
+# cluster would read as enforcing. So these cases pin the FAILING paths, not just
+# the happy one, and the #2856 state (bin_dir present, directory present, empty)
+# gets its own case because it is the one that actually happened.
+#
+# The credential case is not decoration. The script reads
+# /etc/cri/conf.d/cri.toml, which carries registry auth on this cluster, and its
+# output goes to CI logs. A refactor that echoes the file — or quotes it in an
+# error — would publish a token. That is pinned here so it fails loudly.
+#
+# talosctl and kubectl are faked from fixture directories; no cluster, no
+# secrets, no network. Bash 3.2 compatible so it runs on a maintainer's macOS
+# as well as CI.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly script="${root_dir}/scripts/validate-image-verifier-liveness.sh"
+
+work_dir="$(mktemp -d)"
+readonly work_dir
+cleanup() {
+  rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+readonly fake_bin="${work_dir}/bin"
+readonly fixtures="${work_dir}/fixtures"
+mkdir -p "${fake_bin}" "${fixtures}"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+require_text() {
+  local haystack="$1" needle="$2" description="$3"
+  if ! grep -Fq -- "${needle}" <<<"${haystack}"; then
+    printf 'FAIL: %s\n--- actual output ---\n%s\n---\n' "${description}" "${haystack}" >&2
+    exit 1
+  fi
+}
+
+refute_text() {
+  local haystack="$1" needle="$2" description="$3"
+  if grep -Fq -- "${needle}" <<<"${haystack}"; then
+    printf 'FAIL: %s\n--- actual output ---\n%s\n---\n' "${description}" "${haystack}" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fake talosctl: serves `read <file>` and `ls [-l] <dir>` from a fixture tree.
+# A path with no fixture behaves like the real thing — non-zero, nothing on
+# stdout — which is what makes the "directory does not exist" case real rather
+# than simulated by a special-case flag.
+# ---------------------------------------------------------------------------
+cat >"${fake_bin}/talosctl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+node=''
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -n) node="$2"; shift 2 ;;
+    read)
+      path="$2"
+      file="${FIXTURES}/${node}/files/${path//\//_}"
+      [[ -f "${file}" ]] || exit 1
+      cat "${file}"
+      exit 0
+      ;;
+    ls)
+      shift
+      [[ "${1:-}" == '-l' ]] && shift || true
+      path="$1"
+      listing="${FIXTURES}/${node}/dirs/${path//\//_}"
+      [[ -f "${listing}" ]] || { printf 'lstat %s: no such file or directory\n' "${path}" >&2; exit 1; }
+      cat "${listing}"
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+exit 1
+FAKE
+chmod +x "${fake_bin}/talosctl"
+
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+cat "${FIXTURES}/nodes.json"
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+# A real `talosctl ls -l` header plus rows. Column 2 is MODE, last column is
+# NAME, and the LABEL column is EMPTY for some files on this cluster — which is
+# why the script must not parse positionally from the left past column 2. One
+# fixture below reproduces that empty-label row on purpose.
+listing_header='NODE       MODE         UID   GID   SIZE(B)   LASTMOD           LABEL                                      NAME'
+
+write_node() {
+  local node="$1"
+  mkdir -p "${fixtures}/${node}/files" "${fixtures}/${node}/dirs"
+}
+
+write_config() {
+  local node="$1" path="$2"
+  cat >"${fixtures}/${node}/files/${path//\//_}"
+}
+
+write_dir() {
+  local node="$1" path="$2"
+  cat >"${fixtures}/${node}/dirs/${path//\//_}"
+}
+
+run_script() {
+  env PATH="${fake_bin}:${PATH}" FIXTURES="${fixtures}" \
+    TALOSCTL="${fake_bin}/talosctl" KUBECTL="${fake_bin}/kubectl" \
+    "$@" bash "${script}"
+}
+
+# --- The credential that must never appear in output. -----------------------
+readonly canary='ghp_TESTCANARYVALUEmustNeverBePrinted0001'
+
+verifier_config() {
+  local bin_dir="$1"
+  cat <<EOF
+version = 3
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
+      password = '${canary}'
+      username = 'devantler'
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '${bin_dir}'
+EOF
+}
+
+no_verifier_config() {
+  cat <<EOF
+version = 3
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
+      password = '${canary}'
+      username = 'devantler'
+EOF
+}
+
+# ===========================================================================
+# Case 1 — GREEN: bin_dir configured, exists, holds an executable.
+# ===========================================================================
+write_node good
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/good/files/_etc_cri_conf.d_cri.toml"
+write_dir good /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+output="$(run_script TALOS_NODES=good 2>&1)" || fail "case 1: expected exit 0 for a node that can enforce"
+require_text "${output}" 'OK   good' 'case 1: reports the healthy node'
+require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 1: reports the summary'
+
+# ===========================================================================
+# Case 2 — RED, and this is the #2856 state: bin_dir configured, directory
+# present, NO executable in it. containerd permits every pull here.
+# ===========================================================================
+write_node empty
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/empty/files/_etc_cri_conf.d_cri.toml"
+write_dir empty /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     3         Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+EOF
+
+if output="$(run_script TALOS_NODES=empty 2>&1)"; then
+  fail "case 2: an empty bin_dir MUST fail — this is the exact state that let an unsigned image run (#2856)"
+fi
+require_text "${output}" 'FAIL empty' 'case 2: names the failing node'
+require_text "${output}" 'holds no executable' 'case 2: names the condition that failed'
+
+# ===========================================================================
+# Case 3 — RED: no bin_dir configured at all in any config file. This is what
+# the cluster actually looked like when #2856 was found.
+# ===========================================================================
+write_node unset
+no_verifier_config >"${fixtures}/unset/files/_etc_cri_conf.d_cri.toml"
+no_verifier_config >"${fixtures}/unset/files/_etc_containerd_config.toml"
+
+if output="$(run_script TALOS_NODES=unset 2>&1)"; then
+  fail 'case 3: a node with no bin_dir configured MUST fail'
+fi
+require_text "${output}" 'FAIL unset' 'case 3: names the failing node'
+require_text "${output}" 'no bin_dir configured' 'case 3: names the condition that failed'
+
+# ===========================================================================
+# Case 4 — RED: bin_dir configured but the directory does not exist.
+# ===========================================================================
+write_node missing
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/missing/files/_etc_cri_conf.d_cri.toml"
+
+if output="$(run_script TALOS_NODES=missing 2>&1)"; then
+  fail 'case 4: a configured-but-absent bin_dir MUST fail'
+fi
+require_text "${output}" 'does not exist' 'case 4: names the condition that failed'
+
+# ===========================================================================
+# Case 5 — SECURITY: cri.toml carries registry auth and this output goes to CI
+# logs. No path through the script may print it — including the failure paths,
+# which are the tempting place to dump "the config we read".
+# ===========================================================================
+for node in good empty unset missing; do
+  output="$(run_script TALOS_NODES="${node}" 2>&1 || true)"
+  refute_text "${output}" "${canary}" "case 5: leaked the registry credential from ${node}'s config into output"
+  refute_text "${output}" 'password' "case 5: echoed a config auth key from ${node}"
+done
+
+# ===========================================================================
+# Case 6 — a mixed fleet fails, and reports EVERY bad node rather than stopping
+# at the first. A partial rollout that left one node unverified is precisely the
+# case a first-failure exit would hide.
+# ===========================================================================
+if output="$(run_script TALOS_NODES=good,empty,unset 2>&1)"; then
+  fail 'case 6: a fleet containing an unenforcing node MUST fail'
+fi
+require_text "${output}" 'OK   good' 'case 6: still reports the healthy node'
+require_text "${output}" 'FAIL empty' 'case 6: reports the empty-bindir node'
+require_text "${output}" 'FAIL unset' 'case 6: reports the unconfigured node'
+require_text "${output}" '2 of 3 node(s) cannot enforce' 'case 6: counts every failure, not just the first'
+
+# ===========================================================================
+# Case 7 — node discovery. With no --nodes/TALOS_NODES the script reads the
+# cluster, so autoscaled nodes are covered without anyone maintaining a list.
+# The autoscaler node was central to #2856's evidence.
+# ===========================================================================
+cat >"${fixtures}/nodes.json" <<'EOF'
+{
+  "items": [
+    {"status": {"addresses": [{"type": "Hostname", "address": "prod-worker-1"}, {"type": "InternalIP", "address": "good"}]}},
+    {"status": {"addresses": [{"type": "InternalIP", "address": "empty"}]}}
+  ]
+}
+EOF
+
+if output="$(run_script 2>&1)"; then
+  fail 'case 7: discovery must surface the unenforcing discovered node'
+fi
+require_text "${output}" 'OK   good' 'case 7: discovered the healthy node'
+require_text "${output}" 'FAIL empty' 'case 7: discovered the unenforcing node'
+refute_text "${output}" 'prod-worker-1' 'case 7: used InternalIP, not Hostname'
+
+# ===========================================================================
+# Case 8 — the SYSTEM containerd config counts too. A verifier wired only into
+# the CRI containerd leaves Talos' own image pulls unverified, so a bin_dir
+# found in either file satisfies the check.
+# ===========================================================================
+write_node systemonly
+no_verifier_config >"${fixtures}/systemonly/files/_etc_cri_conf.d_cri.toml"
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/systemonly/files/_etc_containerd_config.toml"
+write_dir systemonly /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+output="$(run_script TALOS_NODES=systemonly 2>&1)" ||
+  fail 'case 8: a bin_dir declared only in the system containerd config must still count'
+
+# ===========================================================================
+# Case 9 — a row whose LABEL column is empty must still be parsed. Real
+# `talosctl ls -l` output on this cluster omits the label for some files, which
+# breaks any parser that counts columns from the left past MODE.
+# ===========================================================================
+write_node nolabel
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/nolabel/files/_etc_cri_conf.d_cri.toml"
+write_dir nolabel /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug 11 19:39:51                                              cosign-verifier
+EOF
+
+output="$(run_script TALOS_NODES=nolabel 2>&1)" ||
+  fail 'case 9: an executable whose ls row has no SELinux label must still be counted'
+require_text "${output}" 'holds 1 executable' 'case 9: counted the unlabelled executable'
+
+# ===========================================================================
+# Case 10 — a NON-executable file in bin_dir does not satisfy the check.
+# containerd executes the binaries there; a stray README enforces nothing.
+# ===========================================================================
+write_node nonexec
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/nonexec/files/_etc_cri_conf.d_cri.toml"
+write_dir nonexec /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rw-r--r--   0     0     42        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   README
+EOF
+
+if output="$(run_script TALOS_NODES=nonexec 2>&1)"; then
+  fail 'case 10: a bin_dir holding only a non-executable file MUST fail'
+fi
+require_text "${output}" 'holds no executable' 'case 10: names the condition that failed'
+
+# ===========================================================================
+# Case 12 — a config file that does NOT exist must be skipped, not fatal.
+#
+# Every other fixture here has both config files present, which is also true of
+# today's nodes — so this path is reachable only on a node image where one is
+# absent, and it would then abort the whole run at an assignment under
+# `set -e` + `pipefail` rather than reporting anything. A checker that dies
+# silently on the drift it exists to watch is worse than no checker.
+# ===========================================================================
+write_node onlycri
+no_verifier_config >"${fixtures}/onlycri/files/_etc_cri_conf.d_cri.toml"
+# deliberately NO _etc_containerd_config.toml fixture
+
+if output="$(run_script TALOS_NODES=onlycri 2>&1)"; then
+  fail 'case 12: a node with no bin_dir anywhere must FAIL, not pass'
+fi
+require_text "${output}" 'FAIL onlycri' 'case 12: reported the node instead of aborting on the missing config file'
+require_text "${output}" 'no bin_dir configured' 'case 12: reached the real verdict'
+
+# The mirror image: a missing FIRST file must not stop the second from being
+# read, or a verifier declared only in the system config would be invisible.
+write_node onlysystem
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/onlysystem/files/_etc_containerd_config.toml"
+write_dir onlysystem /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+run_script TALOS_NODES=onlysystem >/dev/null 2>&1 ||
+  fail 'case 12: a missing first config file must not stop the second being read'
+
+# ===========================================================================
+# Case 11 — KUBECTL_CONTEXT is forwarded to kubectl. The restored kubeconfig's
+# current-context is not guaranteed to be prod, which is why the deploy
+# composite pins --context; a check that silently read the wrong cluster would
+# report a healthy fleet that is not the one being gated.
+# ===========================================================================
+cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FIXTURES}/kubectl-args"
+cat "${FIXTURES}/nodes.json"
+FAKE
+chmod +x "${fake_bin}/kubectl"
+
+: >"${fixtures}/kubectl-args"
+run_script KUBECTL_CONTEXT=admin@prod >/dev/null 2>&1 || true
+grep -Fq -- '--context admin@prod' "${fixtures}/kubectl-args" ||
+  fail 'case 11: KUBECTL_CONTEXT was not forwarded to kubectl'
+
+# ...and is omitted entirely when unset, rather than passed as an empty flag,
+# which kubectl rejects.
+: >"${fixtures}/kubectl-args"
+run_script >/dev/null 2>&1 || true
+refute_text "$(cat "${fixtures}/kubectl-args")" '--context' 'case 11: passed an empty --context when KUBECTL_CONTEXT was unset'
+
+printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -820,7 +820,12 @@ printf '%s\n' '{"items":[
 exit 0
 FAKE
 chmod +x "${fake_bin}/kubectl"
-run_script >/dev/null 2>&1 ||
+# Assert a verdict line for EACH address, not just exit 0: a regression that
+# silently drops one discovered node from the fleet still exits 0, so an
+# exit-status-only control would keep passing while enumeration shrank.
+output="$(run_script 2>&1)" ||
   fail 'case 23: a fleet of distinct nodes with distinct InternalIPs must still be accepted'
+require_text "${output}" 'good' 'case 23: control reports the first discovered node'
+require_text "${output}" 'onlysystem' 'case 23: control reports the second discovered node'
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -57,10 +57,19 @@ refute_text() {
 }
 
 # ---------------------------------------------------------------------------
-# Fake talosctl: serves `read <file>` and `ls [-l] <dir>` from a fixture tree.
+# Fake talosctl: serves `read <file>` and `ls [-l] <path>` from a fixture tree.
 # A path with no fixture behaves like the real thing — non-zero, nothing on
 # stdout — which is what makes the "directory does not exist" case real rather
 # than simulated by a special-case flag.
+#
+# Two behaviours mirror the real tool because the script now depends on them:
+#   * `ls` reports EXISTENCE for files as well as directories (verified against
+#     prod: `talosctl ls /etc/cri/conf.d/cri.toml` succeeds), so it can probe a
+#     config file without reading — and therefore without touching the registry
+#     credentials that file carries.
+#   * a node with no fixture directory at all is UNREACHABLE: every subcommand
+#     fails, including `ls /`. That is what lets the unreachable case be tested
+#     for real instead of via a special-case flag.
 # ---------------------------------------------------------------------------
 cat >"${fake_bin}/talosctl" <<'FAKE'
 #!/usr/bin/env bash
@@ -78,12 +87,25 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     ls)
       shift
-      [[ "${1:-}" == '-l' ]] && shift || true
-      path="$1"
+      long=0
+      [[ "${1:-}" == '-l' ]] && { long=1; shift; } || true
+      path="${1:-/}"
+      # An unreachable node fails everything, exactly as the real client does
+      # when it cannot talk to the API.
+      [[ -d "${FIXTURES}/${node}" ]] || { printf 'error connecting to %s\n' "${node}" >&2; exit 1; }
+      # `ls /` is the reachability probe: the node answered, so it succeeds.
+      [[ "${path}" == '/' ]] && exit 0
       listing="${FIXTURES}/${node}/dirs/${path//\//_}"
-      [[ -f "${listing}" ]] || { printf 'lstat %s: no such file or directory\n' "${path}" >&2; exit 1; }
-      cat "${listing}"
-      exit 0
+      content="${FIXTURES}/${node}/files/${path//\//_}"
+      if [[ -f "${listing}" ]]; then
+        [[ "${long}" -eq 1 ]] && cat "${listing}"
+        exit 0
+      fi
+      # A regular file exists but has no directory listing — `ls` on it succeeds
+      # and never emits its CONTENTS.
+      [[ -f "${content}" ]] && exit 0
+      printf 'lstat %s: no such file or directory\n' "${path}" >&2
+      exit 1
       ;;
     *) shift ;;
   esac
@@ -206,7 +228,7 @@ if output="$(run_script TALOS_NODES=unset 2>&1)"; then
   fail 'case 3: a node with no bin_dir configured MUST fail'
 fi
 require_text "${output}" 'FAIL unset' 'case 3: names the failing node'
-require_text "${output}" 'no bin_dir configured' 'case 3: names the condition that failed'
+require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 3: names the condition that failed'
 
 # ===========================================================================
 # Case 4 — RED: bin_dir configured but the directory does not exist.
@@ -265,20 +287,41 @@ require_text "${output}" 'FAIL empty' 'case 7: discovered the unenforcing node'
 refute_text "${output}" 'prod-worker-1' 'case 7: used InternalIP, not Hostname'
 
 # ===========================================================================
-# Case 8 — the SYSTEM containerd config counts too. A verifier wired only into
-# the CRI containerd leaves Talos' own image pulls unverified, so a bin_dir
-# found in either file satisfies the check.
+# Case 8 — a verifier in ONE containerd must not vouch for the other.
+#
+# Both config files exist on every prod node (measured), and the two instances
+# pull different images: the CRI one pulls workload images, the system one pulls
+# Talos' own. So a node wired up on one side and bare on the other is HALF
+# unprotected — and an implementation that stops at the first config declaring a
+# bin_dir reports it as healthy. Both directions are pinned, because the
+# short-circuit only ever hides whichever file is read second.
 # ===========================================================================
-write_node systemonly
-no_verifier_config >"${fixtures}/systemonly/files/_etc_cri_conf.d_cri.toml"
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/systemonly/files/_etc_containerd_config.toml"
-write_dir systemonly /opt/containerd/image-verifier/bin <<EOF
+write_node systembare
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/systembare/files/_etc_cri_conf.d_cri.toml"
+no_verifier_config >"${fixtures}/systembare/files/_etc_containerd_config.toml"
+write_dir systembare /opt/containerd/image-verifier/bin <<EOF
 ${listing_header}
 10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
 EOF
 
-output="$(run_script TALOS_NODES=systemonly 2>&1)" ||
-  fail 'case 8: a bin_dir declared only in the system containerd config must still count'
+if output="$(run_script TALOS_NODES=systembare 2>&1)"; then
+  fail 'case 8: a bare SYSTEM containerd must fail even when the CRI one is wired up'
+fi
+require_text "${output}" '/etc/containerd/config.toml' 'case 8: names the unprotected containerd'
+require_text "${output}" 'OK   systembare [/etc/cri/conf.d/cri.toml]' 'case 8: still reports the wired-up one'
+
+write_node cribare
+no_verifier_config >"${fixtures}/cribare/files/_etc_cri_conf.d_cri.toml"
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/cribare/files/_etc_containerd_config.toml"
+write_dir cribare /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+if output="$(run_script TALOS_NODES=cribare 2>&1)"; then
+  fail 'case 8: a bare CRI containerd must fail even when the system one is wired up'
+fi
+require_text "${output}" '/etc/cri/conf.d/cri.toml' 'case 8: names the unprotected containerd'
 
 # ===========================================================================
 # Case 9 — a row whose LABEL column is empty must still be parsed. Real
@@ -329,7 +372,7 @@ if output="$(run_script TALOS_NODES=onlycri 2>&1)"; then
   fail 'case 12: a node with no bin_dir anywhere must FAIL, not pass'
 fi
 require_text "${output}" 'FAIL onlycri' 'case 12: reported the node instead of aborting on the missing config file'
-require_text "${output}" 'no bin_dir configured' 'case 12: reached the real verdict'
+require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 12: reached the real verdict'
 
 # The mirror image: a missing FIRST file must not stop the second from being
 # read, or a verifier declared only in the system config would be invisible.
@@ -414,5 +457,57 @@ run_script TALOS_NODES=good,,good >/dev/null 2>&1 || status=$?
 [[ "${status}" -eq 2 ]] ||
   fail "case 13: an empty node entry must exit 2 (usage), got ${status}"
 require_text "${output}" 'empty entry' 'case 13: names the malformed list'
+
+# ===========================================================================
+# Case 14 — a bin_dir belonging to a DIFFERENT plugin must not count.
+#
+# `bin_dir` is a generic TOML key. containerd consults only the one under
+# `io.containerd.image-verifier.v1.bindir` when verifying images, so a match
+# anywhere else reports a node as enforcing on the strength of a setting that
+# has nothing to do with verification — a fail-open produced by the parser
+# rather than by the cluster.
+# ===========================================================================
+write_node otherplugin
+cat >"${fixtures}/otherplugin/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
+      password = '${canary}'
+      username = 'devantler'
+
+  [plugins.'io.containerd.nri.v1.nri']
+    bin_dir = '/opt/nri/bin'
+EOF
+# The unrelated plugin's directory is fully populated: if the check were to read
+# it, it would report a healthy node. Only the SCOPE keeps this failing.
+write_dir otherplugin /opt/nri/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   nri-plugin
+EOF
+
+if output="$(run_script TALOS_NODES=otherplugin 2>&1)"; then
+  fail 'case 14: a bin_dir from an unrelated plugin table MUST NOT satisfy the check'
+fi
+require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 14: reached the real verdict'
+refute_text "${output}" '/opt/nri/bin' 'case 14: read a bin_dir from the wrong table'
+
+# ===========================================================================
+# Case 15 — an UNREACHABLE node aborts; it is never reported as checked.
+#
+# The failure this guards is quiet: if a config file's absence is inferred from
+# a failed read, a node the runner cannot talk to looks identical to one that
+# simply does not ship that file. Every config would be "absent", the node would
+# be skipped, and the fleet summary would report a clean result for a node
+# nothing ever looked at.
+# ===========================================================================
+status=0
+output="$(run_script TALOS_NODES=unreachable 2>&1)" || status=$?
+if [[ "${status}" -ne 2 ]]; then
+  fail "case 15: an unreachable node must exit 2 (infrastructure), got ${status}"
+fi
+require_text "${output}" 'cannot reach node unreachable' 'case 15: names the unreachable node'
+refute_text "${output}" 'can enforce image verification.' 'case 15: reported a verdict for a node it never checked'
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -630,7 +630,7 @@ fi
 refute_text "${output}" 'can enforce image verification.' 'case 18: reported a fleet it only partly enumerated'
 
 # ===========================================================================
-# Case 19 — a discovered node with NO InternalIP must not be silently dropped.
+# Case 22 — a discovered node with NO InternalIP must not be silently dropped.
 #
 # Distinct from case 18, and the distinction is the whole point: there the node
 # has no `status.addresses` at all, so jq ERRORS and discovery already fails
@@ -654,12 +654,12 @@ chmod +x "${fake_bin}/kubectl"
 status=0
 output="$(run_script 2>&1)" || status=$?
 [[ "${status}" -ne 0 ]] ||
-  fail 'case 19: a node with no InternalIP MUST NOT yield exit 0 — it was never checked'
+  fail 'case 22: a node with no InternalIP MUST NOT yield exit 0 — it was never checked'
 [[ "${status}" -eq 2 ]] ||
-  fail "case 19: a node with no InternalIP must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'prod-worker-2' 'case 19: names the node that has no InternalIP'
+  fail "case 22: a node with no InternalIP must exit 2 (infrastructure), got ${status}"
+require_text "${output}" 'prod-worker-2' 'case 22: names the node that has no InternalIP'
 refute_text "${output}" 'can enforce image verification.' \
-  'case 19: reported a verdict for a fleet that was only partly enumerated'
+  'case 22: reported a verdict for a fleet that was only partly enumerated'
 
 # The healthy-fleet control: without it, a discover_nodes that rejected EVERY
 # node would pass every assertion above.
@@ -672,7 +672,7 @@ exit 0
 FAKE
 chmod +x "${fake_bin}/kubectl"
 run_script >/dev/null 2>&1 ||
-  fail 'case 19: a fleet whose nodes all have an InternalIP must still be accepted'
+  fail 'case 22: a fleet whose nodes all have an InternalIP must still be accepted'
 
 # ===========================================================================
 # Case 20 — an explicitly EMPTY node list is a usage error, not a fallback.

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -92,30 +92,68 @@ discover_nodes() {
     fail_infra 'could not parse node addresses from kubectl output'
 }
 
-# Emits the configured bin_dir, or nothing when no config declares one.
-# The config file is piped directly into sed: its contents never land anywhere
-# this script could print them. See the SECURITY note above.
-extract_bin_dir() {
-  local node="$1" file value
-  for file in "${config_files[@]}"; do
-    # INTENT: a config file that does not exist on this node image is skipped so
-    # the next one still gets its turn. The `|| true` states that explicitly
-    # rather than relying on how `set -e` and `pipefail` interact with a failing
-    # first stage inside a command substitution — behaviour subtle enough that
-    # two isolated probes of it disagreed, so it is not something this script
-    # should depend on either way. The missing-config case in the test pins the
-    # behaviour itself.
-    value="$(
-      { "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null || true; } |
-        sed -n "s/^[[:space:]]*bin_dir[[:space:]]*=[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" |
-        head -n 1
-    )"
-    if [[ -n "${value}" ]]; then
-      printf '%s' "${value}"
-      return 0
-    fi
-  done
-  return 0
+# `ls` reports a path's EXISTENCE without emitting its contents, so its exit
+# status is safe to branch on; `read` emits the whole config, so a failed read
+# must never be the thing that tells "absent" apart from "unreachable".
+#
+# That distinction is load-bearing. Inferring absence from a failed read means a
+# node the runner cannot reach — expired talosconfig, network partition, API
+# down — looks exactly like a node that simply does not ship that config file.
+# Such a node would be skipped silently, and if any OTHER containerd config
+# declared a verifier the fleet would pass while nothing had been checked: the
+# same fail-open shape this script exists to detect, reintroduced in the
+# detector.
+path_exists() {
+  "${talosctl_bin}" -n "$1" ls "$2" >/dev/null 2>&1
+}
+
+node_reachable() {
+  "${talosctl_bin}" -n "$1" ls / >/dev/null 2>&1
+}
+
+# Emits the bin_dir declared by ONE config file's image-verifier plugin, or
+# nothing when that file declares none.
+#
+# Scoped to the `io.containerd.image-verifier.v1.bindir` table on purpose.
+# `bin_dir` is a generic key name, and an unscoped match accepts one from an
+# unrelated plugin's table — reporting a node as enforcing on the strength of a
+# setting containerd never consults for image verification.
+#
+# The config is piped straight into awk and only the extracted value is ever
+# printed. `/etc/cri/conf.d/cri.toml` carries registry credentials and this
+# script's output goes to CI logs, so the file must never be captured — not into
+# a variable, not into a temp file, not into an error message. See the SECURITY
+# note at the top.
+#
+# awk rather than sed because the table scoping needs state across lines, and
+# because awk consumes all input: a `sed ... | head -n 1` pipeline closes the
+# pipe early, and under `pipefail` the resulting SIGPIPE is indistinguishable
+# from a genuine read failure.
+extract_bin_dir_from() {
+  local node="$1" file="$2"
+  "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
+    BEGIN { SQ = sprintf("%c", 39); DQ = sprintf("%c", 34); want = 0; found = 0 }
+    found { next }
+    /^[ \t]*\[/ {
+      header = $0
+      gsub(/[ \t]/, "", header)
+      gsub(SQ, "", header)
+      gsub(DQ, "", header)
+      want = (header == "[plugins.io.containerd.image-verifier.v1.bindir]")
+      next
+    }
+    want && match($0, /^[ \t]*bin_dir[ \t]*=/) {
+      value = substr($0, RSTART + RLENGTH)
+      sub(/^[ \t]*/, "", value)
+      quote = substr(value, 1, 1)
+      if (quote != SQ && quote != DQ) next
+      value = substr(value, 2)
+      end = index(value, quote)
+      if (end == 0) next
+      print substr(value, 1, end - 1)
+      found = 1
+    }
+  '
 }
 
 # Counts executable entries, skipping the directory's own '.' entry. MODE is
@@ -166,35 +204,70 @@ fi
 
 [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
 
-failures=0
-for node in "${nodes[@]}"; do
-  [[ -n "${node}" ]] || continue
+# Verdict for ONE containerd instance on one node. Returns 0 when that instance
+# can enforce, 1 when it cannot.
+check_config() {
+  local node="$1" file="$2" bin_dir status=0 executables
 
-  bin_dir="$(extract_bin_dir "${node}")"
+  bin_dir="$(extract_bin_dir_from "${node}" "${file}")" || status=$?
+  # The file's existence was proven before this call, so a read failure here is
+  # an infrastructure fault, never a verdict. Reporting it as "cannot enforce"
+  # would be a misdiagnosis; swallowing it would be a fail-open.
+  [[ "${status}" -eq 0 ]] ||
+    fail_infra "could not read ${file} on ${node} (the file exists but talosctl read failed)"
 
   if [[ -z "${bin_dir}" ]]; then
-    printf 'FAIL %s: no bin_dir configured in %s — the image-verifier plugin has no directory to run, so containerd permits every pull\n' \
-      "${node}" "${config_files[*]}"
-    failures=$((failures + 1))
-    continue
+    printf 'FAIL %s [%s]: no bin_dir in the io.containerd.image-verifier.v1.bindir table — the plugin has no directory to run, so containerd permits every pull\n' \
+      "${node}" "${file}"
+    return 1
   fi
 
   if ! directory_exists "${node}" "${bin_dir}"; then
-    printf 'FAIL %s: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
-      "${node}" "${bin_dir}"
-    failures=$((failures + 1))
-    continue
+    printf 'FAIL %s [%s]: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
+      "${node}" "${file}" "${bin_dir}"
+    return 1
   fi
 
   executables="$(count_executables "${node}" "${bin_dir}")"
   if [[ "${executables}" -eq 0 ]]; then
-    printf 'FAIL %s: bin_dir %s holds no executable — containerd permits every pull\n' \
-      "${node}" "${bin_dir}"
-    failures=$((failures + 1))
-    continue
+    printf 'FAIL %s [%s]: bin_dir %s holds no executable — containerd permits every pull\n' \
+      "${node}" "${file}" "${bin_dir}"
+    return 1
   fi
 
-  printf 'OK   %s: bin_dir %s holds %s executable(s)\n' "${node}" "${bin_dir}" "${executables}"
+  printf 'OK   %s [%s]: bin_dir %s holds %s executable(s)\n' \
+    "${node}" "${file}" "${bin_dir}" "${executables}"
+  return 0
+}
+
+failures=0
+for node in "${nodes[@]}"; do
+  [[ -n "${node}" ]] || continue
+
+  # Every containerd instance present on the node is evaluated INDEPENDENTLY.
+  # Accepting the first config that declares a bin_dir would let a wired-up CRI
+  # containerd mask an unprotected system containerd (or the reverse) — and the
+  # two pull different images: CRI pulls workload images, the system instance
+  # pulls Talos' own. A verifier on one leaves the other open, which is the
+  # whole point of checking both.
+  configs_present=0
+  node_failures=0
+  for config_file in "${config_files[@]}"; do
+    if ! path_exists "${node}" "${config_file}"; then
+      node_reachable "${node}" ||
+        fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+      continue
+    fi
+    configs_present=$((configs_present + 1))
+    check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
+  done
+
+  # No containerd configuration at all is not a clean node — it means this check
+  # looked at nothing and would otherwise pass the node by default.
+  [[ "${configs_present}" -gt 0 ]] ||
+    fail_infra "no containerd configuration found on ${node} (looked in ${config_files[*]})"
+
+  [[ "${node_failures}" -eq 0 ]] || failures=$((failures + 1))
 done
 
 if [[ "${failures}" -gt 0 ]]; then

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -121,10 +121,18 @@ extract_bin_dir() {
 # Counts executable entries, skipping the directory's own '.' entry. MODE is
 # always column 2; NAME is always last. The LABEL column is empty for some files
 # on this cluster, so positional parsing from the left past column 2 is unsafe.
+#
+# The MODE's first character is the entry TYPE, and it must be checked: a
+# directory's mode ('drwxr-xr-x') carries an 'x' too, so counting any entry with
+# an 'x' would let a bin_dir holding nothing but a subdirectory report as
+# enforcing. containerd executes FILES in bin_dir and does not descend into
+# subdirectories, so such a node permits every pull while this check calls it
+# healthy — the precise fail-open this script exists to detect. Regular files
+# ('-') and symlinks ('l') count; everything else does not.
 count_executables() {
   local node="$1" dir="$2"
   "${talosctl_bin}" -n "${node}" ls -l "${dir}" 2>/dev/null |
-    awk 'NR > 1 && $NF != "." && $2 ~ /x/ { n++ } END { print n + 0 }'
+    awk 'NR > 1 && $NF != "." && substr($2, 1, 1) ~ /^[-l]$/ && $2 ~ /x/ { n++ } END { print n + 0 }'
 }
 
 directory_exists() {
@@ -138,6 +146,17 @@ directory_exists() {
 nodes=()
 if [[ -n "${nodes_arg}" ]]; then
   IFS=',' read -r -a nodes <<<"${nodes_arg}"
+  # An empty element means the caller's list was malformed ('a,,b', a trailing
+  # comma, a shell variable that expanded to nothing). Skipping it silently
+  # would check FEWER nodes than were asked for and still exit 0 — a checker
+  # reporting a clean fleet it never looked at, which is the same silence this
+  # script exists to break. Refuse the list instead.
+  for node in "${nodes[@]}"; do
+    [[ -n "${node}" ]] || {
+      printf 'ERROR: --nodes/TALOS_NODES contains an empty entry: %s\n' "${nodes_arg}" >&2
+      usage
+    }
+  done
 else
   while IFS= read -r discovered; do
     [[ -n "${discovered}" ]] || continue

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -167,9 +167,18 @@ extract_bin_dir_from() {
 # subdirectories, so such a node permits every pull while this check calls it
 # healthy — the precise fail-open this script exists to detect. Regular files
 # ('-') and symlinks ('l') count; everything else does not.
+#
+# The listing's exit status is preserved, not discarded. The caller only reaches
+# this after the directory was proven to exist, so a failure here means the node
+# stopped answering mid-check — which must be an infrastructure error, never the
+# "holds no executable" verdict. `awk` on empty input prints 0 quite happily, so
+# swallowing the status turns an unreachable node into a confident FAIL line.
 count_executables() {
-  local node="$1" dir="$2"
-  "${talosctl_bin}" -n "${node}" ls -l "${dir}" 2>/dev/null |
+  local node="$1" dir="$2" listing status=0
+  listing="$("${talosctl_bin}" -n "${node}" ls -l "${dir}" 2>/dev/null)" || status=$?
+  [[ "${status}" -eq 0 ]] ||
+    fail_infra "could not list ${dir} on ${node} (the directory exists but talosctl ls failed)"
+  printf '%s\n' "${listing}" |
     awk 'NR > 1 && $NF != "." && substr($2, 1, 1) ~ /^[-l]$/ && $2 ~ /x/ { n++ } END { print n + 0 }'
 }
 
@@ -183,23 +192,33 @@ directory_exists() {
 # a check nobody verifies before shipping.
 nodes=()
 if [[ -n "${nodes_arg}" ]]; then
+  # A malformed list ('a,,b', a leading or trailing comma, a shell variable that
+  # expanded to nothing) is refused rather than quietly shortened: checking FEWER
+  # nodes than were asked for and still exiting 0 is a checker reporting a clean
+  # fleet it never looked at — the same silence this script exists to break.
+  #
+  # Validate the RAW STRING, before splitting. `read -a` discards a trailing
+  # empty field, so 'worker-1,' splits to exactly one element and a
+  # post-split scan for empty entries cannot see the malformation at all.
+  if [[ "${nodes_arg}" == ,* || "${nodes_arg}" == *, || "${nodes_arg}" == *,,* ]]; then
+    printf 'ERROR: --nodes/TALOS_NODES has an empty entry (leading, trailing or doubled comma): %s\n' \
+      "${nodes_arg}" >&2
+    usage
+  fi
   IFS=',' read -r -a nodes <<<"${nodes_arg}"
-  # An empty element means the caller's list was malformed ('a,,b', a trailing
-  # comma, a shell variable that expanded to nothing). Skipping it silently
-  # would check FEWER nodes than were asked for and still exit 0 — a checker
-  # reporting a clean fleet it never looked at, which is the same silence this
-  # script exists to break. Refuse the list instead.
-  for node in "${nodes[@]}"; do
-    [[ -n "${node}" ]] || {
-      printf 'ERROR: --nodes/TALOS_NODES contains an empty entry: %s\n' "${nodes_arg}" >&2
-      usage
-    }
-  done
 else
+  # Discovery runs in a command substitution so its exit status reaches this
+  # shell. A process substitution would NOT: `fail_infra` inside it exits only
+  # that subshell, the loop keeps whatever partial output jq already emitted,
+  # and if those nodes happen to be healthy the script exits 0 having silently
+  # dropped the rest of the fleet. jq emitting a valid address and then failing
+  # on a malformed one is exactly that case.
+  discovered_nodes="$(discover_nodes)" ||
+    fail_infra 'node discovery failed — refusing to report a fleet that was only partly enumerated'
   while IFS= read -r discovered; do
     [[ -n "${discovered}" ]] || continue
     nodes+=("${discovered}")
-  done < <(discover_nodes)
+  done <<<"${discovered_nodes}"
 fi
 
 [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
@@ -207,7 +226,7 @@ fi
 # Verdict for ONE containerd instance on one node. Returns 0 when that instance
 # can enforce, 1 when it cannot.
 check_config() {
-  local node="$1" file="$2" bin_dir status=0 executables
+  local node="$1" file="$2" bin_dir status=0 executables exec_status=0
 
   bin_dir="$(extract_bin_dir_from "${node}" "${file}")" || status=$?
   # The file's existence was proven before this call, so a read failure here is
@@ -223,12 +242,23 @@ check_config() {
   fi
 
   if ! directory_exists "${node}" "${bin_dir}"; then
+    # "The directory is not there" and "the node stopped answering" are the same
+    # failed `ls` from here. Only the first is a verdict; reporting the second as
+    # one would blame the cluster for a runner-side fault.
+    node_reachable "${node}" ||
+      fail_infra "cannot reach node ${node} while checking ${bin_dir} (talosctl ls / failed)"
     printf 'FAIL %s [%s]: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
       "${node}" "${file}" "${bin_dir}"
     return 1
   fi
 
-  executables="$(count_executables "${node}" "${bin_dir}")"
+  # `fail_infra` inside count_executables would exit only the command
+  # substitution, so its status is carried out explicitly — the same subshell
+  # trap that made partial node discovery pass silently.
+  executables="$(count_executables "${node}" "${bin_dir}")" || exec_status=$?
+  [[ "${exec_status}" -eq 0 ]] ||
+    fail_infra "could not list ${bin_dir} on ${node} (the directory exists but talosctl ls failed)"
+
   if [[ "${executables}" -eq 0 ]]; then
     printf 'FAIL %s [%s]: bin_dir %s holds no executable — containerd permits every pull\n' \
       "${node}" "${file}" "${bin_dir}"
@@ -242,8 +272,6 @@ check_config() {
 
 failures=0
 for node in "${nodes[@]}"; do
-  [[ -n "${node}" ]] || continue
-
   # Every containerd instance present on the node is evaluated INDEPENDENTLY.
   # Accepting the first config that declares a bin_dir would let a wired-up CRI
   # containerd mask an unprotected system containerd (or the reverse) — and the

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+# Assert that the node image verifier can enforce AT ALL.
+#
+# `talos/cluster/verify-first-party-images.yaml` declares ImageVerificationConfig
+# rules. Those rules are inert on their own: containerd does not verify images
+# itself, it delegates to the `io.containerd.image-verifier.v1.bindir` plugin,
+# which executes every binary in a configured `bin_dir`. containerd's documented
+# behaviour when that directory is unset, absent, or empty is to permit the pull:
+#
+#   "If bin_dir does not exist or contains no files, the image verifier does not
+#    block image pulls."
+#
+# So a cluster with perfect rules and no verifier binary reads EXACTLY like a
+# compliant one from every surface we routinely check — the rules are present,
+# the node config matches the repository, CI is green — while every image pulls
+# unverified. That is not hypothetical: it was the live state of this cluster,
+# found only by hand (devantler-tech/platform#2856).
+#
+# This check asserts the ENFORCEMENT PATH, not the configuration. Asserting that
+# the rules exist would NOT have caught #2856 — the rules were correct
+# throughout. It is deliberately the weaker of the two signals that issue asks
+# for; the strong one is a behavioural test that a known-unsigned image is
+# actually refused (#3101). This one's value is that it needs no node rollout
+# and fails loudly while the verifier is missing.
+#
+# It reads LIVE NODE STATE on purpose. A variant that read the repository would
+# re-create the exact blind spot it exists to close.
+#
+# SECURITY: the rendered `/etc/cri/conf.d/cri.toml` carries registry
+# credentials. Every read of it is piped straight into a key extractor; the
+# file's contents are never stored in a variable, echoed, or included in an
+# error message. Keep it that way — this script's output goes to CI logs.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: validate-image-verifier-liveness.sh [--nodes <ip>[,<ip>...]]
+
+Asserts, for every node, that containerd's image-verifier bin_dir is configured,
+exists, and holds at least one executable.
+
+Nodes are discovered from the cluster when --nodes/TALOS_NODES is not given, so
+autoscaled nodes are covered without anyone maintaining a list.
+
+Environment overrides: TALOSCTL, KUBECTL, TALOS_NODES, CONTAINERD_CONFIG_FILES
+Exit: 0 every node can enforce; 1 at least one cannot; 2 usage/infrastructure error.
+USAGE
+  exit 2
+}
+
+readonly talosctl_bin="${TALOSCTL:-talosctl}"
+readonly kubectl_bin="${KUBECTL:-kubectl}"
+
+nodes_arg="${TALOS_NODES:-}"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --nodes)
+      [[ "$#" -ge 2 ]] || usage
+      nodes_arg="$2"
+      shift 2
+      ;;
+    -h | --help) usage ;;
+    *) usage ;;
+  esac
+done
+
+# Both containerd instances matter: the CRI one pulls workload images, the system
+# one pulls Talos' own. A verifier wired into only one leaves the other open.
+readonly default_config_files='/etc/cri/conf.d/cri.toml /etc/containerd/config.toml'
+read -r -a config_files <<<"${CONTAINERD_CONFIG_FILES:-${default_config_files}}"
+
+fail_infra() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 2
+}
+
+# KUBECTL must name a bare binary, never a command with flags: it is invoked
+# quoted, so "kubectl --context x" would be looked up as a single executable
+# name and fail. Pin the context with KUBECTL_CONTEXT instead — the deploy
+# composite pins `--context admin@prod` for the same reason, because the
+# restored kubeconfig's current-context is not guaranteed to be prod.
+discover_nodes() {
+  local json
+  local -a context_args=()
+  [[ -n "${KUBECTL_CONTEXT:-}" ]] && context_args=(--context "${KUBECTL_CONTEXT}")
+  json="$("${kubectl_bin}" "${context_args[@]+"${context_args[@]}"}" get nodes -o json 2>/dev/null)" ||
+    fail_infra 'could not list cluster nodes (kubectl get nodes failed)'
+  printf '%s' "${json}" |
+    jq -r '.items[].status.addresses[] | select(.type == "InternalIP") | .address' 2>/dev/null ||
+    fail_infra 'could not parse node addresses from kubectl output'
+}
+
+# Emits the configured bin_dir, or nothing when no config declares one.
+# The config file is piped directly into sed: its contents never land anywhere
+# this script could print them. See the SECURITY note above.
+extract_bin_dir() {
+  local node="$1" file value
+  for file in "${config_files[@]}"; do
+    # INTENT: a config file that does not exist on this node image is skipped so
+    # the next one still gets its turn. The `|| true` states that explicitly
+    # rather than relying on how `set -e` and `pipefail` interact with a failing
+    # first stage inside a command substitution — behaviour subtle enough that
+    # two isolated probes of it disagreed, so it is not something this script
+    # should depend on either way. The missing-config case in the test pins the
+    # behaviour itself.
+    value="$(
+      { "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null || true; } |
+        sed -n "s/^[[:space:]]*bin_dir[[:space:]]*=[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" |
+        head -n 1
+    )"
+    if [[ -n "${value}" ]]; then
+      printf '%s' "${value}"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# Counts executable entries, skipping the directory's own '.' entry. MODE is
+# always column 2; NAME is always last. The LABEL column is empty for some files
+# on this cluster, so positional parsing from the left past column 2 is unsafe.
+count_executables() {
+  local node="$1" dir="$2"
+  "${talosctl_bin}" -n "${node}" ls -l "${dir}" 2>/dev/null |
+    awk 'NR > 1 && $NF != "." && $2 ~ /x/ { n++ } END { print n + 0 }'
+}
+
+directory_exists() {
+  local node="$1" dir="$2"
+  "${talosctl_bin}" -n "${node}" ls "${dir}" >/dev/null 2>&1
+}
+
+# Built with a read loop rather than `mapfile` so the script and its tests run
+# on bash 3.2 (macOS) as well as CI's bash 5. A check nobody can run locally is
+# a check nobody verifies before shipping.
+nodes=()
+if [[ -n "${nodes_arg}" ]]; then
+  IFS=',' read -r -a nodes <<<"${nodes_arg}"
+else
+  while IFS= read -r discovered; do
+    [[ -n "${discovered}" ]] || continue
+    nodes+=("${discovered}")
+  done < <(discover_nodes)
+fi
+
+[[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
+
+failures=0
+for node in "${nodes[@]}"; do
+  [[ -n "${node}" ]] || continue
+
+  bin_dir="$(extract_bin_dir "${node}")"
+
+  if [[ -z "${bin_dir}" ]]; then
+    printf 'FAIL %s: no bin_dir configured in %s — the image-verifier plugin has no directory to run, so containerd permits every pull\n' \
+      "${node}" "${config_files[*]}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if ! directory_exists "${node}" "${bin_dir}"; then
+    printf 'FAIL %s: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
+      "${node}" "${bin_dir}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  executables="$(count_executables "${node}" "${bin_dir}")"
+  if [[ "${executables}" -eq 0 ]]; then
+    printf 'FAIL %s: bin_dir %s holds no executable — containerd permits every pull\n' \
+      "${node}" "${bin_dir}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  printf 'OK   %s: bin_dir %s holds %s executable(s)\n' "${node}" "${bin_dir}" "${executables}"
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  printf '\n%s of %s node(s) cannot enforce image verification.\n' "${failures}" "${#nodes[@]}" >&2
+  printf 'The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml are not being evaluated on those nodes.\n' >&2
+  printf 'See devantler-tech/platform#2856 (finding) and #3101 (installing the verifier).\n' >&2
+  exit 1
+fi
+
+printf '\nAll %s node(s) can enforce image verification.\n' "${#nodes[@]}"

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -120,7 +120,7 @@ discover_nodes() {
     ' 2>/dev/null)" ||
     fail_infra 'could not parse node addresses from kubectl output'
   if [[ -n "${without_ip}" ]]; then
-    fail_infra "no InternalIP address for node(s): $(printf '%s' "${without_ip}" | tr '\n' ' ')— refusing to report a fleet that was only partly enumerated"
+    fail_infra "no InternalIP address for node(s): $(printf '%s' "${without_ip}" | tr '\n' ' ') — refusing to report a fleet that was only partly enumerated"
   fi
 
   printf '%s' "${json}" |

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -54,11 +54,24 @@ readonly talosctl_bin="${TALOSCTL:-talosctl}"
 readonly kubectl_bin="${KUBECTL:-kubectl}"
 
 nodes_arg="${TALOS_NODES:-}"
+
+# Whether an explicit fleet was REQUESTED is tracked separately from whether the
+# list is non-empty. `--nodes "$TALOS_NODES"` with the variable unset expands to
+# an empty string: the option WAS supplied and named nothing. Falling back to
+# cluster discovery there checks a different fleet than the caller asked for and
+# still exits 0 — and explicit addresses are usually explicit precisely because
+# the current kube context is not that fleet.
+#
+# `${VAR+set}` distinguishes set-but-empty from unset, so an exported
+# `TALOS_NODES=` is caught too; that is how CI passes the list.
+nodes_requested=0
+[[ -n "${TALOS_NODES+set}" ]] && nodes_requested=1
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --nodes)
       [[ "$#" -ge 2 ]] || usage
       nodes_arg="$2"
+      nodes_requested=1
       shift 2
       ;;
     -h | --help) usage ;;
@@ -82,13 +95,41 @@ fail_infra() {
 # composite pins `--context admin@prod` for the same reason, because the
 # restored kubeconfig's current-context is not guaranteed to be prod.
 discover_nodes() {
-  local json
+  local json without_ip
   local -a context_args=()
   [[ -n "${KUBECTL_CONTEXT:-}" ]] && context_args=(--context "${KUBECTL_CONTEXT}")
   json="$("${kubectl_bin}" "${context_args[@]+"${context_args[@]}"}" get nodes -o json 2>/dev/null)" ||
     fail_infra 'could not list cluster nodes (kubectl get nodes failed)'
+
+  # Every node must yield an InternalIP, and a node that does not is refused
+  # rather than dropped. A `select(.type == "InternalIP")` over a node whose
+  # addresses hold only a Hostname or an ExternalIP matches nothing and SUCCEEDS
+  # — so that node silently leaves the fleet, and if the remaining ones are
+  # healthy the script prints a green verdict for a fleet it never enumerated.
+  # That is the same fail-open the script exists to detect, one layer earlier.
+  #
+  # Checked as its own pass so the offending node can be NAMED. Deriving it from
+  # a jq error instead would either lose the name or push kubectl's output into
+  # an error message.
+  without_ip="$(printf '%s' "${json}" |
+    jq -r '
+      .items[]
+      | select([(.status.addresses // [])[]
+                | select(.type == "InternalIP" and ((.address // "") | tostring) != "")] | length == 0)
+      | .metadata.name // "<unnamed node>"
+    ' 2>/dev/null)" ||
+    fail_infra 'could not parse node addresses from kubectl output'
+  if [[ -n "${without_ip}" ]]; then
+    fail_infra "no InternalIP address for node(s): $(printf '%s' "${without_ip}" | tr '\n' ' ')— refusing to report a fleet that was only partly enumerated"
+  fi
+
   printf '%s' "${json}" |
-    jq -r '.items[].status.addresses[] | select(.type == "InternalIP") | .address' 2>/dev/null ||
+    jq -r '
+      .items[]
+      | (.status.addresses // [])[]
+      | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
+      | .address
+    ' 2>/dev/null ||
     fail_infra 'could not parse node addresses from kubectl output'
 }
 
@@ -103,8 +144,29 @@ discover_nodes() {
 # declared a verifier the fleet would pass while nothing had been checked: the
 # same fail-open shape this script exists to detect, reintroduced in the
 # detector.
-path_exists() {
-  "${talosctl_bin}" -n "$1" ls "$2" >/dev/null 2>&1
+# Three-state probe: 'present', 'absent', or 'error'.
+#
+# A failed `ls` is ambiguous — the path may not be there, or the node may have
+# hiccuped — and only the first of those is a verdict. Collapsing both into
+# "this node does not ship that config" lets a transient fault silently drop one
+# containerd from the check; if the OTHER one is wired up, `configs_present`
+# stays nonzero and the node passes with half its image paths never inspected.
+#
+# Only a CONFIRMED not-found counts as absent, and the discriminator has to be
+# the stderr text because talosctl exits 1 for both. `ls` on a path emits only
+# that path's name and never file contents, so matching its stderr cannot expose
+# the registry credentials that `/etc/cri/conf.d/cri.toml` carries.
+path_probe() {
+  local node="$1" path="$2" err status=0
+  err="$("${talosctl_bin}" -n "${node}" ls "${path}" 2>&1 >/dev/null)" || status=$?
+  if [[ "${status}" -eq 0 ]]; then
+    printf 'present\n'
+    return 0
+  fi
+  case "${err}" in
+    *'no such file or directory'* | *'NotFound'* | *'not found'*) printf 'absent\n' ;;
+    *) printf 'error\n' ;;
+  esac
 }
 
 node_reachable() {
@@ -191,6 +253,11 @@ directory_exists() {
 # on bash 3.2 (macOS) as well as CI's bash 5. A check nobody can run locally is
 # a check nobody verifies before shipping.
 nodes=()
+if [[ "${nodes_requested}" -eq 1 && -z "${nodes_arg}" ]]; then
+  printf 'ERROR: --nodes/TALOS_NODES was supplied but names no node — refusing to fall back to cluster discovery, which would check a different fleet than was asked for\n' >&2
+  usage
+fi
+
 if [[ -n "${nodes_arg}" ]]; then
   # A malformed list ('a,,b', a leading or trailing comma, a shell variable that
   # expanded to nothing) is refused rather than quietly shortened: checking FEWER
@@ -281,11 +348,27 @@ for node in "${nodes[@]}"; do
   configs_present=0
   node_failures=0
   for config_file in "${config_files[@]}"; do
-    if ! path_exists "${node}" "${config_file}"; then
-      node_reachable "${node}" ||
-        fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
-      continue
-    fi
+    case "$(path_probe "${node}" "${config_file}")" in
+      present) ;;
+      absent)
+        # A confirmed not-found normally proves the node answered — but the same
+        # phrase can come from a client-side fault (a missing talosconfig, say),
+        # which would otherwise read as "this node does not ship that config".
+        # The reachability probe is what tells those two apart.
+        node_reachable "${node}" ||
+          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+        continue
+        ;;
+      *)
+        # Both "the node is gone" and "the node answered but this one probe
+        # failed" arrive here, and they deserve different diagnoses: the first
+        # is a fleet-wide fault, the second is specific to one containerd.
+        # Neither is a verdict, so both stop the run either way.
+        node_reachable "${node}" ||
+          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+        fail_infra "could not determine whether ${config_file} exists on ${node} (talosctl ls failed for a reason other than the file being absent) — refusing to report a node whose containerd was never inspected"
+        ;;
+    esac
     configs_present=$((configs_present + 1))
     check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
   done

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -95,32 +95,48 @@ fail_infra() {
 # composite pins `--context admin@prod` for the same reason, because the
 # restored kubeconfig's current-context is not guaranteed to be prod.
 discover_nodes() {
-  local json without_ip
+  local json bad_nodes
   local -a context_args=()
   [[ -n "${KUBECTL_CONTEXT:-}" ]] && context_args=(--context "${KUBECTL_CONTEXT}")
   json="$("${kubectl_bin}" "${context_args[@]+"${context_args[@]}"}" get nodes -o json 2>/dev/null)" ||
     fail_infra 'could not list cluster nodes (kubectl get nodes failed)'
 
-  # Every node must yield an InternalIP, and a node that does not is refused
-  # rather than dropped. A `select(.type == "InternalIP")` over a node whose
-  # addresses hold only a Hostname or an ExternalIP matches nothing and SUCCEEDS
-  # — so that node silently leaves the fleet, and if the remaining ones are
-  # healthy the script prints a green verdict for a fleet it never enumerated.
-  # That is the same fail-open the script exists to detect, one layer earlier.
+  # Every node must map to EXACTLY ONE InternalIP, and those addresses must be
+  # unique across the fleet. Both halves are fail-opens the flattening hides:
   #
-  # Checked as its own pass so the offending node can be NAMED. Deriving it from
-  # a jq error instead would either lose the name or push kubectl's output into
+  #   * a node whose addresses hold only a Hostname or an ExternalIP matches
+  #     nothing and the select SUCCEEDS, so that node silently leaves the fleet;
+  #   * two nodes publishing the SAME InternalIP — a malformed or stale cloud
+  #     registration — emit that address twice, so both passes inspect the same
+  #     machine while the other node is never looked at.
+  #
+  # Either way the remaining nodes report OK and the run prints a green verdict
+  # for a fleet it never fully enumerated: the same fail-open this script exists
+  # to detect, one layer earlier. `scripts/refresh-flux-ghcr-auth.sh`'s
+  # `validate_talos_node_inventory` refuses the same two shapes before it mutates
+  # anything, for the same reason.
+  #
+  # Checked as its own pass so the offending nodes can be NAMED. Deriving it from
+  # a jq error instead would either lose the names or push kubectl's output into
   # an error message.
-  without_ip="$(printf '%s' "${json}" |
+  bad_nodes="$(printf '%s' "${json}" |
     jq -r '
-      .items[]
-      | select([(.status.addresses // [])[]
-                | select(.type == "InternalIP" and ((.address // "") | tostring) != "")] | length == 0)
-      | .metadata.name // "<unnamed node>"
+      [.items[] | {
+        name: (.metadata.name // "<unnamed node>"),
+        ips: [(.status.addresses // [])[]
+              | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
+              | .address]
+      }] as $nodes
+      | ($nodes | map(select(.ips | length != 1))
+          | map("\(.name) (has \(.ips | length) InternalIP addresses, expected 1)")),
+        ($nodes | map(select(.ips | length == 1))
+          | group_by(.ips[0]) | map(select(length > 1))
+          | map("\(map(.name) | join(" and ")) share InternalIP \(.[0].ips[0])"))
+      | .[]
     ' 2>/dev/null)" ||
     fail_infra 'could not parse node addresses from kubectl output'
-  if [[ -n "${without_ip}" ]]; then
-    fail_infra "no InternalIP address for node(s): $(printf '%s' "${without_ip}" | tr '\n' ' ') — refusing to report a fleet that was only partly enumerated"
+  if [[ -n "${bad_nodes}" ]]; then
+    fail_infra "unusable node inventory — refusing to report a fleet that was only partly enumerated: $(printf '%s' "${bad_nodes}" | tr '\n' ';' | sed 's/;$//')"
   fi
 
   printf '%s' "${json}" |


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A security control this platform documents and relies on has never actually worked, and nothing we
check routinely could tell. The rules that are supposed to block unsigned first-party images at the
node pull layer are correct and active — and no component exists on the nodes to evaluate them, so
every image pulls unverified. An unsigned image is running in production on that basis today.

The dangerous part is that an inert control and a working one look **identical** from every surface
we normally look at: the rules are present, the node config matches the repository, CI is green. It
was found only by reading node state by hand.

This adds the missing signal, so the next time enforcement silently stops being real we hear about it
from CI rather than from an audit.

### What

A check that asserts every node can enforce image verification **at all**, reading live node state,
and reports which node and which condition failed. It deliberately does not assert that the rules
exist — that would have passed throughout the whole incident.

It ships **dormant**: runnable on demand, with the daily cadence switched on by #3101 as one line.
The verdict today is red on all 9 nodes, which is correct but is exactly what #3101 already tracks —
so publishing it daily would leave `main` permanently red and spend our "something broke, fix it now"
signal on a known open issue. The checker's own tests do gate every PR that touches it.

Fixes #3102 · Part of #2856
