### PR TITLE
security(k8s): disposition the first-party RBAC trivy findings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,6 +145,11 @@ jobs:
               - 'scripts/megalinter-scan-counts.sh'
               - 'scripts/tests/test-megalinter-scan-counts-ignorefile.sh'
               - 'scripts/tests/test-trivyignore-vendored-operator-boundary.sh'
+              # The first-party RBAC dispositions and the roles they describe are one
+              # contract: the disposition is only valid while the role stays bound and
+              # scoped the way it was reviewed. The roles themselves are already covered
+              # by the k8s/** entry above.
+              - 'scripts/tests/test-trivyignore-first-party-rbac-boundary.sh'
               # The version-drift guard reads its constants out of
               # megalinter-scan-counts.sh, so the three move together.
               - 'scripts/check-megalinter-version-drift.sh'
@@ -406,6 +411,17 @@ jobs:
         run: |
           shellcheck scripts/tests/test-trivyignore-vendored-operator-boundary.sh
           bash scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+
+      - name: 🧱 Validate first-party RBAC disposition premises
+        if: needs.changes.outputs.k8s == 'true'
+        # The four first-party RBAC dispositions rest on facts trivy cannot see: the tenant
+        # role is only ever RoleBinding-bound, cluster-reader grants no write verb, and KRO
+        # runs with no standing access. If one of those stops holding, the finding stays
+        # suppressed while its reason is gone and the count never moves — so assert the
+        # premises rather than the prose.
+        run: |
+          shellcheck scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+          bash scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
 
       - name: 🔢 Validate scanner version-drift guard
         if: needs.changes.outputs.k8s == 'true'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -97,7 +97,7 @@ DISABLE_ERRORS_LINTERS:
   # (#3205). Its dispositions are documented below because they are what holds that zero — each one
   # is a scoped, resource-level skip naming its reason, not a disabled check.
   #
-  # trivy (66 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
+  # trivy (38 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
   # section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of
@@ -128,7 +128,8 @@ DISABLE_ERRORS_LINTERS:
   # or Role named for the operator itself, and narrowing those grants would break the operator
   # and diverge the bundle from the checksum it is verified against. See .trivyignore.yaml for the
   # reasoning and #2990 for the measurement. The five checks stay live on the cluster roles this
-  # repository does author, where 7 HIGH/CRITICAL remain, and
+  # repository does author, where the residual HIGH/CRITICAL was dispositioned per class by #2990
+  # (see the entry below), and
   # scripts/tests/test-trivyignore-vendored-operator-boundary.sh fails the build if that boundary
   # is ever lost. KSV-0014 on the two operator Deployments is deliberately left reporting: a
   # read-only root filesystem is a container setting a kustomize patch can supply without
@@ -153,6 +154,23 @@ DISABLE_ERRORS_LINTERS:
   #
   # The list is load-bearing, verified by ablation rather than asserted: deleting the single
   # `quay.io` entry returns exactly 11 findings, and all 11 are quay.io-hosted containers.
+  #
+  # It then went 66 -> 38 when the first-party RBAC this repository authors was dispositioned per
+  # class — 7 findings, and every remaining CRITICAL on this tree, so HIGH+CRITICAL went 9 -> 2 and
+  # CRITICAL 3 -> 0. Each verdict turns on how the role is BOUND rather than on the rules trivy
+  # reads: the tenant role is aggregated into `tenant-edit` and bound only by a namespace-scoped
+  # RoleBinding (no ClusterRoleBinding for it exists in the repository, nor among the 179 on the
+  # live cluster); `cluster-reader` uses resources ["*"] but grants get/list/watch only, and
+  # KSV-0046 was shown by paired fixture to ignore verbs entirely; and the two KRO RGD roles
+  # aggregate into a controller running with `rbac.mode: aggregation`, so it holds no standing
+  # access. See .trivyignore.yaml for each statement and
+  # scripts/tests/test-trivyignore-first-party-rbac-boundary.sh, which fails the build if any of
+  # those premises stops holding — a disposition outliving its reason is the failure mode here.
+  #
+  # The 2 that remain are both KSV-0014 on the vendored operator Deployments, deliberately left
+  # reporting. Note that the kustomize patch that note anticipates hardens the RENDERED workload
+  # but does NOT clear the finding: trivy scans the raw vendored file, not the kustomize output
+  # (measured). #2990 owns closing that last pair.
   #
   # checkov is at 0 failed checks on all three frameworks CI runs. Its last two findings were both
   # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as a scoped

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -255,6 +255,7 @@ misconfigurations:
     statement: >-
       This check fires on resources ["*"] and does not consider verbs — verified with a paired
       fixture in which an identical read-only rule and a write rule both trigger it. cluster-reader
