### PR TITLE
fix(umami): disposition CKV_K8S_38 as a required Lease credential

### DIFF
--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -56,6 +56,18 @@ metadata:
     # the image asks for, and this workload is only deployed to the Hetzner
     # provider, so nothing in CI would catch it going wrong.
     checkov.io/skip1: CKV_K8S_40=UID 1001 is the umami image's baked `nextjs` user, which owns its /app WORKDIR
+    # The token is genuinely used, not mounted by habit: the provisioning script
+    # reads /var/run/secrets/kubernetes.io/serviceaccount/{token,namespace,ca.crt}
+    # and calls coordination.k8s.io directly to hold the umami-provision-tenants
+    # Lease, which serialises the scheduled CronJob against the bootstrap Job.
+    # It is also already the least-privilege shape this check asks for:
+    # role-provision-tenants.yaml grants only `get` + `update` on `leases`,
+    # narrowed by resourceNames to that single Lease — no Secrets, no workloads,
+    # no other coordination object — and the ServiceAccount keeps
+    # automountServiceAccountToken: false as its default, so the token is opted
+    # into per pod rather than granted to everything naming the account.
+    # Dropping the mount would break run serialisation; there is nothing to tighten.
+    checkov.io/skip2: CKV_K8S_38=the script reads its SA token to hold the umami-provision-tenants Lease; the Role grants get/update on that one Lease only
 spec:
   schedule: "*/15 * * * *"
   # Never run two reconciles at once; a slow run (e.g. waiting on a down Umami)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

One of the three remaining checkov findings on this repository was flagging the umami
tenant-provisioning CronJob for mounting a ServiceAccount token. It is a false positive: the job
genuinely needs that token, and the access around it is already as narrow as the check is asking
for — so it was reporting on every pull request without anything left to fix.

### Changes

Records the reason as a scoped suppression on that one check for that one resource, matching the
disposition style already used elsewhere in this repo. No check is disabled repository-wide and no
other finding is affected.

This takes the repository's checkov backlog from 3 findings to 2. The two that remain are the
`CKV_K8S_40` pair tracked by #2904, which needs a maintainer decision rather than a code change.

Fixes #3198
Part of #2787
