### PR TITLE
fix(deploy): ignore the autoscaler's advisory removal-candidate taint

### DIFF
--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -139,22 +139,23 @@ node_claim_preconditions_still_hold() {
     --arg uid "${initial_node_uid}" \
     --argjson was_cordoned "${was_cordoned}" \
     --argjson initial_taints "${initial_node_taints}" '
+    def scheduling_taints:
+      map(select((
+        (.key == "node.kubernetes.io/unschedulable"
+          and .effect == "NoSchedule"
+          and (.value // "") == "")
+        or (.key == "DeletionCandidateOfClusterAutoscaler"
+          and .effect == "PreferNoSchedule")
+      ) | not))
+      | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]);
     .metadata.uid == $uid
     and .metadata.deletionTimestamp == null
     and ((.metadata.annotations[$owner_annotation] // "") == "")
     and ((.metadata.annotations[$recovery_annotation] // "") == "")
     and ((if (.spec.unschedulable // false) then 1 else 0 end)
       == $was_cordoned)
-    and (((.spec.taints // [])
-      | map(select((
-          (.key == "node.kubernetes.io/unschedulable"
-            and .effect == "NoSchedule"
-            and (.value // "") == "")
-          or (.key == "DeletionCandidateOfClusterAutoscaler"
-            and .effect == "PreferNoSchedule")
-        ) | not))
-      | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]))
-      == $initial_taints)
+    and (((.spec.taints // []) | scheduling_taints)
+      == ($initial_taints | scheduling_taints))
   ' "${state_file}" >/dev/null
 }
 
@@ -178,20 +179,21 @@ node_scheduling_state_is_safe_to_reboot() {
     --arg uid "${initial_node_uid}" \
     --argjson was_cordoned "${was_cordoned}" \
     --argjson initial_taints "${initial_node_taints}" '
+    def scheduling_taints:
+      map(select((
+        (.key == "node.kubernetes.io/unschedulable"
+          and .effect == "NoSchedule"
+          and (.value // "") == "")
+        or (.key == "DeletionCandidateOfClusterAutoscaler"
+          and .effect == "PreferNoSchedule")
+      ) | not))
+      | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]);
     .metadata.uid == $uid
     and .metadata.deletionTimestamp == null
     and .spec.unschedulable == true
     and .metadata.annotations[$owner_annotation] == $owner
-    and (((.spec.taints // [])
-      | map(select((
-          (.key == "node.kubernetes.io/unschedulable"
-            and .effect == "NoSchedule"
-            and (.value // "") == "")
-          or (.key == "DeletionCandidateOfClusterAutoscaler"
-            and .effect == "PreferNoSchedule")
-        ) | not))
-      | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]))
-      == $initial_taints)
+    and (((.spec.taints // []) | scheduling_taints)
+      == ($initial_taints | scheduling_taints))
   ' "${state_file}" >/dev/null
 }
 

--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -147,9 +147,11 @@ node_claim_preconditions_still_hold() {
       == $was_cordoned)
     and (((.spec.taints // [])
       | map(select((
-          .key == "node.kubernetes.io/unschedulable"
-          and .effect == "NoSchedule"
-          and (.value // "") == ""
+          (.key == "node.kubernetes.io/unschedulable"
+            and .effect == "NoSchedule"
+            and (.value // "") == "")
+          or (.key == "DeletionCandidateOfClusterAutoscaler"
+            and .effect == "PreferNoSchedule")
         ) | not))
       | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]))
       == $initial_taints)
@@ -182,9 +184,11 @@ node_scheduling_state_is_safe_to_reboot() {
     and .metadata.annotations[$owner_annotation] == $owner
     and (((.spec.taints // [])
       | map(select((
-          .key == "node.kubernetes.io/unschedulable"
-          and .effect == "NoSchedule"
-          and (.value // "") == ""
+          (.key == "node.kubernetes.io/unschedulable"
+            and .effect == "NoSchedule"
+            and (.value // "") == "")
+          or (.key == "DeletionCandidateOfClusterAutoscaler"
+            and .effect == "PreferNoSchedule")
         ) | not))
       | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]))
       == $initial_taints)
@@ -216,6 +220,8 @@ node_scheduling_state_is_safe_while_lifecycle_taints_clear() {
         (.key == "node.kubernetes.io/unschedulable"
           and .effect == "NoSchedule"
           and (.value // "") == "")
+        or (.key == "DeletionCandidateOfClusterAutoscaler"
+          and .effect == "PreferNoSchedule")
         or .key == "node.kubernetes.io/not-ready"
         or .key == "node.kubernetes.io/unreachable"
         or .key == "node.cilium.io/agent-not-ready"

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -569,9 +569,11 @@ report_fences_now() {
     # ignore, so the report would refuse releases the bridge would perform.
     def scheduling_taints:
       map(select((
-        .key == "node.kubernetes.io/unschedulable"
-        and .effect == "NoSchedule"
-        and (.value // "") == ""
+        (.key == "node.kubernetes.io/unschedulable"
+          and .effect == "NoSchedule"
+          and (.value // "") == "")
+        or (.key == "DeletionCandidateOfClusterAutoscaler"
+          and .effect == "PreferNoSchedule")
       ) | not))
       | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]);
     .items[]
@@ -2480,9 +2482,11 @@ prepare_runtime_bootstrap_roll() {
     if ! initial_taints="$(jq -ecS '
       (.spec.taints // [])
       | map(select((
-          .key == "node.kubernetes.io/unschedulable"
-          and .effect == "NoSchedule"
-          and (.value // "") == ""
+          (.key == "node.kubernetes.io/unschedulable"
+            and .effect == "NoSchedule"
+            and (.value // "") == "")
+          or (.key == "DeletionCandidateOfClusterAutoscaler"
+            and .effect == "PreferNoSchedule")
         ) | not))
       | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")])
     ' "${cordon_state_file}")"; then
@@ -2833,9 +2837,11 @@ process_talos_node_target() {
     initial_node_taints="$(jq -cS '
         (.spec.taints // [])
         | map(select((
-            .key == "node.kubernetes.io/unschedulable"
-            and .effect == "NoSchedule"
-            and (.value // "") == ""
+            (.key == "node.kubernetes.io/unschedulable"
+              and .effect == "NoSchedule"
+              and (.value // "") == "")
+            or (.key == "DeletionCandidateOfClusterAutoscaler"
+              and .effect == "PreferNoSchedule")
           ) | not))
         | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")])
       ' "${cordon_state_file}")"

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1328,6 +1328,20 @@ func fakeKubectlGetNode(args []string) int {
 			"effect": "NoSchedule",
 		})
 	}
+	// Reproduce the autoscaler's advisory removal-candidate marker being RELEASED
+	// while the bridge holds the node: present when the claim captures the node's
+	// taints, gone by the time the pre-reboot guard re-reads it. Observed in prod on
+	// 2026-08-17, where the autoscaler added the taint at 00:11:26, released it at
+	// 00:15:43, and the deploy's guard refused 23s later. The value is a timestamp the
+	// autoscaler regenerates on every add, so it churns even key-for-key.
+	if nodeName == os.Getenv("FAKE_AUTOSCALER_DELETION_CANDIDATE_RELEASED_NODE") &&
+		!markerExists("drained-"+nodeName) {
+		taints = append(taints, map[string]any{
+			"key":    "DeletionCandidateOfClusterAutoscaler",
+			"value":  "1786925486",
+			"effect": "PreferNoSchedule",
+		})
+	}
 	if markerExists("uncordoned-"+nodeName) &&
 		nodeName == os.Getenv("FAKE_TRANSIENT_UNSCHEDULABLE_TAINT_AFTER_RELEASE_NODE") {
 		readMarker := "post-release-node-read-count-" + nodeName

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
@@ -400,6 +400,27 @@ func TestAutoscalerTaintIsNeverUncordoned(t *testing.T) {
 	}
 }
 
+// The autoscaler's DeletionCandidateOfClusterAutoscaler taint is advisory
+// (PreferNoSchedule) and churns on the autoscaler's ~10s re-evaluation loop. It says a
+// node COULD be removed, never that it is being removed, so its coming and going is not
+// a scheduling-safety change and must not evict the deploy from the merge queue.
+// TestAutoscalerTaintIsNeverUncordoned is the negative control: the hard
+// ToBeDeletedByClusterAutoscaler taint must still fail closed.
+func TestAutoscalerDeletionCandidateTaintDoesNotBlockDeploy(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_AUTOSCALER_DELETION_CANDIDATE_RELEASED_NODE": "prod-worker-1",
+	})
+	requireSuccessResult(t, result)
+	requireNotContains(t, result.stdout+result.stderr, "scheduling safety state changed")
+	operations := readLines(f.operationLog)
+	requireLine(t, operations, "node-drain:prod-worker-1")
+	requireLine(t, operations, "talos-reboot:10.0.0.2")
+	requireLine(t, operations, "node-uncordon:prod-worker-1")
+	requireLine(t, operations, "root-patch")
+}
+
 func TestExternalUncordonAfterDrainBlocksReboot(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)

--- a/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/tests/test-refresh-flux-ghcr-auth-safety.sh
@@ -573,6 +573,33 @@ else
   fail "an etcd status error blocks a control-plane reboot"
 fi
 
+# The cluster autoscaler's advisory removal-candidate taint must not read as a
+# scheduling-safety change, in EITHER observation. A recovery journal written before
+# that exclusion existed still carries the taint in its captured initialTaints, so the
+# comparison normalizes both sides; otherwise the fix would hold on a fresh deploy and
+# still refuse on the recovery path a killed deploy leaves behind.
+autoscaler_node="${work_dir}/autoscaler-candidate-node.json"
+jq -n '{
+  metadata: {uid: "node-uid-1", annotations: {"platform.devantler.tech/ghcr-auth-drain-owner": "owner-token"}},
+  spec: {unschedulable: true, taints: [{key: "node.kubernetes.io/unschedulable", effect: "NoSchedule"}]}
+}' >"${autoscaler_node}"
+
+if node_scheduling_state_is_safe_to_reboot \
+  "${autoscaler_node}" 1 owner-token node-uid-1 \
+  '[{"key":"DeletionCandidateOfClusterAutoscaler","value":"1786925486","effect":"PreferNoSchedule"}]'; then
+  pass "a released autoscaler removal-candidate taint still permits a reboot"
+else
+  fail "a released autoscaler removal-candidate taint still permits a reboot"
+fi
+
+if node_scheduling_state_is_safe_to_reboot \
+  "${autoscaler_node}" 1 owner-token node-uid-1 \
+  '[{"key":"ToBeDeletedByClusterAutoscaler","effect":"NoSchedule"}]'; then
+  fail "a released autoscaler deletion taint blocks a reboot"
+else
+  pass "a released autoscaler deletion taint blocks a reboot"
+fi
+
 if ((failures > 0)); then
   printf '%d safety regression test(s) failed\n' "${failures}" >&2
   exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Every platform merge has been blocked: three prod deploys were evicted from the merge queue in
under two hours, each refusing with `scheduling safety state changed`. The deploy's node-safety
transaction was treating an ordinary autoscaler scale event as a safety violation.

The cluster autoscaler continuously marks under-used nodes as *removal candidates* and then
un-marks them, roughly every ten seconds. The deploy holds a node for minutes, so it was almost
guaranteed to see that marker come or go and refuse — even though nothing about the node's actual
safety had changed.

### What

The deploy now ignores that advisory "could be removed" marker when deciding whether a node is
still safe to touch, so routine autoscaling no longer evicts a deploy.

The separate marker that means a node **is** being deleted is deliberately left in place and still
stops the deploy, so nothing is loosened where it matters. A test covering that case is included
alongside the fix and is what proves the distinction holds.

Verified against the real failure: the new test reproduces the exact production error, fails
without the fix, and passes with it.

Refs #3184
