### PR TITLE
security(k8s): disposition vendored KubeVirt and CDI operator RBAC as a class

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,7 @@ jobs:
               - '.trivyignore.yaml'
               - 'scripts/megalinter-scan-counts.sh'
               - 'scripts/tests/test-megalinter-scan-counts-ignorefile.sh'
+              - 'scripts/tests/test-trivyignore-vendored-operator-boundary.sh'
               # The version-drift guard reads its constants out of
               # megalinter-scan-counts.sh, so the three move together.
               - 'scripts/check-megalinter-version-drift.sh'
@@ -388,6 +389,19 @@ jobs:
         # reproduction helper at its command boundary so a future argument
         # cleanup cannot silently turn every scoped disposition back on.
         run: bash scripts/tests/test-megalinter-scan-counts-ignorefile.sh
+
+      - name: 🧱 Validate vendored-operator disposition boundary
+        if: needs.changes.outputs.k8s == 'true'
+        # The KubeVirt/CDI RBAC dispositions are path-scoped to those two
+        # vendored bundles. If one ever loses its paths key or widens, the
+        # same checks go quiet on the first-party cluster roles this
+        # repository authors, where they are still open findings — and the
+        # count would drop, which reads exactly like progress. yq-only
+        # structural checks always run here; the trivy paired control runs
+        # wherever trivy is installed.
+        run: |
+          shellcheck scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+          bash scripts/tests/test-trivyignore-vendored-operator-boundary.sh
 
       - name: 🔢 Validate scanner version-drift guard
         if: needs.changes.outputs.k8s == 'true'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -97,7 +97,7 @@ DISABLE_ERRORS_LINTERS:
   # (#3205). Its dispositions are documented below because they are what holds that zero — each one
   # is a scoped, resource-level skip naming its reason, not a disabled check.
   #
-  # trivy (108 in the local v0.73.0 reproduction): Kubernetes misconfiguration in k8s/, which the
+  # trivy (93 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
   # section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -120,6 +120,23 @@ DISABLE_ERRORS_LINTERS:
   # KSV-0109's two HIGH findings are path-scoped false positives (#2990): one ConfigMap embeds
   # JavaScript that reads an ESO-mounted Secret and the other exposes the public
   # `external_secrets_replicas` count. Trivy matched those identifier strings, not credential data.
+  #
+  # It then went 109 -> 93 when the RBAC breadth in the vendored KubeVirt and CDI operator
+  # bundles was dispositioned as a class — 16 findings, and 16 of the 25 HIGH/CRITICAL on this
+  # tree. Both files are upstream release artifacts that update-vendored-operators.sh fetches at
+  # a pinned version and verifies against a recorded SHA-256; every finding sits on a ClusterRole
+  # or Role named for the operator itself, and narrowing those grants would break the operator
+  # and diverge the bundle from the checksum it is verified against. See .trivyignore.yaml for the
+  # reasoning and #2990 for the measurement. The five checks stay live on the cluster roles this
+  # repository does author, where 7 HIGH/CRITICAL remain, and
+  # scripts/tests/test-trivyignore-vendored-operator-boundary.sh fails the build if that boundary
+  # is ever lost. KSV-0014 on the two operator Deployments is deliberately left reporting: a
+  # read-only root filesystem is a container setting a kustomize patch can supply without
+  # touching upstream rules.
+  #
+  # ⚠️ That 109 is NOT 108 plus a regression. 108 was measured on trivy v0.73.0 and 109 on v0.74.0
+  # with no manifest change in between, so that 1 is a scanner rule-set difference rather than new
+  # backlog — the same drift the KSV-0037 note above records. Only the 16 are this slice's work.
   #
   # checkov is at 0 failed checks on all three frameworks CI runs. Its last two findings were both
   # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as a scoped

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -106,3 +106,78 @@ misconfigurations:
     statement: >-
       Port 53 is the required DNS service port; the pinned CoreDNS binary carries the file
       capability needed to bind it while the container runs as non-root UID/GID 65532.
