### PR TITLE
security(k8s): disposition the 8 RBAC-breadth trivy findings

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -357,9 +357,11 @@ misconfigurations:
       bound ONLY by a namespace-scoped RoleBinding to the tenant's own ServiceAccount in its own
       namespace (resource-graph-definitions/tenant), so managing workloads is confined to that one
       namespace and cannot reach any other. Verified: no ClusterRoleBinding references this role in
-      the repository or on the live cluster, where the only bindings are three namespace-scoped
-      RoleBindings (ascoachingogvaner, doggy-countdown, wedding-app). The role also omits the
-      exec-family pod subresources, so it cannot exec into the pods it manages.
+      the repository or on the live cluster, where every binding is a namespace-scoped RoleBinding
+      to a single tenant ServiceAccount (three at the time of writing: ascoachingogvaner,
+      doggy-countdown, wedding-app; onboarding another tenant adds a fourth without weakening
+      this). The role also omits the exec-family pod subresources, so it cannot exec into the pods
+      it manages.
   - id: KSV-0049
     paths:
       - k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -384,12 +384,15 @@ misconfigurations:
     statement: >-
       Unlike the three entries above this grant IS cluster-wide, and deliberately so: the KRO
       controller runs with rbac.mode aggregation and holds NO standing access of its own,
-      aggregating only ClusterRoles labelled rbac.kro.run/aggregate-to-controller. This role grants
-      exactly the child kinds the WebApp ResourceGraphDefinition renders — Deployment, Service,
-      HTTPRoute — and a WebApp instance may be created in any namespace, so the Deployment grant
-      cannot be namespace-scoped without breaking the RGD. Each RGD's blast radius is therefore its
-      own declared resources. The same subject's controller-grade breadth is already accepted on
-      the Kubescape side, where cluster-security-exceptions/delete-rbac.yaml excepts the
+      aggregating only ClusterRoles labelled rbac.kro.run/aggregate-to-controller. The role carries
+      two grants. The first is the instance kind itself — get/list/watch/update/patch on kro.run
+      webapps and webapps/status — which KRO's per-RGD micro-controller needs to open its informer
+      and write status back; without it the RGD never reaches Active. The second is the child kinds
+      the WebApp ResourceGraphDefinition renders — Deployment, Service, HTTPRoute — and it is the
+      Deployment verbs that this check reports. A WebApp instance may be created in any namespace,
+      so that grant cannot be namespace-scoped without breaking the RGD. Each RGD's blast radius is
+      therefore its own declared resources. The same subject's controller-grade breadth is already
+      accepted on the Kubescape side, where cluster-security-exceptions/delete-rbac.yaml excepts the
       kro:controller ClusterRoleBinding; leaving this reported while that stands would be the two
       scanners disagreeing about one deliberate decision.
   - id: KSV-0113

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -341,3 +341,66 @@ misconfigurations:
       resources — nodes and persistentvolumes — rather than wildcarding them, so Secrets are
       out of reach; only the non-core rule uses resources ["*"], and Secrets do not live
       there. The role cannot write any resource.