-      grants get/list/watch and nothing else, and its apiGroups are enumerated rather than
-      wildcarded precisely so the core group, and therefore secrets, is never included. The role
-      cannot write any resource.
+      grants get/list/watch and nothing else. Its one core-group ("") rule enumerates its
+      resources — nodes and persistentvolumes — rather than wildcarding them, so Secrets are
+      out of reach; only the non-core rule uses resources ["*"], and Secrets do not live
+      there. The role cannot write any resource.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -210,3 +210,51 @@ misconfigurations:
       Role, does grant create/patch/delete — but is resourceNames-scoped to sixteen explicitly named
       kubevirt-* certificate secrets it issues and rotates, so it cannot reach any other secret in
       the namespace. The grant is upstream's, in a SHA-256 pinned release artifact vendored verbatim.
+
+  # First-party RBAC this repository authors — the 7 HIGH/CRITICAL the vendored-operator block
+  # above deliberately left live, now dispositioned per class (#2990). Each verdict was checked
+  # against how the role is actually BOUND, which is the fact these checks cannot see: trivy
+  # evaluates a ClusterRole's rules in isolation, so it reads every grant as cluster-wide even
+  # when the only binding is namespace-scoped. Every entry below is path-scoped, so all three
+  # checks stay live on every other role in the tree.
+  #
+  # scripts/tests/test-trivyignore-first-party-rbac-boundary.sh fails the build if the premise
+  # behind any of these verdicts stops holding — a ClusterRoleBinding appearing for the tenant
+  # role, cluster-reader gaining a write verb, or KRO losing aggregation mode. A disposition that
+  # outlives its reason is the failure mode this block must not have.
+  - id: KSV-0041
+    paths:
+      - k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+    statement: >-
+      tenant-base-edit is the built-in edit role minus the exec-family subresources, aggregated
+      into tenant-edit and bound ONLY by a namespace-scoped RoleBinding to the tenant's own
+      ServiceAccount in its own namespace (resource-graph-definitions/tenant). A tenant's Flux
+      identity manages the secrets it reconciles into its own namespace; the grant cannot reach
+      any other namespace. Verified: no ClusterRoleBinding references this role in the repository
+      or on the live cluster.
+  - id: KSV-0056
+    paths:
+      - k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+    statement: >-
+      Same namespace-scoped RoleBinding as above. Creating Services and Ingresses for its own
+      workloads is the core capability a tenant namespace-admin role exists to grant, and it is
+      confined to the tenant's own namespace.
+  - id: KSV-0056
+    paths:
+      - k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml
+      - k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml
+    statement: >-
+      The KRO controller runs with rbac.mode aggregation and holds NO standing access; it
+      aggregates only ClusterRoles labelled rbac.kro.run/aggregate-to-controller. Each of these
+      grants exactly the child kinds its own ResourceGraphDefinition renders, so the networking
+      verbs are what lets KRO create the Service and HTTPRoute it is asked to render, and each
+      RGD's blast radius is its own declared resources.
+  - id: KSV-0046
+    paths:
+      - k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml
+    statement: >-
+      This check fires on resources ["*"] and does not consider verbs — verified with a paired
+      fixture in which an identical read-only rule and a write rule both trigger it. cluster-reader
+      grants get/list/watch and nothing else, and its apiGroups are enumerated rather than
+      wildcarded precisely so the core group, and therefore secrets, is never included. The role
+      cannot write any resource.

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -149,7 +149,7 @@ while IFS= read -r rule; do
   resources="${rule#*|}"
   core=0
   old_ifs="$IFS"
-  set -f  # a resource may literally be "*"; without this, word-splitting globs it away
+  set -f # a resource may literally be "*"; without this, word-splitting globs it away
   IFS=','
   for g in $groups; do
     [ -z "$g" ] && core=1

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -10,7 +10,9 @@
 #   tenant-base-edit  — aggregated into tenant-edit and bound ONLY by a namespace-scoped
 #                       RoleBinding, so its secrets and networking grants cannot leave the tenant's
 #                       own namespace.
