### PR TITLE
chore(security): disposition KSV-0020/0021 on the vendored VM operators

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -138,10 +138,12 @@ DISABLE_ERRORS_LINTERS:
   # other container control, and the two Deployments ship only to the docker (local/CI) provider —
   # a premise the same boundary test asserts, so the exception fails the build if the VM stack ever
   # reaches production.
-  # It then went 36 -> 32 when KSV-0020 and KSV-0021 on those same two Deployments were
-  # dispositioned (#2787). Both bundles set runAsNonRoot: true and omit runAsUser/runAsGroup, which
-  # is what those two checks read as UID/GID <= 10000 — an absent value rather than a low one, so
-  # the kubelet still refuses to start them as root. Same three facts as KSV-0014 above, and the
+  # It then went 36 -> 32 TOTAL findings when KSV-0020 and KSV-0021 on those same two Deployments
+  # were dispositioned (#2787). Both are LOW: the HIGH/CRITICAL count was already 0 before this and
+  # stays 0 after, so this figure moves the total only. Both bundles set runAsNonRoot: true and omit
+  # runAsUser/runAsGroup, which is what those two checks read as UID/GID <= 10000 — an absent value
+  # rather than a low one. Note the two residuals differ: runAsNonRoot rejects UID 0 but constrains
+  # the UID only, so the primary GID may still be 0. Same three facts as KSV-0014 above, and the
   # same boundary test asserts them: its checks array lists both ids.
   #
   # ⚠️ That 109 is NOT 108 plus a regression. 108 was measured on trivy v0.73.0 and 109 on v0.74.0

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -138,6 +138,11 @@ DISABLE_ERRORS_LINTERS:
   # other container control, and the two Deployments ship only to the docker (local/CI) provider —
   # a premise the same boundary test asserts, so the exception fails the build if the VM stack ever
   # reaches production.
+  # It then went 36 -> 32 when KSV-0020 and KSV-0021 on those same two Deployments were
+  # dispositioned (#2787). Both bundles set runAsNonRoot: true and omit runAsUser/runAsGroup, which
+  # is what those two checks read as UID/GID <= 10000 — an absent value rather than a low one, so
+  # the kubelet still refuses to start them as root. Same three facts as KSV-0014 above, and the
+  # same boundary test asserts them: its checks array lists both ids.
   #
   # ⚠️ That 109 is NOT 108 plus a regression. 108 was measured on trivy v0.73.0 and 109 on v0.74.0
   # with no manifest change in between, so that 1 is a scanner rule-set difference rather than new

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -182,13 +182,19 @@ misconfigurations:
   # these two checks read as "UID/GID <= 10000" — an absent value, not a low one. The three facts
   # that carry the KSV-0014 entry above carry these unchanged: trivy reads the raw committed file,
   # so a kustomize patch would move the deployed posture while the count stayed at four; the
-  # omission is upstream's, in a SHA-256 pinned artifact vendored verbatim, and pinning a UID that
-  # upstream does not set risks a component whose filesystem ownership we do not own; and the VM
-  # stack ships only through k8s/providers/docker/, never to production.
+  # omission is upstream's, inside a release artifact whose SHA-256 update-vendored-operators.sh
+  # verifies on download before this repository adds its resource-scoped Checkov annotations (so
+  # the committed file is upstream plus those annotations, not a verbatim copy — the securityContext
+  # fields at issue here are untouched upstream ones), and pinning a UID upstream does not set risks
+  # a component whose filesystem ownership we do not own; and the VM stack ships only through
+  # k8s/providers/docker/, never to production.
   #
-  # Severity note, because it bounds what is actually being excepted: runAsNonRoot: true IS set on
-  # both, so the kubelet refuses to start these containers as root regardless. The residual is an
-  # unpinned non-root UID inside a local/CI-only workload, not a root container.
+  # Severity note, stated precisely because it bounds what is actually being excepted. runAsNonRoot
+  # rejects UID 0; it does NOT require a UID above 10000, and it constrains the UID only. So the
+  # residual differs per check: for KSV-0020 it is an unpinned but guaranteed non-root UID, while
+  # for KSV-0021 the primary GID is left image- or runtime-defined and MAY be 0 — runAsGroup sets
+  # the primary GID, not supplementary groups, and nothing here constrains it. That is a real
+  # residual, accepted only because these two Deployments never run outside the local/CI provider.
   #
   # Both ids stay live on every other workload in this repository, and the same
   # scripts/tests/test-trivyignore-vendored-operator-boundary.sh that guards KSV-0014 asserts it —
@@ -198,21 +204,25 @@ misconfigurations:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
       - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
     statement: >-
-      Both operator Deployments set runAsNonRoot but omit runAsUser, so the kubelet enforces a
-      non-root UID that the manifest does not pin. The bundles are SHA-256 pinned artifacts
-      vendored verbatim and trivy reads the raw file, so a kustomize patch would change the
-      deployed posture without clearing the finding. They ship only to the docker (local/CI)
-      provider and are excluded from the production overlay.
+      Both operator Deployments set runAsNonRoot and omit runAsUser, so the kubelet rejects UID 0
+      while the specific non-root UID stays image-defined; runAsNonRoot does not itself require a
+      UID above 10000. The bundles are upstream release artifacts whose SHA-256 is verified on
+      download before this repository adds its resource-scoped Checkov annotations, and trivy reads
+      the raw committed file, so a kustomize patch would change the deployed posture without
+      clearing the finding. They ship only to the docker (local/CI) provider and are excluded from
+      the production overlay.
   - id: KSV-0021
     paths:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
       - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
     statement: >-
