### PR TITLE
ci(security): fail when a checkov skip reason is truncated by YAML comment syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -585,14 +585,18 @@ jobs:
         # when the scan step moves, and the wiring that reaches it.
         run: bash scripts/tests/test-kubescape-gate-frameworks-guard.sh
 
-      - name: 🧷 Validate checkov skip reasons survive YAML parsing
+      - name: 🧷 Validate checkov skip reasons are quoted and intact
         if: needs.changes.outputs.k8s == 'true'
         # A `checkov.io/skipN` whose reason parses away still suppresses its
         # finding, because the check id sits before the `#`. The suppression then
         # reads as reviewed while asserting nothing, and no other check in CI can
-        # see it. This runs the guard over the tree and pins its verdict in both
-        # directions — a guard that has only ever seen passing input has proved
-        # nothing about what it rejects.
+        # see it. The guard removes that failure rather than detecting it: every skip
+        # value must be an explicitly QUOTED scalar, because a quoted `#` is literal.
+        # (Detecting truncation from source text is impossible — a complete reason plus
+        # a trailing comment is lexically identical to a truncated one.) This runs the
+        # guard over the tree and pins its verdict in all three directions — pass,
+        # reject, and cannot-check — because a guard that has only ever seen passing
+        # input has proved nothing about what it rejects.
         run: |
           bash scripts/guard-checkov-skip-reasons.sh k8s
           bash scripts/tests/test-guard-checkov-skip-reasons.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,10 @@ jobs:
               # Both halves, for the same reason as the guard above.
               - 'scripts/guard-kubescape-gate-frameworks.sh'
               - 'scripts/tests/test-kubescape-gate-frameworks-guard.sh'
+              # Both halves, so editing the guard alone — or its test alone —
+              # still runs the check that covers it.
+              - 'scripts/guard-checkov-skip-reasons.sh'
+              - 'scripts/tests/test-guard-checkov-skip-reasons.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -580,6 +584,18 @@ jobs:
         # would otherwise revert in silence — plus its fail-closed behaviour
         # when the scan step moves, and the wiring that reaches it.
         run: bash scripts/tests/test-kubescape-gate-frameworks-guard.sh
+
+      - name: 🧷 Validate checkov skip reasons survive YAML parsing
+        if: needs.changes.outputs.k8s == 'true'
+        # A `checkov.io/skipN` whose reason parses away still suppresses its
+        # finding, because the check id sits before the `#`. The suppression then
+        # reads as reviewed while asserting nothing, and no other check in CI can
+        # see it. This runs the guard over the tree and pins its verdict in both
+        # directions — a guard that has only ever seen passing input has proved
+        # nothing about what it rejects.
+        run: |
+          bash scripts/guard-checkov-skip-reasons.sh k8s
+          bash scripts/tests/test-guard-checkov-skip-reasons.sh
 
       - name: 📋 Validate Kubescape finding summary
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -55,7 +55,7 @@ metadata:
     # tree is the one to run as. Raising it above 10000 would break the match
     # the image asks for, and this workload is only deployed to the Hetzner
     # provider, so nothing in CI would catch it going wrong.
-    checkov.io/skip1: CKV_K8S_40=UID 1001 is the umami image's baked `nextjs` user, which owns its /app WORKDIR
+    checkov.io/skip1: "CKV_K8S_40=UID 1001 is the umami image's baked `nextjs` user, which owns its /app WORKDIR"
     # The token is genuinely used, not mounted by habit: the provisioning script
     # reads /var/run/secrets/kubernetes.io/serviceaccount/{token,namespace,ca.crt}
     # and calls coordination.k8s.io directly to hold the umami-provision-tenants
@@ -67,7 +67,7 @@ metadata:
     # automountServiceAccountToken: false as its default, so the token is opted
     # into per pod rather than granted to everything naming the account.
     # Dropping the mount would break run serialisation; there is nothing to tighten.
-    checkov.io/skip2: CKV_K8S_38=the script reads its SA token to hold the umami-provision-tenants Lease; the Role grants get/update on that one Lease only
+    checkov.io/skip2: "CKV_K8S_38=the script reads its SA token to hold the umami-provision-tenants Lease; the Role grants get/update on that one Lease only"
 spec:
   schedule: "*/15 * * * *"
   # Never run two reconciles at once; a slow run (e.g. waiting on a down Umami)

--- a/k8s/bases/apps/umami/job.yaml
+++ b/k8s/bases/apps/umami/job.yaml
@@ -15,8 +15,8 @@ metadata:
   name: umami-provision-tenants-bootstrap
   namespace: umami
   annotations:
-    checkov.io/skip1: CKV_K8S_8=inert source template is replaced before apply
-    checkov.io/skip2: CKV_K8S_9=inert source template is replaced before apply
+    checkov.io/skip1: "CKV_K8S_8=inert source template is replaced before apply"
+    checkov.io/skip2: "CKV_K8S_9=inert source template is replaced before apply"
     kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   # Kubernetes stores this as a signed int32. Using its maximum keeps transient

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -59,7 +59,7 @@ metadata:
   name: cnpg-degraded-alert
   namespace: observability
   annotations:
-    checkov.io/skip1: CKV_K8S_38=the check container reads its SA token to list CNPG Clusters through the API server
+    checkov.io/skip1: "CKV_K8S_38=the check container reads its SA token to list CNPG Clusters through the API server"
     # `${GRACE_SECONDS}` in the script below is the container's own env var, NOT
     # a Flux post-build variable. The infrastructure-controllers Kustomization
     # runs substituteFrom, so Flux's envsubst expanded it to the empty string and

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: metrics-exporter
     platform.devantler.tech/replica-floor: exempt
   annotations:
-    checkov.io/skip1: CKV_K8S_38=kube-state-metrics reads the managed resources it exports through the API server
+    checkov.io/skip1: "CKV_K8S_38=kube-state-metrics reads the managed resources it exports through the API server"
     # Both containers bind 127.0.0.1 only (--host/--telemetry-host and --web.listen-address
     # below), because the agent scrapes kube-state-metrics from inside the pod and nothing
     # reaches either port from the network. A kubelet httpGet/tcpSocket probe dials the POD IP,
@@ -17,8 +17,8 @@ metadata:
     # reason. Binding either port to the pod network purely to satisfy the check would widen
     # the attack surface this design deliberately closes, so the workload is dispositioned
     # rather than changed.
-    checkov.io/skip2: CKV_K8S_8=loopback-only listeners are unreachable from a kubelet probe; see the note above
-    checkov.io/skip3: CKV_K8S_9=loopback-only listeners are unreachable from a kubelet probe; see the note above
+    checkov.io/skip2: "CKV_K8S_8=loopback-only listeners are unreachable from a kubelet probe; see the note above"
+    checkov.io/skip3: "CKV_K8S_9=loopback-only listeners are unreachable from a kubelet probe; see the note above"
 spec:
   # A second replica would export identical series and race them into the
   # remote-write receiver. Recreate avoids an overlapping rollout; the agent's

--- a/k8s/bases/infrastructure/opencost/components/usage-scraper/deployment.yaml
+++ b/k8s/bases/infrastructure/opencost/components/usage-scraper/deployment.yaml
@@ -9,14 +9,14 @@ metadata:
     app.kubernetes.io/component: metrics-scraper
     platform.devantler.tech/replica-floor: exempt
   annotations:
-    checkov.io/skip1: CKV_K8S_38=Prometheus kubernetes_sd and authenticated kubelet scraping both need the token
+    checkov.io/skip1: "CKV_K8S_38=Prometheus kubernetes_sd and authenticated kubelet scraping both need the token"
     # The agent binds 127.0.0.1:9090 (--web.listen-address below) and pushes via remote_write to
     # coroot-prometheus; nothing scrapes it, and no Service selects this pod. A kubelet
     # httpGet/tcpSocket probe dials the POD IP, so it cannot reach a loopback listener. Opening
     # 9090 to the pod network purely to satisfy the check would expose an admin endpoint that has
     # no consumer, so the workload is dispositioned rather than changed.
-    checkov.io/skip2: CKV_K8S_8=loopback-only listener is unreachable from a kubelet probe; see the note above
-    checkov.io/skip3: CKV_K8S_9=loopback-only listener is unreachable from a kubelet probe; see the note above
+    checkov.io/skip2: "CKV_K8S_8=loopback-only listener is unreachable from a kubelet probe; see the note above"
+    checkov.io/skip3: "CKV_K8S_9=loopback-only listener is unreachable from a kubelet probe; see the note above"
 spec:
   # Two replicas would scrape identical node series and race them into the
   # remote-write receiver. Recreate avoids an overlapping rollout; the WAL is

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -26,7 +26,7 @@ metadata:
   name: vault-snapshot
   namespace: openbao
   annotations:
-    checkov.io/skip1: CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth
+    checkov.io/skip1: "CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth"
     # Both containers run the pod's UID 100, for two different reasons.
     # The snapshot container's 100 IS the openbao image's baked identity:
     # the image carries `openbao:x:100:1000` in its own /etc/passwd (the

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -28,7 +28,7 @@ metadata:
   annotations:
     # Jobs are immutable; let Flux delete-and-recreate on spec change.
     kustomize.toolkit.fluxcd.io/force: enabled