+
+  # RBAC breadth in the vendored KubeVirt and CDI operator bundles — 16 of the 25 HIGH/CRITICAL
+  # findings on this tree, dispositioned here once as a class rather than finding by finding
+  # (#2990, which follows the precedent #2899 set for the same bundles under checkov).
+  #
+  # Both files are upstream release artifacts, not manifests this repository authors.
+  # scripts/update-vendored-operators.sh fetches each one from its project's release URL at a
+  # pinned version and verifies it against a recorded SHA-256 before it replaces the committed
+  # copy, so the bytes carrying these rules are upstream's and are re-verified on every refresh.
+  # The only local modification the updater makes is injecting resource-scoped checkov
+  # annotations; it never edits a rule.
+  #
+  # Every finding sits on a ClusterRole or Role named for the operator itself —
+  # cdi-operator-cluster, cdi-operator and kubevirt-operator — and each grant is one the operator
+  # needs to do its job: reconciling VirtualMachines and DataVolumes across every namespace,
+  # registering its own admission webhooks, and managing the services and endpoints that front
+  # them. Narrowing them at the manifest would break the operators, and would also diverge the
+  # bundle from the checksum-verified artifact, which the updater treats as a hard failure. There
+  # is no manifest-level fix available short of forking upstream, which is why these are excepted
+  # rather than repaired.
+  #
+  # SCOPE, and what still fails. Each entry is path-scoped to the two bundles, so all five checks
+  # stay live everywhere else — including on the cluster roles this repository does author, where
+  # they continue to report and are owned by #2990. The paths are written out on every entry
+  # rather than shared through a YAML anchor: an alias that a reader or tool resolves to an empty
+  # list would read as an unscoped skip, which is the one failure mode this block must not have.
+  # The boundary is not left to review either —
+  # scripts/tests/test-trivyignore-vendored-operator-boundary.sh writes identical offending
+  # ClusterRole bytes to a vendored path and to a first-party path and fails if the suppression
+  # reaches the second, so widening a glob or dropping a paths key breaks the build instead of
+  # silently going quiet.
+  #
+  # Deliberately NOT covered here: KSV-0014 on the two operator Deployments. A read-only root
+  # filesystem is a container setting rather than an RBAC grant, so a kustomize patch can supply
+  # it without touching upstream's rules, and it stays reported.
+  - id: KSV-0041
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      The operators reconcile DataVolumes and VirtualMachines that carry their own TLS material and
+      registry pull credentials, so their install bundles grant secret access cluster-wide. The
+      grant is upstream's, in a SHA-256 pinned release artifact this repository vendors verbatim.
+  - id: KSV-0046
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      The KubeVirt and CDI operators install and reconcile their own CustomResourceDefinitions and
+      the controllers behind them, which upstream expresses as a wildcard rule in the install
+      bundle. The grant is upstream's, in a SHA-256 pinned release artifact vendored verbatim.
+  - id: KSV-0053
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      virt-operator execs into the virt-handler and virt-launcher pods it manages, for VM lifecycle
+      and migration. The grant is upstream's, in a SHA-256 pinned release artifact vendored
+      verbatim. This disposition covers both operator bundles as one class; of the two, only the
+      KubeVirt bundle currently carries such a rule.
+  - id: KSV-0056
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Both operators create and reconcile the services and endpoints fronting their API and webhook
+      deployments. The grant is upstream's, in a SHA-256 pinned release artifact vendored verbatim.
+  - id: KSV-0114
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Both operators register, update and remove their own validating and mutating admission
+      webhooks as part of installing and upgrading themselves. The grant is upstream's, in a
+      SHA-256 pinned release artifact vendored verbatim.

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -48,7 +48,10 @@ status=0
 
 # ---------------------------------------------------------------- structure --
 for check in "${checks[@]}"; do
