### PR TITLE
docs(autoscaling): make stranded autoscaler nodes a visible failure mode

### DIFF
--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -478,11 +478,77 @@ kubectl get nodes -o name | grep '/autoscale-'
 ```
 
 Any `autoscale-<type>-*` node whose `<type>` has no matching `--nodes=` group is
-stranded. Drain it and delete its server (same `hcloud server delete` as above).
-Longhorn replicas must move first; `restrict-storage-to-baseline-workers` and
-`drain-autoscale-node-storage` cover these nodes because they key on the node
-*name*, not on the `ksail.io/autoscaled` label — which a node predating
-ksail#5113 does not carry.
+stranded.
+
+#### Pre-flight — check these before draining anything
+
+`hcloud server delete` neither cordons nor drains the node, and it does not wait
+for Longhorn to evict replicas. Deleting a server directly destroys any replica
+still on it, so the drain is what makes removal safe, and these checks are what
+make the drain safe.
+
+```bash
+# 1. Every storage node must actually be able to ATTACH volumes. A node whose
+#    iSCSI database has an unparseable record accepts replicas but cannot start
+#    an engine, and reports Ready/Schedulable while doing so (#3180). A node
+#    with zero attachments while others have many is the tell.
+kubectl -n longhorn-system get volumes.longhorn.io -o json |
+  jq -r '[.items[]|select(.status.state=="attached")]|group_by(.status.currentNodeID)[]|"\(.[0].status.currentNodeID) attached=\(length)"'
+```
+
+```bash
+# 2. Replica scheduling must have somewhere to go. With hard anti-affinity
+#    (replica-soft-anti-affinity=false) and only three storage nodes, one node
+#    below storage-minimal-available-percentage means degraded volumes can never
+#    rebuild — they sit at ReplicaSchedulingFailure indefinitely.
+kubectl -n longhorn-system get nodes.longhorn.io -o json |
+  jq -r '.items[]|.metadata.name as $n|(.status.diskStatus//{}|to_entries[0].value) as $s|"\($n) avail=\((($s.storageAvailable//0)*100/($s.storageMaximum//1))|floor)% \([$s.conditions[]?|select(.type=="Schedulable")|"Schedulable=\(.status)"]|join(""))"'
+```
+
+```bash
+# 3. Reclaim orphaned replica directories first — they are the usual reason a
+#    node drifts under the threshold. Delete the listed orphans to free the
+#    space (see #3180 for making this automatic).
+kubectl -n longhorn-system get orphans.longhorn.io
+```
+
+```bash
+# 4. Nothing already degraded.
+kubectl -n longhorn-system get volumes.longhorn.io -o json |
+  jq -r '.items[]|select(.status.robustness!="healthy" or .status.state!="attached")|"\(.metadata.name) \(.status.state)/\(.status.robustness)"'
+```
+
+#### Removal sequence
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --timeout=20m
+```
+
+The drain normally stalls at the end on the node's Longhorn `instance-manager`,
+which carries a PDB with zero allowed disruptions. That is expected: once the
+node is storage-idle the instance-manager is idle too, and Longhorn usually
+removes it on its own. Confirm idleness before forcing anything — both must
+return `0`:
+
+```bash
+kubectl -n longhorn-system get engines.longhorn.io -o json | jq -r --arg n <node> '[.items[]|select(.spec.nodeID==$n)]|length'
+kubectl -n longhorn-system get replicas.longhorn.io -o json | jq -r --arg n <node> '[.items[]|select(.spec.nodeID==$n)]|length'
+```
+
+Only then delete the server, and finally the now-orphaned Node object:
+
+```bash
+hcloud server delete <server-id>
+kubectl delete node <node>
+```
+
+Do one node at a time and let volumes return to `healthy` in between. Deleting
+the server is also what frees a slot under `maxNodesTotal`, so the autoscaler
+cannot replace capacity until that step completes.
+
+`restrict-storage-to-baseline-workers` and `drain-autoscale-node-storage` do
+cover these nodes, because they key on the node *name* rather than the
+`ksail.io/autoscaled` label — which a node predating ksail#5113 does not carry.
 
 Whenever you remove a pool, check for its running nodes in the same change.
 

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -470,12 +470,18 @@ never rolled, so it drifts behind on Kubernetes and Talos.
 Detect it by comparing live node names against the configured groups:
 
 ```bash
-# pools the autoscaler actually manages
+# pools the autoscaler actually manages — read BOTH command and args: the chart
+# currently passes every flag in `command`, so an `args`-only query returns an
+# empty stream and the grep matches nothing.
 kubectl -n kube-system get deploy cluster-autoscaler-hetzner-cluster-autoscaler \
-  -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{@}{"\n"}{end}' | grep '^--nodes='
+  -o jsonpath='{range .spec.template.spec.containers[0].command[*]}{@}{"\n"}{end}{range .spec.template.spec.containers[0].args[*]}{@}{"\n"}{end}' | grep '^--nodes='
 # every autoscaler-provisioned node currently registered
 kubectl get nodes -o name | grep '/autoscale-'
 ```
