### PR TITLE
feat(observability): alert when Kubescape posture data goes stale

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/cluster-role-binding-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cluster-role-binding-posture-staleness-alert.yaml
@@ -1,0 +1,16 @@
+# Grants the posture-staleness-alert ServiceAccount its list-only view of the
+# stored configuration scans. See cluster-role-posture-staleness-alert.yaml for
+# the scope rationale.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: posture-staleness-alert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: posture-staleness-alert
+subjects:
+  - kind: ServiceAccount
+    name: posture-staleness-alert
+    namespace: observability

--- a/k8s/bases/infrastructure/controllers/coroot/cluster-role-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cluster-role-posture-staleness-alert.yaml
@@ -1,0 +1,22 @@
+# What the posture-staleness-alert CronJob may read.
+#
+# Read-only, and ONLY the stored configuration-scan objects. The check has to see
+# scans in every scanned namespace to find the newest one, so it is cluster-scoped
+# by necessity — but it is list-only on a single resource type, which is the least
+# privilege that satisfies that.
+#
+# It deliberately does NOT grant the summary kinds. Those carry a zero-valued
+# creationTimestamp, so they cannot answer a freshness question and reading them
+# would widen the grant for no signal.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: posture-staleness-alert
+rules:
+  - apiGroups:
+      - spdx.softwarecomposition.kubescape.io
+    resources:
+      - workloadconfigurationscans
+    verbs:
+      - list

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
@@ -147,39 +147,56 @@ spec:
                       ;;
                   esac
 
+                  # `0` is non-empty and all-digit, so the pattern above admits
+                  # it while the message promises a POSITIVE integer — and a zero
+                  # threshold makes `age -le 0` false for every scan, so every run
+                  # alerts. Reject the zero VALUE rather than one spelling of it:
+                  # `00` and `000` are equally zero and equally all-digit.
+                  if [ "${MAX_AGE_SECONDS}" -le 0 ]; then
+                    echo "ERROR: MAX_AGE_SECONDS must be a positive integer, got '${MAX_AGE_SECONDS}'" >&2
+                    exit 1
+                  fi
+
                   # Follow `continue` to exhaustion. A partial read would report
                   # one page's newest timestamp as the collection's.
                   cont=''
                   pages=0
+                  # Initialised because `set -u` aborts on an unset expansion,
+                  # and this flag is only assigned on the 404 path.
+                  api_absent=0
                   : > /tmp/ts
                   while :; do
+                    # The continuation token is opaque and base64-derived, so it
+                    # can carry `+`, `/` and `=`. Interpolated into a query
+                    # string a `+` decodes server-side as a SPACE, corrupting the
+                    # token and breaking pagination on exactly the large
+                    # collections that need it. Let curl encode it instead.
+                    set -- --get --data-urlencode "limit=500"
                     if [ -n "$cont" ]; then
-                      url="$BASE?limit=500&continue=$cont"
-                    else
-                      url="$BASE?limit=500"
+                      set -- "$@" --data-urlencode "continue=$cont"
                     fi
                     code=$(curl -sS -o /tmp/body -w '%{http_code}' \
                       --cacert "$SA/ca.crt" \
                       -H "Authorization: Bearer $(cat "$SA/token")" \
-                      "$url")
-                    # Not-served means Kubescape is not installed here, which is
-                    # the ordinary local/CI shape: the docker overlay comments
-                    # coroot and kubescape out INDEPENDENTLY, so enabling coroot
-                    # alone deploys this CronJob onto a cluster with no scanner.
-                    # Exiting 1 there would be a permanently failing Job every 6h
-                    # that never reaches the placeholder-webhook skip, making the
-                    # header's "local/CI stays quiet by design" claim false. Same
-                    # resolution as cron-job-cnpg-degraded-alert.yaml's missing-CRD
-                    # branch.
+                      "$@" "$BASE")
+                    # A 404 means the aggregated configuration-scan API is not
+                    # served. Locally that is ordinary — the docker overlay
+                    # comments coroot and kubescape out INDEPENDENTLY, so coroot
+                    # alone lands this CronJob on a scanner-less cluster. In prod
+                    # the scanner is always installed, so the same 404 means its
+                    # API has GONE AWAY: posture data has stopped existing, which
+                    # is precisely what this Job exists to report.
                     #