-  entries="$(yq "[.misconfigurations[] | select(.id == \"$check\")] | length" "$ignorefile")"
+  # A yq failure here must take the MISSING DISPOSITION path below, not become an
+  # integer-expression error that evaluates false and silently treats the id as present.
+  entries="$(yq "[.misconfigurations[] | select(.id == \"$check\")] | length" "$ignorefile" 2>/dev/null || printf '0')"
+  entries="${entries:-0}"
   if [ "$entries" -lt 1 ]; then
     printf 'MISSING DISPOSITION: %s has no entry in .trivyignore.yaml\n' "$check" >&2
     status=1
@@ -136,10 +139,21 @@ write_probe "$first_party"
 cp "$ignorefile" "$scratch/.trivyignore.yaml"
 
 findings="$scratch/findings.txt"
-(cd "$scratch" && trivy fs --scanners misconfig --exit-code 0 \
-  --ignorefile .trivyignore.yaml --format json --quiet . 2>/dev/null) |
-  jq -r '.Results[]? as $r | $r.Misconfigurations[]?
-         | select(.Status=="FAIL") | "\($r.Target)\t\(.ID)"' |
+trivy_json="$scratch/trivy.json"
+trivy_err="$scratch/trivy.err"
+
+# trivy's stderr is kept rather than discarded: `set -o pipefail` means a trivy failure would
+# otherwise exit this script non-zero with no diagnostic, which is the "guardrail that blocks
+# without naming the fix" shape. Run it on its own so its status is checked directly.
+if ! (cd "$scratch" && trivy fs --scanners misconfig --exit-code 0 \
+  --ignorefile .trivyignore.yaml --format json --quiet . >"$trivy_json" 2>"$trivy_err"); then
+  printf 'trivy failed while scanning the probe fixture; its stderr follows\n' >&2
+  cat "$trivy_err" >&2
+  exit 1
+fi
+
+jq -r '.Results[]? as $r | $r.Misconfigurations[]?
+       | select(.Status=="FAIL") | "\($r.Target)\t\(.ID)"' "$trivy_json" |
   sed 's|^\./||' | sort -u >"$findings"
 
 [ -s "$findings" ] || {

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -17,9 +17,10 @@
 #
 # Verified here in two layers, because they fail for different reasons:
 #
-#   STRUCTURE (always) — every dispositioned check id still carries a non-empty `paths:` list, and
-#   every path in it is one of the two vendored bundles, written literally. This is the layer that
-#   catches the regression above, and it needs nothing but yq.
+#   STRUCTURE (always) — every dispositioned check id is scoped to EXACTLY the two vendored bundles,
+#   written literally: no entry may lose its `paths:` key, gain a path outside them, or drop one of
+#   them. It needs nothing but yq, so it is the layer that still holds when the behavioural control
+#   below is skipped.
 #
 #   BEHAVIOUR (when trivy is installed) — the paired control the KSV-0037 entry describes: the same
 #   offending ClusterRole bytes are written to a vendored path AND to a first-party path, and the
@@ -62,16 +63,31 @@ for check in "${checks[@]}"; do
     fi
   done < <(yq ".misconfigurations[] | select(.id == \"$check\") | (.paths // []) | length" "$ignorefile")
 
+  seen_cdi=0
+  seen_kubevirt=0
   while IFS= read -r path; do
     [ -n "$path" ] || continue
     case "$path" in
-      "$vendored_cdi" | "$vendored_kubevirt") ;;
+      "$vendored_cdi") seen_cdi=1 ;;
+      "$vendored_kubevirt") seen_kubevirt=1 ;;
       *)
         printf 'WIDENED SKIP: %s is scoped to %s, which is not one of the two vendored operator bundles\n' "$check" "$path" >&2
         status=1
         ;;
     esac
   done < <(yq ".misconfigurations[] | select(.id == \"$check\") | (.paths // [])[]" "$ignorefile")