+
+An empty result from the first command means the **query** is wrong, not that no
+pools are configured — check the container spec directly before concluding
+anything. It should print one `--nodes=` line per configured pool.
 
 Any `autoscale-<type>-*` node whose `<type>` has no matching `--nodes=` group is
 stranded.

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -458,6 +458,34 @@ hcloud server list --selector hcloud/node-group
 hcloud server delete <server-id>
 ```
 
+### Stranded autoscaler nodes on a LIVE cluster (removed pool)
+
+Removing a pool from `ksail.prod.yaml` does **not** delete servers already
+running in it. The autoscaler only ever considers nodes that belong to one of
+its configured node groups, so a node whose pool no longer exists becomes
+invisible to scale-down and survives indefinitely — however idle the cluster
+gets. It keeps consuming `maxNodesTotal`, which starves real bursts, and it is
+never rolled, so it drifts behind on Kubernetes and Talos.
+
+Detect it by comparing live node names against the configured groups:
+
+```bash
+# pools the autoscaler actually manages
+kubectl -n kube-system get deploy cluster-autoscaler-hetzner-cluster-autoscaler \
+  -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{@}{"\n"}{end}' | grep '^--nodes='
+# every autoscaler-provisioned node currently registered
+kubectl get nodes -o name | grep '/autoscale-'
+```
+
+Any `autoscale-<type>-*` node whose `<type>` has no matching `--nodes=` group is
+stranded. Drain it and delete its server (same `hcloud server delete` as above).
+Longhorn replicas must move first; `restrict-storage-to-baseline-workers` and
+`drain-autoscale-node-storage` cover these nodes because they key on the node
+*name*, not on the `ksail.io/autoscaled` label — which a node predating
+ksail#5113 does not carry.
+
+Whenever you remove a pool, check for its running nodes in the same change.
+
 ### Autoscaler node not joining cluster
 
 ```bash

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -14,7 +14,7 @@ KSail natively installs and manages the Cluster Autoscaler when
 ```
 KSail (static baseline)
 ├── 3 control planes (cx33, 4 vCPU / 8 GB, never autoscaled)
-└── 3 static workers (cx33, 4 vCPU / 8 GB, guaranteed minimum, Longhorn storage nodes)
+└── 3 static workers (cx43, 8 vCPU / 16 GB, guaranteed minimum, Longhorn storage nodes)
 
 Cluster Autoscaler (dynamic workers, managed by KSail)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
@@ -1,7 +1,7 @@
 # Prod / FinOps-only: bias workload scheduling toward the static baseline
 # workers so the cost-optimized autoscaler nodes (the `autoscale-cx*` pools in
 # ksail.prod.yaml) stay idle and scale back to zero whenever the baseline has
-# room. The baseline (3 cx33 workers) is paid for 24/7; every autoscaler node
+# room. The baseline (3 cx43 workers) is paid for 24/7; every autoscaler node
 # is incremental spend, so keeping them empty until the baseline is full is the
 # cheapest steady state.
 #
@@ -17,17 +17,25 @@
 # planes do NOT. SHIPPED: KSail stamps the label since ksail#5113, so this
 # policy is ACTIVE — pods are biased toward the baseline workers.
 #
-# ⚠️ COVERAGE IS NOT UNIVERSAL — the label is stamped at node CREATION and is
-# never applied retroactively, so any autoscaler node that predates ksail#5113
-# carries no label and this policy silently does not see it. That is not
-# hypothetical: measured on prod 2026-08-16, the two long-lived
-# `autoscale-cx33-*` nodes had NO `ksail.io/autoscaled` label while the current
-# cx43 node did. Those two were created about a day before the label shipped,
-# so workloads kept landing on them and they sat at ~63% CPU requests — above
-# the 50% scale-down-utilization threshold, which is self-reinforcing. Node
-# affinity matches label VALUES and supports no wildcard, so a name-based
-# `autoscale-*` discriminator (the one its two sibling policies use) is not
-# expressible here; the durable fix is deleting stranded nodes, see #3178.
+# ⚠️ AN UNLABELLED AUTOSCALER NODE IS PREFERRED, NOT IGNORED — and that is the
+# dangerous direction. The preference below matches `ksail.io/autoscaled` with
+# `DoesNotExist`, so a node lacking the label is indistinguishable from a
+# baseline worker and receives the SAME weight-100 preference. The bias does not
+# merely fail to steer pods away from such a node; it actively steers them
+# toward it.
+#
+# The label is stamped at node CREATION and never applied retroactively, so any
+# autoscaler node predating ksail#5113 is permanently in that state. Measured on
+# prod 2026-08-16: the two long-lived `autoscale-cx33-*` nodes carried NO
+# `ksail.io/autoscaled` label while the then-current cx43 node did. They had
+# been created about a day before the label shipped, and had accumulated 34 and
+# 33 pods at ~63% CPU requests — above the 50% scale-down-utilization threshold,
+# so the accumulation was self-reinforcing (#3178).
+#
+# There is no in-policy fix: node affinity matches label VALUES and supports no
+# wildcard, so the name-based `autoscale-*` discriminator its two sibling
+# policies use is not expressible here. The durable fix is to not leave stranded
+# nodes running — see #3178 and docs/dr/runbook.md.
 #
 # Note the label does NOT gate Longhorn's default-disk creation (that keys exclusively
 # on node.longhorn.io/create-default-disk, still stamped by the shared Talos
@@ -61,7 +69,9 @@ metadata:
       Adds a soft (preferred) node affinity biasing pods toward the static
       baseline workers and away from the cost-optimized autoscaler nodes
       (labelled ksail.io/autoscaled=true), so autoscaler capacity stays minimal
-      for better FinOps. Inert until KSail labels its autoscaler nodes.
+      for better FinOps. Active since KSail began stamping the label
+      (ksail#5113); a node created before that carries no label and is treated
+      as baseline.
 spec:
   rules:
     - name: prefer-baseline-nodes

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
@@ -14,10 +14,22 @@
 #
 # DISCRIMINATOR — KSail contract: autoscaler-provisioned nodes carry the node
 # label `ksail.io/autoscaled: "true"`; baseline (static) workers and control
-# planes do NOT. SHIPPED: KSail stamps the label since ksail#5113 (verified on
-# the live prod autoscale-cx33 nodes, 2026-07-01), so this policy is ACTIVE —
-# pods created since then are biased toward the baseline workers. Note the
-# label does NOT gate Longhorn's default-disk creation (that keys exclusively
+# planes do NOT. SHIPPED: KSail stamps the label since ksail#5113, so this
+# policy is ACTIVE — pods are biased toward the baseline workers.
+#
+# ⚠️ COVERAGE IS NOT UNIVERSAL — the label is stamped at node CREATION and is
+# never applied retroactively, so any autoscaler node that predates ksail#5113
+# carries no label and this policy silently does not see it. That is not
+# hypothetical: measured on prod 2026-08-16, the two long-lived
+# `autoscale-cx33-*` nodes had NO `ksail.io/autoscaled` label while the current
+# cx43 node did. Those two were created about a day before the label shipped,
+# so workloads kept landing on them and they sat at ~63% CPU requests — above
+# the 50% scale-down-utilization threshold, which is self-reinforcing. Node
+# affinity matches label VALUES and supports no wildcard, so a name-based
+# `autoscale-*` discriminator (the one its two sibling policies use) is not
+# expressible here; the durable fix is deleting stranded nodes, see #3178.
+#
+# Note the label does NOT gate Longhorn's default-disk creation (that keys exclusively
 # on node.longhorn.io/create-default-disk, still stamped by the shared Talos
 # worker config) — replica placement is handled separately by
 # restrict-storage-to-baseline-workers.yaml in this folder. Also note the bias

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/capacity-buffer.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/capacity-buffer.yaml
@@ -38,7 +38,7 @@ metadata:
     app.kubernetes.io/part-of: platform
 spec:
   # One warm spare node. Raise to widen the buffer (N chunks ~= N warm nodes),
-  # bounded by ksail.prod.yaml's maxNodesTotal: 10.
+  # bounded by ksail.prod.yaml's maxNodesTotal: 9.
   replicas: 1
   # Shape of one chunk — see pod-template.yaml (same namespace).
   podTemplateRef:

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -99,6 +99,14 @@ spec:
         # ships ksail#5277 (post-v7.58.3); the CI/CD KSAIL_VERSION pin
         # (renovate-managed) must reach it first.
         capacityBuffers: true
+        # ⚠️ REMOVING A POOL DOES NOT DELETE ITS RUNNING SERVERS. The autoscaler
+        # only considers nodes inside a configured node group, so a node whose
+        # pool is deleted here becomes invisible to scale-down and survives
+        # indefinitely — still consuming maxNodesTotal and still billed. Dropping
+        # the cx33 pool in #2420 stranded two live cx33 nodes for 47 days exactly
+        # this way (#3178). When removing a pool, drain and delete its nodes in
+        # the same change: docs/dr/runbook.md → "Stranded autoscaler nodes on a
+        # LIVE cluster".
         pools:
           - name: autoscale-cx43
             serverType: cx43


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Two autoscaler nodes have been running for 47 days that nothing will ever reclaim. Removing a pool from `ksail.prod.yaml` does not delete servers already running in it, and the autoscaler only ever considers nodes inside a configured node group — so those nodes become invisible to scale-down while still consuming the node budget. Dropping the cx33 pool in #2420 stranded two live nodes exactly this way, and nothing in the repo said it could happen.

Three statements in the repo were also disproved by measuring the live cluster, including one that claimed a FinOps guard covered nodes it does not actually see.

### What

Documents the live-cluster stranding case in the DR runbook with a detection command, warns at the pools block where pool removal is actually made, and corrects the three stale statements.

Comments and documentation only — no policy or config behaviour changes.

**This PR does not free the capacity.** Deleting the stranded servers is an imperative operation that evicts ~67 running pods, tracked in #3178.

Part of #3178
