### PR TITLE
fix(crossview): tell the app the request arrived over https

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -54,6 +54,16 @@ data:
         crossview:
           rule: "Host(`crossview.${domain}`)"
           entryPoints: ["web"]
+          # Crossview builds its OIDC redirect_uri from the incoming request
+          # rather than from OIDC_CALLBACK_URL -- proven in prod: with the env
+          # set to the https public callback it still sent http://. Every hop in
+          # front of it is plaintext (Gateway terminates TLS, then oauth2-proxy,
+          # then this entryPoint), and Traefik sets X-Forwarded-Proto from its
+          # OWN entryPoint scheme, so without this the app sees http and Dex
+          # rejects the redirect_uri it did not register. This router is only
+          # ever reached through the public HTTPS Gateway, so asserting https
+          # here states a fact about the traffic, not a preference.
+          middlewares: ["forwarded-proto-https"]
           service: crossview
         # Kyverno Policy Reporter UI. Prod-only (the app lives in the
         # `infrastructure` layer, pulled in full only by the hetzner overlay), so
@@ -67,6 +77,19 @@ data:
           rule: "Host(`vault.${domain}`)"
           entryPoints: ["web"]
           service: openbao
+      middlewares:
+        # Restores the scheme the client actually used. Traefik derives
+        # X-Forwarded-Proto from the entryPoint it received on, and this
+        # entryPoint is plaintext (:8080) because TLS is terminated out at the
+        # Gateway -- so an app that trusts the header would otherwise be told
+        # every request arrived over http. Attach it only to routers whose app
+        # builds absolute URLs from the request; apps given an explicit public
+        # hostname (actual-budget's ACTUAL_OPENID_SERVER_HOSTNAME) do not need
+        # it and are deliberately left alone.
+        forwarded-proto-https:
+          headers:
+            customRequestHeaders:
+              X-Forwarded-Proto: "https"
       services:
         actual-budget:
           loadBalancer:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Crossview login fails at Dex with `Unregistered redirect_uri`, and the app is the one getting it
wrong: it builds the redirect from the incoming request rather than from the callback URL it is
configured with.

That is now proven rather than inferred. After the pod was restarted it had definitely resolved the
correct HTTPS callback from its config — and it still sent `http://`. So the configured value is not
what it uses.

The reason it sees `http` is that every hop in front of it is plaintext: TLS is terminated at the
Gateway, then the request passes through oauth2-proxy and auth-proxy. Traefik reports the scheme of
the entry point it received on, so the app is told every request arrived over plain HTTP — and Dex
correctly refuses a callback it does not register.

### What

Assert the real client scheme on the way in, attached to the crossview route only. That route is
reachable solely through the public HTTPS gateway, so this states a fact about the traffic rather
than a preference. Apps that are given an explicit public hostname instead are deliberately left
untouched.

Fixes #3172. Independent of #3171, which fixes a different problem (config changes never rolling the
app) and is blocked by #3175.
