### PR TITLE
chore(security): rule on the vendored CDI and KubeVirt operator RBAC findings

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -181,3 +181,32 @@ misconfigurations:
       Both operators register, update and remove their own validating and mutating admission
       webhooks as part of installing and upgrading themselves. The grant is upstream's, in a
       SHA-256 pinned release artifact vendored verbatim.
+  - id: KSV-0048
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Creating and reconciling workloads is what both operators are for. CDI creates the importer,
+      uploader and cloner pods that populate a DataVolume; virt-operator creates and upgrades the
+      virt-api, virt-controller and virt-handler deployments that make up KubeVirt itself. A grant
+      narrow enough to satisfy this check would stop either operator installing or running. The
+      grant is upstream's, in a SHA-256 pinned release artifact vendored verbatim.
+  - id: KSV-0049
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Both operators own the configmaps that configure the components they install, including their
+      generated CA bundles, and must create them to install and rotate them. The grant is upstream's,
+      in a SHA-256 pinned release artifact vendored verbatim.
+  - id: KSV-0113
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Every rule this fires on concerns the serving certificates the operators are issued or
+      generate, in their own namespace. Three of the five grant only get/list/watch; CDI's own cert
+      rule adds create because CDI generates that material itself. The fifth, KubeVirt's namespaced
+      Role, does grant create/patch/delete — but is resourceNames-scoped to sixteen explicitly named
+      kubevirt-* certificate secrets it issues and rotates, so it cannot reach any other secret in
+      the namespace. The grant is upstream's, in a SHA-256 pinned release artifact vendored verbatim.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Kubernetes misconfiguration scanning still can't be enforced, because the scan reports a backlog of
findings that nobody has ruled on yet. Just under half of what was left came from two files we did
not write: the vendored CDI and KubeVirt operator releases, which we ship exactly as upstream
publishes them.

The findings say those two operators have broad permissions. They do — because that is what the
operators are for. CDI creates the pods that load a disk image; KubeVirt creates and upgrades the
components that make KubeVirt itself run. Narrowing either grant would stop them working, and we
cannot edit the files without breaking the way we take upstream's releases.

### What this changes

Records a ruling for the three permission checks that fire on those two files, each scoped to just
those files, so the checks stay fully enforced everywhere else. Every ruling names why that specific
grant is legitimate and was checked against the actual rules rather than assumed.

The remaining backlog drops from 66 findings to 45. Nothing that gets deployed changes.

Deliberately **not** covered: ten findings on the same two files about the operators' own resource
limits and read-only root filesystem. Those describe real, fixable state — one is HIGH — so they are
left reported and want a proper fix, not a ruling.

Part of #2787