-    checkov.io/skip1: CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth
+    checkov.io/skip1: "CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth"
     # Both containers run the pod's UID 100, for two different reasons.
     # The snapshot container's 100 IS the openbao image's baked identity:
     # the image carries `openbao:x:100:1000` in its own /etc/passwd (the

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -43,7 +43,7 @@ metadata:
     # Jobs are immutable, so without this Flux cannot reapply spec changes.
     # The Job script itself is idempotent — each command checks state first.
     kustomize.toolkit.fluxcd.io/force: enabled
-    checkov.io/skip1: CKV_K8S_38=the store-keys container writes the openbao-unseal Secret through kubectl
+    checkov.io/skip1: "CKV_K8S_38=the store-keys container writes the openbao-unseal Secret through kubectl"
     # Only the two openbao containers run below 10000, and their 100 IS the
     # openbao image's own baked identity rather than a choice this manifest
     # makes: the image carries `openbao:x:100:1000::/home/openbao` in its
@@ -59,7 +59,7 @@ metadata:
     # have been an unjustified low-UID execution that this annotation then hid.
     # They take the pod's high 65532 default instead, leaving the suppression
     # covering only the two executions its rationale actually accounts for.
-    checkov.io/skip2: CKV_K8S_40=UID 100 is the openbao image's baked `openbao` user (openbao:x:100:1000 in its /etc/passwd), which runAsUser/runAsGroup restate; only the two openbao containers run it
+    checkov.io/skip2: "CKV_K8S_40=UID 100 is the openbao image's baked `openbao` user (openbao:x:100:1000 in its /etc/passwd), which runAsUser/runAsGroup restate; only the two openbao containers run it"
 spec:
   # Auto-delete the Job (and its pods) 10 minutes after completion. Without
   # this, the `kustomize.toolkit.fluxcd.io/force: enabled` annotation above

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -12,11 +12,11 @@ metadata:
     # The Corefile enables the `kubernetes cluster.local` plugin, which serves
     # cluster DNS by watching Services, Endpoints and Pods through the API
     # server. Without the token CoreDNS cannot resolve any in-cluster name.
-    checkov.io/skip1: CKV_K8S_38=CoreDNS resolves cluster DNS by watching Services/Endpoints via the API server
+    checkov.io/skip1: "CKV_K8S_38=CoreDNS resolves cluster DNS by watching Services/Endpoints via the API server"
     # CoreDNS must serve cluster DNS on port 53. The pinned non-root image's
     # binary carries the file capability, so the container needs only this one
     # capability in its bounding set and drops every other capability below.
-    checkov.io/skip2: CKV_K8S_25=CoreDNS requires only NET_BIND_SERVICE in its bounding set to serve DNS on port 53
+    checkov.io/skip2: "CKV_K8S_25=CoreDNS requires only NET_BIND_SERVICE in its bounding set to serve DNS on port 53"
     # The CPU limit is supplied at admission by the kube-system `default-limitrange`
     # (`k8s/bases/infrastructure/limit-ranges/kube-system.yaml`, `default.cpu: "2"`),
     # which is a base resource and so applies to both provider overlays. checkov
@@ -32,7 +32,7 @@ metadata:
     # throttles under burst (CPU is compressible and a limit does not affect
     # scheduling), and hard-coding a lower per-workload number would reintroduce
     # exactly the throttling it avoids.
-    checkov.io/skip3: CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission; checkov reads the stored spec
+    checkov.io/skip3: "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission; checkov reads the stored spec"
 spec:
   progressDeadlineSeconds: 600
   replicas: 2

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cron-job-stale-node-cleanup.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cron-job-stale-node-cleanup.yaml
@@ -33,7 +33,7 @@ metadata:
   name: longhorn-stale-node-cleanup
   namespace: longhorn-system
   annotations:
-    checkov.io/skip1: CKV_K8S_38=the cleanup script reconciles Longhorn Node CRs through kubectl
+    checkov.io/skip1: "CKV_K8S_38=the cleanup script reconciles Longhorn Node CRs through kubectl"
 spec:
   # Daily, off the top of the hour. Stale CRs are pure cosmetic/bookkeeping
   # debt, never urgent, so one reconcile a day is ample.

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
@@ -40,8 +40,8 @@ metadata:
     # into the autoscaler's in-memory scheduling simulation and never creates them, so the
     # overprovisioning namespace holds zero pods (verified against prod). A probe on a pod that
     # is never instantiated can never execute, and the pause image serves nothing to probe.
-    checkov.io/skip1: CKV_K8S_8=virtual scheduling placeholder, never instantiated; see the note above
-    checkov.io/skip2: CKV_K8S_9=virtual scheduling placeholder, never instantiated; see the note above
+    checkov.io/skip1: "CKV_K8S_8=virtual scheduling placeholder, never instantiated; see the note above"
+    checkov.io/skip2: "CKV_K8S_9=virtual scheduling placeholder, never instantiated; see the note above"
 template:
   metadata:
     labels:

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -154,7 +154,10 @@ while IFS= read -r file; do
   # Full-line comments are dropped first: a `#`-leading line is never an annotation
   # key, in a comment or inside a block scalar, and this tree does carry prose
   # cross-references shaped like one.
-  raw_keys=$(grep -vE '^[[:space:]]*#' -- "$file" | grep -cE "$key_shape")
+  # `grep -o | wc -l` counts each KEY, not each matching line: a flow map can carry
+  # several annotations on one line, and counting lines there would under-count and
+  # reject valid YAML as uncheckable.
+  raw_keys=$(grep -vE '^[[:space:]]*#' -- "$file" | grep -oE "$key_shape" | wc -l | tr -d ' ')
   raw_rc=$?
   if [ "$raw_rc" -gt 1 ]; then
     die "could not count annotations in $file (grep exit $raw_rc)"

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -159,7 +159,14 @@ while IFS= read -r file; do
     -- "$file" 2>&1); then
     die "could not scan $file for block scalars: $blocks"
   fi
