### PR TITLE
fix(coredns): disposition CKV_K8S_11 as a stored-spec blind spot

### DIFF
--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -17,6 +17,22 @@ metadata:
     # binary carries the file capability, so the container needs only this one
     # capability in its bounding set and drops every other capability below.
     checkov.io/skip2: CKV_K8S_25=CoreDNS requires only NET_BIND_SERVICE in its bounding set to serve DNS on port 53
+    # The CPU limit is supplied at admission by the kube-system `default-limitrange`
+    # (`k8s/bases/infrastructure/limit-ranges/kube-system.yaml`, `default.cpu: "2"`),
+    # which is a base resource and so applies to both provider overlays. checkov
+    # reads the stored Deployment spec, where an admission-time default is absent —
+    # the same blind spot the Kyverno-injected fields have for Kubescape.
+    #
+    # Observable rather than inferred: on the prod cluster the stored spec carries
+    # only `limits.memory`, while the running CoreDNS pods carry a CPU limit that no
+    # manifest states.
+    #
+    # Stating a CPU limit here instead would be a regression, not a fix: that
+    # LimitRange sets a deliberately generous ceiling so the DNS datapath never
+    # throttles under burst (CPU is compressible and a limit does not affect
+    # scheduling), and hard-coding a lower per-workload number would reintroduce
+    # exactly the throttling it avoids.
+    checkov.io/skip3: CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission; checkov reads the stored spec
 spec:
   progressDeadlineSeconds: 600
   replicas: 2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Kubernetes misconfiguration scanners still report on every pull request without failing the
build, while their backlog is worked off. That backlog is now almost gone, and this clears the last
finding that was a scanner blind spot rather than a real gap: CoreDNS looks like it has no CPU limit,
but the cluster gives it one automatically at deploy time — the scanner just cannot see that.

Setting a limit on the manifest instead would have made things *worse*, by replacing a deliberately
generous ceiling with a hard-coded number and reintroducing the DNS slowdown that ceiling exists to
prevent. So this records why the finding is not real, rather than changing how DNS runs.

## What

Records the reason on the CoreDNS deployment, checked against the live cluster rather than argued
from the manifest.

This takes the checkov backlog to **4 findings, every one of which now has an owning issue** — the
remaining work is tracked rather than loose, which is the point at which the scanner can eventually
be turned back into a hard gate.

One of those four had no owner, so it is now filed as #3112.

Part of #2787
