### PR TITLE
security(vault-backup): disposition the last two CKV_K8S_40 findings as one deferred exception

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -93,7 +93,7 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (8) and trivy (108 in the local v0.73.0 reproduction): Kubernetes misconfiguration
+  # checkov (0 since #2904) and trivy (108 in the local v0.73.0 reproduction): Kubernetes misconfiguration
   # in k8s/, which the section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -117,19 +117,26 @@ DISABLE_ERRORS_LINTERS:
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
   # `external_secrets_replicas` count. Trivy matched those identifier strings, not credential data.
   #
-  # checkov's 8 are all `kubernetes` framework, and 2 of them are CKV_K8S_40, at exactly these
-  # sites: the two vault-backup jobs.
-  # Re-derive that list from the scan rather than adjusting a number here — every figure in this
+  # checkov is at 0 failed checks on every framework CI runs. Its last two findings were both
+  # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as one scoped
+  # deferred exception each rather than the eleven per-site constraints that issue was filed for.
+  # Re-derive that from the scan rather than adjusting a number here — every figure in this
   # block is a measurement, and the running arithmetic that used to track it went stale twice.
   #
-  # The two vault-backup jobs carry no suppression: their scoped skip claimed to share the
-  # vault-snapshots PVC with the OpenBao StatefulSet, and the live StatefulSet mounts
-  # `config`/`unseal-keys`/`tmp`/`home` plus claim templates `data`/`audit`, never that PVC at all,
-  # so there is no shared ownership to preserve. They are two of the three `vault-snapshots`
-  # writers — the third is the dr-rebuild workflow's helper pod, which this check does not reach
-  # because it is not a committed Kubernetes manifest — and all three
-  # share one RWO PVC at `100:1000`, so they move together. That touches the DR restore path, so
-  # #2904 holds their remediation and the risk-acceptance question.
+  # Both vault-backup workloads run pod-level UID 100, and each of their two containers has its
+  # own reason. The snapshot container's 100 is the openbao image's baked `openbao:x:100:1000`
+  # identity, from the same pinned digest vault-config reads. The mirror container inherits it
+  # because the snapshot lands `-rw-------` owned by `100:1000` while `minio/mc` mounts
+  # /snapshots readOnly and bakes no uid-100 entry of its own, so opening it as its owner is the
+  # only access it has — `fsGroup` fixes the volume's ownership and mode at mount time, not the
+  # mode `bao operator raft snapshot save` writes the file with afterwards.
+  #
+  # Neither UID is remapped: the openbao namespace carries no
+  # `pod-security.devantler.tech/user-namespaces: enabled` label, so the add-user-namespaces rule
+  # does not match, hostUsers stays on, and 100 is a host UID. #3202 removes that residual by
+  # making the snapshot group-readable first and raising the UIDs after. All three
+  # `vault-snapshots` writers move together; the third is the dr-rebuild workflow's helper pod,
+  # which this check does not reach because it is not a committed Kubernetes manifest.
   #
   # The user-namespace probes are resolved rather than excepted, because the UID was never the
   # measurement subject: `/proc/self/uid_map` describes the pod's namespace and reads identically
@@ -141,9 +148,9 @@ DISABLE_ERRORS_LINTERS:
   # openbao image carries `openbao:x:100:1000::/home/openbao` in its own /etc/passwd — read from
   # the pinned digest's layers, not the tag — which is exactly the `runAsUser: 100` /
   # `runAsGroup: 1000` the Job sets. That is the same demonstrated image-baked disposition umami's