-  if printf '%s' "$blocks" | jq -r '.[]' 2>/dev/null | grep -qE "$key_shape"; then
+  # Read the block content through the same fail-closed discipline as the yq call
+  # above: if jq cannot render it, that is a guard that could not check, not a file
+  # with nothing to find. Discarding jq's status here would let the one integrity
+  # check in this file end in the silent pass the whole script exists to prevent.
+  if ! block_text=$(printf '%s' "$blocks" | jq -r '.[]' 2>&1); then
+    die "could not read block scalars from $file: $block_text"
+  fi
+  if printf '%s' "$block_text" | grep -qE "$key_shape"; then
     die "$file: a checkov.io/skipN directive appears inside a block scalar (such as a kustomize 'patch: |'), where the parser cannot reach it — so this file cannot be checked"
   fi
 done <<EOF

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -85,7 +85,7 @@ report() { # <file> <key> <problem> <detail>
 # the checkov.io/skip2 rationale"), which is why the tree's own cross-references do
 # not inflate the count.
 sq="'"
-key_shape="(^|[[:space:]]|\"|$sq)checkov\.io/skip[0-9]+[\"$sq]?[[:space:]]*:"
+key_shape="(^|[^A-Za-z0-9_./-])checkov\.io/skip[0-9]+[\"$sq]?[[:space:]]*:"
 
 while IFS= read -r file; do
   [ -n "$file" ] || continue

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Fail when a `checkov.io/skipN` annotation carries no readable reason.
+#
+# `.mega-linter.yml` states the rule this protects: "No suppression lands without
+# its stated reason being checked against the manifest it describes." Two shapes
+# defeat that rule without failing anything, because checkov reads only the check
+# id, which sits before the damage:
+#
+#   1. TRUNCATION. In a YAML plain (unquoted) scalar, whitespace followed by `#`
+#      opens a comment. So
+#          checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- <the whole reason>
+#      parses as `CKV_K8S_40=deferred to`. The suppression still works and the
+#      stated reason is simply gone. Quoting the scalar is the fix.
+#   2. AN ABSENT REASON. `CKV_K8S_40=` (or a bare id with no `=`) suppresses just
+#      as effectively while asserting nothing.
+#
+# Both leave a bare suppression that reads as reviewed. Nothing else in CI can see
+# either one, which is why this guard exists.
+#
+# Usage: guard-checkov-skip-reasons.sh [root]        (default: k8s)
+# Exit:  0 every annotation carries an intact reason
+#        1 at least one does not (each is named)
+#        2 the guard could not check — missing tool, unreadable root, parse failure
+#
+# Exit 2 is deliberately distinct from both. A guard that cannot run must never be
+# indistinguishable from a clean tree: that is the failure mode where CI goes green
+# having checked nothing.
+
+set -uo pipefail
+
+root=${1:-k8s}
+
+die() { printf 'guard-checkov-skip-reasons: %s\n' "$1" >&2; exit 2; }
+
+command -v yq >/dev/null 2>&1 || die 'yq is required but not on PATH'
+command -v jq >/dev/null 2>&1 || die 'jq is required but not on PATH'
+[ -d "$root" ] || die "not a directory: $root"
+
+# Only files that actually carry the annotation are parsed. The vendored operator
+# bundles are thousands of lines each, and every other YAML file in the tree would
+# be walked for nothing.
+files=$(grep -rlE 'checkov\.io/skip[0-9]+' --include='*.yaml' --include='*.yml' -- "$root" 2>/dev/null)
+grep_rc=$?
+# grep exits 1 for "no matches", which is a legitimately clean tree, and >1 for a
+# real error. Only the latter is an infrastructure failure.
+if [ "$grep_rc" -gt 1 ]; then
+  die "could not search $root for annotations (grep exit $grep_rc)"
+fi
+[ -n "$files" ] || { printf 'checkov skip reasons: no annotations under %s\n' "$root"; exit 0; }
+
+findings=0
+checked=0
+
+report() { # <file> <key> <problem> <detail>
+  printf '  %s\n    %s: %s\n      %s\n' "$1" "$2" "$3" "$4" >&2
+  findings=$((findings + 1))
+}
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  # --- Parsed pass: does the reason survive YAML parsing at all? --------------
+  # Recursive descent, because these annotations sit on several different objects
+  # (pod templates, job specs, bare metadata) and a fixed path would miss most.
+  # -I=0 keeps one JSON document per line so multi-document files stay parseable.
+  if ! parsed=$(yq -o=json -I=0 \
+    '[.. | select(kind == "map") | to_entries[]
+        | select(.key | test("^checkov\.io/skip[0-9]+$"))]' -- "$file" 2>&1); then
+    die "could not parse $file as YAML: $parsed"
+  fi
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    key=$(printf '%s' "$entry" | jq -r '.key') || die "could not read a key from $file"
+    value=$(printf '%s' "$entry" | jq -r '.value') || die "could not read a value from $file"
+    checked=$((checked + 1))
+
+    case $value in
+      *=*)
+        reason=${value#*=}
+        # A reason of only whitespace asserts nothing, so it is treated as absent
+        # rather than present-but-short.
+        if [ -z "$(printf '%s' "$reason" | tr -d '[:space:]')" ]; then
+          report "$file" "$key" 'the reason is empty' \
+            "parsed value was '${value}' — everything after '=' is blank"
+        fi
+        ;;
+      *)
+        report "$file" "$key" 'no "=" separator, so there is no reason at all' \
+          "parsed value was '${value}'"
+        ;;
+    esac
+  done < <(printf '%s' "$parsed" | jq -c '.[]')
+
+  # --- Raw pass: did a reason exist in the source but parse away? -------------
+  # This cannot be answered from the parsed value alone — truncation is lossless
+  # from YAML's point of view, so the parse looks perfectly well-formed. It has to
+  # be read off the source text.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    lineno=${line%%:*}
+    text=${line#*:}
+    # The scalar is everything after the annotation key's colon.
+    scalar=${text#*checkov.io/skip}
+    scalar=${scalar#*:}
+    # Strip leading blanks without a subshell.
+    scalar=${scalar#"${scalar%%[![:space:]]*}"}
+
+    # An empty scalar here means a block scalar or a value on a following line.
+    # The parsed pass above already validated its reason; there is no plain-scalar
+    # comment to detect, so there is nothing further to check.
+    [ -n "$scalar" ] || continue
+
+    # A quoted scalar cannot be truncated by a comment: inside quotes `#` is
+    # literal. This is exactly the fix, so flagging it would punish the remedy.
+    case $scalar in
+      '"'*|"'"*) continue ;;
+    esac
+
+    # In a plain scalar, whitespace followed by `#` opens a comment and everything
+    # after it is discarded. A `#` NOT preceded by whitespace (issue#3202) is a
+    # literal character and must not be reported.
+    if printf '%s' "$scalar" | grep -qE '[[:space:]]#'; then
+      keyname=$(printf '%s' "$text" | grep -oE 'checkov\.io/skip[0-9]+' | head -1)
+      report "$file" "${keyname:-checkov.io/skipN}" \
+        'the reason is truncated by an unquoted YAML comment' \
+        "line ${lineno}: everything from ' #' onward is discarded — wrap the value in double quotes"
+    fi
+  done < <(grep -nE 'checkov\.io/skip[0-9]+[[:space:]]*:' -- "$file" || true)
+done <<EOF
+$files
+EOF
+
+if [ "$findings" -ne 0 ]; then
+  printf '\ncheckov skip reasons: %d annotation(s) carry no readable reason (%d checked)\n' \
+    "$findings" "$checked" >&2
+  exit 1
+fi
+
+printf 'checkov skip reasons: %d annotation(s) checked, all carry an intact reason\n' "$checked"

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -31,7 +31,10 @@ set -uo pipefail
 
 root=${1:-k8s}
 
-die() { printf 'guard-checkov-skip-reasons: %s\n' "$1" >&2; exit 2; }
+die() {
+  printf 'guard-checkov-skip-reasons: %s\n' "$1" >&2
+  exit 2
+}
 
 command -v yq >/dev/null 2>&1 || die 'yq is required but not on PATH'
 command -v jq >/dev/null 2>&1 || die 'jq is required but not on PATH'
@@ -47,7 +50,10 @@ grep_rc=$?
 if [ "$grep_rc" -gt 1 ]; then
   die "could not search $root for annotations (grep exit $grep_rc)"
 fi
-[ -n "$files" ] || { printf 'checkov skip reasons: no annotations under %s\n' "$root"; exit 0; }
+[ -n "$files" ] || {
+  printf 'checkov skip reasons: no annotations under %s\n' "$root"
+  exit 0
+}
 
 findings=0
 checked=0
@@ -115,7 +121,7 @@ while IFS= read -r file; do
     # A quoted scalar cannot be truncated by a comment: inside quotes `#` is
     # literal. This is exactly the fix, so flagging it would punish the remedy.
     case $scalar in
-      '"'*|"'"*) continue ;;
+      '"'* | "'"*) continue ;;
     esac
 
     # In a plain scalar, whitespace followed by `#` opens a comment and everything

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -3,25 +3,38 @@
 # Fail when a `checkov.io/skipN` annotation carries no readable reason.
 #
 # `.mega-linter.yml` states the rule this protects: "No suppression lands without
-# its stated reason being checked against the manifest it describes." Two shapes
-# defeat that rule without failing anything, because checkov reads only the check
-# id, which sits before the damage:
+# its stated reason being checked against the manifest it describes." checkov reads
+# only the check id, which sits before the reason, so a reason can be lost while the
+# suppression keeps working — leaving a bare exception that still reads as reviewed.
+#
+# Two shapes lose it:
 #
 #   1. TRUNCATION. In a YAML plain (unquoted) scalar, whitespace followed by `#`
 #      opens a comment. So
 #          checkov.io/skip2: CKV_K8S_40=deferred to #3202 -- <the whole reason>
-#      parses as `CKV_K8S_40=deferred to`. The suppression still works and the
-#      stated reason is simply gone. Quoting the scalar is the fix.
-#   2. AN ABSENT REASON. `CKV_K8S_40=` (or a bare id with no `=`) suppresses just
-#      as effectively while asserting nothing.
+#      parses as `CKV_K8S_40=deferred to`, losslessly as far as YAML is concerned.
+#   2. AN ABSENT REASON. `CKV_K8S_40=` (or a bare id with no `=`) suppresses just as
+#      effectively while asserting nothing.
 #
-# Both leave a bare suppression that reads as reviewed. Nothing else in CI can see
-# either one, which is why this guard exists.
+# THE RULE THIS ENFORCES: every `checkov.io/skipN` VALUE MUST BE AN EXPLICITLY
+# QUOTED SCALAR.
+#
+# That is a deliberate inversion. Detecting truncation after the fact is not merely
+# hard, it is impossible from the source text: `reason  # trailing note` (a complete
+# reason plus an ordinary comment) and `reason  # rest of the reason` (a truncated
+# one) are LEXICALLY IDENTICAL, and only the author's intent separates them. Any
+# guard that pattern-matches source text must therefore mis-handle one of them.
+#
+# Requiring the quote removes the failure instead of detecting it: inside quotes `#`
+# is a literal character, so a quoted reason CANNOT be comment-truncated. That makes
+# this check purely structural — it asks yq for each value node's STYLE and never
+# lexes YAML itself.
 #
 # Usage: guard-checkov-skip-reasons.sh [root]        (default: k8s)
-# Exit:  0 every annotation carries an intact reason
-#        1 at least one does not (each is named)
-#        2 the guard could not check — missing tool, unreadable root, parse failure
+# Exit:  0 every annotation is quoted and carries an intact reason
+#        1 at least one does not (each is named, with the edit that fixes it)
+#        2 the guard could not check — missing tool, unreadable root, parse failure,
+#          or an annotation the parser cannot see (see the reconciliation below)
 #
 # Exit 2 is deliberately distinct from both. A guard that cannot run must never be
 # indistinguishable from a clean tree: that is the failure mode where CI goes green
@@ -63,25 +76,57 @@ report() { # <file> <key> <problem> <detail>
   findings=$((findings + 1))
 }
 
+# A key-shaped occurrence: the annotation name in KEY position, i.e. followed by an
+# optional closing quote and an optional-blank colon. The optional quote matters —
+# `"checkov.io/skip1": value` is a legitimate shape, and omitting it here would make
+# the reconciliation below reject that file as uncheckable instead of judging it.
+#
+# This deliberately does NOT match prose that merely mentions the annotation ("see
+# the checkov.io/skip2 rationale"), which is why the tree's own cross-references do
+# not inflate the count.
+sq="'"
+key_shape="(^|[[:space:]]|\"|$sq)checkov\.io/skip[0-9]+[\"$sq]?[[:space:]]*:"
+
 while IFS= read -r file; do
   [ -n "$file" ] || continue
 
-  # --- Parsed pass: does the reason survive YAML parsing at all? --------------
   # Recursive descent, because these annotations sit on several different objects
   # (pod templates, job specs, bare metadata) and a fixed path would miss most.
   # -I=0 keeps one JSON document per line so multi-document files stay parseable.
+  #
+  # `.key | type == "!!str"` is load-bearing: a YAML merge key (`<<: *anchor`) has
+  # tag !!merge, and calling test() on it aborts the whole run with a parse error —
+  # so a single merge key anywhere in an annotated file would take the guard down
+  # before it checked anything.
   if ! parsed=$(yq -o=json -I=0 \
     '[.. | select(kind == "map") | to_entries[]
-        | select(.key | test("^checkov\.io/skip[0-9]+$"))]' -- "$file" 2>&1); then
+        | select((.key | type == "!!str")
+             and (.key | test("^checkov\.io/skip[0-9]+$")))
+        | {"key": .key, "value": .value, "style": (.value | style)}]' -- "$file" 2>&1); then
     die "could not parse $file as YAML: $parsed"
   fi
 
