### PR TITLE
chore(security): disposition the umami provisioner's SA-token finding

### DIFF
--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -56,6 +56,17 @@ metadata:
     # the image asks for, and this workload is only deployed to the Hetzner
     # provider, so nothing in CI would catch it going wrong.
     checkov.io/skip1: CKV_K8S_40=UID 1001 is the umami image's baked `nextjs` user, which owns its /app WORKDIR
+    # The pod requests a projected SA token because the provisioning script holds a
+    # Lease to serialise the scheduled run against the bootstrap Job: it reads the
+    # token, namespace and CA from /var/run/secrets/kubernetes.io/serviceaccount and
+    # calls coordination.k8s.io directly. The grant behind that token is the narrowest
+    # this check can be answered with, which is why the mount is stated rather than
+    # removed: the bound Role permits `get` and `update` on the single
+    # `umami-provision-tenants` Lease BY resourceName and nothing else, and the
+    # ServiceAccount keeps its own default off, so a later pod naming that account
+    # receives no token unless it asks for one. Dropping the mount would not harden
+    # anything -- it would break run serialisation and leave two provisioners racing.
+    checkov.io/skip2: CKV_K8S_38=the provisioner reads its SA token to hold the umami-provision-tenants Lease, and the bound Role grants get/update on that one Lease alone
 spec:
   schedule: "*/15 * * * *"
   # Never run two reconciles at once; a slow run (e.g. waiting on a down Umami)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Kubernetes misconfiguration backlog (#2787) is the reason checkov and trivy
still report on every pull request without failing the build. It closes only when
every finding is either fixed at the manifest or carries a stated reason — a
blanket disable was explicitly ruled out, because these two scanners are the only
static checks covering that tree.

checkov is now down to **three** findings. One of them is the umami tenant
provisioner, flagged for mounting a service-account token. That mount turns out to
be necessary and already about as narrow as it can be, so there was nothing to fix
here — what was missing was the recorded reason.

## What

Records a scoped suppression on that one CronJob, naming the check and why the
token is needed: the provisioner uses it to hold a Lease so its scheduled run and
its bootstrap Job cannot run over each other, and the permission behind that token
is read-and-update on **that single Lease and nothing else**. The account it uses
keeps token mounting switched off by default, so nothing else inherits it.

**checkov goes 3 → 2 failing.** The two that remain are the vault-backup pair,
which #2904 already holds because they touch the disaster-recovery restore path —
deliberately not swept in here.

No behaviour changes: this adds two annotation lines and their explanation.

Part of #2787
