### PR TITLE
fix(longhorn): reclaim orphaned replica directories automatically

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -65,7 +65,7 @@ spec:
       # ReplicaSchedulingFailure indefinitely rather than recovering. Measured on
       # prod 2026-08-16: 16 orphan directories, 14 of them on prod-worker-1,
       # which sat at 24% available and DiskPressure while two CNPG databases
-      # stayed stuck at 2 of 3 replicas (#3180).
+      # stayed stuck at 2 of 3 replicas (#3201).
       #
       # replica-data is the only type that reclaims disk; orphaned instances are
       # runtime processes and are deliberately not swept here.

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -50,6 +50,26 @@ spec:
       # healthy replica behind. (Use least-effort if rebuild churn on frequent
       # autoscaler scale-ups becomes a concern.)
       replicaAutoBalance: best-effort
+      # Reclaim orphaned replica DIRECTORIES, not just deleted volumes. Longhorn
+      # detects replica data left behind on disk (an Orphan CR per directory,
+      # DataCleanable=True) but with this setting empty — the chart default — it
+      # never deletes any of it. Autoscaler scale-downs and worker rolls produce
+      # these steadily, so a storage node accumulates dead directories until it
+      # crosses storage-minimal-available-percentage (25%) and its disk flips to
+      # Schedulable=False (DiskPressure).
+      #
+      # That is not cosmetic: replica-soft-anti-affinity is false (hard
+      # anti-affinity), so with three storage nodes every replica of a
+      # 3-replica volume needs a distinct node. One node under the threshold
+      # means a degraded volume can NEVER rebuild — it sits at
+      # ReplicaSchedulingFailure indefinitely rather than recovering. Measured on
+      # prod 2026-08-16: 16 orphan directories, 14 of them on prod-worker-1,
+      # which sat at 24% available and DiskPressure while two CNPG databases
+      # stayed stuck at 2 of 3 replicas (#3180).
+      #
+      # replica-data is the only type that reclaims disk; orphaned instances are
+      # runtime processes and are deliberately not swept here.
+      orphanResourceAutoDeletion: replica-data
       # Reclaim space from deleted volumes automatically.
       autoDeletePodWhenVolumeDetachedUnexpectedly: true
       # Only create default disks on nodes explicitly labeled for storage.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -838,23 +838,40 @@ const (
 // That accounting is inherited from that measurement and has NOT been re-verified
 // against 9a84e92b.
 //
-// ⚠️ THE VALUE BELOW IS AN UNMEASURED PLACEHOLDER — it is clean main's digest
-// carried through, and the merge result is known NOT to equal it, because the
-// Longhorn HelmRelease is a selected document whose content moved. It is recorded
-// this way rather than guessed: neither renderer could measure the merge result
-// during this run. The render accumulates a pinned remote resource
-// (kubelet-serving-cert-approver v0.11.0 ha-install.yaml) and
-// raw.githubusercontent.com returned HTTP 429 on both attempts, so the local
-// render aborted before producing any surface — an infrastructure failure, not a
-// measurement.
+// MEASURED — this discharges the placeholder that stood here. The required
+// `🔐 Validate EKS Authorization` job rejected clean main's carried-through digest
+// exactly as predicted and reported the merge result's actual value, recorded
+// below from run 32070742779 at head 74676d5a.
 //