+  file_checked=0
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
     key=$(printf '%s' "$entry" | jq -r '.key') || die "could not read a key from $file"
     value=$(printf '%s' "$entry" | jq -r '.value') || die "could not read a value from $file"
+    style=$(printf '%s' "$entry" | jq -r '.style') || die "could not read a style from $file"
     checked=$((checked + 1))
+    file_checked=$((file_checked + 1))
 
+    # --- The structural rule -------------------------------------------------
+    # yq reports the VALUE node's style, so this is correct even when the KEY is
+    # quoted and the value is not — a shape that defeats every source-text match.
+    case $style in
+      double | single) ;;
+      *)
+        report "$file" "$key" 'the value is an unquoted (plain) scalar' \
+          "a ' #' anywhere in it would silently truncate the reason — wrap the value in double quotes"
+        ;;
+    esac
+
+    # --- The reason is present at all ----------------------------------------
     case $value in
       *=*)
         reason=${value#*=}
@@ -99,41 +144,24 @@ while IFS= read -r file; do
     esac
   done < <(printf '%s' "$parsed" | jq -c '.[]')
 
-  # --- Raw pass: did a reason exist in the source but parse away? -------------
-  # This cannot be answered from the parsed value alone — truncation is lossless
-  # from YAML's point of view, so the parse looks perfectly well-formed. It has to
-  # be read off the source text.
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    lineno=${line%%:*}
-    text=${line#*:}
-    # The scalar is everything after the annotation key's colon.
-    scalar=${text#*checkov.io/skip}
-    scalar=${scalar#*:}
-    # Strip leading blanks without a subshell.
-    scalar=${scalar#"${scalar%%[![:space:]]*}"}
-
-    # An empty scalar here means a block scalar or a value on a following line.
-    # The parsed pass above already validated its reason; there is no plain-scalar
-    # comment to detect, so there is nothing further to check.
-    [ -n "$scalar" ] || continue
-
-    # A quoted scalar cannot be truncated by a comment: inside quotes `#` is
-    # literal. This is exactly the fix, so flagging it would punish the remedy.
-    case $scalar in
-      '"'* | "'"*) continue ;;
-    esac
-
-    # In a plain scalar, whitespace followed by `#` opens a comment and everything
-    # after it is discarded. A `#` NOT preceded by whitespace (issue#3202) is a
-    # literal character and must not be reported.
-    if printf '%s' "$scalar" | grep -qE '[[:space:]]#'; then
-      keyname=$(printf '%s' "$text" | grep -oE 'checkov\.io/skip[0-9]+' | head -1)
-      report "$file" "${keyname:-checkov.io/skipN}" \
-        'the reason is truncated by an unquoted YAML comment' \
-        "line ${lineno}: everything from ' #' onward is discarded — wrap the value in double quotes"
-    fi
-  done < <(grep -nE 'checkov\.io/skip[0-9]+[[:space:]]*:' -- "$file" || true)
+  # --- Reconciliation: did the parser SEE every annotation in this file? ------
+  # An annotation nested inside a block scalar (a kustomize `patch: |`) is opaque
+  # string content, so yq reports nothing for it and the loop above would report a
+  # contented "0 checked" while a real suppression went unread. Comparing the
+  # key-shaped source count against what was actually checked is what turns that
+  # silent gap into an explicit "cannot check".
+  #
+  # Full-line comments are dropped first: a `#`-leading line is never an annotation
+  # key, in a comment or inside a block scalar, and this tree does carry prose
+  # cross-references shaped like one.
+  raw_keys=$(grep -vE '^[[:space:]]*#' -- "$file" | grep -cE "$key_shape")
+  raw_rc=$?
+  if [ "$raw_rc" -gt 1 ]; then
+    die "could not count annotations in $file (grep exit $raw_rc)"
+  fi
+  if [ "$raw_keys" -ne "$file_checked" ]; then
+    die "$file: $raw_keys annotation(s) in the source but $file_checked reached the parser — one is not a plain map entry (a block scalar such as a kustomize 'patch: |' hides it), so this file cannot be checked"
+  fi
 done <<EOF
 $files
 EOF
@@ -144,4 +172,4 @@ if [ "$findings" -ne 0 ]; then
   exit 1
 fi
 
-printf 'checkov skip reasons: %d annotation(s) checked, all carry an intact reason\n' "$checked"
+printf 'checkov skip reasons: %d annotation(s) checked, all quoted and carrying an intact reason\n' "$checked"

--- a/scripts/guard-checkov-skip-reasons.sh
+++ b/scripts/guard-checkov-skip-reasons.sh
@@ -106,14 +106,12 @@ while IFS= read -r file; do
     die "could not parse $file as YAML: $parsed"
   fi
 
-  file_checked=0
   while IFS= read -r entry; do
     [ -n "$entry" ] || continue
     key=$(printf '%s' "$entry" | jq -r '.key') || die "could not read a key from $file"
     value=$(printf '%s' "$entry" | jq -r '.value') || die "could not read a value from $file"
     style=$(printf '%s' "$entry" | jq -r '.style') || die "could not read a style from $file"
     checked=$((checked + 1))
-    file_checked=$((file_checked + 1))
 
     # --- The structural rule -------------------------------------------------
     # yq reports the VALUE node's style, so this is correct even when the KEY is
@@ -144,26 +142,25 @@ while IFS= read -r file; do
     esac
   done < <(printf '%s' "$parsed" | jq -c '.[]')
 
-  # --- Reconciliation: did the parser SEE every annotation in this file? ------
+  # --- Parser-invisible content: is a directive hidden in a BLOCK SCALAR? ------
   # An annotation nested inside a block scalar (a kustomize `patch: |`) is opaque
-  # string content, so yq reports nothing for it and the loop above would report a
-  # contented "0 checked" while a real suppression went unread. Comparing the
-  # key-shaped source count against what was actually checked is what turns that
-  # silent gap into an explicit "cannot check".
+  # string content, so the loop above cannot see it and would report a contented
+  # "0 checked" over a real directive.
   #
-  # Full-line comments are dropped first: a `#`-leading line is never an annotation
-  # key, in a comment or inside a block scalar, and this tree does carry prose
-  # cross-references shaped like one.
-  # `grep -o | wc -l` counts each KEY, not each matching line: a flow map can carry
-  # several annotations on one line, and counting lines there would under-count and
-  # reject valid YAML as uncheckable.
-  raw_keys=$(grep -vE '^[[:space:]]*#' -- "$file" | grep -oE "$key_shape" | wc -l | tr -d ' ')
-  raw_rc=$?
-  if [ "$raw_rc" -gt 1 ]; then
-    die "could not count annotations in $file (grep exit $raw_rc)"
+  # Ask yq WHICH scalars are block content rather than counting source text. yq is
+  # the parser, so it knows; and this is the same reason the check above reads node
+  # `style` instead of matching quotes. Counting source occurrences cannot work
+  # here for exactly the reason the raw pass was removed: a quoted value that
+  # merely MENTIONS the directive
+  #     app.example/note: "See checkov.io/skip1: in the security guide."
+  # is textually identical to a key, and only the parser can tell them apart.
+  if ! blocks=$(yq -o=json -I=0 \
+    '[.. | select(kind == "scalar") | select(style == "literal" or style == "folded")]' \
+    -- "$file" 2>&1); then
+    die "could not scan $file for block scalars: $blocks"
   fi
-  if [ "$raw_keys" -ne "$file_checked" ]; then
-    die "$file: $raw_keys annotation(s) in the source but $file_checked reached the parser — one is not a plain map entry (a block scalar such as a kustomize 'patch: |' hides it), so this file cannot be checked"
+  if printf '%s' "$blocks" | jq -r '.[]' 2>/dev/null | grep -qE "$key_shape"; then
+    die "$file: a checkov.io/skipN directive appears inside a block scalar (such as a kustomize 'patch: |'), where the parser cannot reach it — so this file cannot be checked"
   fi
 done <<EOF
 $files

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -100,7 +100,8 @@ expect 'trailing comment after a quoted reason is not a finding' 0 \
 
 # Defect 6: a commented-out template is not an annotation at all.
 expect 'commented-out template is not a finding' 0 \
-  "$(tree_with okcommented okcommented.yaml <<'YAML'
+  "$(
+    tree_with okcommented okcommented.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
@@ -109,11 +110,12 @@ metadata:
     # checkov.io/skip1: CKV_K8S_1=okcommented template line
     app: real
 YAML
-)" '0 annotation(s) checked'
+  )" '0 annotation(s) checked'
 
 # Defect 7: a merge key has tag !!merge; calling test() on it used to abort the run.
 expect 'a YAML merge key does not abort the guard' 0 \
-  "$(tree_with okmerge okmerge.yaml <<'YAML'
+  "$(
+    tree_with okmerge okmerge.yaml <<'YAML'
 defaults: &defaults
   team: platform
 apiVersion: v1
@@ -124,11 +126,12 @@ metadata:
   annotations:
     checkov.io/skip1: "CKV_K8S_1=okmerge the reason"
 YAML
-)" 'all quoted'
+  )" 'all quoted'
 
 # A prose cross-reference must not inflate the reconciliation count.
 expect 'prose mentioning the annotation does not break reconciliation' 0 \
