### PR TITLE
fix(ci): keep prod deploys on the stable API endpoint

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -89,6 +89,18 @@ runs:
         printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
         chmod 600 ~/.kube/config
 
+    - name: 🔗 Select stable prod API endpoint
+      # KUBE_CONFIG can outlive the control-plane node whose public IP was the
+      # endpoint when the secret was minted. `cluster update` deliberately
+      # rolls those nodes, so retaining that address makes this deploy sever
+      # its own API connection even while the other control planes are Ready.
+      # Resolve the KSail-owned floating IP live, fail closed on missing or
+      # foreign ownership labels, and switch admin@prod before any API call.
+      shell: bash
+      env:
+        HCLOUD_TOKEN: ${{ inputs.hcloud-token }}
+      run: ./scripts/use-prod-stable-api-endpoint.sh
+
     - name: 🔑 Restore talosconfig
       # ksail cluster update talks to the Talos API to sync machine config.
       # Without the talosconfig it uses stale/derived certs and fails with

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,8 @@ jobs:
               - 'scripts/refresh-flux-ghcr-auth-safety.sh'
               - 'scripts/ghcr-auth-lib.sh'
               - 'scripts/run-ksail-prod-with-pull-auth.sh'
+              - 'scripts/use-prod-stable-api-endpoint.sh'
+              - 'scripts/tests/test-use-prod-stable-api-endpoint.sh'
               - 'scripts/tests/test-refresh-flux-ghcr-auth-safety.sh'
               - 'scripts/tests/refresh-flux-ghcr-auth/**'
               - 'docs/dr/runbook.md'
@@ -305,13 +307,18 @@ jobs:
             scripts/refresh-flux-ghcr-auth-safety.sh \
             scripts/refresh-flux-ghcr-auth.sh \
             scripts/run-ksail-prod-with-pull-auth.sh \
+            scripts/use-prod-stable-api-endpoint.sh \
+            scripts/tests/test-use-prod-stable-api-endpoint.sh \
             scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
           shellcheck \
             scripts/ghcr-auth-lib.sh \
             scripts/refresh-flux-ghcr-auth-safety.sh \
             scripts/refresh-flux-ghcr-auth.sh \
             scripts/run-ksail-prod-with-pull-auth.sh \
+            scripts/use-prod-stable-api-endpoint.sh \
+            scripts/tests/test-use-prod-stable-api-endpoint.sh \
             scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
+          bash scripts/tests/test-use-prod-stable-api-endpoint.sh
           bash scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
           go test -timeout=20m ./scripts/tests/refresh-flux-ghcr-auth
 

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -239,6 +239,7 @@ variables_secret_cas_patch_file="${work_dir}/variables-secret-cas-patch.json"
 sync_lease_holder=""
 sync_lease_acquired=false
 sync_lease_heartbeat_pid=""
+sync_lease_renewal_failure=""
 flux_policy_handoff_acquired=false
 flux_policy_handoff_owner=""
 flux_policy_handoff_uid=""