+
+  # ---------------------------------------------------------------------------
+  # RBAC BREADTH on four first-party roles (#3235) — trivy's KSV-0048 / KSV-0049 /
+  # KSV-0113 read a role's `rules` in isolation and cannot see how the role is BOUND,
+  # so a namespace-confined grant is reported exactly like a cluster-wide one.
+  # Every premise below is asserted by
+  # scripts/tests/test-trivyignore-first-party-rbac-boundary.sh.
+  - id: KSV-0048
+    paths:
+      - k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+    statement: >-
+      Fires on the core write rule, the apps write rule and the batch rule — the three grants a
+      namespace-admin role exists to give. tenant-base-edit is aggregated into tenant-edit and
+      bound ONLY by a namespace-scoped RoleBinding to the tenant's own ServiceAccount in its own
+      namespace (resource-graph-definitions/tenant), so managing workloads is confined to that one
+      namespace and cannot reach any other. Verified: no ClusterRoleBinding references this role in
+      the repository or on the live cluster, where the only bindings are three namespace-scoped
+      RoleBindings (ascoachingogvaner, doggy-countdown, wedding-app). The role also omits the
+      exec-family pod subresources, so it cannot exec into the pods it manages.
+  - id: KSV-0049
+    paths:
+      - k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+    statement: >-
+      Same namespace-scoped RoleBinding as above, firing on the same core write rule. Managing its
+      own ConfigMaps is a core capability of a tenant namespace-admin role and is confined to the
+      tenant's own namespace.
+  - id: KSV-0048
+    paths:
+      - k8s/bases/infrastructure/controllers/kyverno/role.yaml
+    statement: >-
+      This is a namespaced Role in the umami namespace, not a ClusterRole, and its single rule is
+      pinned by resourceNames to exactly one object — the generated Deployment umami-umami-primary
+      — with verbs get, update and patch. It grants no create and no delete, so it cannot bring up
+      or remove any workload, and it cannot reach any Deployment other than that one. Bound to the
+      kyverno/kyverno-background-controller ServiceAccount. The pinning, the verb set and the
+      binding subject are additionally asserted against the rendered output by
+      scripts/tests/test-kyverno-umami-mutation-rbac.sh.
+  - id: KSV-0048
+    paths:
+      - k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml
+    statement: >-
+      Unlike the three entries above this grant IS cluster-wide, and deliberately so: the KRO
+      controller runs with rbac.mode aggregation and holds NO standing access of its own,
+      aggregating only ClusterRoles labelled rbac.kro.run/aggregate-to-controller. This role grants
+      exactly the child kinds the WebApp ResourceGraphDefinition renders — Deployment, Service,
+      HTTPRoute — and a WebApp instance may be created in any namespace, so the Deployment grant
+      cannot be namespace-scoped without breaking the RGD. Each RGD's blast radius is therefore its
+      own declared resources. The same subject's controller-grade breadth is already accepted on
+      the Kubescape side, where cluster-security-exceptions/delete-rbac.yaml excepts the
+      kro:controller ClusterRoleBinding; leaving this reported while that stands would be the two
+      scanners disagreeing about one deliberate decision.
+  - id: KSV-0113
+    paths:
+      - k8s/bases/infrastructure/vault-config/role.yaml
+    statement: >-
+      This is a namespaced Role in the openbao namespace, bound to the openbao/vault-config
+      ServiceAccount, and it fires twice because the grant is deliberately split. The read/write
+      rule is scoped by resourceNames to the single openbao-unseal Secret. The other rule grants
+      create alone, which Kubernetes RBAC cannot restrict by resourceNames because the name does
+      not exist at admission time. Neither rule grants list, watch or delete, so the identity
+      cannot enumerate the namespace's Secrets, cannot read any Secret other than openbao-unseal,
+      and cannot destroy one. The residual capability is creating a NEW Secret in the openbao
+      namespace, which is what the store-keys init container does with the unseal material.

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -44,6 +44,8 @@ readonly reader_role='k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml
 readonly kro_tenant='k8s/bases/infrastructure/resource-graph-definitions/tenant/cluster-role.yaml'
 readonly kro_webapp='k8s/bases/infrastructure/resource-graph-definitions/webapp/cluster-role.yaml'
 readonly kro_release='k8s/bases/infrastructure/controllers/kro/helm-release.yaml'
+readonly kyverno_role='k8s/bases/infrastructure/controllers/kyverno/role.yaml'
+readonly vault_config_role='k8s/bases/infrastructure/vault-config/role.yaml'
 
 status=0
 
@@ -53,6 +55,11 @@ readonly pairs=(
   "KSV-0041:$tenant_role"
   "KSV-0056:$tenant_role"
   "KSV-0046:$reader_role"
+  "KSV-0048:$tenant_role"
+  "KSV-0049:$tenant_role"
+  "KSV-0048:$kyverno_role"
+  "KSV-0048:$kro_webapp"
+  "KSV-0113:$vault_config_role"
 )
 for pair in "${pairs[@]}"; do
   check="${pair%%:*}"
@@ -77,7 +84,7 @@ while IFS= read -r n; do
     printf 'UNSCOPED SKIP: a first-party RBAC entry has no paths key\n' >&2
     status=1
   fi
-done < <(yq '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0056") | (.paths // []) | length' "$ignorefile")
+done < <(yq '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0048" or .id == "KSV-0049" or .id == "KSV-0056" or .id == "KSV-0113") | (.paths // []) | length' "$ignorefile")
 
 # Nothing beyond the reviewed matrix. The check ids here are also dispositioned for the two vendored
 # operator bundles, so those two paths are expected; ANY other first-party pair is an unreviewed
