### PR TITLE
fix(deploy): avoid redundant GHCR node reboots

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -171,9 +171,14 @@ runs:
       # the declared incoming image on every stale Talos node, then stage and
       # verify the Kubernetes fan-out BEFORE publishing latest. Every pull
       # consumer has one known-readable credential before the mutable tag can
-      # be observed.
+      # be observed. The non-secret exact-node proof survives only in this job
+      # so the post-update pass can distinguish annotation loss from real
+      # credential, image, or node drift.
       shell: bash
-      run: ./scripts/refresh-flux-ghcr-auth.sh
+      run: >-
+        ./scripts/refresh-flux-ghcr-auth.sh
+        --record-runtime-proof
+        "${RUNNER_TEMP}/ghcr-runtime-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
 
     # Publish the GitOps manifests (stage → sign → attest → promote → reconcile) BEFORE
     # syncing Talos machine config (the "🔄 Update cluster" step runs LAST).
@@ -328,9 +333,16 @@ runs:
       # later deploy failed to acquire the Lease. A merge-queue eviction
       # cancels this job routinely. The next deploy's staging step performs
       # this same reassertion with a full time budget.
+      # `ksail cluster update` re-renders Talos node annotations. Reuse only
+      # the same job's credential+image+Node-UID proof to restore those markers
+      # without another uncached pull or rolling reboot. Any mismatch falls
+      # back to the full safety path.
       if: >-
         !cancelled() &&
         steps.verify_flux_ghcr_auth_after_push.outcome == 'success' &&
         steps.reconcile.outcome == 'success'
       shell: bash
-      run: ./scripts/refresh-flux-ghcr-auth.sh
+      run: >-
+        ./scripts/refresh-flux-ghcr-auth.sh
+        --reuse-runtime-proof
+        "${RUNNER_TEMP}/ghcr-runtime-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Production uses **Talos + Hetzner** via KSail's native Hetzner provider. KSail o
 6. `scripts/run-ksail-prod-with-pull-auth.sh workload push` packages manifests and pushes them with the separate Actions write token.
 7. `scripts/refresh-flux-ghcr-auth.sh --check-only` revalidates the newly-published artifact without mutating the cluster.
 8. `scripts/run-ksail-prod-with-pull-auth.sh workload reconcile` triggers Flux with Git/SOPS pull auth. Both normal delivery and DR then require `infrastructure-controllers` to apply the exact newly-published digest and report `Ready`.
-9. After `cluster update`, the full bridge reasserts every pull path in case a partial update or older managed state was applied. DR applies the same Cilium rollout guard around publish and convergence, and also runs the bridge after an OpenBao raft restore because the snapshot may contain an older GHCR value.
+9. After `cluster update`, the full bridge reasserts every pull path in case a partial update or older managed state was applied. The normal deploy passes a non-secret, same-job handoff that binds the staged credential revision and image to each Kubernetes Node UID. If KSail only erased the Talos proof annotation, the reassert restores that marker without repeating the uncached pull or rolling reboot; a changed credential, image, or Node UID still takes the full proof path. DR applies the same Cilium rollout guard around publish and convergence, and also runs the bridge after an OpenBao raft restore because the snapshot may contain an older GHCR value.
 
 **Key differences from local:**
 

--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -48,16 +48,19 @@ report_residual_bridge_ownership() {
 }
 
 # Select nodes that have not completed the v2 proof for the incoming credential