-                    # ACCEPTED TRADE-OFF: in prod the scanner is always installed,
-                    # so a 404 there would mean its aggregated API has gone away —
-                    # a real fault this check will not report. It is not silent
-                    # overall (a dead storage layer surfaces through Flux and
-                    # Coroot), and the alternative breaks every local cluster.
+                    # So do not exit 0 here. Route it through the alert path and
+                    # let the placeholder-webhook branch below decide: local and
+                    # CI clusters point at the reserved `example.invalid` host and
+                    # stay silent there, while a real webhook gets the alert. That
+                    # keeps local quiet WITHOUT making prod report success for a
+                    # vanished scanner — the exact silent-healthy reading this
+                    # check was built to catch.
                     if [ "$code" = "404" ]; then
-                      echo "Kubescape configuration scans are not served on this cluster; nothing to check."
-                      exit 0
+                      api_absent=1
+                      break
                     fi
                     if [ "$code" != "200" ]; then
                       echo "ERROR: kube API returned HTTP $code listing configuration scans" >&2
@@ -208,7 +225,11 @@ spec:
                   newest=$(sort < /tmp/ts | tail -1)
 
                   now=$(date -u +%s)
-                  if [ "$count" -gt 0 ] && [ -n "$newest" ]; then
+                  if [ "$api_absent" = "1" ]; then
+                    # Distinct from the empty-collection case below: there the API
+                    # answers and holds nothing; here it does not answer at all.
+                    detail="The Kubescape configuration-scan API is NOT SERVED (HTTP 404) — the scanner's aggregated API has gone away, so no posture data exists to read."
+                  elif [ "$count" -gt 0 ] && [ -n "$newest" ]; then
                     newest_epoch=$(jq -rn --arg t "$newest" '$t | fromdate')
                     age=$((now - newest_epoch))
                     if [ "$age" -le "${MAX_AGE_SECONDS}" ]; then

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
@@ -1,0 +1,264 @@
+# Alerts when Kubescape's stored configuration-scan data stops moving.
+#
+# WHY THIS EXISTS
+#
+# A broken posture scanner and a compliant cluster read IDENTICALLY. When the
+# scan aborts it persists nothing, so every consumer sees "no new findings" —
+# which is exactly what a clean cluster looks like. Nothing anywhere treats that
+# as a failure.
+#
+# That is not hypothetical. Measured on prod 2026-08-19 while picking up #3024:
+# the newest stored `workloadconfigurationscan` was 2026-06-27 — posture had been
+# frozen for FIFTY-THREE DAYS and no signal existed on any surface. The scheduler
+# CronJob kept reporting `lastSuccessfulTime` daily (it only POSTs the scan
+# request; it does not observe the outcome) and the CI posture gate stayed green
+# (it scans manifests, not the cluster). The control that rules out the storage
+# layer: `applicationprofiles` and `vulnerabilitymanifestsummaries`, served by the
+# same aggregated API, were fresh to the same day.
+#
+# This check keys on DATA AGE rather than on any particular failure. #2933's
+# original cause (offline mode starving the policy-artifact fetch) had already
+# been fixed and the scan was failing a THIRD way by the time this was written —
+# so a rule that watched for a known error string would have gone quiet exactly
+# when it mattered. Age covers every abort cause, including the next one.
+#
+# WHY IT PAGINATES — this is load-bearing, not defensive habit
+#
+# The aggregated storage API returns a `continue` token: a single unpaginated GET
+# returns only the first page. Measured, the collection is 1542 objects over 4
+# pages of 500. Taking the newest timestamp from page 1 alone would report an
+# arbitrary subset's maximum as though it were the collection's — silently, and
+# in either direction. The loop below follows `continue` to exhaustion and fails
+# loudly if it does not terminate, rather than reporting a partial answer.
+#
+# WHY ZERO OBJECTS ALERTS RATHER THAN PASSES
+#
+# An empty collection is the silent zero this check exists to catch, so it is
+# treated as a failure signal — never as "nothing to report". Same reasoning as
+# the non-200 and response-shape guards.
+#
+# Lives in the observability namespace to reuse the allow-coroot
+# CiliumNetworkPolicy (endpointSelector: {}), which already permits
+# kube-apiserver, hooks.slack.com:443 and DNS egress — the same reason
+# cron-job-cnpg-degraded-alert.yaml sits here despite being a CNPG concern. It
+# reads the Kubescape API through the kube-apiserver, so no egress to the
+# kubescape namespace is involved.
+#
+# The webhook is injected by Flux substitution from the per-cluster SOPS secret.
+# Unset (local/CI) it defaults to the reserved example.invalid host, which the
+# script matches explicitly and skips, so local/CI stays quiet by design.
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: posture-staleness-alert
+  namespace: observability
+  annotations:
+    checkov.io/skip1: "CKV_K8S_38=the check container reads its SA token to list Kubescape scan objects through the API server"
+    # `${MAX_AGE_SECONDS}` in the script below is the container's own env var,
+    # NOT a Flux post-build variable. The infrastructure-controllers Kustomization
+    # runs substituteFrom, which would expand it to the empty string and leave the
+    # script comparing against nothing — the same defect that left
+    # cnpg-degraded-alert dead from birth. This resource needs no Flux
+    # substitution, so opt it out.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+spec:
+  # The scan is scheduled daily (12 9 * * *). Checking every 6h detects a stall
+  # within a quarter-day while giving the daily run ample room to land.
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      # Four paginated API reads plus DNS resolution and curl's retry budget.
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app: posture-staleness-alert
+        spec:
+          restartPolicy: Never
+          serviceAccountName: posture-staleness-alert
+          # This check DOES call the Kubernetes API, so it needs its token.
+          # C-0034 is already excepted for the observability namespace
+          # (cluster-security-exceptions/service-account-tokens.yaml).
+          automountServiceAccountToken: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            # fsGroup is what makes the mounted webhook readable at all: secret
+            # volume files are owned root:fsGroup, never uid:fsGroup, so an
+            # owner-only mode would be unreadable by this container's own
+            # non-root user. Same rationale as cnpg-degraded-alert.
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: docker.io/badouralix/curl-jq:latest@sha256:1e7c0284e24572ace7170df9fc91f15fd3b79ebf056d4dde17244d5d74bbfabc
+              env:
+                # 48h: two full daily scan intervals, so a single missed or slow
+                # run cannot alert. Anything past this means the scan has failed
+                # at least twice.
+                - name: MAX_AGE_SECONDS
+                  value: "172800"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  API=https://kubernetes.default.svc
+                  SA=/var/run/secrets/kubernetes.io/serviceaccount
+                  BASE="$API/apis/spdx.softwarecomposition.kubescape.io/v1beta1/workloadconfigurationscans"
+
+                  # Read from the mounted Secret rather than an env var
+                  # (checkov CKV_K8S_35): an env value sits in /proc/self/environ
+                  # for the pod's whole life and is inherited by every child
+                  # process; the file is mounted 0440 and read once, here.
+                  WEBHOOK_URL=$(cat /etc/posture-staleness-alert/url)
+
+                  # The value becomes a curl CONFIG directive below, where a
+                  # newline starts a SECOND directive — so an LF in the Secret
+                  # could redirect the request. A valid URL cannot contain a
+                  # control character, so rejecting them turns a malformed Secret
+                  # into a loud failure instead of a silently reconfigured POST.
+                  if [ "$(printf '%s' "$WEBHOOK_URL" | tr -d '[:cntrl:]')" != "$WEBHOOK_URL" ]; then
+                    echo "ERROR: webhook URL contains control characters" >&2
+                    exit 1
+                  fi
+
+                  # Follow `continue` to exhaustion. A partial read would report
+                  # one page's newest timestamp as the collection's.
+                  cont=''
+                  pages=0
+                  : > /tmp/ts
+                  while :; do
+                    if [ -n "$cont" ]; then
+                      url="$BASE?limit=500&continue=$cont"
+                    else
+                      url="$BASE?limit=500"
+                    fi
+                    code=$(curl -sS -o /tmp/body -w '%{http_code}' \
+                      --cacert "$SA/ca.crt" \
+                      -H "Authorization: Bearer $(cat "$SA/token")" \
+                      "$url")
+                    if [ "$code" = "404" ]; then
+                      echo "ERROR: Kubescape scan CRD not served; the scanner is not installed or its storage is down" >&2
+                      exit 1
+                    fi
+                    if [ "$code" != "200" ]; then
+                      echo "ERROR: kube API returned HTTP $code listing configuration scans" >&2
+                      exit 1
+                    fi
+                    # `has("items")` is satisfied by {"items":{}}, which would
+                    # then contribute zero timestamps and read as a healthy empty
+                    # page. Require the ARRAY.
+                    if ! jq -e '(.items | type) == "array"' /tmp/body >/dev/null; then
+                      echo "ERROR: unexpected response shape from kube API" >&2
+                      exit 1
+                    fi
+                    jq -r '.items[].metadata.creationTimestamp // empty' /tmp/body >> /tmp/ts
+                    pages=$((pages + 1))
+                    cont=$(jq -r '.metadata.continue // empty' /tmp/body)
+                    if [ -z "$cont" ]; then
+                      break
+                    fi
+                    if [ "$pages" -ge 50 ]; then
+                      echo "ERROR: pagination did not terminate after $pages pages; refusing to report a partial result" >&2
+                      exit 1
+                    fi
+                  done
+
+                  count=$(wc -l < /tmp/ts | tr -d ' ')
+                  newest=$(sort < /tmp/ts | tail -1)
+
+                  now=$(date -u +%s)
+                  if [ "$count" -gt 0 ] && [ -n "$newest" ]; then
+                    newest_epoch=$(jq -rn --arg t "$newest" '$t | fromdate')
+                    age=$((now - newest_epoch))
+                    if [ "$age" -le "${MAX_AGE_SECONDS}" ]; then
+                      echo "Posture scan data is current: $count object(s), newest $newest (${age}s old)."
+                      exit 0
+                    fi
+                    detail="Newest stored scan is \`$newest\` — $((age / 86400)) day(s) old, across $count object(s)."
+                  else
+                    # The silent zero: an empty collection is a broken scanner,
+                    # never a clean cluster.
+                    detail="The scan collection is EMPTY — no stored configuration scans at all."
+                  fi
+
+                  echo "Posture scan data is stale: $detail"
+
+                  text=$(printf '*Kubescape posture data is stale*\n\n%s\n\n_Posture has stopped updating, so every consumer now reads "no findings" whether or not the cluster is compliant. The scan scheduler reports success even when the scan itself aborts, and the CI gate scans manifests rather than the cluster, so neither will show this. Check the kubescape scanner pod logs for the abort reason._' \
+                    "$detail")
+                  jq -n --arg t "$text" '{text: $t}' > /tmp/payload.json
+
+                  # Only the known placeholder host skips delivery.
+                  # example.invalid is RFC 2606 reserved, so it can never be a
+                  # real endpoint — matching it explicitly keeps local/CI inert
+                  # without swallowing a REAL prod delivery failure.
+                  case "$WEBHOOK_URL" in
+                    https://example.invalid/*)
+                      echo "No Slack webhook configured; alert not delivered."
+                      exit 0
+                      ;;
+                  esac
+
+                  # No `|| true`. Nothing outside this Job notices a failed POST,
+                  # so swallowing it would record a successful run having sent
+                  # nothing — the same silent zero, at the other end of the check.
+                  #
+                  # The URL reaches curl on stdin as a config file rather than as
+                  # an argument: an argv copy is readable from /proc/<pid>/cmdline
+                  # for the life of the request, which would relocate the exposure
+                  # CKV_K8S_35 names instead of removing it. The value is unquoted
+                  # because curl reads an unquoted config value as everything to
+                  # end of line, with no escape syntax; the control-character
+                  # guard above is what makes that total.
+                  printf 'url = %s\n' "$WEBHOOK_URL" |
+                    curl -sf --max-time 15 \
+                      --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
+                      -H 'Content-Type: application/json' \
+                      --data @/tmp/payload.json \
+                      --config -
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                # readOnlyRootFilesystem: true, so give the script a writable
+                # scratch dir for the paged responses and the webhook payload.
+                - name: tmp
+                  mountPath: /tmp
+                - name: webhook
+                  mountPath: /etc/posture-staleness-alert
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 5m
+                  memory: 32Mi
+                limits:
+                  # CPU limit set for kubescape C-0270. Generous: jq parses four
+                  # ~500KB pages.
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            # 288 is 0440: readable by root and by the pod's fsGroup (65532),
+            # rather than by anything else that lands in this pod. Written in
+            # DECIMAL deliberately — an unquoted `0440` is read as octal 288 by
+            # Kubernetes' own YAML 1.1 parser and as decimal 440 (mode 0670) by
+            # every YAML 1.2 reader, and nothing validates the difference.
+            - name: webhook
+              secret:
+                secretName: posture-staleness-alert-webhook
+                defaultMode: 288

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
@@ -130,6 +130,23 @@ spec:
                     exit 1
                   fi
 