@@ -88,6 +95,11 @@ readonly reviewed_pairs=(
   "KSV-0056:$kro_tenant"
   "KSV-0056:$kro_webapp"
   "KSV-0046:$reader_role"
+  "KSV-0048:$tenant_role"
+  "KSV-0049:$tenant_role"
+  "KSV-0048:$kyverno_role"
+  "KSV-0048:$kro_webapp"
+  "KSV-0113:$vault_config_role"
 )
 readonly vendored_cdi='k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml'
 readonly vendored_kubevirt='k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml'
@@ -107,7 +119,7 @@ while IFS= read -r pair; do
     printf 'UNREVIEWED DISPOSITION: %s is not one of the reviewed first-party verdicts\n' "$pair" >&2
     status=1
   fi
-done < <(yq -N '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0053" or .id == "KSV-0056" or .id == "KSV-0114") | .id + ":" + (.paths // [])[]' "$ignorefile")
+done < <(yq -N '.misconfigurations[] | select(.id == "KSV-0041" or .id == "KSV-0046" or .id == "KSV-0048" or .id == "KSV-0049" or .id == "KSV-0053" or .id == "KSV-0056" or .id == "KSV-0113" or .id == "KSV-0114") | .id + ":" + (.paths // [])[]' "$ignorefile")
 
 # ----------------------------------------------------------------- premises --
 # 1. The tenant role is never bound cluster-wide. Recursive, so a ClusterRoleBinding nested in an
@@ -183,5 +195,82 @@ for role in "$kro_tenant" "$kro_webapp"; do
   fi
 done
 
+# 4. The Kyverno background-controller grant stays a namespaced, resourceNames-pinned Role.
+#    The KSV-0048 disposition on it rests on three separable facts, so assert each: it is a Role
+#    (not a ClusterRole), it lives in the umami namespace, and every rule is pinned to the one
+#    generated Deployment with a verb set that cannot create or destroy a workload. Widening any
+#    one of them — a missing resourceNames, an added `create`, a promotion to ClusterRole — turns
+#    this into write access over arbitrary workload pod templates, which is exactly what the
+#    role's own header warns about.
+kyverno_kind="$(yq -N '.kind // ""' "$repo_root/$kyverno_role" 2>/dev/null || printf '')"
+if [ "$kyverno_kind" != "Role" ]; then
+  printf 'PREMISE BROKEN: %s is a %s, not a namespaced Role; the KSV-0048 disposition assumes it cannot leave the umami namespace\n' "$kyverno_role" "${kyverno_kind:-unset}" >&2
+  status=1
+fi
+kyverno_ns="$(yq -N '.metadata.namespace // ""' "$repo_root/$kyverno_role" 2>/dev/null || printf '')"
+if [ "$kyverno_ns" != "umami" ]; then
+  printf 'PREMISE BROKEN: %s is namespaced to %s, not umami\n' "$kyverno_role" "${kyverno_ns:-unset}" >&2
+  status=1
+fi
+# Every rule must name the one Deployment. An empty resourceNames yields the literal below.
+while IFS= read -r names; do
+  if [ "$names" != "umami-umami-primary" ]; then
+    printf 'PREMISE BROKEN: a rule in %s is pinned to [%s], not to umami-umami-primary alone; the KSV-0048 disposition assumes it can reach exactly one Deployment\n' "$kyverno_role" "${names:-<unpinned>}" >&2
+    status=1
+  fi
+done < <(yq -N '.rules[] | ((.resourceNames // []) | join(","))' "$repo_root/$kyverno_role")
+while IFS= read -r verb; do
+  [ -n "$verb" ] || continue
+  case "$verb" in
+    get | update | patch) ;;
+    *)
+      printf 'PREMISE BROKEN: %s grants verb %s; the KSV-0048 disposition assumes get/update/patch only, so the grant can neither create nor delete a workload\n' "$kyverno_role" "$verb" >&2
+      status=1
+      ;;
+  esac
+done < <(yq -N '.rules[].verbs[]' "$repo_root/$kyverno_role")
+
+# 5. The vault-config grant stays a namespaced Role that cannot enumerate or read the namespace's
+#    other Secrets. The KSV-0113 disposition concedes one unscoped verb — `create`, which RBAC
+#    cannot restrict by resourceNames — and its safety rests on everything else being scoped. So
+#    assert the shape rather than the prose: no rule may grant list, watch or delete at all, and
+#    any rule that is NOT resourceNames-scoped may grant nothing except create. That admits the
+#    documented residual and fails on any widening of it, including a `get` that loses its pin.
+vault_kind="$(yq -N '.kind // ""' "$repo_root/$vault_config_role" 2>/dev/null || printf '')"
+if [ "$vault_kind" != "Role" ]; then
+  printf 'PREMISE BROKEN: %s is a %s, not a namespaced Role; the KSV-0113 disposition assumes it cannot leave the openbao namespace\n' "$vault_config_role" "${vault_kind:-unset}" >&2
+  status=1
+fi
+vault_ns="$(yq -N '.metadata.namespace // ""' "$repo_root/$vault_config_role" 2>/dev/null || printf '')"
+if [ "$vault_ns" != "openbao" ]; then
+  printf 'PREMISE BROKEN: %s is namespaced to %s, not openbao\n' "$vault_config_role" "${vault_ns:-unset}" >&2
+  status=1
+fi
+while IFS= read -r rule; do
+  [ -n "$rule" ] || continue
+  rule_names="${rule%%|*}"
+  rule_verbs="${rule#*|}"
+  old_ifs="$IFS"
+  IFS=','
+  for v in $rule_verbs; do
+    [ -n "$v" ] || continue
+    case "$v" in
+      list | watch | delete | deletecollection)
+        IFS="$old_ifs"
+        printf 'PREMISE BROKEN: %s grants %s on secrets; the KSV-0113 disposition assumes the identity cannot enumerate or destroy Secrets in openbao\n' "$vault_config_role" "$v" >&2
+        status=1
+        IFS=','
+        ;;
+    esac
+    if [ -z "$rule_names" ] && [ "$v" != "create" ]; then
+      IFS="$old_ifs"
+      printf 'PREMISE BROKEN: %s grants %s in a rule with no resourceNames; the KSV-0113 disposition assumes create is the ONLY unscoped verb\n' "$vault_config_role" "$v" >&2
+      status=1
+      IFS=','
+    fi
+  done
+  IFS="$old_ifs"
+done < <(yq -N '.rules[] | ((.resourceNames // []) | join(",")) + "|" + ((.verbs // []) | join(","))' "$repo_root/$vault_config_role")
+
 [ "$status" -eq 0 ] || exit 1
