### PR TITLE
feat(ci): recover a provably-dead GHCR deploy fence automatically

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -31,6 +31,16 @@ inputs:
       (secrets.WG_SERVER_PRIVATE_KEY); env-expanded by ksail into
       talos/control-planes/wireguard.yaml when rendering machine config.
     required: true
+  recover-orphaned-fence:
+    description: >-
+      Release the GHCR synchronization Lease before staging when its holder is a
+      GitHub run the API reports terminal, no other fence is held, and its
+      heartbeat has stopped. Default-off: a deploy that dies holding the Lease
+      blocks every later deploy AND its own heal path, and clearing that today
+      needs a human with cluster write access. Any unproven condition refuses
+      rather than releasing.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -175,6 +185,20 @@ runs:
       env:
         HCLOUD_TOKEN: ${{ inputs.hcloud-token }}
       run: ./scripts/guard-cilium-homogeneous-device-rollout.sh --before-publish
+
+    - name: 🧯 Recover an orphaned GHCR deploy fence
+      # Runs BEFORE staging, because staging is what fails when the Lease is
+      # orphaned — and both the deploy job and the heal job reach this composite,
+      # so one step covers the two paths that wedge together.
+      #
+      # GH_TOKEN is what makes the liveness proof possible: the holder identity
+      # embeds its run reference, and only the API can say whether that attempt
+      # is terminal. Without it the script refuses rather than guessing.
+      if: inputs.recover-orphaned-fence == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/refresh-flux-ghcr-auth.sh --recover-fences
 
     - name: 🔑 Stage Flux and consumer GHCR pull credential
       id: stage_flux_ghcr_auth

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -172,6 +172,7 @@ jobs:
       packages: write # push OCI artifacts to GHCR
       id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
       attestations: write # write SBOM + SLSA provenance attestations (see deploy-prod action)
+      actions: read # read a prior run attempt status, to prove an orphaned fence holder is dead (deploy-prod recover-orphaned-fence)
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1047,6 +1047,7 @@ jobs:
       packages: write # push OCI artifacts to GHCR
       id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
       attestations: write # write SBOM + SLSA provenance attestations (see deploy-prod action)
+      actions: read # read a prior run attempt status, to prove an orphaned fence holder is dead (deploy-prod recover-orphaned-fence)
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1107,6 +1108,7 @@ jobs:
       packages: write # push OCI artifacts to GHCR
       id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
       attestations: write # write SBOM + SLSA provenance attestations (see deploy-prod action)