-  # 1001 carries (#2901). Whether the two remaining vault-backup writers are the same class is open
-  # in #2904 and is not settled here — #2898 named an image-baked class covering them, but on a
-  # shared-PVC reason that issue itself refuted, so their membership needs its own evidence.
+  # 1001 carries (#2901). The two vault-backup writers share that class for their snapshot
+  # container, which runs the same pinned openbao digest, and diverge for their mirror container,
+  # whose 100 is a file-ownership constraint rather than a baked identity (see above).
   #
   # `checkov.io/skipN` is RESOURCE-scoped, so the Job sets `runAsUser` per container instead of
   # once on the pod: its `minio/mc` and `alpine/k8s` containers carry no uid-100 line in their own

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -93,8 +93,9 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (0 since #2904) and trivy (108 in the local v0.73.0 reproduction): Kubernetes misconfiguration
-  # in k8s/, which the section above explains is NOT covered elsewhere. Tracked by #2787.
+  # checkov (0 since #2904; #3205 removes this entry) and trivy (108 in the local v0.73.0
+  # reproduction): Kubernetes misconfiguration in k8s/, which the section above explains is NOT
+  # covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
   # those
@@ -117,9 +118,10 @@ DISABLE_ERRORS_LINTERS:
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
   # `external_secrets_replicas` count. Trivy matched those identifier strings, not credential data.
   #
-  # checkov is at 0 failed checks on every framework CI runs. Its last two findings were both
-  # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as one scoped
-  # deferred exception each rather than the eleven per-site constraints that issue was filed for.
+  # checkov is at 0 failed checks on all three frameworks CI runs. Its last two findings were both
+  # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as a scoped
+  # deferred exception on each workload — neither the eleven per-site constraints #2898 claimed nor
+  # the single risk acceptance #2904 proposed, both of which the measurements below rule out.
   # Re-derive that from the scan rather than adjusting a number here — every figure in this
   # block is a measurement, and the running arithmetic that used to track it went stale twice.
   #

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -27,6 +27,24 @@ metadata:
   namespace: openbao
   annotations:
     checkov.io/skip1: CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth
+    # Both containers run the pod's UID 100, for two different reasons.
+    # The snapshot container's 100 IS the openbao image's baked identity:
+    # the image carries `openbao:x:100:1000` in its own /etc/passwd (the
+    # same pinned digest vault-config reads), which runAsUser/runAsGroup
+    # restate. The mirror container inherits it because the snapshot it
+    # uploads lands `-rw-------` owned by 100:1000, so `minio/mc` — which
+    # bakes no uid-100 entry of its own and mounts /snapshots readOnly —
+    # can open it only as its owner. fsGroup fixes the volume's ownership
+    # and mode at mount time, not the mode `bao operator raft snapshot
+    # save` creates the file with afterwards.
+    #
+    # Neither UID is remapped. The openbao namespace carries no
+    # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
+    # add-user-namespaces rule does not match, hostUsers stays on, and 100
+    # is a host UID. That residual is what #3202 removes: it makes the
+    # snapshot group-readable first, then raises the UIDs, which the three
+    # writers sharing this one RWO PVC have to do together.
+    checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC
 spec:
   schedule: "30 3 * * *"
   # Pin the cron evaluation to UTC instead of inheriting kube-controller-manager's

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -44,7 +44,7 @@ metadata:
     # is a host UID. That residual is what #3202 removes: it makes the
     # snapshot group-readable first, then raises the UIDs, which the three
     # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC
+    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC"
 spec:
   schedule: "30 3 * * *"
   # Pin the cron evaluation to UTC instead of inheriting kube-controller-manager's

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -46,7 +46,7 @@ metadata:
     # is a host UID. That residual is what #3202 removes: it makes the
     # snapshot group-readable first, then raises the UIDs, which the three
     # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC
+    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC"
 spec:
   # No ttlSecondsAfterFinished (intentional). This is a one-shot "snapshot at
   # deploy/change time" Job (see header) -- it must run ONCE per vault-backup

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -29,6 +29,24 @@ metadata:
     # Jobs are immutable; let Flux delete-and-recreate on spec change.
     kustomize.toolkit.fluxcd.io/force: enabled
     checkov.io/skip1: CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth
+    # Both containers run the pod's UID 100, for two different reasons.
+    # The snapshot container's 100 IS the openbao image's baked identity:
+    # the image carries `openbao:x:100:1000` in its own /etc/passwd (the
+    # same pinned digest vault-config reads), which runAsUser/runAsGroup
+    # restate. The mirror container inherits it because the snapshot it
+    # uploads lands `-rw-------` owned by 100:1000, so `minio/mc` — which
+    # bakes no uid-100 entry of its own and mounts /snapshots readOnly —
+    # can open it only as its owner. fsGroup fixes the volume's ownership
+    # and mode at mount time, not the mode `bao operator raft snapshot
+    # save` creates the file with afterwards.
+    #
+    # Neither UID is remapped. The openbao namespace carries no
+    # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
+    # add-user-namespaces rule does not match, hostUsers stays on, and 100
+    # is a host UID. That residual is what #3202 removes: it makes the
+    # snapshot group-readable first, then raises the UIDs, which the three
+    # writers sharing this one RWO PVC have to do together.
+    checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC
 spec:
   # No ttlSecondsAfterFinished (intentional). This is a one-shot "snapshot at
   # deploy/change time" Job (see header) -- it must run ONCE per vault-backup

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -82,12 +82,15 @@ readonly CI_MEGALINTER_VERSION='10.0.0'
 # kubernetes moved 15 -> 3 in the SAME step that took MegaLinter 9.6.0 -> 10.0.0 (checkov
 # 3.3.2 -> 3.3.9). That drop is NOT recorded as backlog progress, and #2787 must not read it as any:
 # a major scanner bump adds and retires rules, which is indistinguishable from findings being fixed
-# unless the two versions are run against the same tree. Nobody has done that here. What CI does
-# state is which three findings remain, all in the kubernetes framework:
-#   CKV_K8S_40  CronJob.openbao.vault-snapshot                (high UID)
-#   CKV_K8S_40  Job.openbao.vault-snapshot-init               (high UID)
-#   CKV_K8S_38  CronJob.umami.umami-provision-tenants         (SA token mounted)
-readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:3 github_actions:0)
+# unless the two versions are run against the same tree. Nobody has done that here.
+#
+# Every framework CI runs is now at zero. The three that were left are all dispositioned with
+# scoped, resource-level skips naming their reason:
+#   CKV_K8S_38  CronJob.umami.umami-provision-tenants         (SA token mounted)   #3198
+#   CKV_K8S_40  CronJob.openbao.vault-snapshot                (high UID)           #2904
+#   CKV_K8S_40  Job.openbao.vault-snapshot-init               (high UID)           #2904
+# The two CKV_K8S_40 skips are DEFERRED, not accepted — #3202 removes them.
+readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:0 github_actions:0)
 
 # A parsing error means a file was NOT analysed, so findings can hide behind it. CI's run has
 # exactly one (in the cloudformation framework) and so does a correct local run, which is why this


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Two security findings were the last thing standing between us and a scanner that can block bad
Kubernetes changes again. Both said the same thing — the nightly OpenBao backup runs as a low user
id — and the issue behind them assumed we could simply accept that risk, because the cluster
remaps low ids elsewhere. Checking that against the live cluster showed the remapping does not
reach these two workloads, so the assumption was wrong and the finding is real.

What is genuinely true is narrower: the backup container runs the id its own image defines, and the
container that ships the backup off-site has to match it to read the file. That is a real
constraint today, but a removable one.

### What

Records that constraint against each of the two workloads, with the evidence, so the scanner stops
flagging them — and files the follow-up that removes the exception rather than leaving it
open-ended. The repository's linter notes are corrected to match what the scan now reports; both
figures in them had gone stale.

No runtime behaviour changes: this is annotation and documentation only.

The follow-up (#3202) is sequenced deliberately — it changes how the backup file is written before
it changes who writes it, and the second half touches the disaster-recovery restore path, so it
wants a watched window rather than an unattended run.

Fixes #2904
Part of #2787