-      Both operator Deployments omit runAsGroup, leaving the supplementary group unpinned while
-      runAsNonRoot keeps the container off root. The bundles are SHA-256 pinned artifacts vendored
-      verbatim and trivy reads the raw file, so a kustomize patch would change the deployed posture
-      without clearing the finding. They ship only to the docker (local/CI) provider and are
-      excluded from the production overlay.
+      Both operator Deployments omit runAsGroup, which sets the PRIMARY GID rather than any
+      supplementary group, so the primary GID stays image- or runtime-defined and may be 0;
+      runAsNonRoot constrains the UID only and does not cover this. The bundles are upstream
+      release artifacts whose SHA-256 is verified on download before this repository adds its
+      resource-scoped Checkov annotations, and trivy reads the raw committed file, so a kustomize
+      patch would change the deployed posture without clearing the finding. They ship only to the
+      docker (local/CI) provider and are excluded from the production overlay.
   - id: KSV-0041
     paths:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -176,6 +176,43 @@ misconfigurations:
       are SHA-256 pinned artifacts vendored verbatim, and trivy reads the raw file, so a kustomize
       patch would change the deployed posture without clearing this finding. The two Deployments
       ship only to the docker (local/CI) provider and are excluded from the production overlay.
+  #
+  # ALSO covered here: KSV-0020 and KSV-0021 on the same two operator Deployments (#2787). Both
+  # bundles set runAsNonRoot: true and then omit runAsUser and runAsGroup entirely, which is what
+  # these two checks read as "UID/GID <= 10000" — an absent value, not a low one. The three facts
+  # that carry the KSV-0014 entry above carry these unchanged: trivy reads the raw committed file,
+  # so a kustomize patch would move the deployed posture while the count stayed at four; the
+  # omission is upstream's, in a SHA-256 pinned artifact vendored verbatim, and pinning a UID that
+  # upstream does not set risks a component whose filesystem ownership we do not own; and the VM
+  # stack ships only through k8s/providers/docker/, never to production.
+  #
+  # Severity note, because it bounds what is actually being excepted: runAsNonRoot: true IS set on
+  # both, so the kubelet refuses to start these containers as root regardless. The residual is an
+  # unpinned non-root UID inside a local/CI-only workload, not a root container.
+  #
+  # Both ids stay live on every other workload in this repository, and the same
+  # scripts/tests/test-trivyignore-vendored-operator-boundary.sh that guards KSV-0014 asserts it —
+  # its checks array now lists them, so dropping a path or widening a glob fails the build.
+  - id: KSV-0020
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Both operator Deployments set runAsNonRoot but omit runAsUser, so the kubelet enforces a
+      non-root UID that the manifest does not pin. The bundles are SHA-256 pinned artifacts
+      vendored verbatim and trivy reads the raw file, so a kustomize patch would change the
+      deployed posture without clearing the finding. They ship only to the docker (local/CI)
+      provider and are excluded from the production overlay.
+  - id: KSV-0021
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Both operator Deployments omit runAsGroup, leaving the supplementary group unpinned while
+      runAsNonRoot keeps the container off root. The bundles are SHA-256 pinned artifacts vendored
+      verbatim and trivy reads the raw file, so a kustomize patch would change the deployed posture
+      without clearing the finding. They ship only to the docker (local/CI) provider and are
+      excluded from the production overlay.
   - id: KSV-0041
     paths:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -59,7 +59,7 @@ readonly first_party_pairs=(
 )
 
 # Every check id dispositioned for the vendored bundles. Keep in sync with .trivyignore.yaml.
-readonly checks=(KSV-0014 KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
+readonly checks=(KSV-0014 KSV-0020 KSV-0021 KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
 
 status=0
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

`k8s/` misconfiguration findings still don't fail the build — `REPOSITORY_TRIVY` sits in `DISABLE_ERRORS_LINTERS` while the backlog is worked off, so a workload shipping a bad security context would be reported and merged anyway. This clears the next chunk of that backlog.

Worth flagging, because it changes what #2787 is actually asking for: its body says "checkov 286, trivy 1". Measured today, checkov is at **0 and is already a hard gate**, and trivy is at **36** — the "1" was MegaLinter's counting artifact, not a finding count. Two of that issue's three acceptance criteria are already met; only trivy is outstanding. Full measurement posted on the issue.

### Changes

Dispositions the last two check families trivy raises on the two vendored VM-operator bundles, taking it **36 → 32**. These are genuinely irreducible here rather than a threshold being relaxed: the bundles are checksum-verified upstream artifacts, trivy reads the raw committed file so patching them would move the deployed posture without clearing the finding, and the VM stack never runs in production.

Both checks stay live on every other workload, and the existing boundary test now asserts these two as well — so if the suppression ever widened, or the VM stack ever reached production, the build fails instead of quietly keeping an expired exception.

Part of #2787