-printf 'first-party RBAC dispositions hold: tenant role never cluster-bound, cluster-reader read-only, KRO aggregation-scoped\n'
+printf 'first-party RBAC dispositions hold: tenant role never cluster-bound, cluster-reader read-only, KRO aggregation-scoped, kyverno grant pinned to one Deployment, vault-config unscoped only for create\n'

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -137,7 +137,6 @@ if [ "$bindings" -ne 0 ]; then
   status=1
 fi
 
-
 # The tenant disposition also claims the role cannot exec into the pods it manages. That is an
 # asserted fact like any other, so it is checked rather than trusted: adding pods/exec (or any
 # exec-family subresource) would let a namespace-admin grant reach into running containers, and

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -212,6 +212,20 @@ if [ "$kyverno_ns" != "umami" ]; then
   printf 'PREMISE BROKEN: %s is namespaced to %s, not umami\n' "$kyverno_role" "${kyverno_ns:-unset}" >&2
   status=1
 fi
+# The grant is ONE rule over apps/deployments and nothing else. Without this, a rule pinned to the
+# same resourceNames but naming statefulsets — or a second rule entirely — satisfies every check
+# below while reaching a different workload kind.
+kyverno_rules="$(yq -N '.rules | length' "$repo_root/$kyverno_role" 2>/dev/null || printf '0')"
+if [ "${kyverno_rules:-0}" -ne 1 ]; then
+  printf 'PREMISE BROKEN: %s declares %s rules; the KSV-0048 disposition assumes exactly one\n' "$kyverno_role" "${kyverno_rules:-unset}" >&2
+  status=1
+fi
+while IFS= read -r shape; do
+  if [ "$shape" != "apps/deployments" ]; then
+    printf 'PREMISE BROKEN: a rule in %s targets [%s], not apps/deployments; the KSV-0048 disposition assumes the one generated Deployment\n' "$kyverno_role" "${shape:-<empty>}" >&2
+    status=1
+  fi
+done < <(yq -N '.rules[] | ((.apiGroups // []) | join(",")) + "/" + ((.resources // []) | join(","))' "$repo_root/$kyverno_role")
 # Every rule must name the one Deployment. An empty resourceNames yields the literal below.
 while IFS= read -r names; do
   if [ "$names" != "umami-umami-primary" ]; then
