### PR TITLE
fix(networking): keep default-deny schema valid

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-deny.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-deny.yaml
@@ -59,6 +59,10 @@ spec:
             # Selecting every endpoint activates whitelist mode. Keep this as
             # default-deny-by-selection: an explicit ingressDeny/egressDeny
             # rule would take precedence over the namespace's allow policies.
+            # Cilium's CRD also requires at least one policy direction to be
+            # present, so retain empty allow lists for both directions.
+            ingress: []
+            egress: []
             enableDefaultDeny:
               ingress: true
               egress: true

--- a/scripts/tests/crossplane-egress-policy-rules.yaml
+++ b/scripts/tests/crossplane-egress-policy-rules.yaml
@@ -357,6 +357,8 @@ rules:
                'namespace': '{{request.object.metadata.name}}',
                'data': {'spec': {
                  'endpointSelector': {},
+                 'ingress': [],
+                 'egress': [],
                  'enableDefaultDeny': {'ingress': true, 'egress': true}
                }}
              }

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -479,7 +479,7 @@ assert_generated_policy_contract() {
   )"
   expected_contract="$(
     printf '%s\n' \
-      'ClusterPolicy//add-default-deny|generate-default-deny|cilium.io/v2|CiliumNetworkPolicy|default-deny|{{request.object.metadata.name}}|true|true|["Namespace"]|["kube-system","kube-public","kube-node-lease"]|{"enableDefaultDeny":{"egress":true,"ingress":true},"endpointSelector":{}}' \
+      'ClusterPolicy//add-default-deny|generate-default-deny|cilium.io/v2|CiliumNetworkPolicy|default-deny|{{request.object.metadata.name}}|true|true|["Namespace"]|["kube-system","kube-public","kube-node-lease"]|{"egress":[],"enableDefaultDeny":{"egress":true,"ingress":true},"endpointSelector":{},"ingress":[]}' \
       'ClusterPolicy//add-default-deny|generate-allow-dns|cilium.io/v2|CiliumNetworkPolicy|allow-dns|{{request.object.metadata.name}}|true|true|["Namespace"]|["kube-system","kube-public","kube-node-lease"]|{"egress":[{"toEndpoints":[{"matchLabels":{"k8s-app":"kube-dns","k8s:io.kubernetes.pod.namespace":"kube-system"}}],"toPorts":[{"ports":[{"port":"53","protocol":"UDP"},{"port":"53","protocol":"TCP"}]}]}],"endpointSelector":{}}' \
       'ClusterPolicy//add-default-deny|generate-default-deny-networkpolicy|networking.k8s.io/v1|NetworkPolicy|default-deny|{{request.object.metadata.name}}|true|true|["Namespace"]|["kube-system","kube-public","kube-node-lease"]|{"podSelector":{},"policyTypes":["Ingress","Egress"]}'
   )"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary
- add empty ingress and egress allow lists to the generated Cilium default-deny policy
- preserve default-deny-by-selection without explicit deny rules overriding additive allows
- pin the complete generated policy contract in the focused regression test

## Root cause
Platform #3164 correctly removed explicit ingressDeny and egressDeny rules, but the deployed Cilium v2 CRD requires at least one ingress or egress field. Kyverno rejected synchronization of every generated default-deny object, leaving the previous explicit-deny objects live. Empty ingress and egress arrays satisfy the CRD while continuing to isolate both directions through enableDefaultDeny.

## Proof
- RED: focused Crossplane egress test rejected the implementation without the required direction arrays
- GREEN: bash scripts/tests/test-crossplane-egress-policy.sh
- live API schema: server-side dry-run accepted the exact generated CiliumNetworkPolicy spec

Follow-up to #3164.