-#   cluster-reader    — uses resources ["*"] but grants get/list/watch and nothing else.
+#   cluster-reader    — its non-core rule uses resources ["*"], but every rule grants
+#                       get/list/watch only, and the core ("") group enumerates its
+#                       resources so Secrets are out of reach.
 #   kro-*-rgd         — aggregated into a KRO controller that runs with rbac.mode `aggregation` and
 #                       therefore holds no standing access of its own.
 #
@@ -21,7 +23,8 @@
 # So this test asserts the premises, not the prose:
 #   * no ClusterRoleBinding anywhere under k8s/ binds the tenant role (checked recursively, so a
 #     binding nested inside a ResourceGraphDefinition template counts too);
-#   * cluster-reader grants no verb outside get/list/watch;
+#   * cluster-reader grants no verb outside get/list/watch, and its core-group rules never
+#     wildcard resources or name secrets;
 #   * KRO keeps rbac.mode `aggregation` and both RGD roles keep the aggregation label;
 #   * each disposition stays scoped to its own file, never loses its paths key, and no pair beyond
 #     the reviewed matrix appears.
@@ -133,6 +136,38 @@ while IFS= read -r verb; do
       ;;
   esac
 done < <(yq -N '.. | select(tag == "!!map") | select(.kind == "ClusterRole") | select(.metadata.name == "cluster-reader") | .rules[].verbs[]' "$repo_root/$reader_role")
+
+# 2b. cluster-reader's CORE-group rules stay resource-enumerated.
+#     Read-only is necessary but NOT sufficient: KSV-0046 is about breadth, and a get/list/watch
+#     grant on core `secrets` would read every Secret in the cluster while passing check 2 above.
+#     The protection is that the core ("") group enumerates its resources instead of wildcarding —
+#     so assert exactly that, rather than trusting the prose. Non-core groups may wildcard
+#     resources; the core group is where Secrets live.
+while IFS= read -r rule; do
+  [ -n "$rule" ] || continue
+  groups="${rule%%|*}"
+  resources="${rule#*|}"
+  core=0
+  old_ifs="$IFS"
+  set -f  # a resource may literally be "*"; without this, word-splitting globs it away
+  IFS=','
+  for g in $groups; do
+    [ -z "$g" ] && core=1
+  done
+  # A rule whose apiGroups list is exactly [""] joins to the empty string, so the loop above sees
+  # no fields at all; catch that case explicitly.
+  [ -z "$groups" ] && core=1
+  for r in $resources; do
+    if [ "$core" -eq 1 ] && { [ "$r" = '*' ] || [ "$r" = 'secrets' ]; }; then
+      IFS="$old_ifs"
+      printf 'PREMISE BROKEN: cluster-reader grants core-group resource %s; the KSV-0046 disposition assumes the core group enumerates resources so Secrets stay out of reach\n' "$r" >&2
+      status=1
+      IFS=','
+    fi
+  done
+  IFS="$old_ifs"
+  set +f
+done < <(yq -N '.. | select(tag == "!!map") | select(.kind == "ClusterRole") | select(.metadata.name == "cluster-reader") | .rules[] | ((.apiGroups // []) | join(",")) + "|" + ((.resources // []) | join(","))' "$repo_root/$reader_role")
 
 # 3. KRO holds no standing access, and both RGD roles are aggregated into it.
 mode="$(yq -N '.spec.values.rbac.mode // ""' "$repo_root/$kro_release" 2>/dev/null || printf '')"

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -23,7 +23,8 @@
 #     binding nested inside a ResourceGraphDefinition template counts too);
 #   * cluster-reader grants no verb outside get/list/watch;
 #   * KRO keeps rbac.mode `aggregation` and both RGD roles keep the aggregation label;
-#   * each disposition stays scoped to its own file and never loses its paths key.
+#   * each disposition stays scoped to its own file, never loses its paths key, and no pair beyond
+#     the reviewed matrix appears.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -75,6 +76,36 @@ while IFS= read -r n; do
   fi
 done < <(yq '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0056") | (.paths // []) | length' "$ignorefile")
 