+
+  # Both bundles, or the disposition is no longer the one that was reviewed. Without this the
+  # structural layer accepts a dropped path, and the behavioural half that would notice is skipped
+  # wherever trivy or jq is absent.
+  [ "$seen_cdi" -eq 1 ] || {
+    printf 'NARROWED SKIP: %s is no longer scoped to %s\n' "$check" "$vendored_cdi" >&2
+    status=1
+  }
+  [ "$seen_kubevirt" -eq 1 ] || {
+    printf 'NARROWED SKIP: %s is no longer scoped to %s\n' "$check" "$vendored_kubevirt" >&2
+    status=1
+  }
 done
 
 # ---------------------------------------------------------------- behaviour --

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# The vendored-operator RBAC dispositions in .trivyignore.yaml are PATH-SCOPED, and this test is
+# what keeps them that way.
+#
+# WHY THIS EXISTS
+# KubeVirt's and CDI's install bundles are upstream release artifacts, vendored verbatim and
+# SHA-256 verified by scripts/update-vendored-operators.sh. Their ClusterRoles grant wildcard,
+# secret, webhook, exec and networking permissions because the operators require them, and those
+# grants are not ours to narrow — see the disposition block in .trivyignore.yaml and #2990.
+#
+# The risk that disposition creates is NOT that it is wrong; it is that it silently stops being
+# path-scoped. Drop a `paths:` key, or widen one to k8s/**, and every one of these checks goes
+# quiet across the whole repository — including on the FIRST-PARTY cluster roles this repository
+# does author, where the same permissions are a real finding and four of them are still open.
+# Nothing else would fail: the scan still runs, the count still drops, and the gate still reports
+# a smaller number, which reads exactly like progress.
+#
+# Verified here in two layers, because they fail for different reasons:
+#
+#   STRUCTURE (always) — every dispositioned check id still carries a non-empty `paths:` list, and
+#   every path in it is one of the two vendored bundles, written literally. This is the layer that
+#   catches the regression above, and it needs nothing but yq.
+#
+#   BEHAVIOUR (when trivy is installed) — the paired control the KSV-0037 entry describes: the same
+#   offending ClusterRole bytes are written to a vendored path AND to a first-party path, and the
+#   suppression must apply to exactly the first. This proves trivy agrees with the structure rather
+#   than assuming it. It is skipped, loudly, where trivy is not on PATH.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly repo_root
+readonly ignorefile="$repo_root/.trivyignore.yaml"
+
+command -v yq >/dev/null 2>&1 || {
+  printf 'yq is required to check the vendored-operator disposition boundary\n' >&2
+  exit 1
+}
+
+readonly vendored_cdi='k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml'
+readonly vendored_kubevirt='k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml'
+readonly first_party='k8s/bases/infrastructure/cluster-roles/boundary-probe.yaml'
+
+# Every check id dispositioned for the vendored bundles. Keep in sync with .trivyignore.yaml.
+readonly checks=(KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
+
+status=0
+
+# ---------------------------------------------------------------- structure --
+for check in "${checks[@]}"; do
+  entries="$(yq "[.misconfigurations[] | select(.id == \"$check\")] | length" "$ignorefile")"
+  if [ "$entries" -lt 1 ]; then
+    printf 'MISSING DISPOSITION: %s has no entry in .trivyignore.yaml\n' "$check" >&2
+    status=1
+    continue
+  fi
+
+  # One line per entry, so an entry that lost its paths key cannot hide behind one that kept it.
+  while IFS= read -r n; do
+    if [ "$n" -eq 0 ]; then
+      printf 'UNSCOPED SKIP: an entry for %s has no paths, which suppresses it everywhere including first-party cluster roles\n' "$check" >&2
+      status=1
+    fi
+  done < <(yq ".misconfigurations[] | select(.id == \"$check\") | (.paths // []) | length" "$ignorefile")
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in
+      "$vendored_cdi" | "$vendored_kubevirt") ;;
+      *)
+        printf 'WIDENED SKIP: %s is scoped to %s, which is not one of the two vendored operator bundles\n' "$check" "$path" >&2
+        status=1
+        ;;
+    esac
+  done < <(yq ".misconfigurations[] | select(.id == \"$check\") | (.paths // [])[]" "$ignorefile")
+done
+
+# ---------------------------------------------------------------- behaviour --
+if ! command -v trivy >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+  printf 'NOTE: trivy or jq not on PATH; structural checks ran, paired control skipped\n'
+  [ "$status" -eq 0 ] || exit 1
+  printf 'vendored-operator RBAC disposition is path-scoped (structure only): %d checks\n' "${#checks[@]}"
+  exit 0
+fi
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# One ClusterRole that trips all five: wildcard resources, secrets, webhook configurations,
+# pods/exec and service/endpoint management.
+write_probe() {
+  local dest="$scratch/$1"
+  mkdir -p "$(dirname "$dest")"
+  cat >"$dest" <<'PROBE'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: boundary-probe
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "delete"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list", "create", "update", "delete"]
+PROBE
+}
+
+write_probe "$vendored_cdi"
+write_probe "$vendored_kubevirt"
+write_probe "$first_party"
+cp "$ignorefile" "$scratch/.trivyignore.yaml"
+
+findings="$scratch/findings.txt"
+(cd "$scratch" && trivy fs --scanners misconfig --exit-code 0 \
+  --ignorefile .trivyignore.yaml --format json --quiet . 2>/dev/null) |
+  jq -r '.Results[]? as $r | $r.Misconfigurations[]?
+         | select(.Status=="FAIL") | "\($r.Target)\t\(.ID)"' |
+  sed 's|^\./||' | sort -u >"$findings"
+
+[ -s "$findings" ] || {
+  printf 'probe produced no findings at all: fixture or scan is broken, so this control would pass vacuously\n' >&2
+  exit 1
+}
+
+fires() { grep -qxF -- "$1	$2" "$findings"; }
+
+# The control half. Without it, a blanket suppression satisfies every assertion below it.
+for check in "${checks[@]}"; do
+  fires "$first_party" "$check" || {
+    printf 'BOUNDARY LOST: %s no longer fires on a first-party cluster role; the disposition is hiding real findings\n' "$check" >&2
+    status=1
+  }
+done
+
+for path in "$vendored_cdi" "$vendored_kubevirt"; do
+  for check in "${checks[@]}"; do
+    if fires "$path" "$check"; then
+      printf 'MISSING DISPOSITION: %s still fires on vendored bundle %s\n' "$check" "$path" >&2
+      status=1
+    fi
+  done
+done
+
+[ "$status" -eq 0 ] || exit 1
+
+printf 'vendored-operator RBAC disposition is path-scoped: %d checks suppressed on both vendored bundles, all still live on first-party roles\n' "${#checks[@]}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Trivy reports RBAC findings on the KubeVirt and CDI operator bundles, and they are the largest block of high-severity noise on the cluster manifests — 16 of the 25 HIGH/CRITICAL findings on the tree. They are also not ours to fix: both bundles are upstream release artifacts we vendor verbatim and verify against a recorded checksum, and every finding is a permission the operator genuinely needs to run. Editing them would break the operators and break the checksum. While they sit in the count, the findings that *are* ours are buried underneath them.

### What

Records a single, reasoned exception covering that class, so the remaining high-severity findings are the ones on cluster roles this repository actually authors. Trivy goes 109 → 93 overall and 25 → 9 at HIGH/CRITICAL; the 9 left are 7 first-party findings plus 2 deliberately kept reporting because they *are* fixable here.

The exception is deliberately narrow, and a new check fails the build if it ever stops being narrow — the risk with a suppression like this is not that it is wrong today, but that it later goes quiet on our own manifests while the shrinking count reads like progress.

This does not yet let trivy block the build; the medium and low findings remain, and #2787 owns those.

Part of #2990