### PR TITLE
security(trivy): declare the trusted registries so KSV-0125 gates instead of noises

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -97,7 +97,7 @@ DISABLE_ERRORS_LINTERS:
   # (#3205). Its dispositions are documented below because they are what holds that zero — each one
   # is a scoped, resource-level skip naming its reason, not a disabled check.
   #
-  # trivy (93 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
+  # trivy (66 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
   # section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -137,6 +137,22 @@ DISABLE_ERRORS_LINTERS:
   # ⚠️ That 109 is NOT 108 plus a regression. 108 was measured on trivy v0.73.0 and 109 on v0.74.0
   # with no manifest change in between, so that 1 is a scanner rule-set difference rather than new
   # backlog — the same drift the KSV-0037 note above records. Only the 16 are this slice's work.
+  # It then went 93 -> 66 across 29 -> 16 targets when KSV-0125's trusted-registry list was DECLARED
+  # rather than left at its default — 27 findings, the single largest family on this tree. The check
+  # ships trusting only Azure ACR, AWS ECR and GCR, so on a repository that uses quay.io, docker.io,
+  # registry.k8s.io and ghcr.io it flagged literally every container and measured nothing. The list
+  # lives in .trivy/data/trusted-registries.yaml and is wired in through REPOSITORY_TRIVY_ARGUMENTS
+  # below; see that file for why suffix matching means this catches an unexpected registry rather
+  # than a deliberately look-alike one.
+  #
+  # This is NOT a suppression: the check is live and now discriminating. It proved that by surviving
+  # on one container — vault-config's store-keys ran `alpine/k8s`, whose first path segment is a
+  # Docker Hub NAMESPACE, not a registry host, so the check read the registry as "alpine". That one
+  # was fixed at the manifest by writing the image fully-qualified (`docker.io/alpine/k8s`, same
+  # pinned digest), which is what the other 11 docker.io images here already do.
+  #
+  # The list is load-bearing, verified by ablation rather than asserted: deleting the single
+  # `quay.io` entry returns exactly 11 findings, and all 11 are quay.io-hosted containers.
   #
   # checkov is at 0 failed checks on all three frameworks CI runs. Its last two findings were both
   # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as a scoped
@@ -308,6 +324,14 @@ REPOSITORY_TRIVY_ARGUMENTS:
   - .trivyignore.yaml
   - --skip-dirs
   - tests
+  # KSV-0125's BUILT-IN trusted-registry list is Azure ACR, AWS ECR and GCR only — read from the
+  # check itself, not inferred. This repository uses none of those three, so without this argument
+  # every container it declares reads as "untrusted": 27 findings that measured nothing about supply
+  # chain and only said "this is not a Google, Azure or AWS shop". The data file declares the four
+  # registries actually in use, which is what turns the check into a gate that can catch an
+  # unexpected registry. Omitting this argument silently restores those 27.
+  - --config-data
+  - .trivy/data
 
 # zizmor aborts with "fatal: no audit was performed" because MegaLinter strips GITHUB_TOKEN and its
 # artipacked audit then 401s against the GitHub API. Handing it the token makes the audit run

--- a/.trivy/data/trusted-registries.yaml
+++ b/.trivy/data/trusted-registries.yaml
@@ -1,0 +1,34 @@
+# Registries this repository is allowed to pull container images from.
+#
+# WHY THIS FILE EXISTS
+# trivy's KSV-0125 ("Restrict container images to trusted registries") ships a default trusted list
+# of Azure ACR, AWS ECR and GCR only — read from the check itself
+# (policies/kubernetes/policies/uses_untrusted_registry.rego), not inferred. This repository uses
+# none of those three, so every single container it declares was reported "untrusted": 27 findings,
+# which said nothing about supply-chain risk and only said "this is not a Google, Azure or AWS
+# shop". That noise is why REPOSITORY_TRIVY sits in DISABLE_ERRORS_LINTERS (#2787).
+#
+# The check reads `data.ksv0125.trusted_registries` and uses it INSTEAD of its defaults whenever the
+# list is non-empty, so declaring the four registries actually in use turns the control from
+# permanently-failing noise into a real gate: a workload pulling from anywhere else now stands out.
+# The list below is derived from the tree, not chosen — every `image:` in k8s/ that names a registry
+# host resolves to exactly these four.
+#
+# ⚠️ MATCHING IS SUFFIX-BASED, NOT EXACT. The check tests `endswith(registry, trusted)`, so an entry
+# `ghcr.io` also trusts a registry named `evil-ghcr.io`. That is upstream behaviour this file cannot
+# tighten; it is recorded so the guarantee is not overstated. The control catches an unexpected
+# registry, it does not defeat a deliberately look-alike one — image digest pinning and the
+# signature verification in #2856 are what cover that.
+#
+# Adding a registry here is a supply-chain decision: it must be a registry this project genuinely
+# publishes to or consumes from, added in its own reviewed pull request.
+ksv0125:
+  trusted_registries:
+    # Upstream project images (cert-manager, kubevirt, cdi, coroot, minio, openbao, …).
+    - quay.io
+    # Docker Hub — alpine/k8s, minio/mc, traefik and other upstream images.
+    - docker.io
+    # Kubernetes' own registry — coredns and other in-tree components.
+    - registry.k8s.io
+    # GitHub Container Registry — devantler-tech's own published images and upstream charts.
+    - ghcr.io

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -431,7 +431,7 @@ spec:
               echo "Unseal phase complete."
         # --- 2. Persist credentials in K8s Secret (only on fresh init) ---
         - name: store-keys