+# Nothing beyond the reviewed matrix. The check ids here are also dispositioned for the two vendored
+# operator bundles, so those two paths are expected; ANY other first-party pair is an unreviewed
+# suppression, and it must fail here rather than being noticed only if someone re-reads the file.
+readonly reviewed_pairs=(
+  "KSV-0041:$tenant_role"
+  "KSV-0056:$tenant_role"
+  "KSV-0056:$kro_tenant"
+  "KSV-0056:$kro_webapp"
+  "KSV-0046:$reader_role"
+)
+readonly vendored_cdi='k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml'
+readonly vendored_kubevirt='k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml'
+while IFS= read -r pair; do
+  [ -n "$pair" ] || continue
+  pair_path="${pair#*:}"
+  [ "$pair_path" = "$vendored_cdi" ] && continue
+  [ "$pair_path" = "$vendored_kubevirt" ] && continue
+  known=0
+  for rp in "${reviewed_pairs[@]}"; do
+    if [ "$pair" = "$rp" ]; then
+      known=1
+      break
+    fi
+  done
+  if [ "$known" -eq 0 ]; then
+    printf 'UNREVIEWED DISPOSITION: %s is not one of the reviewed first-party verdicts\n' "$pair" >&2
+    status=1
+  fi
+done < <(yq -N '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0053" or .id == "KSV-0056" or .id == "KSV-0114") | .id + ":" + (.paths // [])[]' "$ignorefile")
+
 # ----------------------------------------------------------------- premises --
 # 1. The tenant role is never bound cluster-wide. Recursive, so a ClusterRoleBinding nested in an
 #    RGD resource template is caught as well as a top-level one.
@@ -85,7 +116,7 @@ while IFS= read -r -d '' file; do
   for c in $found; do
     [ "${c:-0}" -gt 0 ] && bindings=$((bindings + c))
   done