@@ -2819,21 +2820,30 @@ renew_sync_lease() {
   local lease_file="${work_dir}/sync-lease-renew-${invocation_id}.json"
   local patch_file_local="${work_dir}/sync-lease-renew-patch-${invocation_id}.json"
   local result_file="${work_dir}/sync-lease-renew-result-${invocation_id}.txt"
-  local resource_version now
+  local resource_version now observed_holder
 
+  sync_lease_renewal_failure=""
   [[ "${sync_lease_acquired}" == "true" && -n "${sync_lease_holder}" ]] || return 1
   if ! kubectl \
     --context "${KUBE_CONTEXT}" \
     --namespace flux-system \
     get lease "${SYNC_LEASE_NAME}" \
-    -o json >"${lease_file}"; then
+    -o json >"${lease_file}" 2>"${result_file}"; then
+    sync_lease_renewal_failure="api-unreachable"
     return 1
   fi
-  resource_version="$(jq -er \
-    --arg holder "${sync_lease_holder}" '
-    select(.spec.holderIdentity == $holder)
-    | .metadata.resourceVersion
-  ' "${lease_file}")" || return 1
+  observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || {
+    sync_lease_renewal_failure="invalid-lease-state"
+    return 1
+  }
+  if [[ "${observed_holder}" != "${sync_lease_holder}" ]]; then
+    sync_lease_renewal_failure="held-by-another"
+    return 1
+  fi
+  resource_version="$(jq -er '.metadata.resourceVersion' "${lease_file}")" || {
+    sync_lease_renewal_failure="invalid-lease-state"
+    return 1
+  }
   now="$(kubernetes_microtime_now)"
   jq -n \
     --arg resource_version "${resource_version}" \
@@ -2864,17 +2874,31 @@ renew_sync_lease() {
     --context "${KUBE_CONTEXT}" \
     --namespace flux-system \
     get lease "${SYNC_LEASE_NAME}" \
-    -o json >"${lease_file}"; then
+    -o json >"${lease_file}" 2>"${result_file}"; then
+    sync_lease_renewal_failure="api-unreachable"
     return 1
   fi
-  jq -e \
+  observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || {
+    sync_lease_renewal_failure="invalid-lease-state"
+    return 1
+  }
+  if [[ "${observed_holder}" != "${sync_lease_holder}" ]]; then
+    sync_lease_renewal_failure="held-by-another"
+    return 1
+  fi
+  if jq -e \
     --arg holder "${sync_lease_holder}" \
     --argjson now_epoch "$(date -u +%s)" '
     .spec.holderIdentity == $holder
     and (((.spec.renewTime // .spec.acquireTime)
       | sub("\\.[0-9]+Z$"; "Z")
       | fromdateiso8601) + .spec.leaseDurationSeconds > $now_epoch)
-  ' "${lease_file}" >/dev/null
+  ' "${lease_file}" >/dev/null; then
+    return 0
+  fi
+
+  sync_lease_renewal_failure="not-live"
+  return 1
 }
 
 sync_lease_heartbeat_loop() {
@@ -2884,17 +2908,61 @@ sync_lease_heartbeat_loop() {
       sleep 1
     done
     if ! renew_sync_lease; then
-      : >"${sync_lease_lost_file}"
+      printf '%s\n' "${sync_lease_renewal_failure:-unknown}" >"${sync_lease_lost_file}"
       return 1
     fi
   done
 }
 
+wait_for_sync_lease_api_recovery() {
+  local attempt
+  for ((attempt = 1; attempt <= SYNC_ATTEMPTS; attempt++)); do
+    if kubectl \
+      --context "${KUBE_CONTEXT}" \
+      get --raw=/readyz \
+      --request-timeout=30s \
+      >"${sync_lease_result_file}" 2>&1; then
+      return 0
+    fi
+    if ((attempt < SYNC_ATTEMPTS)); then
+      sleep "${SYNC_INTERVAL}"
+    fi
+  done
+
+  echo "::error::The Kubernetes API remained unreachable while verifying the GHCR synchronization Lease; no further cluster mutation is safe."
+  emit_safe_operation_output "api-ready" "${sync_lease_result_file}"
+  return 1
+}
+
 assert_sync_lease_held() {
-  if [[ -e "${sync_lease_lost_file}" ]] || ! renew_sync_lease; then
-    echo "::error::The GHCR synchronization lease was lost; refusing further cluster mutation."
-    return 1
+  local failure_reason=""
+  if [[ -e "${sync_lease_lost_file}" ]]; then
+    failure_reason="$(head -n 1 "${sync_lease_lost_file}")"
+  elif renew_sync_lease; then
+    return 0
+  else
+    failure_reason="${sync_lease_renewal_failure:-unknown}"
   fi
+
+  case "${failure_reason}" in
+    api-unreachable)
+      echo "::warning::The Kubernetes API was unreachable while verifying the GHCR synchronization Lease; waiting for API recovery before re-proving the same holder."
+      wait_for_sync_lease_api_recovery || return 1
+      recover_sync_lease_heartbeat_after_transport_interruption
+      ;;
+    held-by-another)
+      echo "::error::The GHCR synchronization Lease is now held by another transaction; refusing further cluster mutation."
+      return 1
+      ;;
+    not-live)
+      echo "::error::The GHCR synchronization Lease is no longer live for this transaction; refusing further cluster mutation."
+      return 1
+      ;;
+    *)
+      echo "::error::The GHCR synchronization Lease state could not be proved (${failure_reason}); refusing further cluster mutation."
+      return 1
+      ;;
+  esac
 }
 
 recover_sync_lease_heartbeat_after_transport_interruption() {
@@ -2908,14 +2976,18 @@ recover_sync_lease_heartbeat_after_transport_interruption() {
     sync_lease_heartbeat_pid=""
   fi
   if ! renew_sync_lease; then
-    echo "::error::The Kubernetes API recovered, but this transaction could not re-prove and renew its synchronization Lease holder."
+    if [[ "${sync_lease_renewal_failure}" == "held-by-another" ]]; then
+      echo "::error::The Kubernetes API recovered, but this transaction could not re-prove and renew its synchronization Lease holder because the Lease is now held by another transaction."
+    else
+      echo "::error::The Kubernetes API recovered, but this transaction could not re-prove and renew its synchronization Lease holder (${sync_lease_renewal_failure:-unknown})."
+    fi
     return 1
   fi
 
   rm -f "${sync_lease_lost_file}"
   sync_lease_heartbeat_loop &
   sync_lease_heartbeat_pid=$!
-  echo "::warning::Re-proved the same GHCR synchronization Lease holder and restarted its heartbeat after API recovery."
+  echo "::warning::Re-proved the same GHCR synchronization Lease holder after API recovery and restarted its heartbeat."
 }
 
 release_sync_lease() {

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -854,6 +854,15 @@ func fakeKubectlGetSyncLease(args []string, namespace string) int {
 		(!containsArg(args, "-o") && !containsArg(args, "--output")) {
 		return commandFailure(91, "invalid synchronization lease lookup")
 	}
+	if os.Getenv("FAKE_TRANSIENT_SYNC_LEASE_API_FAIL_AFTER_FIRST_CLAIM") == "true" &&
+		markerExists("cordon-owner-prod-worker-1") &&
+		!markerExists("sync-lease-api-unreachable-after-first-claim") {
+		touchMarker("sync-lease-api-unreachable-after-first-claim")
+		return commandFailure(
+			54,
+			"The connection to the server api.example.test:6443 was refused: connect: connection refused",
+		)
+	}
 	if os.Getenv("FAKE_INTERRUPT_SYNC_LEASE_HEARTBEAT_DURING_DRAIN") == "true" &&
 		markerExists("transient-drain-attempt-prod-worker-1") &&
 		!markerExists("sync-lease-heartbeat-interrupted") &&

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
@@ -466,6 +466,34 @@ func TestTransientDrainAPITransportFailureRetriesUnderTheSameClaim(t *testing.T)
 	requireLine(t, operations, "root-patch")
 }
 
+func TestTransientAPIFailureWhileAssertingLeaseWaitsAndReprovesHolder(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_TRANSIENT_SYNC_LEASE_API_FAIL_AFTER_FIRST_CLAIM": "true",
+		"FLUX_GHCR_SYNC_LEASE_HEARTBEAT_SECONDS":               "60",
+	})
+	requireSuccessResult(t, result)
+	if !pathExists(filepath.Join(f.syncStateDir, "sync-lease-api-unreachable-after-first-claim")) {
+		t.Fatal("fixture did not interrupt the synchronization Lease lookup after the node claim")
+	}
+	requireContains(
+		t,
+		result.stdout+result.stderr,
+		"Kubernetes API was unreachable while verifying the GHCR synchronization Lease",
+	)
+	requireContains(
+		t,
+		result.stdout+result.stderr,
+		"Re-proved the same GHCR synchronization Lease holder after API recovery",
+	)
+	operations := readLines(f.operationLog)
+	requireLine(t, operations, "node-claim-cordon:prod-worker-1")
+	requireLine(t, operations, "talos-reboot:10.0.0.2")
+	requireLine(t, operations, "node-uncordon:prod-worker-1")
+	requireLine(t, operations, "root-patch")
+}
+
 func TestTransientAPITransportFailureDuringPostRebootReadyWaitRetries(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
@@ -229,6 +229,16 @@ func TestLeaseLossAfterNodeClaimStopsBeforeTalosMutation(t *testing.T) {
 	requireNoLine(t, operations, "talos-auth:10.0.0.2")
 	requireNoLine(t, operations, "node-drain:prod-worker-1")
 	requireNoLine(t, operations, "root-patch")
+	requireContains(
+		t,
+		result.stdout+result.stderr,
+		"GHCR synchronization Lease is now held by another transaction",
+	)
+	requireNotContains(
+		t,
+		result.stdout+result.stderr,
+		"Kubernetes API was unreachable while verifying",
+	)
 	if pathExists(filepath.Join(f.syncStateDir, "cordon-owner-prod-worker-1")) ||
 		pathExists(filepath.Join(f.syncStateDir, "cordoned-prod-worker-1")) {
 		t.Fatal("Lease loss before Talos mutation left a newly-owned cordon behind")

--- a/scripts/tests/test-use-prod-stable-api-endpoint.sh
+++ b/scripts/tests/test-use-prod-stable-api-endpoint.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Behaviour and wiring tests for scripts/use-prod-stable-api-endpoint.sh.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly endpoint_script="${root_dir}/scripts/use-prod-stable-api-endpoint.sh"
+readonly deploy_action="${root_dir}/.github/actions/deploy-prod/action.yml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+mkdir -p "${work_dir}/bin"
+
+cat >"${work_dir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+authorization=""
+while (($# > 0)); do
+  case "$1" in
+    -H | --header)
+      authorization="$2"
+      shift 2
+      ;;
+    http*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+[[ "${url}" == 'https://api.hetzner.cloud/v1/floating_ips?name=prod-floating-ip' ]] || {
+  printf 'unexpected URL: %s\n' "${url}" >&2
+  exit 90
+}
+[[ "${authorization}" == 'Authorization: Bearer fixture-hcloud-token' ]] || {
+  printf 'missing bearer authorization\n' >&2
+  exit 91
+}
+
+if [[ "${FAKE_FLOATING_IP_MODE:-owned}" == "foreign" ]]; then
+  printf '%s\n' '{"floating_ips":[{"name":"prod-floating-ip","ip":"5.75.215.250","labels":{"ksail.owned":"false","ksail.cluster.name":"prod"}}]}'
+else
+  printf '%s\n' '{"floating_ips":[{"name":"prod-floating-ip","ip":"5.75.215.250","labels":{"ksail.owned":"true","ksail.cluster.name":"prod"}}]}'
+fi
+EOF
+chmod +x "${work_dir}/bin/curl"
+
+write_node_bound_kubeconfig() {
+  local path="$1"
+  cat >"${path}" <<'EOF'
+apiVersion: v1
+kind: Config
+clusters:
+  - name: prod
+    cluster:
+      certificate-authority-data: Zml4dHVyZS1jYQ==
+      server: https://49.13.53.183:6443
+contexts:
+  - name: admin@prod
+    context:
+      cluster: prod
+      user: admin@prod
+current-context: admin@prod
+users:
+  - name: admin@prod
+    user:
+      client-certificate-data: Zml4dHVyZS1jZXJ0
+      client-key-data: Zml4dHVyZS1rZXk=
+EOF
+}
+
+server_for_prod() {
+  KUBECONFIG="$1" kubectl config view --raw \
+    -o jsonpath='{.clusters[?(@.name=="prod")].cluster.server}'
+}
+
+kubeconfig="${work_dir}/kubeconfig"
+write_node_bound_kubeconfig "${kubeconfig}"
+
+PATH="${work_dir}/bin:${PATH}" \
+  KUBECONFIG="${kubeconfig}" \
+  HCLOUD_TOKEN="fixture-hcloud-token" \
+  "${endpoint_script}" >"${work_dir}/stdout" 2>"${work_dir}/stderr"
+
+[[ "$(server_for_prod "${kubeconfig}")" == "https://5.75.215.250:6443" ]] ||
+  fail 'the admin@prod cluster was not switched from the node IP to the floating IP'
+grep -Fq '5.75.215.250' "${work_dir}/stdout" ||
+  fail 'successful normalization did not report the selected stable endpoint'
+
+write_node_bound_kubeconfig "${kubeconfig}"
+if PATH="${work_dir}/bin:${PATH}" \
+  KUBECONFIG="${kubeconfig}" \
+  HCLOUD_TOKEN="fixture-hcloud-token" \
+  FAKE_FLOATING_IP_MODE="foreign" \
+  "${endpoint_script}" >"${work_dir}/stdout" 2>"${work_dir}/stderr"; then
+  fail 'an ownership-mismatched floating IP was accepted'
+fi
+[[ "$(server_for_prod "${kubeconfig}")" == "https://49.13.53.183:6443" ]] ||
+  fail 'the kubeconfig changed after floating-IP ownership validation failed'
+grep -Fqi 'not owned by KSail' "${work_dir}/stderr" ||
+  fail 'ownership rejection was not explained'
+
+grep -Fq 'run: ./scripts/use-prod-stable-api-endpoint.sh' "${deploy_action}" ||
+  fail 'deploy-prod does not invoke the stable-endpoint normalization'
+
+printf 'ok — prod deploy selects only its KSail-owned stable API endpoint\n'

--- a/scripts/tests/test-use-prod-stable-api-endpoint.sh
+++ b/scripts/tests/test-use-prod-stable-api-endpoint.sh
@@ -74,9 +74,7 @@ contexts:
 current-context: admin@prod
 users:
   - name: admin@prod
-    user:
-      client-certificate-data: Zml4dHVyZS1jZXJ0
-      client-key-data: Zml4dHVyZS1rZXk=
+    user: {}
 EOF
 }
 

--- a/scripts/use-prod-stable-api-endpoint.sh
+++ b/scripts/use-prod-stable-api-endpoint.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Point admin@prod at the KSail-owned Hetzner floating IP before a deployment
+# can roll the control-plane node named by a stale KUBE_CONFIG secret.
+
+set -euo pipefail
+
+readonly cluster_name="prod"
+readonly kube_context="admin@prod"
+readonly floating_ip_name="${cluster_name}-floating-ip"
+readonly hcloud_api="https://api.hetzner.cloud/v1/floating_ips?name=${floating_ip_name}"
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  echo "::error::HCLOUD_TOKEN is required to resolve the production API floating IP." >&2
+  exit 1
+fi
+
+kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
+readonly kubeconfig_path
+if [[ ! -f "${kubeconfig_path}" ]]; then
+  echo "::error::Kubeconfig ${kubeconfig_path} does not exist." >&2
+  exit 1
+fi
+
+curl_error_file="$(mktemp)"
+readonly curl_error_file
+trap 'rm -f "${curl_error_file}"' EXIT
+if ! response="$(curl \
+  --fail \
+  --silent \
+  --show-error \
+  --retry 3 \
+  --retry-all-errors \
+  --header "Authorization: Bearer ${HCLOUD_TOKEN}" \
+  "${hcloud_api}" 2>"${curl_error_file}")"; then
+  curl_error="$(head -c 1000 "${curl_error_file}" | tr '\r\n' '  ')"
+  readonly curl_error
+  echo "::error::Could not resolve ${floating_ip_name} from the Hetzner API: ${curl_error}" >&2
+  exit 1
+fi
+readonly response
+
+matching_count="$(jq -er \
+  --arg name "${floating_ip_name}" \
+  '[.floating_ips[]? | select(.name == $name)] | length' \
+  <<<"${response}")" || {
+  echo "::error::Hetzner returned an invalid response while resolving ${floating_ip_name}." >&2
+  exit 1
+}
+readonly matching_count
+if [[ "${matching_count}" != "1" ]]; then
+  echo "::error::Expected exactly one Hetzner floating IP named ${floating_ip_name}; found ${matching_count}." >&2
+  exit 1
+fi
+
+stable_ip="$(jq -er \
+  --arg name "${floating_ip_name}" \
+  --arg cluster "${cluster_name}" '
+    .floating_ips[]
+    | select(.name == $name)
+    | select(.labels["ksail.owned"] == "true")
+    | select(.labels["ksail.cluster.name"] == $cluster)
+    | .ip
+    | select(type == "string" and length > 0)
+  ' <<<"${response}")" || {
+  echo "::error::Hetzner floating IP ${floating_ip_name} is not owned by KSail for cluster ${cluster_name}; refusing to adopt it." >&2
+  exit 1
+}
+readonly stable_ip
+if [[ ! "${stable_ip}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+  echo "::error::Hetzner floating IP ${floating_ip_name} returned an invalid IPv4 address." >&2
+  exit 1
+fi
+
+kube_cluster="$(kubectl --kubeconfig "${kubeconfig_path}" config view --raw \
+  -o jsonpath="{.contexts[?(@.name==\"${kube_context}\")].context.cluster}")"
+readonly kube_cluster
+if [[ -z "${kube_cluster}" ]]; then
+  echo "::error::Restored kubeconfig has no ${kube_context} context." >&2
+  exit 1
+fi
+
+old_server="$(kubectl --kubeconfig "${kubeconfig_path}" config view --raw \
+  -o jsonpath="{.clusters[?(@.name==\"${kube_cluster}\")].cluster.server}")"
+readonly old_server
+if [[ -z "${old_server}" ]]; then
+  echo "::error::Context ${kube_context} references missing cluster ${kube_cluster}." >&2
+  exit 1
+fi
+
+readonly stable_server="https://${stable_ip}:6443"
+kubectl --kubeconfig "${kubeconfig_path}" config set-cluster "${kube_cluster}" \
+  --server="${stable_server}" >/dev/null
+
+updated_server="$(kubectl --kubeconfig "${kubeconfig_path}" config view --raw \
+  -o jsonpath="{.clusters[?(@.name==\"${kube_cluster}\")].cluster.server}")"
+readonly updated_server
+if [[ "${updated_server}" != "${stable_server}" ]]; then
+  echo "::error::Failed to persist production API endpoint ${stable_server} in the restored kubeconfig." >&2
+  exit 1
+fi
+
+echo "✅ Production kubeconfig now uses the stable API endpoint ${stable_ip} (was ${old_server})."


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Fixes #3104.

## Root cause

`floatingIPEnabled: true` has already provisioned and configured the stable production endpoint (`5.75.215.250`), but the `KUBE_CONFIG` environment secret still names the creation-time IP of `prod-control-plane-2` (`49.13.53.183`). KSail synchronizes the stable endpoint into its in-memory Talos configuration during `cluster update`; it does not rewrite the restored kubeconfig used by the surrounding deployment steps. Rolling that one control plane therefore interrupts every Kubernetes call from the runner even while the other API servers remain healthy.

The GHCR synchronization Lease guard compounded the diagnosis: every failed Lease read returned the same boolean as a confirmed holder replacement, so an API transport failure was reported as a lost Lease.

## Change

- Resolve `prod-floating-ip` from the Hetzner API before the first Kubernetes call.
- Require exactly one address with KSail's ownership and cluster labels before updating only the `admin@prod` cluster server; fail closed on missing, ambiguous, or foreign state.
- Preserve Lease-renewal failure provenance across the heartbeat marker.
- Wait for API recovery and re-prove the same holder after transport failure, while still fencing immediately when another transaction owns the Lease.
- Run the endpoint behavior test in the existing production-deploy validation job.

This is not feature-flagged: the old path is a node-bound production endpoint that violates the already-enabled HA endpoint invariant, and the replacement fails closed before mutation if its deployment facts cannot be proved.

## Verification

- RED tests reproduced node-bound kubeconfig behavior and the transport/holder misclassification before implementation.
- `bash scripts/tests/test-use-prod-stable-api-endpoint.sh`
- `go test -timeout=20m ./scripts/tests/refresh-flux-ghcr-auth -count=1` (full suite, 119.6s)
- ShellCheck and `bash -n` for the changed shell surfaces
- workflow syntax and the merge-group/Flux/concurrency contract tests
- `ksail --config ksail.prod.yaml workload validate` (115 kustomizations, 565 YAML files)
- read-only `admin@prod` `/readyz` probe through `https://5.75.215.250:6443` returned `ok`

## Delivery proof still required

- [ ] Merge-group deployment rolls a control plane and completes through the stable endpoint.