-// The required job is therefore expected to REJECT this value and report the merge
-// result's actual digest. Before this PR is promoted: record that reported digest
-// here, and re-verify the conservation above against 9a84e92b — membership
-// identical by set difference in both directions, zero per-identity mismatches and
-// zero missing resources against expectedRenderedHashes, so the aggregate is the
-// only control that moved.
-const expectedRenderedSurfaceSHA = "b5b394181a8f2bc325bd427a90990fbc3872fb1f41f3d938f1e28f0aac1075f4"
+// Taken on exact main feaf5059, which is NEWER than the 9a84e92b the placeholder
+// named: the branch was levelled to `behind_by` 0 before the measurement, so this
+// digest describes the current merge result rather than the older one.
+//
+// Conservation re-verified at that head, which is what the placeholder required
+// before promotion: the aggregate is the ONLY control that moved — zero
+// per-identity mismatches, zero missing resources, and zero duplicates against
+// expectedRenderedHashes, so every individually approved entry is byte-identical
+// and surface MEMBERSHIP is unchanged. The run reports the same 35
+// unresolved-substitution notes clean main reports.
+//
+// The earlier CDN failure that blocked measurement is not repaired by this and is
+// not silently dropped: the render still accumulates pinned remote resources over
+// the network (tracked as #3196), so a local render remains unavailable here. Only
+// ONE renderer therefore stands behind this digest — the approved CI toolchain.
+// The local kubectl is v1.36.1 against an approved v1.36.2, so
+// validateRendererVersion fails closed and cannot corroborate.
+//
+// One independent observation does corroborate that only this branch's own delta
+// moves the digest: the required job reported this IDENTICAL value at head
+// 07ec2b5f, before main was merged in, and again at 74676d5a after four further
+// main commits. Those commits therefore did not move the authorization surface.
+// That is evidence about what did NOT change; it is not a second rendering of what
+// did.
+//
+// The delta remains authorization-neutral — one chart value under spec.values,
+// carrying no rules, subjects, verbs, or apiGroups line, and moving no identity,
+// ServiceAccount, binding, or chart/source pin.
+const expectedRenderedSurfaceSHA = "489afc6651045b6643ee40e0098234a873174a8d807690efb0245aaf92f87a4b"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -966,31 +966,49 @@ const (
 // resource, or verb is added anywhere, and nothing granted to the aws/aws service
 // account this validator protects is touched.
 //
-// ⚠️ THE VALUE BELOW IS AN UNMEASURED PLACEHOLDER for the current merge result —
-// it is clean main's digest carried through, and the merge result is known NOT to
-// equal it.
-//
-// Re-approval is required after merging main 6c5506fe into this branch. Both
+// The merge of main 6c5506fe into this branch needed re-approval, because both
 // parents had re-approved this constant independently — this branch for the #3181
 // Longhorn orphan-reclamation chart value (`489afc66`, recorded above), and main
 // for the #2709 Dex maintainers-team narrowing (`8773eaf0`) — so NEITHER parent's
-// value describes the merge result and the conflict cannot be resolved by picking
-// a side. Both records are retained because both deltas are present in the merged
-// surface: main's Dex connector narrowing AND this branch's Longhorn chart value.
+// value described the merge result and the conflict could not be resolved by
+// picking a side. Both records are retained because both deltas are present in the
+// merged surface: main's Dex connector narrowing AND this branch's Longhorn chart
+// value.
 //
-// Both deltas are individually measured and individually authorization-neutral or
-// privilege-reducing, and neither moved surface MEMBERSHIP (each was measured with
-// zero per-identity mismatches, zero missing, zero duplicates). What is unmeasured
-// is only their AGGREGATE digest, which necessarily differs from both parents
-// because both are selected documents whose content moved.
+// The merge result is now MEASURED, and is the value recorded below. The required
+// `🔐 Validate EKS Authorization` job rejected the carried-through placeholder at
+// head 2ec723d9 (run 32073398792) and reported the merge result's actual digest.
+// It was taken with the branch level against main 6c5506fe — `behind_by` is 0 — so
+// it describes the merge result rather than a stale rendering of it.
 //
-// The required `🔐 Validate EKS Authorization` job is therefore expected to REJECT
-// this value and report the merge result's actual digest. Before this PR is
-// promoted: record that reported digest here, and re-verify the conservation above
-// against 6c5506fe — zero per-identity mismatches, zero missing and zero duplicate
-// resources against expectedRenderedHashes, and the substitution-note count equal
-// to clean main's, so the aggregate is the only control that moved.
-const expectedRenderedSurfaceSHA = "8773eaf0015f04f14850c5ef025b81657b0ad8d3aab397d99cf969044c04d7e6"
+// Conservation, measured against this branch's OWN pre-merge rendering at head
+// 74676d5a (run 32071082835). That control is what isolates main's contribution:
+// both renderings already contain this branch's Longhorn delta, so their
+// difference is exactly what the merge brought in. Both report the same 35
+// unresolved-substitution notes, all 35 distinct, with ZERO resources added, ZERO
+// removed and ZERO duplicated — surface MEMBERSHIP is unchanged. Exactly TWO
+// per-identity fingerprints move:
+//
+//	HelmRelease dex/dex                    c62d1a9f… → 6192cf46…
+//	HelmRelease oauth2-proxy/oauth2-proxy  60750d76… → 24f03c83…
+//
+// Those are precisely the two manifests #2709 changes — it touches
+// `controllers/dex/helm-release.yaml`, `controllers/oauth2-proxy/helm-release.yaml`
+// and this validator, the last of which is not in the surface. So the prediction
+// was falsifiable and held: had the merge carried anything else into the
+// authorization surface, a third identity would have moved. Main 6c5506fe contains
+// #2709 and PASSES the required job against its own digest `8773eaf0`, so both
+// moved documents are already approved on main. Nothing outside them moved, which
+// leaves the aggregate as the only control this merge changes. Main's own digest is
+// recorded here in full, so replacing the constant does not lose it:
+//
+//	8773eaf0015f04f14850c5ef025b81657b0ad8d3aab397d99cf969044c04d7e6
+//
+// Only ONE renderer stands behind this value, as with the records above: the
+// approved CI toolchain, via the required job. The local kubectl is v1.36.1
+// against an approved v1.36.2, so validateRendererVersion fails closed and cannot
+// corroborate.
+const expectedRenderedSurfaceSHA = "ed2767037a88348b22ec8ecfcc8b2081e86b7979dfe3c86d554034980af01fdf"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -587,7 +587,26 @@ const (
 // main cdababde. The persistence annotations introduced by #3168 remain in
 // every surviving selected object; #2741 removes only the already-protected
 // Headlamp PVC identity and retains the authorization-neutral changes above.
-const expectedRenderedSurfaceSHA = "6e6753583bbffa59ce236412f63f27e3d77d03739742ef0a3a34596eb96c5f2a"
+//
+// Re-approved for #3181 (2026-08-17), which reclaims orphaned Longhorn replica
+// directories. Measured by rendering the hetzner infrastructure/controllers
+// root with main's copy of the single changed file and again with the head's
+// copy. The complete rendered delta across the whole surface is ONE added line
+// inside an existing object:
+//
+//	helm.toolkit.fluxcd.io/v2  HelmRelease  longhorn-system/longhorn
+//	+      orphanResourceAutoDeletion: replica-data
+//
+// That is a Helm chart value under spec.values. No identity, ServiceAccount,
+// binding, rule, subject, verb, apiGroup, or chart/source pin moved: the root
+// retains 177 documents and 21 distinct Role / ClusterRole / RoleBinding /
+// ClusterRoleBinding objects on both sides, and the delta contains no rules:,
+// subjects:, verbs:, or apiGroups: line. The direct EKS role and
+// permissions-boundary inputs are untouched — the PR changes exactly one file.
+// The value only authorizes Longhorn's own manager to delete replica data it
+// has already marked DataCleanable on disks it owns; it grants nothing to the
+// aws/aws service account this selector protects.
+const expectedRenderedSurfaceSHA = "4e7b77bc8012f412c723a20f9320b7f953c842db450e6e609d943baa68527d24"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Longhorn spots replica data left behind on disk and files an Orphan record for each directory — but it never deletes any of it, because the auto-deletion setting ships empty. Every autoscaler scale-down and worker roll adds more, so a storage node slowly fills with dead data until it drops below the free-space threshold and stops accepting replicas.

That is what just happened on prod: one worker was holding 14 orphaned directories, sat at 24% free, and went `DiskPressure`. Because replicas must live on distinct nodes and there are only three storage nodes, two databases were then **unable to rebuild their third replica at all** — stuck degraded indefinitely rather than recovering on their own.

### What

Turns on automatic reclamation of orphaned replica data, so this space comes back without anyone noticing it was gone.

Verified against the pinned chart: the setting reaches Longhorn's rendered configuration when set, and is absent when not — so this genuinely changes behaviour rather than being a silent no-op. Orphaned *instances* are deliberately left alone; only disk-consuming replica data is swept.

Fixes #3201