-done < <(find "$repo_root/k8s" -name '*.yaml' -type f -print0)
+done < <(find "$repo_root/k8s" -type f \( -name '*.yaml' -o -name '*.yml' \) -print0)
 if [ "$bindings" -ne 0 ]; then
   printf 'PREMISE BROKEN: %d ClusterRoleBinding(s) bind the tenant role; the KSV-0041/KSV-0056 dispositions on %s assume namespace-scoped RoleBindings only\n' "$bindings" "$tenant_role" >&2
   status=1

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# The first-party RBAC dispositions in .trivyignore.yaml rest on facts about how each role is
+# BOUND and what it can do — not on the rules trivy reads. This test is what keeps those facts true.
+#
+# WHY THIS EXISTS
+# trivy evaluates a ClusterRole's rules in isolation, so it reports every grant as cluster-wide.
+# Four first-party roles are dispositioned in .trivyignore.yaml (#2990) because a fact outside the
+# rules makes the grant safe:
+#
+#   tenant-base-edit  — aggregated into tenant-edit and bound ONLY by a namespace-scoped
+#                       RoleBinding, so its secrets and networking grants cannot leave the tenant's
+#                       own namespace.
+#   cluster-reader    — uses resources ["*"] but grants get/list/watch and nothing else.
+#   kro-*-rgd         — aggregated into a KRO controller that runs with rbac.mode `aggregation` and
+#                       therefore holds no standing access of its own.
+#
+# Each of those is a PREMISE, and a disposition that outlives its premise is a silent hole: the
+# finding stays suppressed while the reason for suppressing it has gone. Nothing else would fail —
+# the scan still runs and the count does not move, which reads exactly like nothing happened.
+#
+# So this test asserts the premises, not the prose:
+#   * no ClusterRoleBinding anywhere under k8s/ binds the tenant role (checked recursively, so a
+#     binding nested inside a ResourceGraphDefinition template counts too);
+#   * cluster-reader grants no verb outside get/list/watch;
+#   * KRO keeps rbac.mode `aggregation` and both RGD roles keep the aggregation label;
+#   * each disposition stays scoped to its own file and never loses its paths key.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly repo_root
+readonly ignorefile="$repo_root/.trivyignore.yaml"
+
+command -v yq >/dev/null 2>&1 || {
+  printf 'yq is required to check the first-party RBAC disposition premises\n' >&2
+  exit 1
+}
+
+readonly tenant_role='k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml'
+readonly reader_role='k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml'
+readonly kro_tenant='k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml'
+readonly kro_webapp='k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml'
+readonly kro_release='k8s/bases/infrastructure/controllers/kro/helm-release.yaml'
+
+status=0
+
+# ---------------------------------------------------------------- structure --
+# id:path pairs that must exist, each scoped to exactly that one file.
+readonly pairs=(
+  "KSV-0041:$tenant_role"
+  "KSV-0056:$tenant_role"
+  "KSV-0046:$reader_role"
+)
+for pair in "${pairs[@]}"; do
+  check="${pair%%:*}"
+  path="${pair#*:}"
+  n="$(yq "[.misconfigurations[] | select(.id == \"$check\") | select((.paths // []) | contains([\"$path\"]))] | length" "$ignorefile" 2>/dev/null || printf '0')"
+  if [ "${n:-0}" -lt 1 ]; then
+    printf 'MISSING DISPOSITION: %s is not dispositioned for %s\n' "$check" "$path" >&2
+    status=1
+  fi
+done
+
+# The KRO pair is one entry covering both RGD roles.
+kro_n="$(yq "[.misconfigurations[] | select(.id == \"KSV-0056\") | select((.paths // []) | contains([\"$kro_tenant\", \"$kro_webapp\"]))] | length" "$ignorefile" 2>/dev/null || printf '0')"
+if [ "${kro_n:-0}" -lt 1 ]; then
+  printf 'MISSING DISPOSITION: KSV-0056 does not cover both KRO RGD cluster roles\n' >&2
+  status=1
+fi
+
+# No entry naming a first-party role may be unscoped, which would suppress it everywhere.
+while IFS= read -r n; do
+  if [ "${n:-1}" -eq 0 ]; then
+    printf 'UNSCOPED SKIP: a first-party RBAC entry has no paths key\n' >&2
+    status=1
+  fi
+done < <(yq '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0056") | (.paths // []) | length' "$ignorefile")
+
+# ----------------------------------------------------------------- premises --
+# 1. The tenant role is never bound cluster-wide. Recursive, so a ClusterRoleBinding nested in an
+#    RGD resource template is caught as well as a top-level one.
+bindings=0
+while IFS= read -r -d '' file; do
+  found="$(yq -N "[.. | select(tag == \"!!map\") | select(.kind == \"ClusterRoleBinding\") | select((.roleRef.name // \"\") == \"tenant-edit\" or (.roleRef.name // \"\") == \"tenant-base-edit\")] | length" "$file" 2>/dev/null || printf '0')"
+  # A multi-document file yields one count per document.
+  for c in $found; do
+    [ "${c:-0}" -gt 0 ] && bindings=$((bindings + c))
+  done
+done < <(find "$repo_root/k8s" -name '*.yaml' -type f -print0)
+if [ "$bindings" -ne 0 ]; then
+  printf 'PREMISE BROKEN: %d ClusterRoleBinding(s) bind the tenant role; the KSV-0041/KSV-0056 dispositions on %s assume namespace-scoped RoleBindings only\n' "$bindings" "$tenant_role" >&2
+  status=1
+fi
+
+# 2. cluster-reader stays read-only.
+while IFS= read -r verb; do
+  [ -n "$verb" ] || continue
+  case "$verb" in
+    get | list | watch) ;;
+    *)
+      printf 'PREMISE BROKEN: cluster-reader grants verb %s; the KSV-0046 disposition assumes get/list/watch only\n' "$verb" >&2
+      status=1
+      ;;
+  esac
+done < <(yq -N '.. | select(tag == "!!map") | select(.kind == "ClusterRole") | select(.metadata.name == "cluster-reader") | .rules[].verbs[]' "$repo_root/$reader_role")
+
+# 3. KRO holds no standing access, and both RGD roles are aggregated into it.
+mode="$(yq -N '.spec.values.rbac.mode // ""' "$repo_root/$kro_release" 2>/dev/null || printf '')"
+if [ "$mode" != "aggregation" ]; then
+  printf 'PREMISE BROKEN: KRO rbac.mode is %s, not aggregation; the KSV-0056 disposition on the RGD roles assumes the controller has no standing access\n' "${mode:-unset}" >&2
+  status=1
+fi
+for role in "$kro_tenant" "$kro_webapp"; do
+  label="$(yq -N '.metadata.labels["rbac.kro.run/aggregate-to-controller"] // ""' "$repo_root/$role" 2>/dev/null || printf '')"
+  if [ "$label" != "true" ]; then
+    printf 'PREMISE BROKEN: %s no longer carries the KRO aggregation label\n' "$role" >&2
+    status=1
+  fi
+done
+
+[ "$status" -eq 0 ] || exit 1
+printf 'first-party RBAC dispositions hold: tenant role never cluster-bound, cluster-reader read-only, KRO aggregation-scoped\n'

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -11,8 +11,9 @@
 # The risk that disposition creates is NOT that it is wrong; it is that it silently stops being
 # path-scoped. Drop a `paths:` key, or widen one to k8s/**, and every one of these checks goes
 # quiet across the whole repository — including on the FIRST-PARTY cluster roles this repository
-# does author. Four of those roles now carry their own reviewed dispositions (#2990), listed
-# literally below and guarded by their own premises test; the checks stay live on every other role.
+# does author. A few exact check:path pairs on those roles now carry their own reviewed
+# dispositions (#2990), listed literally below and guarded by their own premises test; every other
+# check:path combination stays live.
 # Nothing else would fail: the scan still runs, the count still drops, and the gate still reports
 # a smaller number, which reads exactly like progress.
 #
@@ -42,15 +43,19 @@ readonly vendored_cdi='k8s/bases/infrastructure/controllers/cdi/cdi-operator.yam
 readonly vendored_kubevirt='k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml'
 readonly first_party='k8s/bases/infrastructure/cluster-roles/boundary-probe.yaml'
 
-# First-party RBAC paths that carry their OWN reviewed disposition for one of these same check ids
-# (#2990). They are listed literally, so this stays fail-closed: any path that is neither a vendored
-# bundle nor one of these fails as a widened skip, exactly as before. Their premises are guarded
-# separately by scripts/tests/test-trivyignore-first-party-rbac-boundary.sh.
-readonly first_party_dispositioned=(
-  'k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml'
-  'k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml'
-  'k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml'
-  'k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml'
+# First-party RBAC dispositions for these same check ids (#2990), as exact CHECK:PATH pairs.
+# Pairs, not bare paths: a path-only allow-list would let ANY of these five checks be suppressed on
+# a reviewed role — KSV-0053 (pods/exec) on the tenant role, say — which is a widening this test
+# exists to catch. Each pair below is one reviewed verdict, and anything else fails as a widened
+# skip. Their premises are guarded separately by
+# scripts/tests/test-trivyignore-first-party-rbac-boundary.sh, which also rejects any pair not
+# listed here so the two files cannot drift apart.
+readonly first_party_pairs=(
+  'KSV-0041:k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml'
+  'KSV-0056:k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml'
+  'KSV-0056:k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml'
+  'KSV-0056:k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml'
+  'KSV-0046:k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml'
 )
 
 # Every check id dispositioned for the vendored bundles. Keep in sync with .trivyignore.yaml.
@@ -87,14 +92,14 @@ for check in "${checks[@]}"; do
       "$vendored_kubevirt") seen_kubevirt=1 ;;
       *)
         reviewed=0
