### PR TITLE
fix(umami): run the tenant-provisioning container on a read-only root filesystem

### DIFF
--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -328,5 +328,9 @@ spec:
           volumes:
             # Writable scratch for the Node runtime, so the container's own root
             # filesystem can stay immutable (readOnlyRootFilesystem above).
+            # sizeLimit matches the umami Deployment's own /tmp (helm-release.yaml):
+            # an unbounded emptyDir draws on the node's ephemeral storage, and this
+            # pod holds no eviction-limiting ephemeral-storage request of its own.
             - name: tmp
-              emptyDir: {}
+              emptyDir:
+                sizeLimit: 128Mi

--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -100,10 +100,19 @@ spec:
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop:
                     - ALL
+              # The script is `node -e` over HTTP only — it uses no filesystem API
+              # at all — so /tmp is the sole writable path it could need, and the
+              # Node runtime gets it from an emptyDir rather than a writable root.
+              # The umami Deployment already runs this same image read-only with
+              # exactly this mount; it additionally mounts /app/.next/cache, which
+              # is the Next.js server's build cache and has no meaning here.
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               resources:
                 requests:
                   cpu: 25m
@@ -316,3 +325,8 @@ spec:
                     }
                     console.log('umami tenant provisioning complete');
                   })().catch((e) => { console.error(String((e && e.stack) || e)); process.exit(1); });
+          volumes:
+            # Writable scratch for the Node runtime, so the container's own root
+            # filesystem can stay immutable (readOnlyRootFilesystem above).
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Umami's tenant-provisioning CronJob was the one workload in its namespace still running with a
writable container root. It does not need one: the container is a `node -e` script that only makes
HTTP calls, and uses no filesystem API at all. Leaving the root writable gave a scheduled,
credential-holding job more than it needs, and it was also the last thing making the platform's
"every other non-privileged workload runs read-only" exception note untrue.

### What

Runs that container on a read-only root filesystem, giving the Node runtime a `/tmp` scratch volume
instead — the same pattern the umami Deployment already uses for this identical image.

Security floor gained: a scheduled job that reads two secrets can no longer write to its own image
filesystem. Everyday cost: none — no interface, schedule or behaviour changes, and nothing new to
remember when editing the job.

Takes the checkov backlog from 4 failing checks to 3. The remaining three are tracked: the
`CKV_K8S_40` pair by #2904, and one `CKV_K8S_35` on this same object, which needs the script
rewritten to read its secrets from files and is deliberately left out of this change.

Part of #2787