-          image: alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+          image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -24,6 +24,25 @@
 # Read them from a "🧹 Lint - mega-linter" job log if they ever need re-deriving:
 #   gh api repos/devantler-tech/platform/actions/jobs/<job-id>/logs | grep -aE '^\S+ - Command: '
 #
+# ⚠️ SCAN THE REPOSITORY ROOT. Narrowing trivy's target to k8s/ INFLATES the count, silently.
+# .trivyignore.yaml's dispositions are path-scoped, and every one of them is written relative to the
+# repository root (k8s/bases/infrastructure/**, k8s/clusters/prod/bootstrap/config-map.yaml, ...).
+# Trivy matches those globs against paths relative to the SCAN ROOT, so a scan rooted at k8s/ sees
+# bases/infrastructure/... instead, and the path-scoped entries stop matching. They deactivate with
+# no warning, and the run re-reports findings this repository has already dispositioned.
+#
+# Measured on this tree with trivy v0.74.0, same subcommand and same flags, scan root the ONLY
+# variable: `... .` reports 66 findings across 16 targets, `... k8s/` reports 133 across 62 — the
+# count doubles. Every check ID that appears only in the k8s/-rooted arm (KSV-0022, KSV-0037,
+# KSV-0053, KSV-0109, KSV-0114, KSV-0117) is already dispositioned there; KSV-0037 alone
+# accounts for 47 of the 67 extra. A few IDs rise without being new to that arm (KSV-0041, KSV-0046,
+# KSV-0056) because their disposition covers only some paths, so the scoped subset deactivates while
+# their other instances legitimately remain.
+#
+# The failure direction is what makes this dangerous: it looks like more backlog to work off, not
+# like a broken measurement, so it reads as plausible and gets believed. Run the command above from
+# the repository root, or the number is not comparable to CI's.
+#
 # TWO DELIBERATE DIFFERENCES FROM THE CI COMMAND, both verified not to change the counts.
 # (--skip-framework secrets is NOT one of them: CI passes it too since MegaLinter 10.0.0, so
 # mirroring it keeps the invocations aligned rather than diverging them. The two --skip-path

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -20,7 +20,7 @@
 #   - Command: [checkov --skip-path tests/ --config-file /action/lib/.automation/.checkov.yml
 #     --skip-path .agents --skip-path megalinter-reports --directory . --skip-framework secrets]
 #   - Command: [trivy fs --scanners vuln,misconfig --exit-code 1 --ignorefile
-#     .trivyignore.yaml --skip-dirs tests .]
+#     .trivyignore.yaml --skip-dirs tests --config-data .trivy/data .]
 # Read them from a "🧹 Lint - mega-linter" job log if they ever need re-deriving:
 #   gh api repos/devantler-tech/platform/actions/jobs/<job-id>/logs | grep -aE '^\S+ - Command: '
 #
@@ -260,7 +260,7 @@ scan_trivy() {
   local out="$OUT_DIR/trivy.txt" rc=0
   printf '\nRunning trivy (this takes ~1 minute)...\n' >&2
   (cd "$REPO_ROOT" && trivy fs --scanners vuln,misconfig --exit-code 1 \
-    --ignorefile .trivyignore.yaml --skip-dirs tests .) \
+    --ignorefile .trivyignore.yaml --skip-dirs tests --config-data .trivy/data .) \
     >"$out" 2>"$OUT_DIR/trivy.err" || rc=$?
   if [ "$rc" -gt 1 ]; then
     printf 'trivy exited %d — refusing to report a count from an incomplete run\n' "$rc" >&2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Our container-image security check was switched on but effectively blind. Trivy ships trusting only Amazon, Google and Microsoft registries — and we use none of them — so it reported **every single container we run** as coming from an untrusted registry. That is 27 findings that told us nothing except "this is not an AWS shop", and it is a large part of why this scanner is still parked as non-blocking.

A check that always fails is a check nobody can act on. If someone added a workload pulling from a registry we do not trust, today it would look exactly like the 27 findings already there.

### What

Declares the four registries we actually pull from, so the check compares against our real supply chain instead of a cloud vendor default. It now passes on what we legitimately use and stands out on anything else.

One image was also written ambiguously enough that the check misread where it came from; it is now written in full, pointing at the same pinned image as before.

It also records a way of measuring this backlog that quietly gives the wrong answer: checking only the Kubernetes folder rather than the whole repository doubles the reported number, because the exemptions we have already agreed stop applying. That reads as more work to do rather than as a broken measurement, so the warning now sits next to the instructions.

**Security floor gained:** an image from an unexpected registry is now a visible finding rather than being lost in permanent noise.
**Everyday cost:** none — no new step for anyone. Adding a registry later is one reviewed line in a documented file. The scanner backlog on this tree drops by roughly a third (93 → 66 findings, 29 → 16 affected files), which makes the remaining work easier to see.

This is one slice of a larger backlog, not the whole of it — the scanner stays non-blocking until the rest is worked off.

Part of #2787