@@ -246,6 +260,21 @@ if [ "$vault_ns" != "openbao" ]; then
   printf 'PREMISE BROKEN: %s is namespaced to %s, not openbao\n' "$vault_config_role" "${vault_ns:-unset}" >&2
   status=1
 fi
+# Both rules must be core-group Secret rules, and there must be exactly two of them. Without this,
+# a third rule — or a rule over some other group/resource — rides along unexamined, and the verb
+# whitelist below would happily approve `create` on something that is not a Secret at all.
+vault_rules="$(yq -N '.rules | length' "$repo_root/$vault_config_role" 2>/dev/null || printf '0')"
+if [ "${vault_rules:-0}" -ne 2 ]; then
+  printf 'PREMISE BROKEN: %s declares %s rules; the KSV-0113 disposition assumes exactly two (unscoped create, scoped read/write)\n' "$vault_config_role" "${vault_rules:-unset}" >&2
+  status=1
+fi
+while IFS= read -r shape; do
+  if [ "$shape" != "/secrets" ]; then
+    printf 'PREMISE BROKEN: a rule in %s targets [%s], not the core group secrets; the KSV-0113 disposition is about Secrets in openbao only\n' "$vault_config_role" "${shape:-<empty>}" >&2
+    status=1
+  fi
+done < <(yq -N '.rules[] | ((.apiGroups // []) | join(",")) + "/" + ((.resources // []) | join(","))' "$repo_root/$vault_config_role")
+
 # A WHITELIST, deliberately: the blacklist this replaced named list/watch/delete and therefore
 # missed every other widening — most importantly a literal `*`, which grants all of them at once.
 # `set -f` is what makes that case reachable at all: without it the unquoted split glob-expands `*`
@@ -254,6 +283,12 @@ while IFS= read -r rule; do
   [ -n "$rule" ] || continue
   rule_names="${rule%%|*}"
   rule_verbs="${rule#*|}"
+  # Exact equality, not merely non-empty: a rule scoped to some OTHER Secret name is still scoped,
+  # so a non-empty test would approve read/write on a Secret nobody reviewed.
+  if [ -n "$rule_names" ] && [ "$rule_names" != "openbao-unseal" ]; then
+    printf 'PREMISE BROKEN: %s scopes a rule to [%s], not openbao-unseal; the KSV-0113 disposition assumes that one Secret\n' "$vault_config_role" "$rule_names" >&2
+    status=1
+  fi
   old_ifs="$IFS"
   set -f
   IFS=','

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -246,18 +246,24 @@ if [ "$vault_ns" != "openbao" ]; then
   printf 'PREMISE BROKEN: %s is namespaced to %s, not openbao\n' "$vault_config_role" "${vault_ns:-unset}" >&2
   status=1
 fi
+# A WHITELIST, deliberately: the blacklist this replaced named list/watch/delete and therefore
+# missed every other widening — most importantly a literal `*`, which grants all of them at once.
+# `set -f` is what makes that case reachable at all: without it the unquoted split glob-expands `*`
+# into filenames, none of which match, so the check passes over the broadest possible grant.
 while IFS= read -r rule; do
   [ -n "$rule" ] || continue
   rule_names="${rule%%|*}"
   rule_verbs="${rule#*|}"
   old_ifs="$IFS"
+  set -f
   IFS=','
   for v in $rule_verbs; do
     [ -n "$v" ] || continue
     case "$v" in
-      list | watch | delete | deletecollection)
+      create | get | update | patch) ;;
+      *)
         IFS="$old_ifs"
-        printf 'PREMISE BROKEN: %s grants %s on secrets; the KSV-0113 disposition assumes the identity cannot enumerate or destroy Secrets in openbao\n' "$vault_config_role" "$v" >&2
+        printf 'PREMISE BROKEN: %s grants %s on secrets; the KSV-0113 disposition assumes create/get/update/patch only, so the identity cannot enumerate or destroy Secrets in openbao\n' "$vault_config_role" "$v" >&2
         status=1
         IFS=','
         ;;