+      actions: read # read a prior run attempt status, to prove an orphaned fence holder is dead (deploy-prod recover-orphaned-fence)
     steps:
       - name: 📑 Checkout main
         # Deploy the CURRENT tip of `main` (the last state that actually landed in

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -409,7 +409,12 @@ fence_report_lease() {
   # A second read could land either side of a fresh acquisition, which would let
   # recovery act on a holder the operator never saw evidence for.
   fence_lease_holder="${holder}"
-  if ! cp -- "${state}" "${fence_lease_state_file}"; then
+  # Only recovery consumes the retained copy, and only the mode dispatch sets the
+  # path. Guarded so a caller that reports without recovering cannot turn an
+  # unset path into a failed `cp` and lose the report itself — which is read
+  # precisely when a deploy is already refusing to start.
+  if [[ -n "${fence_lease_state_file}" ]] &&
+    ! cp -- "${state}" "${fence_lease_state_file}"; then
     echo "::error::Could not retain the GHCR synchronization lease state."
     return 1
   fi

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -19,10 +19,11 @@ require_flux_ghcr_yaml_tool
 check_only=false
 allow_incomplete_fanout=false
 report_fences=false
+recover_fences=false
 record_runtime_proof_path=""
 reuse_runtime_proof_path=""
 usage() {
-  echo "Usage: $0 [--check-only|--allow-incomplete-fanout|--fences|--record-runtime-proof PATH|--reuse-runtime-proof PATH]" >&2
+  echo "Usage: $0 [--check-only|--allow-incomplete-fanout|--fences|--recover-fences|--record-runtime-proof PATH|--reuse-runtime-proof PATH]" >&2
 }
 while (($# > 0)); do
   case "$1" in
@@ -36,6 +37,10 @@ while (($# > 0)); do
       ;;
     --fences)
       report_fences=true
+      shift
+      ;;
+    --recover-fences)
+      recover_fences=true
       shift
       ;;
     --record-runtime-proof | --reuse-runtime-proof)
@@ -66,10 +71,20 @@ fi
 # exits before any credential or proof work runs, so accepting it alongside an
 # operational mode makes that step exit 0 having silently skipped the operation
 # it was configured to perform — an automation failure that looks like a pass.
-if [[ "${report_fences}" == "true" ]] &&
+#
+# --recover-fences is the same kind of alternative mode and carries the same
+# hazard, so it is rejected alongside an operational mode for the same reason.
+# It is also rejected alongside --fences: --recover-fences already emits the
+# full report as the evidence it acts on, so accepting both would leave the
+# caller's intent ambiguous between "report" and "report and then mutate".
+if { [[ "${report_fences}" == "true" ]] || [[ "${recover_fences}" == "true" ]]; } &&
   { [[ "${check_only}" == "true" ]] ||
     [[ "${allow_incomplete_fanout}" == "true" ]] ||
     [[ -n "${record_runtime_proof_path}${reuse_runtime_proof_path}" ]]; }; then
+  usage
+  exit 64
+fi
+if [[ "${report_fences}" == "true" && "${recover_fences}" == "true" ]]; then
   usage
   exit 64
 fi
@@ -325,6 +340,13 @@ runtime_probe_bootstrap_needed=0
 # still held, states whether the holder is provably dead, and prints the exact
 # CAS-guarded release. It performs no mutation by design: an operator running
 # the printed command is the explicit step the fencing model requires.
+# State the fence report hands to --recover-fences. Declared here, beside the
+# report that populates them, so the two cannot drift apart.
+fence_non_lease_held=0
+fence_lease_holder=""
+fence_lease_heartbeat_live=false
+fence_lease_state_file=""
+
 fence_run_segment() {
   if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
     printf 'gh%s.%s' "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT:-1}"
@@ -382,6 +404,15 @@ fence_report_lease() {
   holder="$(jq -r '.spec.holderIdentity // ""' "${state}")"
   [[ -n "${holder}" ]] || return 0
   held=$((held + 1))
+  # Retain what --recover-fences needs to decide, so recovery reasons over the
+  # SAME observation the report just printed rather than re-reading the Lease.
+  # A second read could land either side of a fresh acquisition, which would let
+  # recovery act on a holder the operator never saw evidence for.
+  fence_lease_holder="${holder}"
+  if ! cp -- "${state}" "${fence_lease_state_file}"; then
+    echo "::error::Could not retain the GHCR synchronization lease state."
+    return 1
+  fi
   duration="$(jq -r '.spec.leaseDurationSeconds // 0' "${state}")"
   now_epoch="$(date -u +%s)"
   renew_epoch="$(fence_report_epoch "$(jq -r '.spec.renewTime // ""' "${state}")")"
@@ -389,6 +420,7 @@ fence_report_lease() {
   printf '    holder: %s\n' "${holder}"
   if [[ -n "${renew_epoch}" ]] &&
     ((now_epoch - renew_epoch < duration)); then
+    fence_lease_heartbeat_live=true
     printf '    renewed %ss ago, inside its %ss duration — the holder is LIVE. Do not recover.\n' \
       "$((now_epoch - renew_epoch))" "${duration}"
   else
@@ -805,6 +837,12 @@ report_fences_now() {
     printf '\n'
   done <"${fence_report_nodes}"
 
+  # Captured BEFORE the Lease is reported, so it counts only the fences the
+  # Lease's own ordering rule says must be released first. --recover-fences
+  # refuses while this is non-zero rather than duplicating the node-journal
+  # grouping above, which is the part that is genuinely hard to get right.
+  fence_non_lease_held="${held}"
+
   fence_report_lease "${state}" || return 1
 
   if ((held == 0)); then
@@ -816,6 +854,111 @@ report_fences_now() {
     printf 'Lease. The Lease is the global exclusion fence: clearing it first lets a\n'
     printf 'deploy start against a half-recovered cluster.\n'
   fi
+}
+
+# Answers "is this holder provably dead?" — never "has its lease expired?".
+#
+# Expiry cannot answer it: the script's own acquisition comment explains that an
+# expired shell process can resume after a timeout takeover and write stale
+# credentials even under CAS, which is why automatic expiry takeover is disabled.
+# A run reported `completed` by the API is different in kind: Actions does not
+# resume a completed attempt, so this is a positive death proof rather than an
+# inference from a clock.
+#
+# Every failure path returns non-zero. An unreadable API, an absent gh, a missing
+# token, an empty body, or any status this does not recognise means NOT PROVEN,
+# never "assume dead" — the whole safety property is that the proof and the
+# release cannot be separated.
+fence_run_is_terminal() {
+  local run_id="$1"
+  local run_attempt="$2"
+  local repository="${GITHUB_REPOSITORY:-devantler-tech/platform}"
+  local status
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::Cannot prove the fence holder is dead: gh is not available. Recover manually after confirming the run is terminal — see docs/dr/runbook.md → 'Recover an orphaned GHCR deploy fence'."
+    return 1
+  fi
+  # The ATTEMPT is pinned. A rerun reuses the run id, so an unpinned query
+  # reports the newest attempt: an orphan left by a finished attempt 1 would
+  # read as live while attempt 2 runs, and — worse for an automatic path — a
+  # finished attempt 2 would vouch for an attempt 1 that is still going.
+  if ! status="$(gh api \
+    "repos/${repository}/actions/runs/${run_id}/attempts/${run_attempt}" \
+    --jq '.status' 2>/dev/null)"; then
+    echo "::error::Cannot prove the fence holder is dead: querying run ${run_id} attempt ${run_attempt} failed. Not recovering."
+    return 1
+  fi
+  if [[ -z "${status}" ]]; then
+    echo "::error::Cannot prove the fence holder is dead: run ${run_id} attempt ${run_attempt} reported no status. Not recovering."
+    return 1
+  fi
+  if [[ "${status}" != "completed" ]]; then
+    echo "::error::Fence holder run ${run_id} attempt ${run_attempt} is ${status}, not completed — the holder is LIVE. Not recovering."
+    return 1
+  fi
+  printf '  run %s attempt %s is completed — holder proven dead.\n' \
+    "${run_id}" "${run_attempt}"
+}
+
+recover_fences_now() {
+  local run_reference run_id run_attempt resource_version patch_file
+
+  report_fences_now || return 1
+
+  printf '\n== Automatic recovery ==\n'
+
+  if [[ -z "${fence_lease_holder}" ]]; then
+    printf 'No Lease fence is held; nothing to recover.\n'
+    return 0
+  fi
+  # The Lease is released LAST for the reason the report states: it is the global
+  # exclusion fence, so clearing it while a policy or node fence is still held
+  # lets a deploy start against a half-recovered cluster. Automation therefore
+  # refuses rather than reordering — the remaining fences need the operator.
+  if ((fence_non_lease_held > 0)); then
+    echo "::error::Refusing to recover the Lease while ${fence_non_lease_held} other fence(s) are held. Release those first, in the order the report prints."
+    return 1
+  fi
+  # Belt and braces against a stale or cached API read: if the heartbeat is still
+  # inside its duration the holder is writing right now, whatever any run status
+  # says.
+  if [[ "${fence_lease_heartbeat_live}" == "true" ]]; then
+    echo "::error::Refusing to recover: the Lease heartbeat is still inside its duration, so the holder is live."
+    return 1
+  fi
+  if ! run_reference="$(fence_holder_run_reference "${fence_lease_holder}")"; then
+    echo "::error::Refusing to recover: holder '${fence_lease_holder}' carries no run reference, so its liveness cannot be proven from the API. This is the expected shape for a local run; recover manually."
+    return 1
+  fi
+  run_id="${run_reference%% *}"
+  run_attempt="${run_reference##* }"
+  fence_run_is_terminal "${run_id}" "${run_attempt}" || return 1
+
+  # The same CAS the report prints for an operator: both `test` ops must still
+  # hold, so a holder that changed under us aborts the patch instead of losing a
+  # live acquisition.
+  resource_version="$(jq -r '.metadata.resourceVersion' "${fence_lease_state_file}")"
+  patch_file="${work_dir}/fence-recovery-patch.json"
+  jq -nc \
+    --arg rv "${resource_version}" \
+    --arg holder "${fence_lease_holder}" '[
+    {op: "test", path: "/metadata/resourceVersion", value: $rv},
+    {op: "test", path: "/spec/holderIdentity", value: $holder},
+    {op: "replace", path: "/spec/holderIdentity", value: ""},
+    {op: "replace", path: "/spec/leaseDurationSeconds", value: 1}
+  ]' >"${patch_file}"
+  if ! kubectl \
+    --context "${KUBE_CONTEXT}" \
+    --namespace flux-system \
+    patch lease "${SYNC_LEASE_NAME}" \
+    --type=json \
+    --patch-file "${patch_file}"; then
+    echo "::error::Recovery patch was refused; the Lease was not released. Its holder or resourceVersion changed after the report — re-run to re-evaluate."
+    return 1
+  fi
+  printf 'Released Lease flux-system/%s held by %s.\n' \
+    "${SYNC_LEASE_NAME}" "${fence_lease_holder}"
 }
 
 fence_report_epoch() {
@@ -966,7 +1109,8 @@ fence_kustomization_release_command() {
 # Read-only, and deliberately before any credential work: an operator reaches
 # for this exactly when a deploy is refusing to start, so it must not need a
 # GHCR credential, a SOPS key, or a healthy fence to answer.
-if [[ "${report_fences}" == "true" ]]; then
+if [[ "${report_fences}" == "true" || "${recover_fences}" == "true" ]]; then
+  fence_lease_state_file="${work_dir}/fence-lease-state.json"
   # This mode acquires nothing, so the release pass has nothing to do — and it
   # runs before the rest of the file is parsed into functions, so letting the
   # EXIT trap fire would call a cleanup helper that does not exist yet and turn
@@ -974,7 +1118,17 @@ if [[ "${report_fences}" == "true" ]]; then
   # errexit is suspended there, so a FAILED cluster read still reaches the
   # trap-disable below. A bare call would exit through the very handler this
   # has to avoid — and a failing read is exactly when an operator is reading.
-  if report_fences_now; then
+  #
+  # --recover-fences shares that shape: it acquires nothing either, and its own
+  # release is a single CAS patch that either lands or is refused, so there is
+  # still nothing for the release pass to unwind.
+  if [[ "${recover_fences}" == "true" ]]; then
+    if recover_fences_now; then
+      fence_report_status=0
+    else
+      fence_report_status=$?
+    fi
+  elif report_fences_now; then
     fence_report_status=0
   else
     fence_report_status=$?

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -907,7 +907,7 @@ fence_run_is_terminal() {
 }
 
 recover_fences_now() {
-  local run_reference run_id run_attempt resource_version patch_file
+  local run_reference run_id run_attempt patch_file
 
   report_fences_now || return 1
 
@@ -940,19 +940,12 @@ recover_fences_now() {
   run_attempt="${run_reference##* }"
   fence_run_is_terminal "${run_id}" "${run_attempt}" || return 1
 
-  # The same CAS the report prints for an operator: both `test` ops must still
-  # hold, so a holder that changed under us aborts the patch instead of losing a
-  # live acquisition.
-  resource_version="$(jq -r '.metadata.resourceVersion' "${fence_lease_state_file}")"
+  # Literally the same patch the report prints for an operator — one builder, so
+  # the two cannot diverge. It is built from the state the report RETAINED, never
+  # a fresh read, so the CAS tests the observation this decision was made on.
   patch_file="${work_dir}/fence-recovery-patch.json"
-  jq -nc \
-    --arg rv "${resource_version}" \
-    --arg holder "${fence_lease_holder}" '[
-    {op: "test", path: "/metadata/resourceVersion", value: $rv},
-    {op: "test", path: "/spec/holderIdentity", value: $holder},
-    {op: "replace", path: "/spec/holderIdentity", value: ""},
-    {op: "replace", path: "/spec/leaseDurationSeconds", value: 1}
-  ]' >"${patch_file}"
+  fence_lease_release_patch \
+    "${fence_lease_state_file}" "${fence_lease_holder}" >"${patch_file}"
   if ! kubectl \
     --context "${KUBE_CONTEXT}" \
     --namespace flux-system \
@@ -1002,19 +995,34 @@ fence_shell_quote() {
   printf "'%s'" "${literal//$quote/$escaped}"
 }
 
-fence_lease_release_command() {
+# The ONE release patch. Both consumers build it here — the command the report
+# prints for an operator, and the patch --recover-fences applies itself — so the
+# automated path cannot end up on a weaker CAS than the runbook it mirrors.
+# Kept as a single builder deliberately: two copies of a guard that must stay
+# identical will eventually diverge silently, and nothing would fail when they do.
+#
+# Both `test` ops must still hold at apply time, so a Lease that moved after the
+# observation aborts the whole patch instead of clearing a live acquisition.
+fence_lease_release_patch() {
   local state="$1"
   local holder="$2"
-  local patch
 
-  patch="$(jq -nc \
+  jq -nc \
     --arg rv "$(jq -r '.metadata.resourceVersion' "${state}")" \
     --arg holder "${holder}" '[
     {op: "test", path: "/metadata/resourceVersion", value: $rv},
     {op: "test", path: "/spec/holderIdentity", value: $holder},
     {op: "replace", path: "/spec/holderIdentity", value: ""},
     {op: "replace", path: "/spec/leaseDurationSeconds", value: 1}
-  ]')"
+  ]'
+}
+
+fence_lease_release_command() {
+  local state="$1"
+  local holder="$2"
+  local patch
+
+  patch="$(fence_lease_release_patch "${state}" "${holder}")"
   printf "kubectl --context %s -n flux-system patch lease %s --type=json -p %s" \
     "$(fence_shell_quote "${KUBE_CONTEXT}")" "${SYNC_LEASE_NAME}" "$(fence_shell_quote "${patch}")"
 }

--- a/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
@@ -276,6 +276,18 @@ func TestDeployActionConsumerStagingPrecedesPublishAndIsReassertedAfterUpdate(t 
 	requireBefore(t, recoverStep, firstRefresh, "fence recovery before staging")
 	requireContains(t, action[recoverStep:firstRefresh], "inputs.recover-orphaned-fence == 'true'")
 	requireContains(t, action[recoverStep:firstRefresh], "run: ./scripts/refresh-flux-ghcr-auth.sh --recover-fences")
+	// The gate above keeps this off only while the input's own default does, and
+	// the two fail INDEPENDENTLY: a default flipped to "true" leaves the assertion
+	// above passing unchanged while arming automatic Lease mutation against prod on
+	// every deploy and every heal. Read structurally rather than as a substring, so
+	// a `default: "false"` belonging to some other input cannot satisfy it.
+	recoverDefault, err := yamlScalarAtPath(action, "inputs", "recover-orphaned-fence", "default")
+	if err != nil {
+		t.Fatalf("read the fence recovery input default: %v", err)
+	}
+	if recoverDefault != "false" {
+		t.Errorf("recover-orphaned-fence default = %q, want %q", recoverDefault, "false")
+	}
 	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 4 {
 		t.Errorf("refresh helper references = %d, want 4", count)
 	}

--- a/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
@@ -272,10 +272,10 @@ func TestDeployActionConsumerStagingPrecedesPublishAndIsReassertedAfterUpdate(t 
 	// Anchored on the step, not its `run:` line: the gating `if:` precedes the
 	// command, so a slice starting at `run:` would miss the very condition that
 	// keeps this default-off.
-	recover := requireIndex(t, action, "- name: 🧯 Recover an orphaned GHCR deploy fence")
-	requireBefore(t, recover, firstRefresh, "fence recovery before staging")
-	requireContains(t, action[recover:firstRefresh], "inputs.recover-orphaned-fence == 'true'")
-	requireContains(t, action[recover:firstRefresh], "run: ./scripts/refresh-flux-ghcr-auth.sh --recover-fences")
+	recoverStep := requireIndex(t, action, "- name: 🧯 Recover an orphaned GHCR deploy fence")
+	requireBefore(t, recoverStep, firstRefresh, "fence recovery before staging")
+	requireContains(t, action[recoverStep:firstRefresh], "inputs.recover-orphaned-fence == 'true'")
+	requireContains(t, action[recoverStep:firstRefresh], "run: ./scripts/refresh-flux-ghcr-auth.sh --recover-fences")
 	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 4 {
 		t.Errorf("refresh helper references = %d, want 4", count)
 	}

--- a/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/contracts_test.go
@@ -265,8 +265,19 @@ func TestDeployActionConsumerStagingPrecedesPublishAndIsReassertedAfterUpdate(t 
 	requireContains(t, finalRefreshStep, "steps.reconcile.outcome == 'success'")
 	requireContains(t, finalRefreshStep, "--reuse-runtime-proof")
 	requireContains(t, finalRefreshStep, "${RUNNER_TEMP}/ghcr-runtime-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json")
-	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 3 {
-		t.Errorf("refresh helper references = %d, want 3", count)
+	// The fourth reference is the orphaned-fence pre-flight. It is asserted
+	// explicitly rather than absorbed into the count, so a future invocation still
+	// has to be accounted for here deliberately — which is what this exhaustive
+	// count exists to force.
+	// Anchored on the step, not its `run:` line: the gating `if:` precedes the
+	// command, so a slice starting at `run:` would miss the very condition that
+	// keeps this default-off.
+	recover := requireIndex(t, action, "- name: 🧯 Recover an orphaned GHCR deploy fence")
+	requireBefore(t, recover, firstRefresh, "fence recovery before staging")
+	requireContains(t, action[recover:firstRefresh], "inputs.recover-orphaned-fence == 'true'")
+	requireContains(t, action[recover:firstRefresh], "run: ./scripts/refresh-flux-ghcr-auth.sh --recover-fences")
+	if count := strings.Count(action, "scripts/refresh-flux-ghcr-auth.sh"); count != 4 {
+		t.Errorf("refresh helper references = %d, want 4", count)
 	}
 }
 
@@ -323,6 +334,15 @@ func TestDeployStepsThatTakeTheSyncLeaseNeverRunAfterCancellation(t *testing.T) 
 		}
 		if strings.Contains(step, "--check-only") {
 			// Read-only: exits before acquire_sync_lease, so it holds nothing.
+			continue
+		}
+		if strings.Contains(step, "--recover-fences") {
+			// Alternative mode: dispatches in the same early block as --fences and
+			// exits there, before acquire_sync_lease is even defined, so it holds
+			// nothing either. It RELEASES a Lease under CAS, which is the opposite
+			// of the hazard this test guards — a step that acquires and is then
+			// killed before cleanup. Its own refusals are covered by the
+			// fence-autorecovery tests.
 			continue
 		}
 		inspected++

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_commands_test.go
@@ -533,6 +533,34 @@ func removeMarker(name string) {
 	_ = os.Remove(filepath.Join(os.Getenv("FAKE_SYNC_STATE_DIR"), name))
 }
 
+// The liveness oracle for fence recovery. It exists so a test can drive every
+// answer the real API can give — including the ones that must NOT release the
+// Lease: a non-terminal run, a request that fails, and a response carrying no
+// status at all.
+//
+// It records the request path so a test can prove the ATTEMPT was pinned. An
+// unpinned query reports the newest attempt, which would let a finished attempt
+// 2 vouch for an attempt 1 that is still running.
+func fakeGh(args []string) int {
+	if len(args) < 2 || args[0] != "api" {
+		return commandFailure(64, "unexpected gh invocation: %v", args)
+	}
+	if log := os.Getenv("GH_CALLED"); log != "" {
+		mustWriteCommandFile(log, strings.Join(args, " "))
+	}
+	if os.Getenv("FAKE_GH_REQUEST_FAILS") == "true" {
+		return commandFailure(1, "gh: HTTP 502")
+	}
+	// Absent means the run is terminal — the ordinary case — so a test only sets
+	// this when it wants a different answer.
+	status, present := os.LookupEnv("FAKE_GH_RUN_STATUS")
+	if !present {
+		status = "completed"
+	}
+	fmt.Println(status)
+	return 0
+}
+
 func defaultString(value, fallback string) string {
 	if value == "" {
 		return fallback

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -914,6 +914,21 @@ func fakeKubectlGetSyncLease(args []string, namespace string) int {
 			"leaseTransitions":     parseInt(defaultString(markerContent("sync-lease-transitions"), "0"), 0),
 		},
 	}))
+	// The read above has already returned the state the fence report will retain.
+	// Advancing the resourceVersion now models the one race --recover-fences must
+	// lose: another actor touched the Lease between the report and the patch. The
+	// CAS then fails through the ordinary comparison in fakeKubectlPatchSyncLease
+	// rather than a recovery-specific short circuit, so the test exercises the
+	// real guard instead of a stand-in for it. Once only — the fence report reads
+	// the Lease exactly once by design, and a repeat would mask a second read.
+	if os.Getenv("FAKE_SYNC_LEASE_TOUCHED_AFTER_FENCE_REPORT") == "true" &&
+		!markerExists("sync-lease-touched-after-fence-report") {
+		touchMarker("sync-lease-touched-after-fence-report")
+		setMarkerContent(
+			"sync-lease-resource-version",
+			incrementDecimal(defaultString(markerContent("sync-lease-resource-version"), "10")),
+		)
+	}
 	return 0
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
@@ -1,0 +1,238 @@
+package refreshfluxghcrauth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --recover-fences is the automated half of the fence model: it releases the
+// synchronization Lease when — and only when — the holder is PROVABLY dead.
+//
+// Everything here is a statement about that proof. Expiry alone must never
+// release, because the script's own acquisition comment explains that an expired
+// shell can resume and write stale credentials even under CAS. The API saying a
+// run attempt is `completed` is different in kind, because Actions does not
+// resume a completed attempt — so these tests pin the difference between the two
+// and, more importantly, pin every way the proof can be UNAVAILABLE.
+
+const deadHolderIdentity = "4384f07cc5a864b0-gh31976321946.1-2690-25297"
+
+// seedOrphanedLease puts the cluster in the state a killed deploy leaves behind:
+// a Lease held by a run reference whose heartbeat has stopped.
+func seedOrphanedLease(t *testing.T, f *fixture, holder string) {
+	t.Helper()
+	if err := os.WriteFile(
+		filepath.Join(f.syncStateDir, "sync-lease-holder"), []byte(holder), 0o600); err != nil {
+		t.Fatalf("seed lease holder: %v", err)
+	}
+}
+
+func leaseHolderNow(t *testing.T, f *fixture) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(f.syncStateDir, "sync-lease-holder"))
+	if err != nil {
+		t.Fatalf("read lease holder: %v", err)
+	}
+	return string(content)
+}
+
+// The GREEN case. Note what it asserts beyond the exit code: the holder is
+// actually cleared. A mode that exits 0 having released nothing would leave the
+// deploy lane wedged while reporting success, which is the failure this whole
+// feature exists to prevent.
+func TestRecoverFencesReleasesALeaseWhoseHolderRunIsTerminal(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{"FAKE_EXPIRED_SYNC_LEASE": "true"})
+
+	requireSuccessResult(t, result)
+	if holder := leaseHolderNow(t, f); holder != "" {
+		t.Errorf("lease holder = %q, want it released", holder)
+	}
+	if !strings.Contains(result.stdout, "proven dead") {
+		t.Errorf("recovery did not report its liveness evidence; stdout = %q", result.stdout)
+	}
+}
+
+// The single most important RED case: the run is still going, so the holder can
+// still write. Releasing here is the two-writer hazard the fence exists for.
+func TestRecoverFencesRefusesWhileTheHolderRunIsNotTerminal(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{
+			"FAKE_EXPIRED_SYNC_LEASE": "true",
+			"FAKE_GH_RUN_STATUS":      "in_progress",
+		})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded on a live holder; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+	if !strings.Contains(result.stdout+result.stderr, "in_progress") {
+		t.Errorf("refusal does not name the status it saw; output = %q", result.stdout+result.stderr)
+	}
+}
+
+// An expired heartbeat is NOT a death proof, and this is the case that says so:
+// the lease is expired and the run is terminal, but the identity carries no run
+// reference, so nothing can be proven. That is the shape a local
+// run-ksail-prod-with-pull-auth.sh invocation leaves, and it must never be
+// auto-released — there is no oracle for a laptop.
+func TestRecoverFencesRefusesAHolderThatCarriesNoRunReference(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, "4384f07cc5a864b0-local-2690-25297")
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{"FAKE_EXPIRED_SYNC_LEASE": "true"})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded without a run reference; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); !strings.Contains(holder, "local") {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+}
+
+// A failed query is UNKNOWN, never "assume dead". Without this the mode would
+// release a Lease every time the API had a bad minute.
+func TestRecoverFencesRefusesWhenTheLivenessQueryFails(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{
+			"FAKE_EXPIRED_SYNC_LEASE": "true",
+			"FAKE_GH_REQUEST_FAILS":   "true",
+		})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded on a failed liveness query; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+}
+
+// A response with no status is the other UNKNOWN, and it is distinct from a
+// failed request: the call succeeds, so an exit-status-only check would read it
+// as a usable answer and compare "" against "completed".
+func TestRecoverFencesRefusesWhenTheLivenessQueryReturnsNoStatus(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{
+			"FAKE_EXPIRED_SYNC_LEASE": "true",
+			"FAKE_GH_RUN_STATUS":      "",
+		})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded on an empty status; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+}
+
+// Belt and braces against a stale or cached API read. The run status here says
+// terminal, but the heartbeat is still inside its duration — something is
+// writing right now, and the live observation wins over the remote one.
+func TestRecoverFencesRefusesWhileTheHeartbeatIsStillInsideItsDuration(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	// No FAKE_EXPIRED_SYNC_LEASE, so the fake reports a far-future renewTime.
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"}, nil)
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded against a live heartbeat; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+}
+
+// A rerun REUSES the run id, so an unpinned query reports the newest attempt.
+// Unpinned, a finished attempt 2 would vouch for an attempt 1 that is still
+// running — the exact inversion that makes an automatic path dangerous.
+func TestRecoverFencesPinsTheAttemptWhenProvingLiveness(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{"FAKE_EXPIRED_SYNC_LEASE": "true"})
+
+	request, err := os.ReadFile(f.ghCalled)
+	if err != nil {
+		t.Fatalf("liveness query was never made: %v", err)
+	}
+	if !strings.Contains(string(request), "/attempts/1") {
+		t.Errorf("liveness query did not pin the attempt; request = %q", request)
+	}
+	if !strings.Contains(string(request), "/runs/31976321946/") {
+		t.Errorf("liveness query did not target the holder's run; request = %q", request)
+	}
+}
+
+// Nothing held is a clean no-op, not an error: the pre-flight runs on EVERY
+// deploy once enabled, and the overwhelmingly common case is a healthy lane.
+func TestRecoverFencesIsANoOpWhenNoLeaseIsHeld(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	result := f.runHelper(validConfig(), []string{"--recover-fences"}, nil)
+
+	requireSuccessResult(t, result)
+	if !strings.Contains(result.stdout, "nothing to recover") {
+		t.Errorf("no-op did not say so; stdout = %q", result.stdout)
+	}
+	if _, err := os.Stat(f.ghCalled); err == nil {
+		t.Error("liveness query was made with no fence held; it should not have been")
+	}
+}
+
+// Same hazard --fences guards against: accepting an alternative mode alongside
+// an operational one makes that step exit 0 having silently skipped the work it
+// was configured to do. --fences and --recover-fences are also mutually
+// exclusive, because --recover-fences already prints the report.
+func TestRecoverFencesIsRejectedAlongsideAnotherMode(t *testing.T) {
+	t.Parallel()
+	for _, extra := range []string{"--check-only", "--allow-incomplete-fanout", "--fences"} {
+		t.Run(extra, func(t *testing.T) {
+			t.Parallel()
+			f := newFixture(t)
+
+			result := f.runHelper(validConfig(), []string{"--recover-fences", extra}, nil)
+
+			if result.exitCode != 64 {
+				t.Errorf("exit = %d with %s, want 64", result.exitCode, extra)
+			}
+		})
+	}
+}
+
+func TestUsageAdvertisesRecoverFences(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+
+	result := f.runHelper(validConfig(), []string{"--not-a-flag"}, nil)
+
+	if !strings.Contains(result.stderr, "--recover-fences") {
+		t.Errorf("usage does not advertise --recover-fences; stderr = %q", result.stderr)
+	}
+}

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
@@ -83,6 +83,68 @@ func TestRecoverFencesRefusesWhileTheHolderRunIsNotTerminal(t *testing.T) {
 	}
 }
 