+                  # VALIDATE THE THRESHOLD BEFORE USING IT. `set -u` catches an
+                  # UNSET variable, but Flux envsubst produces an EMPTY one — and
+                  # `[ "$age" -le "" ]` errors inside an `if` CONDITION, where
+                  # `set -e` cannot fire. The else branch would then be taken, so
+                  # a blanked threshold posts a false "posture is stale" alert for
+                  # fresh data and still exits 0, recording lastSuccessfulTime.
+                  # That is strictly worse than the sibling's failure mode: its
+                  # blanked ${GRACE_SECONDS} reached `jq --argjson grace ""`,
+                  # which exits 1 — and that loudness is how its own death was
+                  # eventually discovered. Fail closed instead.
+                  case "${MAX_AGE_SECONDS}" in
+                    ''|*[!0-9]*)
+                      echo "ERROR: MAX_AGE_SECONDS must be a positive integer, got '${MAX_AGE_SECONDS}'" >&2
+                      exit 1
+                      ;;
+                  esac
+
                   # Follow `continue` to exhaustion. A partial read would report
                   # one page's newest timestamp as the collection's.
                   cont=''
@@ -145,9 +162,24 @@ spec:
                       --cacert "$SA/ca.crt" \
                       -H "Authorization: Bearer $(cat "$SA/token")" \
                       "$url")