-        for fp in "${first_party_dispositioned[@]}"; do
-          if [ "$path" = "$fp" ]; then
+        for fp in "${first_party_pairs[@]}"; do
+          if [ "$check:$path" = "$fp" ]; then
             reviewed=1
             break
           fi
         done
         if [ "$reviewed" -eq 0 ]; then
-          printf 'WIDENED SKIP: %s is scoped to %s, which is neither a vendored operator bundle nor a reviewed first-party disposition\n' "$check" "$path" >&2
+          printf 'WIDENED SKIP: %s is scoped to %s, which is neither a vendored operator bundle nor a reviewed first-party disposition for THAT check\n' "$check" "$path" >&2
           status=1
         fi
         ;;
@@ -203,4 +208,4 @@ done
 
 [ "$status" -eq 0 ] || exit 1
 
-printf 'vendored-operator RBAC disposition is path-scoped: %d checks suppressed on both vendored bundles, still live on every first-party role but the %d reviewed exceptions\n' "${#checks[@]}" "${#first_party_dispositioned[@]}"
+printf 'vendored-operator RBAC disposition is path-scoped: %d checks suppressed on both vendored bundles, still live on every first-party role but the %d reviewed check:path exceptions\n' "${#checks[@]}" "${#first_party_pairs[@]}"

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -11,7 +11,8 @@
 # The risk that disposition creates is NOT that it is wrong; it is that it silently stops being
 # path-scoped. Drop a `paths:` key, or widen one to k8s/**, and every one of these checks goes
 # quiet across the whole repository — including on the FIRST-PARTY cluster roles this repository
