### PR TITLE
fix(security): scope the pod-security mutation exception to where the mutation runs

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - image-verification.yaml
   - infrastructure-privileged.yaml
   - kubescape-privileged.yaml
+  - pod-security-mutations-unscoped.yaml
   - pod-security-mutations.yaml
   - readonly-rootfs-pending.yaml
   - secret-reader-rbac.yaml

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -1,0 +1,47 @@
+---
+# The part of the "add-security-context" mutation exemption that cannot yet be
+# scoped to the namespaces that mutation actually runs in.
+#
+# pod-security-mutations.yaml narrows C-0016 and C-0055 to the mutated set,
+# because every workload that narrowing exposes is either covered by another
+# exception or already passes. C-0013 and C-0211 do not have that property, for
+# two different reasons, so they stay cluster-wide here until each is resolved.
+#
+# C-0013 — flux-system is the one namespace the mutation excludes that no other
+# exception covers and that IS scanned in-cluster. Measured there 2026-08-18 on the
+# pre-exception scan surface, all six Flux controllers (flux-operator,
+# helm-controller, kustomize-controller, notification-controller, source-controller,
+# tofu-controller) fail C-0013 on a single missing field,
+# `spec.template.spec.containers[0].securityContext.runAsGroup`. Narrowing C-0013
+# today would therefore surface six real findings with no fix behind them, which
+# lowers the score to absorb a gap instead of closing it. Setting runAsGroup on
+# those six is tracked in #3223; C-0013 narrows once that lands.
+#
+# C-0211 — its field set differs (fsGroupChangePolicy, runAsUser, runAsGroup), no
+# other exception covers it in the excluded namespaces, and its residual population
+# has never been sized. The name-scoped kubescape-privileged.yaml does not list it,
+# so node-agent and storage sit inside that population rather than excepted out of
+# it. Sizing it needs its own per-workload pass, tracked in #3217.
+apiVersion: kubescape.io/v1beta1
+kind: ClusterSecurityException
+metadata:
+  name: pod-security-mutations-unscoped
+  annotations:
+    # Cluster-wide, and knowingly wider than its own rationale: in the twelve
+    # namespaces "add-security-context" excludes, nothing injects these fields.
+    # Both controls are retained rather than narrowed on an unmeasured guess —
+    # C-0013 pending #3223, C-0211 pending #3217.
+    platform.devantler.tech/cluster-wide: declared
+spec:
+  reason: >-
+    Kyverno mutate policy "add-security-context" injects runAsNonRoot, runAsUser,
+    runAsGroup and fsGroupChangePolicy at pod admission. The Deployment spec does
+    not contain them and Kubescape scans the stored spec, not the live pod. These
+    two controls remain cluster-wide because narrowing them is blocked on evidence
+    rather than on expressiveness: C-0013 has a measured six-workload gap in
+    flux-system (#3223) and C-0211's residual population is unsized (#3217).
+  posture:
+    - controlID: C-0013
+      action: ignore
+    - controlID: C-0211
+      action: ignore

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml
@@ -1,83 +1,78 @@
 ---
 # Exempt the pod-level security-context controls that Kyverno's
-# "add-security-context" ClusterPolicy injects at pod admission (seccompProfile,
-# allowPrivilegeEscalation: false, drop ALL capabilities, runAsNonRoot). Kubescape
-# scans the stored Deployment/StatefulSet spec — where these Kyverno-injected
-# fields are absent — so they are exempted cluster-wide.
+# "add-security-context" ClusterPolicy injects at pod admission
+# (allowPrivilegeEscalation: false, drop ALL capabilities, seccompProfile).
+# Kubescape scans the stored Deployment/StatefulSet spec — where these
+# Kyverno-injected fields are absent — so they are exempted wherever that
+# mutation actually runs, and only there.
 #
-# NOTE: readOnlyRootFilesystem (C-0017) is deliberately NOT exempted here anymore.
-# It is now set GENUINELY in each workload's own spec wherever the app tolerates a
-# read-only root (see the app HelmReleases + the Crossplane DeploymentRuntimeConfigs),
-# so the control truly passes rather than being suppressed. The privileged infra
-# namespaces keep their C-0017 exemption in infrastructure-privileged.yaml, and the
-# small remainder that cannot yet run read-only is scoped in readonly-rootfs-pending.yaml.
+# SCOPE. add-pod-security-context and add-container-security-context exclude the
+# twelve namespaces listed below, so this exception excludes them too, expressed
+# as `NotIn` and rendered by namespaceNotInPattern. cert-manager, keda and
+# opencost are deliberately NOT in that set: add-imageuid-pod-security-context
+# matches those three by name and supplies the pod-level fields, so the mutation —
+# and therefore this exception — still applies there. Read the mutation's match
+# blocks, not only its exclusions.
+#
+# Narrowing these two controls surfaces nothing, measured 2026-08-18 rather than
+# reasoned. The twelve excluded namespaces split three ways:
+#   - Six carry scanned workloads. longhorn-system, observability, velero, kubevirt
+#     and cdi are separately excepted for C-0016 and C-0055 in
+#     infrastructure-privileged.yaml. flux-system is the only one no other exception
+#     covers, and all six Flux controllers there read C-0016 `passed` and C-0055
+#     `passed` on the pre-exception scan surface, so both controls hold without this
+#     exception. (kubevirt and cdi have no live namespace in prod — their scan
+#     objects are residual — but they are excepted either way.)
+#   - Four are not scanned at all: kube-system, kube-public, kube-node-lease and
+#     kubescape are excluded by the kubescape-operator's own `excludeNamespaces`
+#     config. Being unscanned is not the same as passing — it means narrowing
+#     cannot change their result.
+#   - Two have no namespace in prod: local-path-storage and chaos-mesh, the storage
+#     and chaos stacks being opt-in.
+# The local overlay opts in to a different set, so re-measure rather than assuming
+# these counts still hold.
+# C-0013 and C-0211 are NOT narrowed with them: both have a measured or unsized
+# gap behind them and stay cluster-wide in pod-security-mutations-unscoped.yaml.
+#
+# readOnlyRootFilesystem (C-0017) is not exempted here. It is set genuinely in each
+# workload's own spec wherever the app tolerates a read-only root (see the app
+# HelmReleases and the Crossplane DeploymentRuntimeConfigs), so the control truly
+# passes rather than being suppressed. The privileged infra namespaces keep their
+# C-0017 exemption in infrastructure-privileged.yaml, and the small remainder that
+# cannot yet run read-only is scoped in readonly-rootfs-pending.yaml.
 apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: pod-security-mutations
-  annotations:
-    # Cluster-wide, and KNOWN to be wider than its own rationale (#2824). The
-    # compensating mutation named below excludes twelve namespaces —
-    # kube-system, kube-public, kube-node-lease, flux-system, longhorn-system,
-    # local-path-storage, kubescape, kubevirt, cdi, observability, velero,
-    # chaos-mesh — so in exactly those namespaces this exception suppresses
-    # C-0013/C-0016/C-0055/C-0211 with nothing injecting them. Six of the twelve
-    # are separately and deliberately excepted for C-0013/C-0016/C-0055 in
-    # infrastructure-privileged.yaml; C-0211 and the other six are not covered
-    # anywhere. The complement scope this needs IS now expressible: #3083 added
-    # `NotIn` support to scripts/generate-kubescape-exceptions, rendered by
-    # namespaceNotInPattern, which is exactly what avoids an In-list failing
-    # every newly-onboarded namespace. What still blocks narrowing is evidence,
-    # not expressiveness — the surfaced set must be re-measured first (#2824),
-    # and C-0211's residual population is unsized (#3217).
-    #
-    # cert-manager, keda and opencost are NOT part of that set even though
-    # add-pod-security-context excludes them: add-imageuid-pod-security-context
-    # matches those three namespaces by name and supplies the pod-level fields.
-    # Read the mutation's match blocks, not only its exclusions.
-    #
-    # Measured surface for C-0013/C-0016/C-0055 (prod, 2026-08-10), which is
-    # what makes the declaration reviewable rather than open ended: half of the
-    # twelve namespaces run no workloads at all. kube-public and kube-node-lease
-    # exist but are empty; local-path-storage, kubevirt, cdi and chaos-mesh have
-    # no namespace in prod, the VM stack and chaos tooling being opt-in. Six run
-    # workloads, and four of those — kube-system, longhorn-system, observability
-    # and velero — are the excepted set above, leaving flux-system and kubescape
-    # as the genuinely uncovered pair. In those two, the container-level fields
-    # these controls check are set in-spec everywhere except the kubescape,
-    # kubevuln and operator Deployments, which lack capabilities.drop: [ALL] and
-    # a container-level seccompProfile. The four excepted namespaces were not
-    # measured, being out of scope.
-    # These counts are a prod-only snapshot: the local overlay opts in to a
-    # different set, so re-measure rather than assuming they still hold.
-    #
-    # SUPERSEDED 2026-08-18, on the three Deployments only: they now set both
-    # fields in-spec via the kubescape HelmRelease patches, and #3064 closed
-    # COMPLETED, so C-0055 has no genuine gap left behind this exception. The
-    # rest of the 2026-08-10 snapshot has NOT been re-measured.
-    #
-    # C-0211 is deliberately NOT sized here. It has no other exception, its
-    # field set differs from the three above (fsGroupChangePolicy, runAsUser
-    # and runAsGroup are supplied by the mutation), and the name-scoped
-    # kubescape-privileged.yaml does not cover it — so node-agent and storage
-    # remain inside its residual population rather than excepted out of it.
-    # Sizing it needs its own per-workload pass. #3064 did NOT carry that — its
-    # only C-0211 criterion was node-agent, and it is closed COMPLETED — so that
-    # pass is tracked in #3217.
-    platform.devantler.tech/cluster-wide: declared
 spec:
+  match:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kube-public
+            - kube-node-lease
+            - flux-system
+            - longhorn-system
+            - local-path-storage
+            - kubescape
+            - kubevirt
+            - cdi
+            - observability
+            - velero
+            - chaos-mesh
   reason: >-
-    Kyverno mutate policy "add-security-context" injects these controls
-    (seccompProfile, allowPrivilegeEscalation: false, drop ALL capabilities,
-    runAsNonRoot) at pod admission. The Deployment spec does not contain them
-    and Kubescape scans the stored spec, not the live pod. readOnlyRootFilesystem
-    (C-0017) is handled separately — set in-spec per workload.
+    Kyverno mutate policy "add-security-context" injects allowPrivilegeEscalation:
+    false, drop ALL capabilities and seccompProfile at pod admission. The
+    Deployment spec does not contain them and Kubescape scans the stored spec, not
+    the live pod. The exception is scoped to the namespaces that mutation runs in,
+    so it cannot suppress a control where nothing injects it.
+    readOnlyRootFilesystem (C-0017) is handled separately — set in-spec per
+    workload.
   posture:
-    - controlID: C-0211
-      action: ignore
     - controlID: C-0016
       action: ignore
     - controlID: C-0055
-      action: ignore
-    - controlID: C-0013
       action: ignore

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -683,25 +683,43 @@ data:
           {
             "designatorType": "Attributes",
             "attributes": {
+              "namespace": "^([^cfklov].*|c|c[^dh].*|cd|cd[^i].*|cdi.+|ch|ch[^a].*|cha|cha[^o].*|chao|chao[^s].*|chaos|chaos[^\\-].*|chaos-|chaos-[^m].*|chaos-m|chaos-m[^e].*|chaos-me|chaos-me[^s].*|chaos-mes|chaos-mes[^h].*|chaos-mesh.+|f|f[^l].*|fl|fl[^u].*|flu|flu[^x].*|flux|flux[^\\-].*|flux-|flux-[^s].*|flux-s|flux-s[^y].*|flux-sy|flux-sy[^s].*|flux-sys|flux-sys[^t].*|flux-syst|flux-syst[^e].*|flux-syste|flux-syste[^m].*|flux-system.+|k|k[^u].*|ku|ku[^b].*|kub|kub[^e].*|kube|kube[^\\-sv].*|kube-|kube-[^nps].*|kube-n|kube-n[^o].*|kube-no|kube-no[^d].*|kube-nod|kube-nod[^e].*|kube-node|kube-node[^\\-].*|kube-node-|kube-node-[^l].*|kube-node-l|kube-node-l[^e].*|kube-node-le|kube-node-le[^a].*|kube-node-lea|kube-node-lea[^s].*|kube-node-leas|kube-node-leas[^e].*|kube-node-lease.+|kube-p|kube-p[^u].*|kube-pu|kube-pu[^b].*|kube-pub|kube-pub[^l].*|kube-publ|kube-publ[^i].*|kube-publi|kube-publi[^c].*|kube-public.+|kube-s|kube-s[^y].*|kube-sy|kube-sy[^s].*|kube-sys|kube-sys[^t].*|kube-syst|kube-syst[^e].*|kube-syste|kube-syste[^m].*|kube-system.+|kubes|kubes[^c].*|kubesc|kubesc[^a].*|kubesca|kubesca[^p].*|kubescap|kubescap[^e].*|kubescape.+|kubev|kubev[^i].*|kubevi|kubevi[^r].*|kubevir|kubevir[^t].*|kubevirt.+|l|l[^o].*|lo|lo[^cn].*|loc|loc[^a].*|loca|loca[^l].*|local|local[^\\-].*|local-|local-[^p].*|local-p|local-p[^a].*|local-pa|local-pa[^t].*|local-pat|local-pat[^h].*|local-path|local-path[^\\-].*|local-path-|local-path-[^s].*|local-path-s|local-path-s[^t].*|local-path-st|local-path-st[^o].*|local-path-sto|local-path-sto[^r].*|local-path-stor|local-path-stor[^a].*|local-path-stora|local-path-stora[^g].*|local-path-storag|local-path-storag[^e].*|local-path-storage.+|lon|lon[^g].*|long|long[^h].*|longh|longh[^o].*|longho|longho[^r].*|longhor|longhor[^n].*|longhorn|longhorn[^\\-].*|longhorn-|longhorn-[^s].*|longhorn-s|longhorn-s[^y].*|longhorn-sy|longhorn-sy[^s].*|longhorn-sys|longhorn-sys[^t].*|longhorn-syst|longhorn-syst[^e].*|longhorn-syste|longhorn-syste[^m].*|longhorn-system.+|o|o[^b].*|ob|ob[^s].*|obs|obs[^e].*|obse|obse[^r].*|obser|obser[^v].*|observ|observ[^a].*|observa|observa[^b].*|observab|observab[^i].*|observabi|observabi[^l].*|observabil|observabil[^i].*|observabili|observabili[^t].*|observabilit|observabilit[^y].*|observability.+|v|v[^e].*|ve|ve[^l].*|vel|vel[^e].*|vele|vele[^r].*|veler|veler[^o].*|velero.+)$"
+            }
+          }
+        ],
+        "posturePolicies": [
+          {
+            "controlID": "^C-0016$"
+          },
+          {
+            "controlID": "^C-0055$"
+          }
+        ],
+        "reason": "Kyverno mutate policy \"add-security-context\" injects allowPrivilegeEscalation: false, drop ALL capabilities and seccompProfile at pod admission. The Deployment spec does not contain them and Kubescape scans the stored spec, not the live pod. The exception is scoped to the namespaces that mutation runs in, so it cannot suppress a control where nothing injects it. readOnlyRootFilesystem (C-0017) is handled separately — set in-spec per workload."
+      },
+      {
+        "name": "pod-security-mutations-unscoped",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+          "alertOnly"
+        ],
+        "resources": [
+          {
+            "designatorType": "Attributes",
+            "attributes": {
               "kind": ".*"
             }
           }
         ],
         "posturePolicies": [
           {
-            "controlID": "^C-0211$"
-          },
-          {
-            "controlID": "^C-0016$"
-          },
-          {
-            "controlID": "^C-0055$"
-          },
-          {
             "controlID": "^C-0013$"
+          },
+          {
+            "controlID": "^C-0211$"
           }
         ],