+                    # Not-served means Kubescape is not installed here, which is
+                    # the ordinary local/CI shape: the docker overlay comments
+                    # coroot and kubescape out INDEPENDENTLY, so enabling coroot
+                    # alone deploys this CronJob onto a cluster with no scanner.
+                    # Exiting 1 there would be a permanently failing Job every 6h
+                    # that never reaches the placeholder-webhook skip, making the
+                    # header's "local/CI stays quiet by design" claim false. Same
+                    # resolution as cron-job-cnpg-degraded-alert.yaml's missing-CRD
+                    # branch.
+                    #
+                    # ACCEPTED TRADE-OFF: in prod the scanner is always installed,
+                    # so a 404 there would mean its aggregated API has gone away —
+                    # a real fault this check will not report. It is not silent
+                    # overall (a dead storage layer surfaces through Flux and
+                    # Coroot), and the alternative breaks every local cluster.
                     if [ "$code" = "404" ]; then
-                      echo "ERROR: Kubescape scan CRD not served; the scanner is not installed or its storage is down" >&2
-                      exit 1
+                      echo "Kubescape configuration scans are not served on this cluster; nothing to check."
+                      exit 0
                     fi
                     if [ "$code" != "200" ]; then
                       echo "ERROR: kube API returned HTTP $code listing configuration scans" >&2

