### PR TITLE
fix(umami): declare the provisioning ServiceAccount so Flux can reconcile it

### DIFF
--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -86,6 +86,14 @@ spec:
           # CronJob schedule provides retries. A failed Job's pod is retained
           # (up to failedJobsHistoryLimit) for log inspection.
           restartPolicy: Never
+          # Named explicitly so this field stays inside kustomize-controller's
+          # server-side-apply fieldset. SSA prunes only fields a manager owns, so
+          # an unowned `serviceAccountName` on the live CronJob is unreachable by
+          # reconciliation and pins every Job to whatever subject it names — if
+          # that account does not exist the controller cannot create the pod at
+          # all, and the run fails on `DeadlineExceeded` rather than on anything
+          # the script did. Declaring it keeps the value reconcilable.
+          serviceAccountName: umami-provision-tenants
           automountServiceAccountToken: false
           securityContext:
             runAsNonRoot: true

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   # Namespace ownership lives in infrastructure-controllers/kyverno so the
   # namespaced background-controller grant exists before its ClusterPolicy.
   - service-account.yaml
+  - service-account-provision-tenants.yaml
   - external-secret.yaml
   - external-secret-admin.yaml
   - external-secret-ascoachingogvaner.yaml

--- a/k8s/bases/apps/umami/service-account-provision-tenants.yaml
+++ b/k8s/bases/apps/umami/service-account-provision-tenants.yaml
@@ -15,3 +15,7 @@ kind: ServiceAccount
 metadata:
   name: umami-provision-tenants
   namespace: umami
+# Set here as well as on the pod so the safe behaviour is the default rather than
+# something each consumer has to remember: a later pod that names this account
+# and omits the pod-level field still gets no projected token.
+automountServiceAccountToken: false

--- a/k8s/bases/apps/umami/service-account-provision-tenants.yaml
+++ b/k8s/bases/apps/umami/service-account-provision-tenants.yaml
@@ -1,0 +1,17 @@
+# ServiceAccount for the tenant-provisioning CronJob. It is declared — and named
+# in the CronJob's pod spec — so that `serviceAccountName` is a field Flux owns.
+# An unowned `serviceAccountName` cannot be reconciled away: server-side apply
+# only prunes fields inside a manager's own fieldset, so a value that reached the
+# live CronJob outside this repo survives every subsequent apply and pins the pod
+# to a subject that may not exist. Naming the account here keeps the field in
+# kustomize-controller's fieldset, so the declared value always wins.
+#
+# No RBAC is bound to it: the provisioning script talks only to Umami's HTTP API
+# with credentials mounted from Secrets, never to the Kubernetes API. The pod
+# therefore also sets `automountServiceAccountToken: false`, so no token is
+# projected into the container — this account is an identity, not a grant.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: umami-provision-tenants
+  namespace: umami


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Production's Umami tenant-provisioning job has been failing every 15 minutes since roughly 01:20Z. It points at a user account that does not exist, so the job never starts and eventually times out. Tenant websites therefore stop being reconciled.

The reason it will not clear on its own is the part worth knowing: the bad value reached the live cluster from outside this repository, and GitOps can only correct settings this repository actually declares. It declared nothing here, so reconciliation had no way to reach the field. It would have stayed broken indefinitely.

### What

Declares the missing account and names it explicitly, bringing the setting back under GitOps control so reconciliation converges it and the job can run again.

No new access is granted — the job only talks to Umami's own API, so this is an identity, not a permission. It also removes a latent trap in #2725, which references this same account without ever creating it.

### Scope — what this does NOT fix

This does **not** unblock the production deploy gate. That is a separate and more urgent fault: the `headlamp` storage claim is stuck mid-deletion, so the apps layer fails its health check on every deploy and nothing can merge. Details and the remediation are in #3167. I initially attributed the deploy failure to this Umami fault because the deploy's diagnostic output prints it — that attribution was wrong, and the two are unrelated.

Hotfix for a live fault, so no tracking issue was filed first.