@@ -270,6 +276,7 @@ while IFS= read -r rule; do
     fi
   done
   IFS="$old_ifs"
+  set +f
 done < <(yq -N '.rules[] | ((.resourceNames // []) | join(",")) + "|" + ((.verbs // []) | join(","))' "$repo_root/$vault_config_role")
 
 [ "$status" -eq 0 ] || exit 1

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -137,6 +137,20 @@ if [ "$bindings" -ne 0 ]; then
   status=1
 fi
 
+
+# The tenant disposition also claims the role cannot exec into the pods it manages. That is an
+# asserted fact like any other, so it is checked rather than trusted: adding pods/exec (or any
+# exec-family subresource) would let a namespace-admin grant reach into running containers, and
+# would silently falsify the statement while the finding stayed suppressed.
+while IFS= read -r res; do
+  [ -n "$res" ] || continue
+  case "$res" in
+    pods/exec | pods/attach | pods/portforward | pods/proxy | services/proxy | */exec | */attach)
+      printf 'PREMISE BROKEN: %s grants %s; the KSV-0048/KSV-0049 dispositions state the role omits the exec-family subresources\n' "$tenant_role" "$res" >&2
+      status=1
+      ;;
+  esac
+done < <(yq -N '.. | select(tag == "!!map") | select(.kind == "ClusterRole") | select(.metadata.name == "tenant-base-edit") | .rules[].resources[]' "$repo_root/$tenant_role")
 # 2. cluster-reader stays read-only.
 while IFS= read -r verb; do
   [ -n "$verb" ] || continue

--- a/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+++ b/scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
@@ -233,7 +233,7 @@ done < <(yq -N '.rules[].verbs[]' "$repo_root/$kyverno_role")
 # 5. The vault-config grant stays a namespaced Role that cannot enumerate or read the namespace's
 #    other Secrets. The KSV-0113 disposition concedes one unscoped verb — `create`, which RBAC
 #    cannot restrict by resourceNames — and its safety rests on everything else being scoped. So
-#    assert the shape rather than the prose: no rule may grant list, watch or delete at all, and
+#    assert the shape rather than the prose: a rule may grant only create/get/update/patch, and
 #    any rule that is NOT resourceNames-scoped may grant nothing except create. That admits the
 #    documented residual and fails on any widening of it, including a `get` that loses its pin.
 vault_kind="$(yq -N '.kind // ""' "$repo_root/$vault_config_role" 2>/dev/null || printf '')"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Kubernetes misconfiguration scanning still cannot be enforced on `k8s/`, because a backlog of
findings sits there that nobody has ruled on. The eight most serious of them all say the same
thing: a role has broad permissions. The scanner reaches that conclusion by reading each role's
rules on their own — it has no way to see that three of these four roles are handed out one
namespace at a time, so a grant that can only ever touch a single tenant's own namespace is
reported exactly like one that reaches the whole cluster.

Leaving them unjudged has a cost beyond the count: a genuine over-grant introduced tomorrow would
look identical to the eight already sitting there.

### What

Records a checked verdict for each of the four roles, so these stop being a number to scroll past.
The remaining backlog drops from 32 findings to 24, and nothing that gets deployed changes.

Three of the four turned out to be the design working as intended — a tenant role that is only ever
granted inside that tenant's own namespace, a Kyverno permission pinned to exactly one named
workload, and a vault job that can create its own secret but cannot read or list anyone else's. The
fourth is different and is written up as such: the resource-graph controller genuinely does hold
broad permissions, because it has to manage whatever an app definition asks it to create. That
breadth is already an accepted decision elsewhere in this repository, so the two scanners now agree
about it rather than disagreeing.

The risk with writing reasons down is that a reason quietly stops being true later and nothing
tells you — the finding stays hidden while the justification for hiding it has gone. Each new
reason is therefore enforced by a check that fails the build if it stops holding. Every one of
those checks was deliberately broken first to confirm it actually catches the problem.

After this, the only misconfigurations left on this tree are three that were already reviewed and
found to be false alarms, plus twenty about user IDs and resource limits. None is high severity.

Fixes #3235
Part of #2787