+// The Lease is the GLOBAL exclusion fence, so it is released last: clearing it
+// while a policy or node fence is still held lets a deploy start against a
+// half-recovered cluster. Automation refuses rather than reordering.
+//
+// The assertion that matters here is the third one. This refusal is reached
+// BEFORE any liveness proof is attempted, so a run that queried the API first
+// would be deciding the ordering question after paying for — and potentially
+// acting on — an answer it must not use.
+func TestRecoverFencesRefusesWhileAnotherFenceIsStillHeld(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{
+			"FAKE_EXPIRED_SYNC_LEASE":        "true",
+			"FAKE_FLUX_POLICY_HANDOFF_OWNED": "true",
+		})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded with another fence held; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+	if _, err := os.Stat(f.ghCalled); err == nil {
+		t.Error("liveness query was made before the ordering refusal; it should not have been")
+	}
+	if output := result.stdout + result.stderr; !strings.Contains(output, "other fence(s) are held") {
+		t.Errorf("refusal does not name the ordering rule it enforced; output = %q", output)
+	}
+}
+
+// The CAS is the last line of defence: the holder and resourceVersion the report
+// observed must BOTH still hold, or something touched the Lease in between and
+// the release could be clearing a live acquisition rather than an orphan.
+//
+// The fixture advances the resourceVersion after the report's read, so the patch
+// is refused by the fake's ordinary CAS comparison — the same one a real cluster
+// applies — rather than by a recovery-specific failure switch.
+func TestRecoverFencesRefusesWhenTheReleasePatchLosesTheCAS(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{
+			"FAKE_EXPIRED_SYNC_LEASE":                    "true",
+			"FAKE_SYNC_LEASE_TOUCHED_AFTER_FENCE_REPORT": "true",
+		})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded on a refused patch; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it untouched", holder)
+	}
+	if output := result.stdout + result.stderr; !strings.Contains(output, "Recovery patch was refused") {
+		t.Errorf("refusal does not report the rejected patch; output = %q", output)
+	}
+}
+
 // An expired heartbeat is NOT a death proof, and this is the case that says so:
 // the lease is expired and the run is terminal, but the identity carries no run
 // reference, so nothing can be proven. That is the shape a local