-  "$(tree_with okprose okprose.yaml <<'YAML'
+  "$(
+    tree_with okprose okprose.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
@@ -137,19 +140,21 @@ metadata:
     checkov.io/skip1: "CKV_K8S_1=okprose the reason"
     # see the checkov.io/skip1 rationale above
 YAML
-)" 'all quoted'
+  )" 'all quoted'
 
 expect 'a tree with no annotations passes' 0 \
-  "$(tree_with okempty okempty.yaml <<'YAML'
+  "$(
+    tree_with okempty okempty.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
   name: okempty
 YAML
-)" 'no annotations'
+  )" 'no annotations'
 
 expect 'multi-document files are checked' 0 \
-  "$(tree_with okmultidoc okmultidoc.yaml <<'YAML'
+  "$(
+    tree_with okmultidoc okmultidoc.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
@@ -164,7 +169,7 @@ metadata:
   annotations:
     checkov.io/skip2: "CKV_K8S_2=okmultidoc second"
 YAML
-)" '2 annotation(s) checked'
+  )" '2 annotation(s) checked'
 
 # ---------------------------------------------------------------------------
 # exit 1 — rejected
@@ -175,7 +180,8 @@ expect 'a plain (unquoted) value is rejected' 1 \
 # Defect 1: the KEY is quoted and the VALUE is not. Reading the value node's style
 # catches this; matching source text after the digits does not.
 expect 'a quoted key with a plain value is rejected' 1 \
-  "$(tree_with badquotedkey badquotedkey.yaml <<'YAML'
+  "$(
+    tree_with badquotedkey badquotedkey.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
@@ -183,12 +189,13 @@ metadata:
   annotations:
     "checkov.io/skip1": CKV_K8S_1=badquotedkey the reason
 YAML
-)" 'badquotedkey.yaml'
+  )" 'badquotedkey.yaml'
 
 # Defect 2: the value sits on the FOLLOWING line — still a plain scalar, still a
 # comment site.
 expect 'a plain value on the following line is rejected' 1 \
-  "$(tree_with badnextline badnextline.yaml <<'YAML'
+  "$(
+    tree_with badnextline badnextline.yaml <<'YAML'
 apiVersion: v1
 kind: Pod
 metadata:
@@ -197,7 +204,7 @@ metadata:
     checkov.io/skip1:
       CKV_K8S_1=badnextline the reason
 YAML
-)" 'badnextline.yaml'
+  )" 'badnextline.yaml'
 
 expect 'a quoted value with no "=" is rejected' 1 \
   "$(scalar_fixture badnoeq '"CKV_K8S_1 badnoeq no separator"')" 'no "=" separator'
@@ -214,7 +221,8 @@ expect 'a quoted value whose reason is only whitespace is rejected' 1 \
 # Defect 4: an annotation inside a block scalar is opaque to the parser. Reporting a
 # contented "0 checked" there is the exact failure this exit distinguishes.
 expect 'an annotation hidden in a block scalar is reported as uncheckable' 2 \
-  "$(tree_with badblockscalar badblockscalar.yaml <<'YAML'
+  "$(
+    tree_with badblockscalar badblockscalar.yaml <<'YAML'
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
@@ -225,7 +233,7 @@ patches:
         annotations:
           checkov.io/skip1: "CKV_K8S_1=badblockscalar hidden reason"
 YAML
-)" 'cannot be checked'
+  )" 'cannot be checked'
 
 expect 'a missing root directory is reported' 2 "$scratch/does-not-exist" 'not a directory'
 

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -144,8 +144,10 @@ fi
 # Proves the truncation check is what rejects the truncated fixture, rather than
 # some unrelated property of it. Quoting the SAME scalar must flip 1 to 0; if both
 # arms agreed, every rejection above could be vacuous.
-run_guard "$(fixture ablate_bad 'CKV_K8S_40=deferred to #3202 -- reason text')"; bad_rc=$GUARD_RC
-run_guard "$(fixture ablate_ok '"CKV_K8S_40=deferred to #3202 -- reason text"')"; ok_rc=$GUARD_RC
+run_guard "$(fixture ablate_bad 'CKV_K8S_40=deferred to #3202 -- reason text')"
+bad_rc=$GUARD_RC
+run_guard "$(fixture ablate_ok '"CKV_K8S_40=deferred to #3202 -- reason text"')"
+ok_rc=$GUARD_RC
 if [ "$bad_rc" -eq 1 ] && [ "$ok_rc" -eq 0 ]; then
   printf 'ok   ablation: quoting the identical scalar flips the verdict (1 -> 0)\n'
 else

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -340,6 +340,53 @@ else
   printf 'ok   missing tooling is reported (exit 2)\n'
 fi
 
+# Fail-closed on the block-scalar scan itself. The guard asks jq to render the
+# block content it just got from yq; if that render fails, the guard has NOT
+# checked the file and must say so rather than fall through to a clean verdict.
+#
+# The stub fails ONLY the block-scan invocation (`-r` with `.[]`) and delegates
+# every other call to the real jq, so the fixture still reaches that line with the
+# earlier per-annotation checks working normally. Without that isolation a broken
+# jq would abort earlier and this would prove nothing about the scan.
+assertions=$((assertions + 1))
+jq_stub_dir="$scratch/jq-stub-bin"
+mkdir -p "$jq_stub_dir"
+real_jq="$(command -v jq)"
+jq_stub_log="$scratch/jq-stub.log"
+: > "$jq_stub_log"
+cat > "$jq_stub_dir/jq" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "-r" ] && [ "\$2" = ".[]" ]; then
+  echo fired >> "$jq_stub_log"
+  echo 'stubbed jq failure' >&2
+  exit 9
+fi
+exec "$real_jq" "\$@"
+STUB
+chmod +x "$jq_stub_dir/jq"
+run_guard "$(scalar_fixture blockscanjq '"CKV_K8S_1=blockscanjq the reason"')" \
+  "$jq_stub_dir:$PATH"
+if [ "$GUARD_RC" -ne 2 ]; then
+  printf 'FAIL block-scan jq failure: expected exit 2, got %s\n%s\n' "$GUARD_RC" "$GUARD_OUT" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$GUARD_OUT" | grep -qF -- 'could not read block scalars'; then
+  printf 'FAIL block-scan jq failure: exit 2 was right, but the report never named the cause\n%s\n' "$GUARD_OUT" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok   a failing block-scalar scan is reported, not passed over (exit 2)\n'
+fi
+
+# Non-vacuity control for the case above: the stub must actually have been reached.
+# A stub that never fires would make that assertion pass for the wrong reason — the
+# fixture is clean, so exit 2 has to come from the stub and nothing else.
+assertions=$((assertions + 1))
+if [ ! -s "$jq_stub_log" ]; then
+  printf 'FAIL control: the jq stub never fired, so the block-scan assertion proves nothing\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'ok   control: the jq stub really was reached\n'
+fi
+
 # ---------------------------------------------------------------------------
 # Meta-assertion: the suite must be able to FAIL. A fixture that is rejected by the
 # guard is asserted to pass, and that assertion is required to break — this is what

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -182,6 +182,23 @@ metadata:
 YAML
   )" '2 annotation(s) checked'
 
+# Directive-shaped text inside a QUOTED scalar value. This is textually identical
+# to a key, so no source-text scan can separate them — which is why the check asks
+# yq which scalars are block content instead of counting occurrences. Reported by
+# CodeRabbit on #3222; it exited 2 and blocked CI on this valid file.
+expect 'directive-shaped text in a quoted scalar is not counted as a key' 0 \
+  "$(
+    tree_with okmention okmention.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okmention
+  annotations:
+    app.example/note: "See checkov.io/skip1: in the security guide."
+    checkov.io/skip1: "CKV_K8S_1=okmention valid reason"
+YAML
+  )" '1 annotation(s) checked'
+
 # The mirror of the above: widening what may precede the key must NOT start
 # counting keys that merely END with the annotation name.
 expect 'look-alike keys are not counted as annotations' 0 \
@@ -288,6 +305,24 @@ patches:
       metadata:
         annotations:
           checkov.io/skip1: "CKV_K8S_1=badblockscalar hidden reason"