-        "reason": "Kyverno mutate policy \"add-security-context\" injects these controls (seccompProfile, allowPrivilegeEscalation: false, drop ALL capabilities, runAsNonRoot) at pod admission. The Deployment spec does not contain them and Kubescape scans the stored spec, not the live pod. readOnlyRootFilesystem (C-0017) is handled separately — set in-spec per workload."
+        "reason": "Kyverno mutate policy \"add-security-context\" injects runAsNonRoot, runAsUser, runAsGroup and fsGroupChangePolicy at pod admission. The Deployment spec does not contain them and Kubescape scans the stored spec, not the live pod. These two controls remain cluster-wide because narrowing them is blocked on evidence rather than on expressiveness: C-0013 has a measured six-workload gap in flux-system (#3223) and C-0211's residual population is unsized (#3217)."
       },
       {
         "name": "readonly-rootfs-pending",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A security exception was switching off four cluster hardening checks everywhere, justified by an
automatic fix that is applied almost everywhere — but not quite. The twelve places the automatic fix
skips are exactly the places the exception was hiding the checks with nothing standing behind them.
Suppression like that is indistinguishable from compliance: a workload that genuinely runs as root
reads the same as one that is correctly hardened, so the score cannot be trusted to catch a
regression there.

### What

Scopes the exception to the places the automatic fix actually runs, for the two checks where that is
provably safe — measured against the real scanner in production, not reasoned from the manifests.
The other two checks are split into their own file and deliberately left as they were, because
measurement showed real gaps behind them: narrowing those today would surface findings with no fix
ready, which lowers the score to absorb a problem instead of closing it. Each now has its own
tracking issue and its own stated reason, so what is left suppressed is visible and finite rather
than a single blanket claim.

Both follow-ups are filed and linked as sub-issues (#3223, #3224).

Part of #2824