--- a/scripts/tests/refresh-flux-ghcr-auth/fixture_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fixture_test.go
@@ -44,6 +44,7 @@ type fixture struct {
 	patchCapture                 string
 	variablesPatchCapture        string
 	kubectlCalled                string
+	ghCalled                     string
 	outputPathLog                string
 	registryReadLog              string
 	fanoutLog                    string
@@ -72,6 +73,8 @@ func TestMain(m *testing.M) {
 		code = fakeCurl(os.Args[1:])
 	case "kubectl":
 		code = fakeKubectl(os.Args[1:])
+	case "gh":
+		code = fakeGh(os.Args[1:])
 	default:
 		cleanup := prepareFakeCommandBinary()
 		code = m.Run()
@@ -154,6 +157,7 @@ func newFixture(t *testing.T) *fixture {
 		patchCapture:                 filepath.Join(workspace, "patch.json"),
 		variablesPatchCapture:        filepath.Join(workspace, "variables-patch.json"),
 		kubectlCalled:                filepath.Join(workspace, "kubectl-called"),
+		ghCalled:                     filepath.Join(workspace, "gh-called"),
 		outputPathLog:                filepath.Join(workspace, "ksail-output-path"),
 		registryReadLog:              filepath.Join(workspace, "registry-reads"),
 		fanoutLog:                    filepath.Join(workspace, "fanout-log"),
@@ -174,7 +178,7 @@ func newFixture(t *testing.T) *fixture {
 	if fakeCommandBinary == "" {
 		t.Fatal("fake-command binary was not prepared; TestMain must run before any fixture")
 	}
-	for _, name := range []string{"ksail", "talosctl", "curl", "kubectl"} {
+	for _, name := range []string{"ksail", "talosctl", "curl", "kubectl", "gh"} {
 		if err := os.Symlink(fakeCommandBinary, filepath.Join(f.binDir, name)); err != nil {
 			t.Fatalf("link fake %s: %v", name, err)
 		}
@@ -305,6 +309,7 @@ func (f *fixture) baseEnvironment() map[string]string {
 	env["PATCH_CAPTURE"] = f.patchCapture
 	env["VARIABLES_PATCH_CAPTURE"] = f.variablesPatchCapture
 	env["KUBECTL_CALLED"] = f.kubectlCalled
+	env["GH_CALLED"] = f.ghCalled
 	env["KSAIL_OUTPUT_PATH_LOG"] = f.outputPathLog
 	env["REGISTRY_READ_LOG"] = f.registryReadLog
 	env["FANOUT_LOG"] = f.fanoutLog


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

When a prod deploy dies holding the GHCR synchronization Lease, it blocks **every
later deploy and its own heal path** — the whole merge queue stops, and clearing it
needs a human with cluster write access. That happened on 2026-08-16 and cost ~50
minutes of blocked merges.

## What

The deploy composite gains a pre-flight step that releases the Lease by itself, but
**only when the holder is provably dead** — the GitHub API reporting its run attempt
terminal, no other fence held, and the heartbeat stopped. Anything it cannot prove,
it refuses and leaves for a human.

This is deliberately *not* "release it when the lease expires": an expired process
can still wake up and write, which is why automatic expiry takeover is switched off
here in the first place. A completed run cannot wake up, which is what makes this
safe.

**Ships default-off.** The step only runs when the new `recover-orphaned-fence`
input is set to `true`, so this merges latent and gets switched on once we've watched
it decline to act on a healthy lane.

Fixes #3183
