### PR TITLE
fix(umami): declare runAsNonRoot on the provisioning container

### DIFF
--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -100,6 +100,17 @@ spec:
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
+                # Restated at container level even though the pod securityContext
+                # above already sets it: `validate-pod-security` autogenerates a
+                # CronJob rule that reads this container path, while
+                # `add-security-context` has no autogen rules, so a CronJob
+                # template is validated but never mutated. Without this field the
+                # manifest is admitted only while the live object is equally
+                # non-compliant (the validate rules set
+                # `allowExistingViolations: true`) — so the moment anything makes
+                # the live CronJob compliant, this manifest stops being
+                # appliable and wedges the apps Kustomization.
+                runAsNonRoot: true
                 readOnlyRootFilesystem: true
                 capabilities:
                   drop:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Production delivery is stopped. The `apps` Kustomization has been unable to reconcile since 22:11Z, so **nothing can merge in this repository** — the merge queue admits a PR, spends a full ~40 minute prod deploy cycle, fails, and evicts it. #3034 was evicted at 23:25Z through no fault of its own, and pr-2710 queued into the same wall.

The cause is one missing field on the Umami provisioning CronJob. The cluster's own security policy requires it, and until the manifest declares it, `main` cannot be applied to prod at all.

### What

Declares `runAsNonRoot: true` on that container, matching what the policy requires and what the live object already has. No runtime behaviour changes — the pod already runs as a non-root user; this makes the manifest state it where the policy reads it.

This is deliberately the smallest change that unblocks delivery, so it can land ahead of the larger Umami provisioning work in #2725 (which carries the same field as part of its feature). It is self-unblocking: once merged, `main` is appliable again and the queue drains.

The general hazard behind this — an evicted deploy leaving prod more compliant than `main`, with no expiry — is filed separately as #3160.

Refs #3160