--- a/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
@@ -19,3 +19,12 @@ resources:
   - cluster-role-cnpg-degraded-alert.yaml
   - cluster-role-binding-cnpg-degraded-alert.yaml
   - cron-job-cnpg-degraded-alert.yaml
+  # Kubescape posture-staleness alert (one resource per file, per the naming
+  # convention). Lives here rather than under controllers/kubescape/ to reuse the
+  # allow-coroot CiliumNetworkPolicy's kube-apiserver + Slack egress, same as the
+  # CNPG alert above:
+  - service-account-posture-staleness-alert.yaml
+  - secret-posture-staleness-alert.yaml
+  - cluster-role-posture-staleness-alert.yaml
+  - cluster-role-binding-posture-staleness-alert.yaml
+  - cron-job-posture-staleness-alert.yaml

--- a/k8s/bases/infrastructure/controllers/coroot/secret-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/secret-posture-staleness-alert.yaml
@@ -1,0 +1,21 @@
+# Slack incoming-webhook for the posture-staleness-alert CronJob. It is the SAME
+# webhook Coroot, flux-notifications, alertmanager and cnpg-degraded-alert post to
+# (${alertmanager_webhook_url}, injected by Flux from the per-cluster
+# variables-cluster Secret), so posture-staleness alerts land in the same channel
+# as everything else and there is no new secret to provision.
+#
+# The URL lives in a Secret rather than inline in the CronJob's env for the same
+# reason as secret-cnpg-degraded-alert.yaml: an inline env value is readable
+# straight off the CronJob spec by anyone who can `get cronjob`.
+#
+# The inline default keeps `ksail workload validate` (which has no SOPS access)
+# building and leaves local/CI inert.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: posture-staleness-alert-webhook
+  namespace: observability
+type: Opaque
+stringData:
+  url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}