+YAML
+  )" 'cannot be checked'
+
+# A hidden directive written in FLOW form inside the block scalar. The detection
+# above matches key-shaped text in block content, so the character that may precede
+# a key matters here too — `{` is not whitespace. Without the widened class this
+# patch slips through and the file reports a contented "0 checked".
+expect 'a flow-form directive hidden in a block scalar is still caught' 2 \
+  "$(
+    tree_with badblockflow badblockflow.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      metadata:
+        annotations: {checkov.io/skip1: "CKV_K8S_1=badblockflow hidden"}
 YAML
   )" 'cannot be checked'
 

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -353,8 +353,8 @@ jq_stub_dir="$scratch/jq-stub-bin"
 mkdir -p "$jq_stub_dir"
 real_jq="$(command -v jq)"
 jq_stub_log="$scratch/jq-stub.log"
-: > "$jq_stub_log"
-cat > "$jq_stub_dir/jq" <<STUB
+: >"$jq_stub_log"
+cat >"$jq_stub_dir/jq" <<STUB
 #!/usr/bin/env bash
 if [ "\$1" = "-r" ] && [ "\$2" = ".[]" ]; then
   echo fired >> "$jq_stub_log"

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Pins the checkov skip-reason guard's verdict in BOTH directions.
+#
+# The guard fails by PASSING: a `checkov.io/skipN` value whose reason parsed away
+# still suppresses its finding, because the check id sits before the `#`. Nothing
+# else in CI notices — the suppression simply reads as reviewed. So the cases that
+# matter most here are the REJECTIONS, and every one of them is asserted to fire on
+# a fixture that differs from a passing fixture in exactly one way.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-checkov-skip-reasons.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+
+# Run the guard against a fixture tree and report its exit status without letting
+# `set -e` abort the test on the (expected) non-zero ones.
+run_guard() { # <tree>
+  set +e
+  GUARD_OUT="$("$guard" "$1" 2>&1)"
+  GUARD_RC=$?
+  set -e
+}
+
+# Build a one-file fixture tree whose single annotation value is supplied verbatim,
+# so each case differs from its neighbour in exactly one scalar.
+fixture() { # <name> <raw-scalar-text>
+  local dir="$scratch/$1"
+  mkdir -p "$dir"
+  cat >"$dir/resource.yaml" <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample
+  annotations:
+    checkov.io/skip1: $2
+spec:
+  replicas: 1
+YAML
+  printf '%s' "$dir"
+}
+
+expect() { # <case> <expected-rc> <tree> [<substring the output must name>]
+  local case_name=$1 want=$2 tree=$3 needle=${4-}
+  run_guard "$tree"
+  if [ "$GUARD_RC" -ne "$want" ]; then
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' \
+      "$case_name" "$want" "$GUARD_RC" "$GUARD_OUT" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$GUARD_OUT" | grep -qF -- "$needle"; then
+    printf 'FAIL %s: exit %s was right, but the report never named %s\n%s\n' \
+      "$case_name" "$want" "$needle" "$GUARD_OUT" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s\n' "$case_name"
+}
+
+# ---------------------------------------------------------------- REJECTIONS ---
+
+# The #3204 case: an unquoted value whose ` #` opens a YAML comment. checkov still
+# suppresses (the id precedes the `#`), so only this guard can see it.
+expect 'truncated: unquoted value containing " #"' 1 \
+  "$(fixture truncated 'CKV_K8S_40=deferred to #3202 -- the whole stated reason')" \
+  'resource.yaml'
+
+# The second invisible shape named in #3204: a value with nothing after `=`.
+expect 'empty reason: nothing after "="' 1 \
+  "$(fixture empty 'CKV_K8S_40=')" \
+  'resource.yaml'
+
+# Whitespace is not a reason.
+expect 'empty reason: only whitespace after "="' 1 \
+  "$(fixture blank '"CKV_K8S_40=   "')" \
+  'resource.yaml'
+
+# A bare id with no `=` at all carries no reason either, and the `.mega-linter.yml`
+# rule is about the reason being present to check.
+expect 'malformed: no "=" separator' 1 \
+  "$(fixture noeq 'CKV_K8S_40')" \
+  'resource.yaml'
+
+# ----------------------------------------------------------- NEGATIVE CONTROLS ---
+# Each of these is one character away from a rejection above. Without them the
+# guard could pass every test by simply rejecting anything containing a "#".
+
+# The correct fix for the truncation case — quoting — must NOT be flagged.
+expect 'accepted: quoted value containing " #"' 0 \
+  "$(fixture quoted '"CKV_K8S_40=deferred to #3202 -- the whole stated reason"')"
+
+# In a YAML plain scalar a `#` only opens a comment when preceded by whitespace, so
+# this one is NOT truncated and must not be reported.
+expect 'accepted: unquoted "#" with no preceding space' 0 \
+  "$(fixture hashnospace 'CKV_K8S_40=see issue#3202 for the deferral rationale')"
+
+# The ordinary shape, which most annotations in the tree use.
+expect 'accepted: plain value with no "#"' 0 \
+  "$(fixture plain 'CKV_K8S_38=the container reads its SA token through the API server')"
+
+# A tree with no annotations at all is vacuously clean, not an error.
+expect 'accepted: tree with no skip annotations' 0 "$(mkdir -p "$scratch/bare" && printf '%s' "$scratch/bare")"
+
+# ------------------------------------------------------------- THE REAL TREE ---
+# #3204's acceptance criterion: the guard passes on the current tree. This is what
+# makes the rejections above a regression gate rather than a lint nobody can adopt.
+expect 'accepted: the repository k8s/ tree as it stands' 0 "$repo_root/k8s"
+
+# ------------------------------------------------------ FAIL-CLOSED ON TOOLING ---
+# A guard that exits 0 when its parser is missing protects nothing: CI would go
+# green having checked no annotation at all. It must be distinguishable from a
+# clean run, and from a finding.
+missing_yq_dir="$scratch/no-yq-bin"
+mkdir -p "$missing_yq_dir"
+set +e
+no_yq_out="$(PATH="$missing_yq_dir" /bin/bash "$guard" "$(fixture plainagain 'CKV_K8S_38=fine')" 2>&1)"
+no_yq_rc=$?
+set -e
+if [ "$no_yq_rc" -ne 2 ]; then
+  printf 'FAIL fail-closed: expected exit 2 without yq, got %s\n%s\n' "$no_yq_rc" "$no_yq_out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok   fail-closed: missing yq is exit 2, not a silent pass\n'
+fi
+
+# A directory that does not exist is an infrastructure error, never "nothing to check".
+set +e
+"$guard" "$scratch/does-not-exist" >/dev/null 2>&1
+absent_rc=$?
+set -e
+if [ "$absent_rc" -ne 2 ]; then
+  printf 'FAIL fail-closed: expected exit 2 for a missing root, got %s\n' "$absent_rc" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok   fail-closed: a missing root is exit 2\n'
+fi
+
+# ------------------------------------------------------------------ ABLATION ---
+# Proves the truncation check is what rejects the truncated fixture, rather than
+# some unrelated property of it. Quoting the SAME scalar must flip 1 to 0; if both
+# arms agreed, every rejection above could be vacuous.
+run_guard "$(fixture ablate_bad 'CKV_K8S_40=deferred to #3202 -- reason text')"; bad_rc=$GUARD_RC
+run_guard "$(fixture ablate_ok '"CKV_K8S_40=deferred to #3202 -- reason text"')"; ok_rc=$GUARD_RC
+if [ "$bad_rc" -eq 1 ] && [ "$ok_rc" -eq 0 ]; then
+  printf 'ok   ablation: quoting the identical scalar flips the verdict (1 -> 0)\n'
+else
+  printf 'FAIL ablation: quoting did not flip the verdict (unquoted=%s quoted=%s)\n' \
+    "$bad_rc" "$ok_rc" >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  printf '\ncheckov skip-reason guard: %d case(s) failed\n' "$failures" >&2
+  exit 1
+fi
+printf '\ncheckov skip-reason guard contract OK\n'

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -142,6 +142,48 @@ metadata:
 YAML
   )" 'all quoted'
 
+# A FLOW MAP annotation. The reconciliation counts key-shaped source occurrences,
+# so the character before the key matters: `{` is a legitimate delimiter and must
+# not make the file look uncheckable. Reported by CodeRabbit on #3222 and real —
+# the first-entry form returned exit 2 on correct YAML.
+expect 'a flow-map annotation as the first entry is checked, not rejected' 0 \
+  "$(
+    tree_with okflowfirst okflowfirst.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okflowfirst
+  annotations: {checkov.io/skip1: "CKV_K8S_1=okflowfirst the reason"}
+YAML
+  )" '1 annotation(s) checked'
+
+expect 'a flow-map annotation after another entry is checked' 0 \
+  "$(
+    tree_with okflowsecond okflowsecond.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okflowsecond
+  annotations: {app: real,checkov.io/skip1: "CKV_K8S_1=okflowsecond the reason"}
+YAML
+  )" '1 annotation(s) checked'
+
+# The mirror of the above: widening what may precede the key must NOT start
+# counting keys that merely END with the annotation name.
+expect 'look-alike keys are not counted as annotations' 0 \
+  "$(
+    tree_with oklookalike oklookalike.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oklookalike
+  annotations:
+    xcheckov.io/skip1: not-ours-and-plain
+    mycorp.checkov.io/skip1: also-not-ours
+    checkov.io/skip1: "CKV_K8S_1=oklookalike the real one"
+YAML
+  )" '1 annotation(s) checked'
+
 expect 'a tree with no annotations passes' 0 \
   "$(
     tree_with okempty okempty.yaml <<'YAML'

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -168,6 +168,20 @@ metadata:
 YAML
   )" '1 annotation(s) checked'
 