-# does author, where the same permissions are a real finding and four of them are still open.
+# does author. Four of those roles now carry their own reviewed dispositions (#2990), listed
+# literally below and guarded by their own premises test; the checks stay live on every other role.
 # Nothing else would fail: the scan still runs, the count still drops, and the gate still reports
 # a smaller number, which reads exactly like progress.
 #
@@ -40,6 +41,17 @@ command -v yq >/dev/null 2>&1 || {
 readonly vendored_cdi='k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml'
 readonly vendored_kubevirt='k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml'
 readonly first_party='k8s/bases/infrastructure/cluster-roles/boundary-probe.yaml'
+
+# First-party RBAC paths that carry their OWN reviewed disposition for one of these same check ids
+# (#2990). They are listed literally, so this stays fail-closed: any path that is neither a vendored
+# bundle nor one of these fails as a widened skip, exactly as before. Their premises are guarded
+# separately by scripts/tests/test-trivyignore-first-party-rbac-boundary.sh.
+readonly first_party_dispositioned=(
+  'k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml'
+  'k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml'
+  'k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml'
+  'k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml'
+)
 
 # Every check id dispositioned for the vendored bundles. Keep in sync with .trivyignore.yaml.
 readonly checks=(KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
@@ -74,8 +86,17 @@ for check in "${checks[@]}"; do
       "$vendored_cdi") seen_cdi=1 ;;
       "$vendored_kubevirt") seen_kubevirt=1 ;;
       *)
-        printf 'WIDENED SKIP: %s is scoped to %s, which is not one of the two vendored operator bundles\n' "$check" "$path" >&2
-        status=1
+        reviewed=0
+        for fp in "${first_party_dispositioned[@]}"; do
+          if [ "$path" = "$fp" ]; then
+            reviewed=1
+            break
+          fi
+        done
+        if [ "$reviewed" -eq 0 ]; then
+          printf 'WIDENED SKIP: %s is scoped to %s, which is neither a vendored operator bundle nor a reviewed first-party disposition\n' "$check" "$path" >&2
+          status=1
+        fi
         ;;
     esac
   done < <(yq ".misconfigurations[] | select(.id == \"$check\") | (.paths // [])[]" "$ignorefile")
@@ -182,4 +203,4 @@ done
 
 [ "$status" -eq 0 ] || exit 1
 
-printf 'vendored-operator RBAC disposition is path-scoped: %d checks suppressed on both vendored bundles, all still live on first-party roles\n' "${#checks[@]}"
+printf 'vendored-operator RBAC disposition is path-scoped: %d checks suppressed on both vendored bundles, still live on every first-party role but the %d reviewed exceptions\n' "${#checks[@]}" "${#first_party_dispositioned[@]}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Trivy's Kubernetes scan reports every RBAC grant as if it were cluster-wide, because it reads a role's rules and cannot see how that role is actually bound. That left nine of its most serious findings — the ones that would matter if one were real — sitting unjudged on roles we wrote ourselves, where a genuine over-grant would look exactly like the noise around it.

### What

Gives each of those a recorded verdict, so the serious findings are now a list someone can act on rather than a number to scroll past. Trivy goes 45 → 38 overall, and the highest-severity band 9 → 2, with zero left at the top severity.

Seven were checked and found to be the design working as intended — a tenant role that only ever applies inside that tenant's own namespace, a reader role that genuinely cannot write anything, and a controller that is granted only what it was asked to create. Each is recorded with the reason that was checked, not a blanket exemption.

The risk with writing reasons down is that the reason quietly stops being true later, and nothing tells you — the finding stays hidden and the number never moves. So each reason is now enforced by a test that fails the build if it stops holding. Every one of its checks was deliberately broken first to confirm it actually catches the problem.

The remaining two are a different kind of fix and stay visible: they sit in vendored upstream bundles we use verbatim, so they need a decision rather than an edit. #3228 tracks them.

Part of #2990
Part of #2787
