### PR TITLE
security(kubescape): drop all capabilities on the operator's own workloads

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -216,3 +216,50 @@ spec:
         limits:
           cpu: 500m
           memory: 1Gi
+  # Drop all capabilities and pin a CONTAINER-level seccompProfile on the four
+  # kubescape-operator Deployments. Post-rendered rather than set through
+  # `values` above because the chart gives us no choice: kubescape-operator
+  # 1.40.3 exposes NO securityContext value anywhere in values.yaml (zero
+  # occurrences), and each component's Deployment template HARDCODES the
+  # container securityContext to exactly `allowPrivilegeEscalation: false`
+  # + `readOnlyRootFilesystem: true` + `runAsNonRoot: true` — with no
+  # `capabilities` and no `seccompProfile`. `storage` is weaker still and ships
+  # only the first and third of those.
+  #
+  # Every component already runs as uid 65532 with allowPrivilegeEscalation
+  # false and binds only high ports (kubescape/kubevuln 8080, operator
+  # 4002/8000/8443, storage none), so no component holds or needs a capability:
+  # dropping ALL is a no-op at runtime and makes that guarantee explicit and
+  # enforceable instead of incidental. A pod-level seccompProfile is already set
+  # by the chart; the container-level copy states the same guarantee on the
+  # container itself, so it survives a future template that sets a container
+  # securityContext without inheriting the pod default.
+  #
+  # NOTE ON SCOPE — this hardens the workloads; it does NOT move a posture
+  # score, and no scan will show the difference. These Deployments are scanned
+  # by NEITHER surface: the operator's own config.json excludes its namespace
+  # (`excludeNamespaces: "kubescape,kube-system,…"`), so the in-cluster scan
+  # holds 0 objects for it (measured: 0 of 1542, across 39 scanned namespaces);
+  # and the CI `ksail workload scan` reads manifests, where these exist only as
+  # this HelmRelease and are never rendered. That blind spot is tracked
+  # separately — do not read a green scan as evidence about this namespace.
+  #
+  # readOnlyRootFilesystem is deliberately NOT added to `storage`: it is an
+  # aggregated APIServer backed by a RWO PVC and its write paths are unverified,
+  # so that one needs its own evidence rather than riding along here.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: ^(kubescape|kubevuln|operator|storage)$
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext/capabilities
+                value:
+                  drop:
+                    - ALL
+              - op: add
+                path: /spec/template/spec/containers/0/securityContext/seccompProfile
+                value:
+                  type: RuntimeDefault

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -247,6 +247,14 @@ spec:
   # readOnlyRootFilesystem is deliberately NOT added to `storage`: it is an
   # aggregated APIServer backed by a RWO PVC and its write paths are unverified,
   # so that one needs its own evidence rather than riding along here.
+  #
+  # UPGRADE HAZARD, deliberately accepted: JSON-Patch `add` REPLACES an existing
+  # key, so if a future chart version starts setting `capabilities` on one of
+  # these containers, this patch silently overrides it rather than conflicting.
+  # That is the intent today — nothing here needs a capability — but it means a
+  # component that legitimately gains one would lose it without any error. Being
+  # non-root does not make that safe on its own: a file capability on the binary
+  # would still take effect. Re-check this patch when bumping the chart.
   postRenderers:
     - kustomize:
         patches:

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1052,7 +1052,39 @@ const (
 // Only ONE renderer stands behind the new value: the approved CI toolchain via
 // the required job. The local kubectl is v1.36.1 against an approved v1.36.2, so
 // validateRendererVersion fails closed and cannot corroborate.
-const expectedRenderedSurfaceSHA = "21195b64582f0cc99b42cc6ee61c77610972c12b1556c3b254f68b15ce95d7fa"
+//
+// This value additionally covers dropping all Linux capabilities and pinning a
+// container-level seccompProfile on the four kubescape-operator Deployments
+// (#3064). The surface moves only because a HelmRelease is an
+// isControllerRBACEmitter, not because any grant changed. Measured by rendering
+// all five authorization overlays from both trees, identical but for that one
+// manifest:
+//
+//	765721 -> 766201 bytes. The ENTIRE delta is 16 added lines and ZERO removed
+//	lines, all of them the one `postRenderers:` block on
+//	helm.toolkit.fluxcd.io/v2 HelmRelease kubescape/kubescape.
+//
+// Grant-bearing document membership is 74 -> 74 and set-IDENTICAL in both
+// directions (Role 11, ClusterRole 22, RoleBinding 16, ClusterRoleBinding 10,
+// ServiceAccount 15) — nothing added, removed or renamed. The count is
+// corroborated by two independent extractions that agree exactly, because the
+// first shapes tried returned a silent 0 and then a nonsense 375058 on the same
+// input.
+//
+// The only `kind: Deployment` line in the delta is the patch TARGET selector,
+// not a granted identity; the patch body only ever removes capability
+// (`drop: [ALL]`) and pins a seccomp profile. No identity, binding, verb, policy
+// document, ServiceAccount or `aws`-bearing line is touched.
+//
+// The previous approved digest is recorded here in full, so replacing the
+// constant does not lose it:
+//
+//	21195b64582f0cc99b42cc6ee61c77610972c12b1556c3b254f68b15ce95d7fa
+//
+// The new fingerprint was read from the required job's own output on the
+// approved renderer (run 32141093701), because the local toolchain is refused as
+// unapproved — the same single-renderer caveat as the value it replaces.
+const expectedRenderedSurfaceSHA = "f204a2d25d468376946989ab2378c41de86f9f66b0cda21b5f80f54bc99d2306"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The Kubescape operator's own workloads are the least-hardened thing it watches. All four of its
Deployments run without dropping Linux capabilities, and `storage` is weaker still. They are also
the workloads nobody can see: the operator excludes its own namespace from scanning, and CI scans
manifests where these exist only as a Helm release — so this gap could sit indefinitely without any
scan ever going red.

### What

Drops all Linux capabilities and pins a seccomp profile on `kubescape`, `kubevuln`, `operator` and
`storage`. The upstream chart offers no setting for this, so it is applied as a post-render step.

Two things worth knowing before merging:

- **This will not move the compliance score, and no scan will show the difference.** That is the
  point of the finding, not a caveat about the fix — see the blind spot below.
- **`storage` was missing from the original measurement.** It is included here because it is the
  same defect in the same chart; hardening three of four would have left the weakest one behind.

`readOnlyRootFilesystem` is deliberately left off `storage` — it is a stateful API server and its
write paths are unverified, so that one needs its own evidence rather than riding along here.

### Blind spot found while verifying this

The `kubescape` namespace is scanned by **neither** posture surface — 0 of 1542 in-cluster scan
records, across 39 namespaces that are covered. Filed separately; it is a measurement gap, not
something this change fixes.

Fixes #3064
Part of #2824