+# TWO annotations on ONE line. The reconciliation counts key occurrences, so counting
+# matching *lines* here under-counts (1 line vs 2 parsed entries) and rejects valid
+# YAML as uncheckable. Reported by CodeRabbit on #3222 after the flow-map fix.
+expect 'two annotations in one flow map are both counted' 0 \
+  "$(
+    tree_with oktwoflow oktwoflow.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oktwoflow
+  annotations: {checkov.io/skip1: "CKV_K8S_1=oktwoflow first",checkov.io/skip2: "CKV_K8S_2=oktwoflow second"}
+YAML
+  )" '2 annotation(s) checked'
+
 # The mirror of the above: widening what may precede the key must NOT start
 # counting keys that merely END with the annotation name.
 expect 'look-alike keys are not counted as annotations' 0 \

--- a/scripts/tests/test-guard-checkov-skip-reasons.sh
+++ b/scripts/tests/test-guard-checkov-skip-reasons.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 #
-# Pins the checkov skip-reason guard's verdict in BOTH directions.
+# Pins the checkov skip-reason guard's verdict in all THREE directions.
 #
-# The guard fails by PASSING: a `checkov.io/skipN` value whose reason parsed away
-# still suppresses its finding, because the check id sits before the `#`. Nothing
-# else in CI notices — the suppression simply reads as reviewed. So the cases that
-# matter most here are the REJECTIONS, and every one of them is asserted to fire on
-# a fixture that differs from a passing fixture in exactly one way.
+# The guard's job is to make a lost suppression reason impossible. It enforces that
+# structurally — every `checkov.io/skipN` value must be an explicitly QUOTED scalar,
+# because a quoted `#` is literal and cannot open a comment. So the cases that matter
+# are:
+#
+#   exit 1  a value that is unquoted, or carries no reason at all
+#   exit 0  a value that is quoted and complete — INCLUDING the two shapes that a
+#           source-text matcher necessarily gets wrong (a trailing comment after a
+#           complete reason, and a commented-out template)
+#   exit 2  the guard could not check — a missing tool, or an annotation the parser
+#           cannot see because a block scalar hides it
+#
+# Every fixture carries its OWN filename and its OWN needle, so an assertion can only
+# be satisfied by the case it belongs to. (A previous revision named every fixture
+# `resource.yaml`, which discriminated nothing beyond "some report was emitted".)
 
 set -euo pipefail
 
@@ -16,40 +26,48 @@ scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 
 failures=0
+assertions=0
 
-# Run the guard against a fixture tree and report its exit status without letting
-# `set -e` abort the test on the (expected) non-zero ones.
-run_guard() { # <tree>
+run_guard() { # <tree> [PATH-override]
   set +e
-  GUARD_OUT="$("$guard" "$1" 2>&1)"
+  if [ $# -ge 2 ]; then
+    GUARD_OUT="$(PATH="$2" /bin/bash "$guard" "$1" 2>&1)"
+  else
+    GUARD_OUT="$("$guard" "$1" 2>&1)"
+  fi
   GUARD_RC=$?
   set -e
 }
 
-# Build a one-file fixture tree whose single annotation value is supplied verbatim,
-# so each case differs from its neighbour in exactly one scalar.
-fixture() { # <name> <raw-scalar-text>
+# A fixture tree holding one file, named distinctly, with content supplied verbatim.
+tree_with() { # <name> <basename>  (body on stdin)
   local dir="$scratch/$1"
   mkdir -p "$dir"
-  cat >"$dir/resource.yaml" <<YAML
+  cat >"$dir/$2"
+  printf '%s' "$dir"
+}
+
+# The common shape: one annotation whose scalar is supplied verbatim, so neighbouring
+# cases differ in exactly one scalar.
+scalar_fixture() { # <name> <raw-scalar-text>
+  tree_with "$1" "$1.yaml" <<YAML
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sample
+  name: $1
   annotations:
     checkov.io/skip1: $2
 spec:
   replicas: 1
 YAML
-  printf '%s' "$dir"
 }
 
-expect() { # <case> <expected-rc> <tree> [<substring the output must name>]
+expect() { # <case> <expected-rc> <tree> [<needle>]
   local case_name=$1 want=$2 tree=$3 needle=${4-}
+  assertions=$((assertions + 1))
   run_guard "$tree"
   if [ "$GUARD_RC" -ne "$want" ]; then
-    printf 'FAIL %s: expected exit %s, got %s\n%s\n' \
-      "$case_name" "$want" "$GUARD_RC" "$GUARD_OUT" >&2
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' "$case_name" "$want" "$GUARD_RC" "$GUARD_OUT" >&2
     failures=$((failures + 1))
     return
   fi
@@ -59,105 +77,192 @@ expect() { # <case> <expected-rc> <tree> [<substring the output must name>]
     failures=$((failures + 1))
     return
   fi
-  printf 'ok   %s\n' "$case_name"
+  printf 'ok   %s (exit %s)\n' "$case_name" "$want"
 }
 
-# ---------------------------------------------------------------- REJECTIONS ---
+# ---------------------------------------------------------------------------
+# exit 0 — quoted and complete
+# ---------------------------------------------------------------------------
+expect 'double-quoted reason passes' 0 \
+  "$(scalar_fixture okdouble '"CKV_K8S_1=okdouble the reason"')" '1 annotation(s) checked'
 
-# The #3204 case: an unquoted value whose ` #` opens a YAML comment. checkov still
-# suppresses (the id precedes the `#`), so only this guard can see it.
-expect 'truncated: unquoted value containing " #"' 1 \
-  "$(fixture truncated 'CKV_K8S_40=deferred to #3202 -- the whole stated reason')" \
-  'resource.yaml'
+expect 'single-quoted reason passes' 0 \
+  "$(scalar_fixture oksingle "'CKV_K8S_1=oksingle the reason'")" 'all quoted'
 
-# The second invisible shape named in #3204: a value with nothing after `=`.
-expect 'empty reason: nothing after "="' 1 \
-  "$(fixture empty 'CKV_K8S_40=')" \
-  'resource.yaml'
+# THE POINT OF THE WHOLE DESIGN: a quoted reason may contain ' #' and keep it.
+expect 'quoted reason containing a hash keeps its whole reason' 0 \
+  "$(scalar_fixture okhash '"CKV_K8S_1=okhash deferred to #3202 -- and this tail survives"')" 'all quoted'
 
-# Whitespace is not a reason.
-expect 'empty reason: only whitespace after "="' 1 \
-  "$(fixture blank '"CKV_K8S_40=   "')" \
-  'resource.yaml'
+# Defect 5: a complete reason followed by an ordinary trailing comment. Lexically
+# identical to a truncation, so a source-text matcher MUST get one of them wrong.
+expect 'trailing comment after a quoted reason is not a finding' 0 \
+  "$(scalar_fixture oktrailing '"CKV_K8S_1=oktrailing complete reason" # yamllint disable-line')" 'all quoted'
 
-# A bare id with no `=` at all carries no reason either, and the `.mega-linter.yml`
-# rule is about the reason being present to check.
-expect 'malformed: no "=" separator' 1 \
-  "$(fixture noeq 'CKV_K8S_40')" \
-  'resource.yaml'
+# Defect 6: a commented-out template is not an annotation at all.
+expect 'commented-out template is not a finding' 0 \
+  "$(tree_with okcommented okcommented.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okcommented
+  annotations:
+    # checkov.io/skip1: CKV_K8S_1=okcommented template line
+    app: real
+YAML
+)" '0 annotation(s) checked'
 
-# ----------------------------------------------------------- NEGATIVE CONTROLS ---
-# Each of these is one character away from a rejection above. Without them the
-# guard could pass every test by simply rejecting anything containing a "#".
+# Defect 7: a merge key has tag !!merge; calling test() on it used to abort the run.
+expect 'a YAML merge key does not abort the guard' 0 \
+  "$(tree_with okmerge okmerge.yaml <<'YAML'
+defaults: &defaults
+  team: platform
+apiVersion: v1
+kind: Pod
+metadata:
+  <<: *defaults
+  name: okmerge
+  annotations:
+    checkov.io/skip1: "CKV_K8S_1=okmerge the reason"
+YAML
+)" 'all quoted'
 
-# The correct fix for the truncation case — quoting — must NOT be flagged.
-expect 'accepted: quoted value containing " #"' 0 \
-  "$(fixture quoted '"CKV_K8S_40=deferred to #3202 -- the whole stated reason"')"
+# A prose cross-reference must not inflate the reconciliation count.
+expect 'prose mentioning the annotation does not break reconciliation' 0 \
+  "$(tree_with okprose okprose.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okprose
+  annotations:
+    checkov.io/skip1: "CKV_K8S_1=okprose the reason"
+    # see the checkov.io/skip1 rationale above
+YAML
+)" 'all quoted'
 
-# In a YAML plain scalar a `#` only opens a comment when preceded by whitespace, so
-# this one is NOT truncated and must not be reported.
-expect 'accepted: unquoted "#" with no preceding space' 0 \
-  "$(fixture hashnospace 'CKV_K8S_40=see issue#3202 for the deferral rationale')"
+expect 'a tree with no annotations passes' 0 \
+  "$(tree_with okempty okempty.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okempty
+YAML
+)" 'no annotations'
 
-# The ordinary shape, which most annotations in the tree use.
-expect 'accepted: plain value with no "#"' 0 \
-  "$(fixture plain 'CKV_K8S_38=the container reads its SA token through the API server')"
+expect 'multi-document files are checked' 0 \
+  "$(tree_with okmultidoc okmultidoc.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okmultidoc-a
+  annotations:
+    checkov.io/skip1: "CKV_K8S_1=okmultidoc first"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: okmultidoc-b
+  annotations:
+    checkov.io/skip2: "CKV_K8S_2=okmultidoc second"
+YAML
+)" '2 annotation(s) checked'
 