--- a/k8s/bases/infrastructure/controllers/coroot/service-account-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/service-account-posture-staleness-alert.yaml
@@ -1,0 +1,10 @@
+# Identity for the posture-staleness-alert CronJob, which lists Kubescape's
+# stored configuration-scan objects across every namespace. See
+# cron-job-posture-staleness-alert.yaml for why the check exists;
+# cluster-role-posture-staleness-alert.yaml for what it may read.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: posture-staleness-alert
+  namespace: observability

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1084,7 +1084,48 @@ const (
 // The new fingerprint was read from the required job's own output on the
 // approved renderer (run 32141093701), because the local toolchain is refused as
 // unapproved — the same single-renderer caveat as the value it replaces.
-const expectedRenderedSurfaceSHA = "f204a2d25d468376946989ab2378c41de86f9f66b0cda21b5f80f54bc99d2306"
+// This value additionally covers adding the posture-staleness-alert check
+// (#3024): a CronJob in the observability namespace that reads Kubescape's
+// stored configuration-scan objects and alerts when they stop being refreshed.
+//
+// Grant-bearing objects DID move here, additively: 74 -> 77 Role / ClusterRole /
+// RoleBinding / ClusterRoleBinding / ServiceAccount documents, being the three
+// this check introduces — one dedicated ServiceAccount, one narrow ClusterRole,
+// and one binding between exactly those two identities. Same shape as the
+// cnpg-degraded-alert addition recorded above. The ClusterRole is list-only on a
+// single resource type (workloadconfigurationscans in the
+// spdx.softwarecomposition.kubescape.io group) and grants nothing else; it is
+// cluster-scoped only because the check must find the newest scan across every
+// scanned namespace.
+//
+// Measured by rendering all five authorization overlays from both trees and
+// diffing grant-bearing document IDENTITIES, not merely counts:
+//
+//	main 353379fd = 74 (Role 11, ClusterRole 22, RoleBinding 16,
+//	ClusterRoleBinding 10, ServiceAccount 15) — which independently reproduces
+//	the membership already recorded above, corroborating the extraction rather
+//	than assuming it.
+//	this branch   = 77 (ClusterRole 23, ClusterRoleBinding 11, ServiceAccount 16;
+//	Role and RoleBinding UNCHANGED).
+//
+// The added-set is exactly ServiceAccount observability/posture-staleness-alert,
+// ClusterRole posture-staleness-alert and ClusterRoleBinding
+// posture-staleness-alert. The removed-set is EMPTY — nothing displaced, renamed
+// or re-scoped. No identity, binding, verb, policy document or `aws`-bearing
+// line belonging to the aws/aws service account this validator protects is
+// touched.
+//
+// The previous approved digest is recorded here in full, so replacing the
+// constant does not lose it:
+//
+//	f204a2d25d468376946989ab2378c41de86f9f66b0cda21b5f80f54bc99d2306
+//
+// The new fingerprint was read from the required job's own output on the
+// approved renderer (run 32215442664), because the local toolchain is refused as
+// unapproved — kubectl v1.36.1 against an approved v1.36.2, so
+// validateRendererVersion fails closed and cannot corroborate. The same
+// single-renderer caveat as the value it replaces.
+const expectedRenderedSurfaceSHA = "3fda03fc7bdccf0a4a9d9057609ea20c0853af6d619523b94d56d21bca77fa71"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Our Kubernetes security posture stopped being measured on **27 June** and nobody found out for
**53 days**. The scanner has been aborting on every run; when it aborts it saves nothing, and
"nothing saved" looks exactly like "nothing wrong". Both dashboards that should have caught it
reported healthy — the scan scheduler because it only checks that it *asked* for a scan, and the CI
gate because it inspects our files rather than the running cluster.

So for those 53 days we would not have noticed a genuine security regression.

### What

Adds a small scheduled check that watches how old the posture data is and posts to the usual Slack
channel when it stops being refreshed. It deliberately watches the **age of the data** rather than
any particular error, because the scanner has already failed three different ways — a check tuned to
one of them goes quiet exactly when the next one arrives.

This makes the failure visible; it does not repair the scanner. That repair needs cluster access this
run did not have and stays open on the parent issue.

Fixes #3024
Part of #2933