-# revision or the exact image used for the registry pull. Credential-stale nodes
-# require a reboot because containerd loads registry auth only at process start;
-# image-only drift needs an uncached pull proof but must not reboot a node whose
-# current credential revision is already proven. Legacy unversioned annotations
-# deliberately select reboot mode once after this contract lands.
+# revision or exact image. A same-job proof may classify a marker-only loss as
+# proof-only when it binds the same revision, image, node name, and immutable
+# Node UID. This is the narrow handoff needed after `ksail cluster update`
+# re-renders machine annotations; it never excuses a changed node or credential.
+# Other credential-stale nodes require a reboot because containerd loads
+# registry auth only at process start. Image-only drift still performs a fresh
+# uncached pull proof.
 select_talos_node_targets() {
   local nodes_file="$1"
   local desired_revision="$2"
   local operator_image="$3"
   local targets_file="$4"
+  local reusable_proof_file="${5:-/dev/null}"
   local unsorted_targets="${targets_file}.unsorted"
 
   if ! jq -r \
@@ -66,7 +69,10 @@ select_talos_node_targets() {
     --arg revision_annotation "${GHCR_PULL_VERIFIED_REVISION_ANNOTATION}" \
     --arg image_annotation "${GHCR_PULL_VERIFIED_IMAGE_ANNOTATION}" \
     --arg owner_annotation "platform.devantler.tech/ghcr-auth-drain-owner" \
-    --arg recovery_annotation "platform.devantler.tech/ghcr-auth-drain-recovery" '
+    --arg recovery_annotation "platform.devantler.tech/ghcr-auth-drain-recovery" \
+    --slurpfile reusable_proof "${reusable_proof_file}" '
+    ($reusable_proof[0].nodes // []) as $proved_nodes
+    |
     if any(.items[];
       ((.metadata.annotations[$owner_annotation] // "") != "")
       or ((.metadata.annotations[$recovery_annotation] // "") != ""))
@@ -75,6 +81,11 @@ select_talos_node_targets() {
       .items[]
       | (.metadata.annotations[$revision_annotation] // "") as $verified_revision
       | (.metadata.annotations[$image_annotation] // "") as $verified_image
+      | .metadata.name as $node_name
+      | (.metadata.uid // "") as $node_uid
+      | ($proved_nodes | any(
+          .name == $node_name and .uid == $node_uid
+        )) as $can_restore_proof
       | select($verified_revision != $revision or $verified_image != $image)
       | (.metadata.labels // {}) as $labels
       | [
@@ -84,9 +95,10 @@ select_talos_node_targets() {
           .metadata.name,
           ([.status.addresses[]
             | select(.type == "InternalIP") | .address][0]),
-          (if $verified_revision != $revision
-            then "reboot" else "image-only" end),
-          (.metadata.uid // "")
+          (if $can_restore_proof then "proof-only"
+           elif $verified_revision != $revision then "reboot"
+           else "image-only" end),
+          $node_uid
         ]
       | @tsv
     end
@@ -311,6 +323,10 @@ stage_fanout_before_talos() {
       return "${rc}"
     }
     if grep -Fxq -- clean "${talos_sync_result}"; then
+      record_runtime_proof "${desired_revision}" "${operator_image}" || {
+        rc=$?
+        return "${rc}"
+      }
       patch_root_secret || {
         rc=$?
         return "${rc}"

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -2439,6 +2439,7 @@ process_talos_node_target() {
   if [[ "${node_mode}" == "proof-only" ]]; then
     reusable_proof_uid="${node_uid}"
   fi
+  # Test hook consumed by fake talosctl to verify Node binding; Talos ignores it.
   if ! FLUX_GHCR_REUSABLE_PROOF_UID="${reusable_proof_uid}" \
     talosctl \
     --nodes "${node_ip}" \

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -18,20 +18,58 @@ require_flux_ghcr_yaml_tool
 
 check_only=false
 allow_incomplete_fanout=false
-if (($# > 1)); then
-  echo "Usage: $0 [--check-only|--allow-incomplete-fanout]" >&2
-  exit 64
-fi
-if (($# == 1)); then
+record_runtime_proof_path=""
+reuse_runtime_proof_path=""
+usage() {
+  echo "Usage: $0 [--check-only|--allow-incomplete-fanout|--record-runtime-proof PATH|--reuse-runtime-proof PATH]" >&2
+}
+while (($# > 0)); do
   case "$1" in
-    --check-only) check_only=true ;;
-    --allow-incomplete-fanout) allow_incomplete_fanout=true ;;
+    --check-only)
+      check_only=true
+      shift
+      ;;
+    --allow-incomplete-fanout)
+      allow_incomplete_fanout=true
+      shift
+      ;;
+    --record-runtime-proof|--reuse-runtime-proof)
+      if (($# < 2)) || [[ -z "$2" ]]; then
+        usage
+        exit 64
+      fi
+      if [[ "$1" == "--record-runtime-proof" ]]; then
+        record_runtime_proof_path="$2"
+      else
+        reuse_runtime_proof_path="$2"
+      fi
+      shift 2
+      ;;
     *)
-      echo "Usage: $0 [--check-only|--allow-incomplete-fanout]" >&2
+      usage
       exit 64
       ;;
   esac
+done
+if [[ "${check_only}" == "true" ||
+  "${allow_incomplete_fanout}" == "true" ]] &&
+  [[ -n "${record_runtime_proof_path}${reuse_runtime_proof_path}" ]]; then
+  usage
+  exit 64
 fi
+if [[ -n "${record_runtime_proof_path}" &&
+  -n "${reuse_runtime_proof_path}" ]]; then
+  usage
+  exit 64
+fi
+for runtime_proof_path in \
+  "${record_runtime_proof_path}" "${reuse_runtime_proof_path}"; do
+  [[ -n "${runtime_proof_path}" ]] || continue
+  if [[ "${runtime_proof_path}" != /* ]]; then
+    echo "::error::Runtime proof paths must be absolute runner-local paths."
+    exit 64
+  fi
+done
 
 readonly SECRET_FILE="${FLUX_GHCR_SECRET_FILE:-k8s/bases/bootstrap/secret.enc.yaml}"
 readonly KUBE_CONTEXT="${KUBE_CONTEXT:-admin@prod}"
@@ -204,6 +242,8 @@ runtime_proved_targets_file="${work_dir}/runtime-proved-targets.txt"
 runtime_probe_manifest_file="${work_dir}/runtime-probe-pod.json"
 runtime_probe_state_file="${work_dir}/runtime-probe-state.json"
 runtime_probe_result_file="${work_dir}/runtime-probe-result.txt"
+normalized_runtime_proof_file="${work_dir}/reusable-runtime-proof.json"
+runtime_proof_nodes_file="${work_dir}/runtime-proof-nodes.json"
 image_verification_policy_patch_file="${work_dir}/image-verification-policy-patch.json"
 image_verification_policy_result_file="${work_dir}/image-verification-policy-result.txt"
 image_verification_mutating_webhooks_file="${work_dir}/image-verification-mutating-webhooks.json"
@@ -1967,10 +2007,13 @@ process_talos_node_target() {
   local probe_image recovery_record=""
   local drain_attempt=1 api_attempt api_ready
   local ready_attempt
+  local reusable_proof_uid=""
 
   assert_sync_lease_held || return 1
 
-  if [[ "${node_mode}" != "reboot" && "${node_mode}" != "image-only" ]]; then
+  if [[ "${node_mode}" != "reboot" &&
+    "${node_mode}" != "image-only" &&
+    "${node_mode}" != "proof-only" ]]; then
     echo "::error::Unknown Talos GHCR synchronization mode '${node_mode}' for ${node_name}."
     return 1
   fi
@@ -2322,63 +2365,65 @@ process_talos_node_target() {
       "${reboot_result_file}" "${node_ip}" "${node_role}" || return 1
   fi
 
-  # A reboot/readiness wait or even a short image-only cordon can outlive a
-  # replacement, uncordon, taint, or owner change. Rebind identity and the
-  # scheduling guard at the final Talos edge before touching the image cache.
-  revalidate_node_scheduling_guard \
-    "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
-    "${initial_node_uid}" "${initial_node_taints}" \
-    "${talos_result_file}" "${node_ip}" "${node_role}" \
-    "image verification" || return 1
+  if [[ "${node_mode}" != "proof-only" ]]; then
+    # A reboot/readiness wait or even a short image-only cordon can outlive a
+    # replacement, uncordon, taint, or owner change. Rebind identity and the
+    # scheduling guard at the final Talos edge before touching the image cache.
+    revalidate_node_scheduling_guard \
+      "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
+      "${initial_node_uid}" "${initial_node_taints}" \
+      "${talos_result_file}" "${node_ip}" "${node_role}" \
+      "image verification" || return 1
 
-  # A cached image can make a pull look healthy without proving that the
-  # node's runtime can authenticate to GHCR. Remove the incoming exact target
-  # first so the following pull must complete a registry round-trip.
-  if ! talosctl \
-    --nodes "${node_ip}" \
-    image remove "${operator_image}" \
-    --namespace cri \
-    >"${talos_result_file}" 2>&1; then
-    if ! talos_image_remove_reports_absent \
-      "${talos_result_file}" "${operator_image}"; then
-      echo "::error::Talos node ${node_name} could not remove the cached incoming KSail image before GHCR verification; it remains cordoned because registry access is unproved."
+    # A cached image can make a pull look healthy without proving that the
+    # node's runtime can authenticate to GHCR. Remove the incoming exact target
+    # first so the following pull must complete a registry round-trip.
+    if ! talosctl \
+      --nodes "${node_ip}" \
+      image remove "${operator_image}" \
+      --namespace cri \
+      >"${talos_result_file}" 2>&1; then
+      if ! talos_image_remove_reports_absent \
+        "${talos_result_file}" "${operator_image}"; then
+        echo "::error::Talos node ${node_name} could not remove the cached incoming KSail image before GHCR verification; it remains cordoned because registry access is unproved."
+        return 1
+      fi
+    fi
+
+    revalidate_node_scheduling_guard \
+      "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
+      "${initial_node_uid}" "${initial_node_taints}" \
+      "${talos_result_file}" "${node_ip}" "${node_role}" \
+      "image pull" || return 1
+
+    # Credential validity against GHCR (see the caveat above: this is not, on
+    # its own, proof that containerd is using it — the reboot is).
+    if ! talosctl \
+      --nodes "${node_ip}" \
+      image pull "${operator_image}" \
+      --namespace cri \
+      >"${talos_result_file}" 2>&1; then
+      echo "::error::Talos node ${node_name} could not pull the exact incoming KSail image after its auth refresh; it remains cordoned because registry access is unproved."
       return 1
     fi
-  fi
 
-  revalidate_node_scheduling_guard \
-    "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
-    "${initial_node_uid}" "${initial_node_taints}" \
-    "${talos_result_file}" "${node_ip}" "${node_role}" \
-    "image pull" || return 1
+    revalidate_node_scheduling_guard \
+      "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
+      "${initial_node_uid}" "${initial_node_taints}" \
+      "${talos_result_file}" "${node_ip}" "${node_role}" \
+      "runtime pull proof" || return 1
 
-  # Credential validity against GHCR (see the caveat above: this is not, on
-  # its own, proof that containerd is using it — the reboot is).
-  if ! talosctl \
-    --nodes "${node_ip}" \
-    image pull "${operator_image}" \
-    --namespace cri \
-    >"${talos_result_file}" 2>&1; then
-    echo "::error::Talos node ${node_name} could not pull the exact incoming KSail image after its auth refresh; it remains cordoned because registry access is unproved."
-    return 1
-  fi
-
-  revalidate_node_scheduling_guard \
-    "${node_name}" "${was_cordoned}" "${cordon_owner_token}" \
-    "${initial_node_uid}" "${initial_node_taints}" \
-    "${talos_result_file}" "${node_ip}" "${node_role}" \
-    "runtime pull proof" || return 1
-
-  # Talos' image API authenticates from machine config, not through the
-  # kubelet's running CRI client. Before this freshly rebooted node can
-  # receive workloads, prove both private images through kubelet/containerd
-  # while the bridge-owned cordon is still in place.
-  if [[ "${node_mode}" == "reboot" ]]; then
-    for probe_image in "${RUNTIME_CREDENTIAL_PROBE_IMAGES[@]}"; do
-      probe_node_runtime_pull "${node_name}" "${probe_image}" || return 1
-    done
-    if ! grep -Fqx -- "${node_uid}" "${runtime_proved_targets_file}"; then
-      printf '%s\n' "${node_uid}" >>"${runtime_proved_targets_file}"
+    # Talos' image API authenticates from machine config, not through the
+    # kubelet's running CRI client. Before this freshly rebooted node can
+    # receive workloads, prove both private images through kubelet/containerd
+    # while the bridge-owned cordon is still in place.
+    if [[ "${node_mode}" == "reboot" ]]; then
+      for probe_image in "${RUNTIME_CREDENTIAL_PROBE_IMAGES[@]}"; do
+        probe_node_runtime_pull "${node_name}" "${probe_image}" || return 1
+      done
+      if ! grep -Fqx -- "${node_uid}" "${runtime_proved_targets_file}"; then
+        printf '%s\n' "${node_uid}" >>"${runtime_proved_targets_file}"
+      fi
     fi
   fi
 
@@ -2391,7 +2436,11 @@ process_talos_node_target() {
   # Record the proof only after the real runtime checks, while the selected
   # machine remains protected by the owned cordon. Releasing ownership first
   # would let a concurrent credential revision race this marker write.
-  if ! talosctl \
+  if [[ "${node_mode}" == "proof-only" ]]; then
+    reusable_proof_uid="${node_uid}"
+  fi
+  if ! FLUX_GHCR_REUSABLE_PROOF_UID="${reusable_proof_uid}" \
+    talosctl \
     --nodes "${node_ip}" \
     patch machineconfig \
     --mode=no-reboot \
@@ -2503,7 +2552,8 @@ sync_talos_registry_auth() {
       "${talos_nodes_file}" \
       "${desired_revision}" \
       "${operator_image}" \
-      "${talos_node_targets}"; then
+      "${talos_node_targets}" \
+      "${normalized_runtime_proof_file}"; then
       echo "::error::Could not select Talos nodes requiring GHCR synchronization."
       return 1
     fi
@@ -2625,6 +2675,101 @@ sync_talos_registry_auth() {
   return 1
 }
 
+# Normalize a runner-local proof from the successful pre-update stage. The
+# document contains no credential: it binds only the encrypted-source digest,
+# declared image, and immutable Kubernetes Node identities. A missing, stale,
+# malformed, or symlinked document is ignored, which safely falls back to the
+# existing uncached-pull/reboot path.
+prepare_reusable_runtime_proof() {
+  local desired_revision="$1"
+  local operator_image="$2"
+
+  jq -n \
+    --arg revision "${desired_revision}" \
+    --arg image "${operator_image}" '
+      {version: 1, credentialRevision: $revision, image: $image, nodes: []}
+    ' >"${normalized_runtime_proof_file}"
+
+  [[ -n "${reuse_runtime_proof_path}" ]] || return 0
+  if [[ ! -f "${reuse_runtime_proof_path}" ||
+    -L "${reuse_runtime_proof_path}" ]] ||
+    ! jq -e \
+      --arg revision "${desired_revision}" \
+      --arg image "${operator_image}" '
+        .version == 1
+        and .credentialRevision == $revision
+        and .image == $image
+        and (.nodes | type == "array" and length > 0)
+        and all(.nodes[];
+          (.name | type == "string" and length > 0)
+          and (.uid | type == "string" and length > 0))
+        and ((.nodes | map(.name) | unique | length) == (.nodes | length))
+        and ((.nodes | map(.uid) | unique | length) == (.nodes | length))
+      ' "${reuse_runtime_proof_path}" >/dev/null 2>&1; then
+    echo "::warning::The pre-update GHCR runtime proof is absent, stale, or malformed; using full per-node verification."
+    return 0
+  fi
+
+  jq -cS . "${reuse_runtime_proof_path}" \
+    >"${normalized_runtime_proof_file}"
+}
+
+# Export an exact-node proof only after the normal transaction has converged.
+# The subsequent reassert can restore a machine annotation erased by KSail,
+# but only for the same credential, image, name, and Kubernetes Node UID.
+record_runtime_proof() {
+  local desired_revision="$1"
+  local operator_image="$2"
+  local proof_parent
+
+  [[ -n "${record_runtime_proof_path}" ]] || return 0
+  proof_parent="$(dirname -- "${record_runtime_proof_path}")"
+  if [[ ! -d "${proof_parent}" ||
+    -e "${record_runtime_proof_path}" ||
+    -L "${record_runtime_proof_path}" ]]; then
+    echo "::error::Refusing to overwrite or create the runtime proof outside an existing runner-local directory."
+    return 1
+  fi
+  if ! kubectl \
+    --context "${KUBE_CONTEXT}" \
+    get nodes \
+    -o json >"${runtime_proof_nodes_file}"; then
+    echo "::error::Could not capture the converged Node identities for the post-update GHCR reassert."
+    return 1
+  fi
+  if ! validate_talos_node_inventory "${runtime_proof_nodes_file}"; then
+    echo "::error::Could not record runtime proof from an invalid Talos node inventory."
+    return 1
+  fi
+  if ! jq -e \
+    --arg revision "${desired_revision}" \
+    --arg image "${operator_image}" \
+    --arg revision_annotation "${GHCR_PULL_VERIFIED_REVISION_ANNOTATION}" \
+    --arg image_annotation "${GHCR_PULL_VERIFIED_IMAGE_ANNOTATION}" '
+      all(.items[];
+        .metadata.annotations[$revision_annotation] == $revision
+        and .metadata.annotations[$image_annotation] == $image)
+    ' "${runtime_proof_nodes_file}" >/dev/null; then
+    echo "::error::Refusing to record a post-update handoff before every exact Node has current runtime proof."
+    return 1
+  fi
+  if ! jq -cS \
+    --arg revision "${desired_revision}" \
+    --arg image "${operator_image}" '
+      {
+        version: 1,
+        credentialRevision: $revision,
+        image: $image,
+        nodes: [.items[] | {name: .metadata.name, uid: .metadata.uid}]
+          | sort_by(.name)
+      }
+    ' "${runtime_proof_nodes_file}" >"${record_runtime_proof_path}"; then
+    rm -f "${record_runtime_proof_path}"
+    return 1
+  fi
+  chmod 600 "${record_runtime_proof_path}"
+}
+
 # KSail embeds SOPS, so the deploy uses the same pinned toolchain as workload
 # reconciliation. Decrypt only the Docker config scalar and never emit it to
 # stdout or place its plaintext/base64 representation in an argument.
@@ -2685,6 +2830,7 @@ jq -n \
   }
 ' >"${talos_revision_patch_file}"
 chmod 600 "${talos_auth_patch_file}" "${talos_revision_patch_file}"
+prepare_reusable_runtime_proof "${pull_revision}" "${KSAIL_OPERATOR_IMAGE}"
 
 # Merge only Secret data fields so ownership metadata survives. The sensitive
 # payload stays in pipes/temp files and never appears in argv or logs.

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -33,7 +33,7 @@ while (($# > 0)); do
       allow_incomplete_fanout=true
       shift
       ;;
-    --record-runtime-proof|--reuse-runtime-proof)
+    --record-runtime-proof | --reuse-runtime-proof)
       if (($# < 2)) || [[ -z "$2" ]]; then
         usage
         exit 64

--- a/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
@@ -255,13 +255,16 @@ func TestDeployActionConsumerStagingPrecedesPublishAndIsReassertedAfterUpdate(t 
 	requireBefore(t, postPushRefresh, reconcile, "post-publish refresh before reconcile")
 	requireBefore(t, reconcile, clusterUpdate, "reconcile before cluster update")
 	requireBefore(t, clusterUpdate, finalRefresh, "cluster update before final refresh")
-	requireContains(t, action[firstRefresh:push], "run: ./scripts/refresh-flux-ghcr-auth.sh\n")
+	requireContains(t, action[firstRefresh:push], "--record-runtime-proof")
+	requireContains(t, action[firstRefresh:push], "${RUNNER_TEMP}/ghcr-runtime-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json")
 	requireNotContains(t, action[firstRefresh:push], "--check-only")
 	requireContains(t, action[postPushRefresh:reconcile], "run: ./scripts/refresh-flux-ghcr-auth.sh --check-only")
 	finalRefreshStep := action[finalRefresh:]
 	requireContains(t, finalRefreshStep, "!cancelled() &&")
 	requireContains(t, finalRefreshStep, "steps.verify_flux_ghcr_auth_after_push.outcome == 'success'")
 	requireContains(t, finalRefreshStep, "steps.reconcile.outcome == 'success'")
+	requireContains(t, finalRefreshStep, "--reuse-runtime-proof")
+	requireContains(t, finalRefreshStep, "${RUNNER_TEMP}/ghcr-runtime-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json")
 	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 3 {
 		t.Errorf("refresh helper references = %d, want 3", count)
 	}

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
@@ -244,15 +244,16 @@ func fakeTalosctl(args []string) int {
 		}
 		nodeName := fakeNodeName(node)
 		reusableProofUID := os.Getenv("FLUX_GHCR_REUSABLE_PROOF_UID")
-		if reusableProofUID != "" {
+		switch {
+		case reusableProofUID != "":
 			if nodeName == "" || reusableProofUID != nodeName+"-uid" {
 				return commandFailure(93, "reusable proof UID does not bind the target Node")
 			}
-		} else if markerExists("talos-auth-" + node) {
+		case markerExists("talos-auth-" + node):
 			if !markerExists("talos-reboot-" + node) {
 				return commandFailure(93, "revision preceded reboot")
 			}
-		} else if os.Getenv("FAKE_TALOS_NODES_CURRENT") != "true" {
+		case os.Getenv("FAKE_TALOS_NODES_CURRENT") != "true":
 			return commandFailure(93, "image-only proof lacks current credential")
 		}
 		if reusableProofUID == "" &&

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
@@ -242,17 +242,23 @@ func fakeTalosctl(args []string) int {
 			}
 			return 0
 		}
-		if markerExists("talos-auth-" + node) {
+		nodeName := fakeNodeName(node)
+		reusableProofUID := os.Getenv("FLUX_GHCR_REUSABLE_PROOF_UID")
+		if reusableProofUID != "" {
+			if nodeName == "" || reusableProofUID != nodeName+"-uid" {
+				return commandFailure(93, "reusable proof UID does not bind the target Node")
+			}
+		} else if markerExists("talos-auth-" + node) {
 			if !markerExists("talos-reboot-" + node) {
 				return commandFailure(93, "revision preceded reboot")
 			}
 		} else if os.Getenv("FAKE_TALOS_NODES_CURRENT") != "true" {
 			return commandFailure(93, "image-only proof lacks current credential")
 		}
-		if !markerExists("talos-remove-"+node) || !markerExists("talos-pull-"+node) {
+		if reusableProofUID == "" &&
+			(!markerExists("talos-remove-"+node) || !markerExists("talos-pull-"+node)) {
 			return commandFailure(93, "revision preceded registry pull proof")
 		}
-		nodeName := fakeNodeName(node)
 		if nodeName == "" || !markerExists("cordoned-"+nodeName) ||
 			markerContent("cordon-owner-"+nodeName) == "" {
 			return commandFailure(93, "Talos revision mutation lacked an owned Kubernetes cordon")

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_contracts_test.go
@@ -1,6 +1,7 @@
 package refreshfluxghcrauth
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,6 +49,38 @@ func TestFakeTalosImageOperationsRequireCRINamespace(t *testing.T) {
 				t.Fatalf("fake Talos %s accepted an image operation without --namespace cri", operation)
 			}
 		})
+	}
+}
+
+func TestFakeRecoveryPhaseHonorsReplacementWorkerUID(t *testing.T) {
+	workspace := t.TempDir()
+	patchPath := filepath.Join(workspace, "recovery.json")
+	const currentRecovery = `{"phase":"active"}`
+	const updatedRecovery = `{"phase":"retain"}`
+	t.Setenv("FAKE_SYNC_STATE_DIR", workspace)
+	t.Setenv("FAKE_WORKER_UID", "replacement-worker-uid")
+	t.Setenv("OPERATION_LOG", filepath.Join(workspace, "operations.log"))
+	setMarkerContent("cordon-owner-prod-worker-1", "fixture-owner")
+	setMarkerContent("cordon-recovery-prod-worker-1", currentRecovery)
+	patch := []jsonPatchOperation{
+		{Operation: "test", Path: "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner", Value: "fixture-owner"},
+		{Operation: "test", Path: "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-recovery", Value: currentRecovery},
+		{Operation: "replace", Path: "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-recovery", Value: updatedRecovery},
+		{Operation: "test", Path: "/metadata/uid", Value: "replacement-worker-uid"},
+		{Operation: "test", Path: "/metadata/resourceVersion", Value: "10"},
+	}
+	contents, err := json.Marshal(patch)
+	if err != nil {
+		t.Fatalf("marshal recovery patch: %v", err)
+	}
+	if err := os.WriteFile(patchPath, contents, 0o600); err != nil {
+		t.Fatalf("write recovery patch: %v", err)
+	}
+
+	exitCode := fakeKubectlPatchNode([]string{"patch", "node", "prod-worker-1"}, patchPath)
+
+	if exitCode != 0 {
+		t.Fatal("fake kubectl rejected a recovery phase bound to the replacement worker UID")
 	}
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1026,8 +1026,9 @@ func fakeKubectlGetNodes() int {
 	revision := os.Getenv("EXPECTED_GHCR_REVISION")
 	image := os.Getenv("EXPECTED_KSAIL_TARGET_IMAGE")
 	verifiedImage := defaultString(os.Getenv("FAKE_TALOS_VERIFIED_IMAGE"), image)
+	workerUID := defaultString(os.Getenv("FAKE_WORKER_UID"), "prod-worker-1-uid")
 	nodes := []any{
-		fakeInventoryNode("prod-worker-1", "prod-worker-1-uid", "10.0.0.2", "198.51.100.2", false, revision, "", "", true),
+		fakeInventoryNode("prod-worker-1", workerUID, "10.0.0.2", "198.51.100.2", false, revision, "", "", true),
 		fakeInventoryNode("prod-control-plane-1", "prod-control-plane-1-uid", "10.0.0.1", "198.51.100.1", true, revision, "", "", true),
 		fakeInventoryNode("prod-control-plane-2", "prod-control-plane-2-uid", "10.0.0.3", "198.51.100.3", true, revision, revision, image, false),
 		fakeInventoryNode("prod-control-plane-3", "prod-control-plane-3-uid", "10.0.0.4", "198.51.100.4", true, revision, revision, image, false),
@@ -1262,6 +1263,9 @@ func fakeKubectlGetNode(args []string) int {
 	}
 
 	nodeUID := nodeName + "-uid"
+	if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
+		nodeUID = os.Getenv("FAKE_WORKER_UID")
+	}
 	nodeIP, controlPlane := fakeNodeAddress(nodeName)
 	if nodeName == os.Getenv("FAKE_NODE_REPLACED_BEFORE_PROCESS_NODE") {
 		nodeUID = nodeName + "-replacement-uid"
@@ -1568,7 +1572,11 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 			patch[0].Path != "/metadata/resourceVersion" || fmt.Sprint(patch[0].Value) != currentResourceVersion {
 			return commandFailure(56, "invalid atomic cordon claim")
 		}
-		if !hasPatchOperation(patch, "test", "/metadata/uid", nodeName+"-uid") {
+		expectedNodeUID := nodeName + "-uid"
+		if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
+			expectedNodeUID = os.Getenv("FAKE_WORKER_UID")
+		}
+		if !hasPatchOperation(patch, "test", "/metadata/uid", expectedNodeUID) {
 			return commandFailure(56, "atomic cordon claim omitted node UID")
 		}
 		setMarkerContent("cordon-owner-"+nodeName, owner)
@@ -1611,9 +1619,13 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 	if nodeName == os.Getenv("FAKE_UNCORDON_FAIL_NODE") || markerContent("cordon-owner-"+nodeName) != expectedOwner {
 		return commandFailure(56, "cordon ownership changed; refusing to uncordon")
 	}
+	expectedNodeUID := nodeName + "-uid"
+	if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
+		expectedNodeUID = os.Getenv("FAKE_WORKER_UID")
+	}
 	if len(patch) == 0 || patch[0].Operation != "test" ||
 		patch[0].Path != "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner" ||
-		!hasPatchOperation(patch, "test", "/metadata/uid", nodeName+"-uid") ||
+		!hasPatchOperation(patch, "test", "/metadata/uid", expectedNodeUID) ||
 		!hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) ||
 		!hasPatchPath(patch, "remove", "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner") {
 		return commandFailure(56, "invalid atomic cordon release")

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1262,10 +1262,7 @@ func fakeKubectlGetNode(args []string) int {
 		}
 	}
 
-	nodeUID := nodeName + "-uid"
-	if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
-		nodeUID = os.Getenv("FAKE_WORKER_UID")
-	}
+	nodeUID := fakeExpectedNodeUID(nodeName)
 	nodeIP, controlPlane := fakeNodeAddress(nodeName)
 	if nodeName == os.Getenv("FAKE_NODE_REPLACED_BEFORE_PROCESS_NODE") {
 		nodeUID = nodeName + "-replacement-uid"
@@ -1420,6 +1417,13 @@ func fakeNodeName(nodeAddress string) string {
 	return ""
 }
 
+func fakeExpectedNodeUID(nodeName string) string {
+	if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
+		return os.Getenv("FAKE_WORKER_UID")
+	}
+	return nodeName + "-uid"
+}
+
 func fakeKubectlDrain(args []string) int {
 	nodeName := argumentAfter(args, "drain")
 	if nodeName == "" || !containsArg(args, "--ignore-daemonsets") ||
@@ -1526,7 +1530,7 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 			expectedOwner == "" || expectedOwner != markerContent("cordon-owner-"+nodeName) ||
 			expectedRecovery == "" || expectedRecovery != markerContent("cordon-recovery-"+nodeName) ||
 			updatedRecovery == "" ||
-			!hasPatchOperation(patch, "test", "/metadata/uid", nodeName+"-uid") ||
+			!hasPatchOperation(patch, "test", "/metadata/uid", fakeExpectedNodeUID(nodeName)) ||
 			!hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) {
 			return commandFailure(56, "invalid bootstrap recovery phase update")
 		}
@@ -1572,10 +1576,7 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 			patch[0].Path != "/metadata/resourceVersion" || fmt.Sprint(patch[0].Value) != currentResourceVersion {
 			return commandFailure(56, "invalid atomic cordon claim")
 		}
-		expectedNodeUID := nodeName + "-uid"
-		if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
-			expectedNodeUID = os.Getenv("FAKE_WORKER_UID")
-		}
+		expectedNodeUID := fakeExpectedNodeUID(nodeName)
 		if !hasPatchOperation(patch, "test", "/metadata/uid", expectedNodeUID) {
 			return commandFailure(56, "atomic cordon claim omitted node UID")
 		}
@@ -1619,10 +1620,7 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 	if nodeName == os.Getenv("FAKE_UNCORDON_FAIL_NODE") || markerContent("cordon-owner-"+nodeName) != expectedOwner {
 		return commandFailure(56, "cordon ownership changed; refusing to uncordon")
 	}
-	expectedNodeUID := nodeName + "-uid"
-	if nodeName == "prod-worker-1" && os.Getenv("FAKE_WORKER_UID") != "" {
-		expectedNodeUID = os.Getenv("FAKE_WORKER_UID")
-	}
+	expectedNodeUID := fakeExpectedNodeUID(nodeName)
 	if len(patch) == 0 || patch[0].Operation != "test" ||
 		patch[0].Path != "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner" ||
 		!hasPatchOperation(patch, "test", "/metadata/uid", expectedNodeUID) ||

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -125,6 +125,10 @@ func TestRuntimeProofCannotBeReusedForReplacementNode(t *testing.T) {
 	operations := readLines(f.operationLog)
 	requireLine(t, operations, "node-drain:prod-worker-1")
 	requireLine(t, operations, "talos-reboot:10.0.0.2")
+	// A replacement worker must not invalidate the control plane's matching proof.
+	requireNoLine(t, operations, "node-drain:prod-control-plane-1")
+	requireNoLine(t, operations, "talos-reboot:10.0.0.1")
+	requireNoLine(t, operations, "talos-pull:10.0.0.1:"+ksailTargetImage)
 }
 
 func TestStaleRuntimeProofFallsBackToFullVerification(t *testing.T) {

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -56,6 +56,108 @@ func TestCurrentTalosNodesSkipTalosAPI(t *testing.T) {
 	}
 }
 
+func TestClusterUpdateCannotEraseVerifiedRuntimeProof(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	runtimeProof := filepath.Join(f.workspace, "ghcr-runtime-proof.json")
+	first := f.runHelper(validConfig(), []string{
+		"--record-runtime-proof", runtimeProof,
+	}, nil)
+	requireSuccessResult(t, first)
+	if !pathExists(runtimeProof) {
+		t.Fatal("stage did not record its exact-node runtime proof")
+	}
+
+	// `ksail cluster update` re-renders Talos machine.nodeAnnotations from the
+	// committed patches. That removes bridge-owned proof stored in machine
+	// config, even though neither the credential nor the running Node changed.
+	// Model only that destructive re-render between the production Stage and
+	// Reassert invocations.
+	for _, address := range []string{"10.0.0.1", "10.0.0.2"} {
+		if err := os.Remove(filepath.Join(f.syncStateDir, "talos-revision-"+address)); err != nil {
+			t.Fatalf("simulate cluster update dropping proof on %s: %v", address, err)
+		}
+	}
+
+	reassert := f.runHelperPreservingClusterState(validConfig(), []string{
+		"--reuse-runtime-proof", runtimeProof,
+	}, nil)
+	requireSuccessResult(t, reassert)
+	operations := readLines(f.operationLog)
+	for _, unexpected := range []string{
+		"node-drain:prod-worker-1",
+		"node-drain:prod-control-plane-1",
+		"talos-reboot:10.0.0.2",
+		"talos-reboot:10.0.0.1",
+		"talos-remove:10.0.0.2:" + ksailTargetImage,
+		"talos-remove:10.0.0.1:" + ksailTargetImage,
+		"talos-pull:10.0.0.2:" + ksailTargetImage,
+		"talos-pull:10.0.0.1:" + ksailTargetImage,
+	} {
+		requireNoLine(t, operations, unexpected)
+	}
+	restored := readLines(f.talosLog)
+	requireLinesEqual(t, restored, []string{
+		"talos-revision:10.0.0.2",
+		"talos-revision:10.0.0.1",
+	})
+}
+
+func TestRuntimeProofCannotBeReusedForReplacementNode(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	runtimeProof := filepath.Join(f.workspace, "ghcr-runtime-proof.json")
+	first := f.runHelper(validConfig(), []string{
+		"--record-runtime-proof", runtimeProof,
+	}, nil)
+	requireSuccessResult(t, first)
+
+	for _, address := range []string{"10.0.0.1", "10.0.0.2"} {
+		if err := os.Remove(filepath.Join(f.syncStateDir, "talos-revision-"+address)); err != nil {
+			t.Fatalf("simulate cluster update dropping proof on %s: %v", address, err)
+		}
+	}
+	reassert := f.runHelperPreservingClusterState(validConfig(), []string{
+		"--reuse-runtime-proof", runtimeProof,
+	}, map[string]string{"FAKE_WORKER_UID": "replacement-worker-uid"})
+	requireSuccessResult(t, reassert)
+
+	operations := readLines(f.operationLog)
+	requireLine(t, operations, "node-drain:prod-worker-1")
+	requireLine(t, operations, "talos-reboot:10.0.0.2")
+}
+
+func TestStaleRuntimeProofFallsBackToFullVerification(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	runtimeProof := filepath.Join(f.workspace, "ghcr-runtime-proof.json")
+	first := f.runHelper(validConfig(), []string{
+		"--record-runtime-proof", runtimeProof,
+	}, nil)
+	requireSuccessResult(t, first)
+
+	for _, address := range []string{"10.0.0.1", "10.0.0.2"} {
+		if err := os.Remove(filepath.Join(f.syncStateDir, "talos-revision-"+address)); err != nil {
+			t.Fatalf("simulate cluster update dropping proof on %s: %v", address, err)
+		}
+	}
+	proof := map[string]any{}
+	if err := json.Unmarshal([]byte(mustRead(runtimeProof)), &proof); err != nil {
+		t.Fatalf("read runtime proof: %v", err)
+	}
+	proof["credentialRevision"] = strings.Repeat("0", 64)
+	mustWriteJSON(t, runtimeProof, proof)
+
+	reassert := f.runHelperPreservingClusterState(validConfig(), []string{
+		"--reuse-runtime-proof", runtimeProof,
+	}, nil)
+	requireSuccessResult(t, reassert)
+	requireContains(t, reassert.stdout+reassert.stderr, "using full per-node verification")
+	operations := readLines(f.operationLog)
+	requireLine(t, operations, "node-drain:prod-worker-1")
+	requireLine(t, operations, "talos-reboot:10.0.0.2")
+}
+
 func TestMatchingRevisionRevalidatesChangedDeclaredImage(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)

--- a/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
@@ -282,8 +282,27 @@ if declare -F stage_fanout_before_talos >/dev/null; then
   else
     fail "verified tenant fanout brackets the Talos rollout"
   fi
+
+  record_runtime_proof() {
+    printf 'record-failed:%s:%s\n' "$1" "$2" >>"${operation_log}"
+    return 1
+  }
+  : >"${operation_log}"
+  talos_sync_call_count=0
+  if stage_fanout_before_talos \
+    "${DESIRED_REVISION}" \
+    "${DESIRED_IMAGE}" \
+    "${work_dir}/talos-stage-result.txt" \
+    wedding-app ascoachingogvaner kyverno; then
+    fail "a failed runtime-proof record blocks the root cutover"
+  elif grep -Fxq -- root-patch "${operation_log}"; then
+    fail "a failed runtime-proof record blocks the root cutover"
+  else
+    pass "a failed runtime-proof record blocks the root cutover"
+  fi
 else
   fail "verified tenant fanout brackets the Talos rollout"
+  fail "a failed runtime-proof record blocks the root cutover"
 fi
 
 control_plane_inventory="${work_dir}/control-planes.json"

--- a/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
@@ -244,6 +244,9 @@ sync_talos_registry_auth() {
 patch_root_secret() {
   printf '%s\n' root-patch >>"${operation_log}"
 }
+record_runtime_proof() {
+  printf 'record:%s:%s\n' "$1" "$2" >>"${operation_log}"
+}
 
 if declare -F stage_fanout_before_talos >/dev/null; then
   : >"${operation_log}"
@@ -272,6 +275,7 @@ if declare -F stage_fanout_before_talos >/dev/null; then
     force:externalsecret/kyverno/ghcr-auth \
     verify:kyverno/ghcr-auth \
     "talos:${DESIRED_REVISION}:${DESIRED_IMAGE}" \
+    "record:${DESIRED_REVISION}:${DESIRED_IMAGE}" \
     root-patch)"
   if [[ "$(<"${operation_log}")" == "${expected_operations}" ]]; then
     pass "verified tenant fanout brackets the Talos rollout"
@@ -321,7 +325,7 @@ jq -n '
 ' >"${control_plane_inventory}"
 
 kubectl() {
-  cp "${control_plane_inventory}" /dev/stdout
+  command cat "${control_plane_inventory}"
 }
 
 talosctl() {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Closes #3042.

## Root cause

The pre-publish GHCR bridge already proved the current encrypted credential and exact KSail image on every existing Node. `ksail cluster update` then re-rendered Talos `machine.nodeAnnotations` from committed config and removed those runtime-proof markers. The final reassert treated marker loss as credential drift and serially drained, rebooted, and re-proved the whole production fleet. In merge-group run 31578345741 that step took 39m32s.

## Fix

- Record a non-secret, runner-local handoff after the staging transaction converges. It binds the encrypted credential digest and declared image to each Kubernetes Node name and immutable UID.
- Let the final reassert use a new `proof-only` mode only when credential digest, image, node name, and UID all match the handoff.
- In proof-only mode retain the synchronization Lease and owned cordon/CAS checks, but restore the Talos proof marker without draining, rebooting, evicting the cached image, or pulling it again.
- Fall back to the existing full verification path for an absent/malformed/stale handoff, a credential or image change, or any replacement Node UID.

## Verification

- `bash -n` for the bridge scripts
- `shellcheck` for the full CI bridge script set
- `bash scripts/tests/test-refresh-flux-ghcr-auth-safety.sh`
- `go test -timeout=20m ./scripts/tests/refresh-flux-ghcr-auth -count=1` (green, 194s)
- New regression proves marker loss causes zero drain/reboot/remove/pull calls.
- New negative regressions prove a replacement UID and stale credential digest take the original full rolling path.

## Expected impact

The 30–45 minute second fleet roll is removed from ordinary deploys. The post-update step still runs the consumer/fan-out checks and two clean inventory observations, plus fast marker restoration, so exact production duration remains to be measured in the merge-group deployment.