-# A tree with no annotations at all is vacuously clean, not an error.
-expect 'accepted: tree with no skip annotations' 0 "$(mkdir -p "$scratch/bare" && printf '%s' "$scratch/bare")"
+# ---------------------------------------------------------------------------
+# exit 1 — rejected
+# ---------------------------------------------------------------------------
+expect 'a plain (unquoted) value is rejected' 1 \
+  "$(scalar_fixture badplain 'CKV_K8S_1=badplain the reason')" 'badplain.yaml'
 
-# ------------------------------------------------------------- THE REAL TREE ---
-# #3204's acceptance criterion: the guard passes on the current tree. This is what
-# makes the rejections above a regression gate rather than a lint nobody can adopt.
-expect 'accepted: the repository k8s/ tree as it stands' 0 "$repo_root/k8s"
+# Defect 1: the KEY is quoted and the VALUE is not. Reading the value node's style
+# catches this; matching source text after the digits does not.
+expect 'a quoted key with a plain value is rejected' 1 \
+  "$(tree_with badquotedkey badquotedkey.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badquotedkey
+  annotations:
+    "checkov.io/skip1": CKV_K8S_1=badquotedkey the reason
+YAML
+)" 'badquotedkey.yaml'
 
-# ------------------------------------------------------ FAIL-CLOSED ON TOOLING ---
-# A guard that exits 0 when its parser is missing protects nothing: CI would go
-# green having checked no annotation at all. It must be distinguishable from a
-# clean run, and from a finding.
-missing_yq_dir="$scratch/no-yq-bin"
-mkdir -p "$missing_yq_dir"
-set +e
-no_yq_out="$(PATH="$missing_yq_dir" /bin/bash "$guard" "$(fixture plainagain 'CKV_K8S_38=fine')" 2>&1)"
-no_yq_rc=$?
-set -e
-if [ "$no_yq_rc" -ne 2 ]; then
-  printf 'FAIL fail-closed: expected exit 2 without yq, got %s\n%s\n' "$no_yq_rc" "$no_yq_out" >&2
+# Defect 2: the value sits on the FOLLOWING line — still a plain scalar, still a
+# comment site.
+expect 'a plain value on the following line is rejected' 1 \
+  "$(tree_with badnextline badnextline.yaml <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badnextline
+  annotations:
+    checkov.io/skip1:
+      CKV_K8S_1=badnextline the reason
+YAML
+)" 'badnextline.yaml'
+
+expect 'a quoted value with no "=" is rejected' 1 \
+  "$(scalar_fixture badnoeq '"CKV_K8S_1 badnoeq no separator"')" 'no "=" separator'
+
+expect 'a quoted value with an empty reason is rejected' 1 \
+  "$(scalar_fixture badempty '"CKV_K8S_1="')" 'the reason is empty'
+
+expect 'a quoted value whose reason is only whitespace is rejected' 1 \
+  "$(scalar_fixture badblank '"CKV_K8S_1=   "')" 'the reason is empty'
+
+# ---------------------------------------------------------------------------
+# exit 2 — the guard could not check
+# ---------------------------------------------------------------------------
+# Defect 4: an annotation inside a block scalar is opaque to the parser. Reporting a
+# contented "0 checked" there is the exact failure this exit distinguishes.
+expect 'an annotation hidden in a block scalar is reported as uncheckable' 2 \
+  "$(tree_with badblockscalar badblockscalar.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      metadata:
+        annotations:
+          checkov.io/skip1: "CKV_K8S_1=badblockscalar hidden reason"
+YAML
+)" 'cannot be checked'
+
+expect 'a missing root directory is reported' 2 "$scratch/does-not-exist" 'not a directory'
+
+# Fail-closed on tooling. An empty PATH removes yq and jq; the guard must say so
+# rather than report a clean tree.
+assertions=$((assertions + 1))
+run_guard "$(scalar_fixture oktooling '"CKV_K8S_1=oktooling the reason"')" "$scratch/empty-path"
+mkdir -p "$scratch/empty-path"
+if [ "$GUARD_RC" -ne 2 ]; then
+  printf 'FAIL missing tooling: expected exit 2, got %s\n%s\n' "$GUARD_RC" "$GUARD_OUT" >&2
   failures=$((failures + 1))
 else
-  printf 'ok   fail-closed: missing yq is exit 2, not a silent pass\n'
+  printf 'ok   missing tooling is reported (exit 2)\n'
 fi
 
-# A directory that does not exist is an infrastructure error, never "nothing to check".
-set +e
-"$guard" "$scratch/does-not-exist" >/dev/null 2>&1
-absent_rc=$?
-set -e
-if [ "$absent_rc" -ne 2 ]; then
-  printf 'FAIL fail-closed: expected exit 2 for a missing root, got %s\n' "$absent_rc" >&2
+# ---------------------------------------------------------------------------
+# Meta-assertion: the suite must be able to FAIL. A fixture that is rejected by the
+# guard is asserted to pass, and that assertion is required to break — this is what
+# proves the needles and exit codes above are doing real work.
+# ---------------------------------------------------------------------------
+run_guard "$(scalar_fixture controlplain 'CKV_K8S_1=controlplain reason')"
+if [ "$GUARD_RC" -eq 0 ]; then
+  printf 'FAIL control: an unquoted fixture passed the guard, so these assertions prove nothing\n' >&2
   failures=$((failures + 1))
 else
-  printf 'ok   fail-closed: a missing root is exit 2\n'
+  printf 'ok   control: the unquoted fixture really is rejected (exit %s)\n' "$GUARD_RC"
 fi
-
-# ------------------------------------------------------------------ ABLATION ---
-# Proves the truncation check is what rejects the truncated fixture, rather than
-# some unrelated property of it. Quoting the SAME scalar must flip 1 to 0; if both
-# arms agreed, every rejection above could be vacuous.
-run_guard "$(fixture ablate_bad 'CKV_K8S_40=deferred to #3202 -- reason text')"
-bad_rc=$GUARD_RC
-run_guard "$(fixture ablate_ok '"CKV_K8S_40=deferred to #3202 -- reason text"')"
-ok_rc=$GUARD_RC
-if [ "$bad_rc" -eq 1 ] && [ "$ok_rc" -eq 0 ]; then
-  printf 'ok   ablation: quoting the identical scalar flips the verdict (1 -> 0)\n'
-else
-  printf 'FAIL ablation: quoting did not flip the verdict (unquoted=%s quoted=%s)\n' \
-    "$bad_rc" "$ok_rc" >&2
+# And the needle check must reject a needle that belongs to a DIFFERENT fixture.
+if printf '%s' "$GUARD_OUT" | grep -qF -- 'badquotedkey.yaml'; then
+  printf 'FAIL control: output matched an unrelated fixture needle\n' >&2
   failures=$((failures + 1))
+else
+  printf 'ok   control: an unrelated needle does not match\n'
 fi
 
 if [ "$failures" -ne 0 ]; then
-  printf '\ncheckov skip-reason guard: %d case(s) failed\n' "$failures" >&2
+  printf '\n%d of %d assertion(s) failed\n' "$failures" "$assertions" >&2
   exit 1
 fi
-printf '\ncheckov skip-reason guard contract OK\n'
+printf '\nall %d assertion(s) passed\n' "$assertions"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A security suppression is only acceptable because someone wrote down *why*. Today that written reason can vanish without anything failing: if the annotation value is unquoted and mentions an issue number, YAML treats ` #` as the start of a comment and throws the rest away. The suppression keeps working — the check id survives — so what is left is a bare exception that still reads as reviewed. `.mega-linter.yml` requires the opposite: no suppression lands without its reason being checked.

### What

Makes the failure impossible instead of trying to spot it after the fact: every `checkov.io/skipN` value must now be an explicitly quoted scalar, which CI checks structurally. A quoted `#` is just a character, so a quoted reason cannot be truncated.

That inversion matters because detecting truncation is not merely hard, it is impossible — a complete reason followed by an ordinary comment and a reason cut in half by one are indistinguishable in the file, and only the author knows which was meant. The first attempt here tried anyway, and got it wrong in both directions.

The 21 annotations that were unquoted are quoted in this PR. No reason changes meaning: every parsed value is identical before and after.

Fixes #3204
Part of #2787
