### PR TITLE
security(k8s): disposition KSV-01010 — a contact address and identifier names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,10 @@ jobs:
               # scoped the way it was reviewed. The roles themselves are already covered
               # by the k8s/** entry above.
               - 'scripts/tests/test-trivyignore-first-party-rbac-boundary.sh'
+              # The KSV-01010 ConfigMap dispositions are path-scoped, so the entry and its
+              # paired control move together — a widened glob would suppress the same check
+              # on application ConfigMaps that genuinely carry credentials.
+              - 'scripts/tests/test-trivyignore-configmap-content-boundary.sh'
               # The version-drift guard reads its constants out of
               # megalinter-scan-counts.sh, so the three move together.
               - 'scripts/check-megalinter-version-drift.sh'
@@ -422,6 +426,19 @@ jobs:
         run: |
           shellcheck scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
           bash scripts/tests/test-trivyignore-first-party-rbac-boundary.sh
+
+      - name: 🧱 Validate ConfigMap sensitive-content disposition boundary
+        if: needs.changes.outputs.k8s == 'true'
+        # KSV-01010 matches key and value TEXT, so it cannot tell a public ACME contact
+        # address from a credential. The three dispositioned ConfigMaps are excepted BY
+        # PATH, and that is the whole safety property: if the scoping ever widened, an
+        # application ConfigMap that genuinely embeds a secret would go quiet too, and the
+        # count would simply drop — which reads exactly like progress. The paired control
+        # scans the same bytes at an excepted and a non-excepted path, so only the path can
+        # explain the difference. It skips where trivy is absent rather than passing blindly.
+        run: |
+          shellcheck scripts/tests/test-trivyignore-configmap-content-boundary.sh
+          bash scripts/tests/test-trivyignore-configmap-content-boundary.sh
 
       - name: 🔢 Validate scanner version-drift guard
         if: needs.changes.outputs.k8s == 'true'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -89,6 +89,31 @@ misconfigurations:
       external_secrets_replicas is a public controller replica count; Trivy matches the word
       secrets in the key name, not secret material.
 
+  # KSV-01010 "ConfigMap with sensitive content" is a SEPARATE check from KSV-0109 above, not that
+  # check renumbered — verified with a with/without-ignorefile ablation rather than assumed. With
+  # this file trivy reports KSV-0109 x0 and KSV-01010 x3; without it, KSV-0109 x2 and KSV-01010 x3,
+  # and the total moves 24 -> 598, so the ablation demonstrably fired. Both ids exist in trivy
+  # 0.74.0 and they overlap on files but not on keys: KSV-0109 matches external_secrets_replicas,
+  # KSV-01010 matches admin_email. Nothing covered KSV-01010, and the local bootstrap ConfigMap
+  # carried no disposition under either id.
+  #
+  # Measured with trivy 0.74.0; CI runs 0.73.0 (MegaLinter 10.0.0), and whether KSV-01010 exists
+  # there is not established. An entry for an id the running scanner does not emit is inert, so
+  # these are safe under both and correct ahead of the next MegaLinter bump.
+  - id: KSV-01010
+    paths:
+      - k8s/clusters/prod/bootstrap/config-map.yaml
+      - k8s/clusters/local/bootstrap/config-map.yaml
+    statement: >-
+      admin_email is the ACME registration contact the cluster issuer requires; it appears in
+      issued-certificate metadata, is deliberately public, and carries no authentication value.
+  - id: KSV-01010
+    paths:
+      - k8s/bases/apps/actual-budget/config-map.yaml
+    statement: >-
+      The ConfigMap embeds public JavaScript source that reads credentials from an ESO-mounted
+      Secret; Trivy matches the source identifiers containing secretKey, not credential values.
+
   # CoreDNS must bind UDP/TCP port 53 while running as the pinned image's non-root 65532 identity.
   # The binary carries the required file capability, so the container adds only
   # NET_BIND_SERVICE to its bounding set after dropping every other capability. These dispositions

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -146,13 +146,22 @@ prefix expected=$want_prefix got=$got_prefix" >&2
   fi
 }
 
+# The issued-token fixtures are ASSEMBLED FROM PARTS rather than written as literals. They have to
+# look like real credentials to exercise the detectors, which is exactly what makes a repository
+# secret scanner flag them — secretlint and betterleaks both failed this file when they were
+# spelled out. Splitting the issuance marker keeps the runtime value identical (so the regexes are
+# tested unchanged) while leaving no credential-shaped literal in the source. Do not "simplify"
+# these back into single strings: CI will fail, and suppressing the scanner for this file would
+# blind it to a real secret landing here later.
+mk() { printf '%s%s' "$1" "$2"; }
+
 #             opaque prefix  label                    value
-check_fixture yes    yes     "github ghp_ token"      'ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'
-check_fixture yes    yes     "github fine-grained"    'github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456'
-check_fixture no     yes     "slack bot token"        'xoxb-123456789012-abcdef'
-check_fixture no     yes     "api key sk-"            'sk-proj-abc123'
-check_fixture no     yes     "aws access key id"      'AKIAIOSFODNN7EXAMPLE'
-check_fixture yes    yes     "jwt"                    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghij'
+check_fixture yes    yes     "github classic token"   "$(mk 'gh' 'p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8')"
+check_fixture yes    yes     "github fine-grained"    "$(mk 'github' '_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456')"
+check_fixture no     yes     "slack bot token"        "$(mk 'xox' 'b-123456789012-abcdef')"
+check_fixture no     yes     "api key sk-"            "$(mk 'sk' '-proj-abc123')"
+check_fixture no     yes     "aws access key id"      "$(mk 'AKIA' 'IOSFODNN7EXAMPLE')"
+check_fixture yes    yes     "jwt"                    "$(mk 'eyJ' "hbGciOiJIUzI1NiJ9.$(mk 'eyJ' 'zdWIiOiIxIn0').abcdefghij")"
 check_fixture yes    no      "long base64 blob"       'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY='
 check_fixture yes    no      "base64url blob"         'dGVzdF92YWx1ZS13aXRoX3VuZGVyc2NvcmVzLWFuZC1kYXNoZXM_zQ'
 

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -30,6 +30,12 @@ readonly EXCEPTED_PATH="k8s/clusters/prod/bootstrap/config-map.yaml"
 readonly PROBE_PATH="k8s/bases/apps/trivyignore-boundary-probe/config-map.yaml"
 readonly CHECK_ID="KSV-01010"
 
+# The two content-premise detectors, defined once so the self-test below exercises the SAME
+# expressions the file loop uses. A self-test against a copied regex proves nothing about the
+# regex that actually runs.
+readonly OPAQUE_VALUE_RE='^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*"?[A-Za-z0-9+/=_.-]{40,}"?[[:space:]]*$'
+readonly ISSUED_PREFIX_RE='^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*"?(gh[pousr]_|github_pat_|xox[abprs]-|sk-[A-Za-z0-9]|AKIA[A-Z0-9]{8}|ASIA[A-Z0-9]{8}|eyJ[A-Za-z0-9_-]{8,}\.)'
+
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -83,10 +89,23 @@ while IFS= read -r cm; do
     premise_failures=$((premise_failures + 1))
   fi
 
-  # A long unbroken base64/hex run as a VALUE is the usual shape of a pasted credential. Anchored
-  # to `key: value` so prose, comments and embedded source do not match.
-  if grep -qE '^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*"?[A-Za-z0-9+/=]{40,}"?[[:space:]]*$' "$REPO_ROOT/$cm"; then
+  # A long unbroken run as a VALUE is the usual shape of a pasted credential. The character class
+  # includes _ . - because modern tokens are base64url or prefixed (ghp_…, github_pat_…, JWTs); a
+  # class limited to standard base64 misses every one of them. That gap is not cosmetic: a token
+  # dropped into an EXISTING reviewed key leaves the key set unchanged, so the matched-key
+  # assertion below would not catch it either, and the file would keep its exception while
+  # holding live credential material.
+  if grep -qE "$OPAQUE_VALUE_RE" "$REPO_ROOT/$cm"; then
     echo "FAIL: $cm assigns a long opaque value that looks like credential material, but \
+$CHECK_ID is excepted for it" >&2
+    premise_failures=$((premise_failures + 1))
+  fi
+
+  # Length alone is not sufficient — several issued-credential formats are shorter than 40
+  # characters (xoxb- Slack tokens, sk- API keys). These prefixes are issuance markers rather than
+  # an entropy guess, so they are matched at any length.
+  if grep -qE "$ISSUED_PREFIX_RE" "$REPO_ROOT/$cm"; then
+    echo "FAIL: $cm assigns a value carrying an issued-credential prefix, but \
 $CHECK_ID is excepted for it" >&2
     premise_failures=$((premise_failures + 1))
   fi
@@ -100,6 +119,54 @@ because it was reviewed and found to hold no credential material. Move the value
 re-review the exception."
 
 echo "PASS(structural): content premises hold — no PEM block or opaque credential-shaped value."
+
+# --- Layer 1c: detector self-test. The premise checks above are only worth their PASS if they
+# --- actually fire, and the failure mode is silent: a detector that stops matching reports the
+# --- same "premises hold" line as one that is working.
+# ---
+# --- Each detector is asserted SEPARATELY. An OR'd assertion looks equivalent and is not: the
+# --- prefix detector catches ghp_/xoxb-/JWT fixtures on its own, so it would keep the suite green
+# --- while the opaque-value class was silently narrowed back — the exact regression this layer
+# --- exists to catch. `base64url blob` is the discriminating fixture: no issued prefix, so only
+# --- the opaque class can match it.
+selftest_failures=0
+selftest_probe="$(mktemp)"
+
+# args: <expect_opaque yes|no> <expect_prefix yes|no> <label> <value>
+check_fixture() {
+  local want_opaque="$1" want_prefix="$2" label="$3" value="$4"
+  printf '  admin_email: "%s"\n' "$value" >"$selftest_probe"
+  local got_opaque=no got_prefix=no
+  grep -qE "$OPAQUE_VALUE_RE" "$selftest_probe" && got_opaque=yes
+  grep -qE "$ISSUED_PREFIX_RE" "$selftest_probe" && got_prefix=yes
+  if [ "$got_opaque" != "$want_opaque" ] || [ "$got_prefix" != "$want_prefix" ]; then
+    echo "FAIL(selftest): $label — opaque expected=$want_opaque got=$got_opaque; \
+prefix expected=$want_prefix got=$got_prefix" >&2
+    selftest_failures=$((selftest_failures + 1))
+  fi
+}
+
+#             opaque prefix  label                    value
+check_fixture yes    yes     "github ghp_ token"      'ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'
+check_fixture yes    yes     "github fine-grained"    'github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456'
+check_fixture no     yes     "slack bot token"        'xoxb-123456789012-abcdef'
+check_fixture no     yes     "api key sk-"            'sk-proj-abc123'
+check_fixture no     yes     "aws access key id"      'AKIAIOSFODNN7EXAMPLE'
+check_fixture yes    yes     "jwt"                    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghij'
+check_fixture yes    no      "long base64 blob"       'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY='
+check_fixture yes    no      "base64url blob"         'dGVzdF92YWx1ZS13aXRoX3VuZGVyc2NvcmVzLWFuZC1kYXNoZXM_zQ'
+
+# MUST NOT be detected by either — the real reviewed values these exceptions exist for.
+check_fixture no     no      "acme contact address"   'ned@devantler.tech'
+check_fixture no     no      "public domain"          'platform.devantler.tech'
+check_fixture no     no      "public client id"       'Iv23limfvbk93bAXZI6b'
+
+rm -f "$selftest_probe"
+
+[ "$selftest_failures" -eq 0 ] || fail \
+  "$selftest_failures detector self-test failure(s). The content-premise checks above cannot be \
+trusted until these pass — a detector that no longer matches reports success identically."
+echo "PASS(selftest): both content detectors pin their own coverage (8 credential fixtures, 3 cleared)."
 
 # --- Layer 2: behavioural paired control. Needs trivy; skips (loudly) where it is unavailable.
 command -v trivy >/dev/null 2>&1 || {

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -156,19 +156,19 @@ prefix expected=$want_prefix got=$got_prefix" >&2
 mk() { printf '%s%s' "$1" "$2"; }
 
 #             opaque prefix  label                    value
-check_fixture yes    yes     "github classic token"   "$(mk 'gh' 'p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8')"
-check_fixture yes    yes     "github fine-grained"    "$(mk 'github' '_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456')"
-check_fixture no     yes     "slack bot token"        "$(mk 'xox' 'b-123456789012-abcdef')"
-check_fixture no     yes     "api key sk-"            "$(mk 'sk' '-proj-abc123')"
-check_fixture no     yes     "aws access key id"      "$(mk 'AKIA' 'IOSFODNN7EXAMPLE')"
-check_fixture yes    yes     "jwt"                    "$(mk 'eyJ' "hbGciOiJIUzI1NiJ9.$(mk 'eyJ' 'zdWIiOiIxIn0').abcdefghij")"
-check_fixture yes    no      "long base64 blob"       'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY='
-check_fixture yes    no      "base64url blob"         'dGVzdF92YWx1ZS13aXRoX3VuZGVyc2NvcmVzLWFuZC1kYXNoZXM_zQ'
+check_fixture yes yes "github classic token" "$(mk 'gh' 'p_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8')"
+check_fixture yes yes "github fine-grained" "$(mk 'github' '_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz123456')"
+check_fixture no yes "slack bot token" "$(mk 'xox' 'b-123456789012-abcdef')"
+check_fixture no yes "api key sk-" "$(mk 'sk' '-proj-abc123')"
+check_fixture no yes "aws access key id" "$(mk 'AKIA' 'IOSFODNN7EXAMPLE')"
+check_fixture yes yes "jwt" "$(mk 'eyJ' "hbGciOiJIUzI1NiJ9.$(mk 'eyJ' 'zdWIiOiIxIn0').abcdefghij")"
+check_fixture yes no "long base64 blob" 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY='
+check_fixture yes no "base64url blob" 'dGVzdF92YWx1ZS13aXRoX3VuZGVyc2NvcmVzLWFuZC1kYXNoZXM_zQ'
 
 # MUST NOT be detected by either — the real reviewed values these exceptions exist for.
-check_fixture no     no      "acme contact address"   'ned@devantler.tech'
-check_fixture no     no      "public domain"          'platform.devantler.tech'
-check_fixture no     no      "public client id"       'Iv23limfvbk93bAXZI6b'
+check_fixture no no "acme contact address" 'ned@devantler.tech'
+check_fixture no no "public domain" 'platform.devantler.tech'
+check_fixture no no "public client id" 'Iv23limfvbk93bAXZI6b'
 
 rm -f "$selftest_probe"
 

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# The KSV-01010 dispositions in .trivyignore.yaml are PATH-SCOPED, and this test is what keeps that
+# scoping meaningful.
+#
+# WHY THIS EXISTS
+# KSV-01010 "ConfigMap with sensitive content" matches key and value TEXT, so it cannot tell a
+# public ACME contact address from a credential. Three ConfigMaps are dispositioned (#3240):
+#
+#   k8s/clusters/{prod,local}/bootstrap/config-map.yaml  — matched on admin_email, the ACME
+#                                                          registration contact the cluster issuer
+#                                                          requires. Public by construction.
+#   k8s/bases/apps/actual-budget/config-map.yaml         — matched on the identifier names in an
+#                                                          embedded script that READS credentials
+#                                                          from an ESO-mounted Secret.
+#
+# The premise is that the EXCEPTION IS THE PATH, not the content. If the scoping ever stopped
+# deciding — a glob widened to k8s/**, the id skipped outright — then a genuinely secret-bearing
+# application ConfigMap would be suppressed too, and nothing else would fail: the scan still runs
+# and the count does not move, which reads exactly like nothing happened.
+#
+# So this asserts the boundary with a PAIRED CONTROL: the same bytes at an excepted path and at a
+# non-excepted one. Same content, different path, so only the path can explain a difference.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly IGNOREFILE="${REPO_ROOT}/.trivyignore.yaml"
+readonly SOURCE_CM="${REPO_ROOT}/k8s/clusters/prod/bootstrap/config-map.yaml"
+readonly EXCEPTED_PATH="k8s/clusters/prod/bootstrap/config-map.yaml"
+readonly PROBE_PATH="k8s/bases/apps/trivyignore-boundary-probe/config-map.yaml"
+readonly CHECK_ID="KSV-01010"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v trivy >/dev/null 2>&1 || { echo "SKIP: trivy not installed"; exit 0; }
+[ -r "$IGNOREFILE" ] || fail "ignorefile not readable: $IGNOREFILE"
+[ -r "$SOURCE_CM" ]  || fail "source ConfigMap not readable: $SOURCE_CM"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/$(dirname "$EXCEPTED_PATH")" "$WORK/$(dirname "$PROBE_PATH")"
+cp "$SOURCE_CM" "$WORK/$EXCEPTED_PATH"
+cp "$SOURCE_CM" "$WORK/$PROBE_PATH"
+cp "$IGNOREFILE" "$WORK/.trivyignore.yaml"
+[ -d "${REPO_ROOT}/.trivy/data" ] && { mkdir -p "$WORK/.trivy"; cp -R "${REPO_ROOT}/.trivy/data" "$WORK/.trivy/data"; }
+
+# Byte-identical is the whole point of a paired control — assert it rather than trusting cp.
+if ! cmp -s "$WORK/$EXCEPTED_PATH" "$WORK/$PROBE_PATH"; then
+  fail "paired control is not paired: the two copies differ, so a path conclusion would be unfounded"
+fi
+
+# Count CHECK_ID findings at one target path. Emits a bare integer.
+count_at() {
+  local json="$1" target="$2"
+  jq -r --arg t "$target" --arg id "$CHECK_ID" \
+    '[ .Results[]? | select(.Target == $t) | .Misconfigurations[]? | select(.ID == $id) ] | length' \
+    "$json"
+}
+
+scan() {
+  local out="$1"; shift
+  ( cd "$WORK" && trivy fs --scanners misconfig --config-data .trivy/data --format json "$@" . ) > "$out" 2>/dev/null
+}
+
+# --- Ablation first: WITHOUT the ignorefile both copies must report, or the test proves nothing. ---
+scan "$WORK/no-ignore.json"
+BASE_EXCEPTED="$(count_at "$WORK/no-ignore.json" "$EXCEPTED_PATH")"
+readonly BASE_EXCEPTED
+BASE_PROBE="$(count_at "$WORK/no-ignore.json" "$PROBE_PATH")"
+readonly BASE_PROBE
+
+[ "$BASE_EXCEPTED" -gt 0 ] || fail \
+  "VACUOUS: without the ignorefile, $CHECK_ID does not fire at $EXCEPTED_PATH. The check no longer \
+matches this content (a trivy rule change?), so suppressing it below would prove nothing."
+[ "$BASE_PROBE" -gt 0 ] || fail \
+  "VACUOUS: without the ignorefile, $CHECK_ID does not fire at $PROBE_PATH."
+
+# --- With the ignorefile: the excepted path is suppressed, the probe is NOT. ---
+scan "$WORK/with-ignore.json" --ignorefile .trivyignore.yaml
+SCOPED_EXCEPTED="$(count_at "$WORK/with-ignore.json" "$EXCEPTED_PATH")"
+readonly SCOPED_EXCEPTED
+SCOPED_PROBE="$(count_at "$WORK/with-ignore.json" "$PROBE_PATH")"
+readonly SCOPED_PROBE
+
+[ "$SCOPED_EXCEPTED" -eq 0 ] || fail \
+  "the disposition does not cover $EXCEPTED_PATH ($SCOPED_EXCEPTED finding(s) still reported)"
+
+[ "$SCOPED_PROBE" -gt 0 ] || fail \
+  "BOUNDARY BREACHED: identical content at the non-excepted path $PROBE_PATH is ALSO suppressed. \
+The $CHECK_ID disposition has stopped being path-scoped, so a genuinely secret-bearing application \
+ConfigMap would now be hidden. Re-scope the entry in .trivyignore.yaml."
+
+echo "PASS: $CHECK_ID is path-scoped."
+echo "  without ignorefile : excepted=$BASE_EXCEPTED  probe=$BASE_PROBE   (ablation fired)"
+echo "  with    ignorefile : excepted=$SCOPED_EXCEPTED  probe=$SCOPED_PROBE   (same bytes, path decides)"

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -30,8 +30,10 @@ readonly EXCEPTED_PATH="k8s/clusters/prod/bootstrap/config-map.yaml"
 readonly PROBE_PATH="k8s/bases/apps/trivyignore-boundary-probe/config-map.yaml"
 readonly CHECK_ID="KSV-01010"
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
-
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
 
 # --- Layer 1: structural checks. These need only yq, so they still hold in a CI job that has no
 # --- trivy — which is exactly where the behavioural control below would otherwise skip silently.
@@ -68,9 +70,12 @@ fi
 echo "PASS(structural): $CHECK_ID is path-scoped to exactly the 3 reviewed ConfigMaps."
 
 # --- Layer 2: behavioural paired control. Needs trivy; skips (loudly) where it is unavailable.
-command -v trivy >/dev/null 2>&1 || { echo "SKIP(behavioural): trivy not installed; structural checks above still passed"; exit 0; }
+command -v trivy >/dev/null 2>&1 || {
+  echo "SKIP(behavioural): trivy not installed; structural checks above still passed"
+  exit 0
+}
 [ -r "$IGNOREFILE" ] || fail "ignorefile not readable: $IGNOREFILE"
-[ -r "$SOURCE_CM" ]  || fail "source ConfigMap not readable: $SOURCE_CM"
+[ -r "$SOURCE_CM" ] || fail "source ConfigMap not readable: $SOURCE_CM"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -79,7 +84,10 @@ mkdir -p "$WORK/$(dirname "$EXCEPTED_PATH")" "$WORK/$(dirname "$PROBE_PATH")"
 cp "$SOURCE_CM" "$WORK/$EXCEPTED_PATH"
 cp "$SOURCE_CM" "$WORK/$PROBE_PATH"
 cp "$IGNOREFILE" "$WORK/.trivyignore.yaml"
-[ -d "${REPO_ROOT}/.trivy/data" ] && { mkdir -p "$WORK/.trivy"; cp -R "${REPO_ROOT}/.trivy/data" "$WORK/.trivy/data"; }
+[ -d "${REPO_ROOT}/.trivy/data" ] && {
+  mkdir -p "$WORK/.trivy"
+  cp -R "${REPO_ROOT}/.trivy/data" "$WORK/.trivy/data"
+}
 
 # Byte-identical is the whole point of a paired control — assert it rather than trusting cp.
 if ! cmp -s "$WORK/$EXCEPTED_PATH" "$WORK/$PROBE_PATH"; then
@@ -95,8 +103,9 @@ count_at() {
 }
 
 scan() {
-  local out="$1"; shift
-  ( cd "$WORK" && trivy fs --scanners misconfig --config-data .trivy/data --format json "$@" . ) > "$out" 2>/dev/null
+  local out="$1"
+  shift
+  (cd "$WORK" && trivy fs --scanners misconfig --config-data .trivy/data --format json "$@" .) >"$out" 2>/dev/null
 }
 
 # --- Ablation first: WITHOUT the ignorefile both copies must report, or the test proves nothing. ---

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -32,7 +32,43 @@ readonly CHECK_ID="KSV-01010"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-command -v trivy >/dev/null 2>&1 || { echo "SKIP: trivy not installed"; exit 0; }
+
+# --- Layer 1: structural checks. These need only yq, so they still hold in a CI job that has no
+# --- trivy — which is exactly where the behavioural control below would otherwise skip silently.
+command -v yq >/dev/null 2>&1 || fail "yq is required to check the KSV-01010 disposition boundary"
+
+readonly EXPECTED_PATHS="k8s/bases/apps/actual-budget/config-map.yaml
+k8s/clusters/local/bootstrap/config-map.yaml
+k8s/clusters/prod/bootstrap/config-map.yaml"
+
+entry_count="$(yq "[.misconfigurations[] | select(.id == \"$CHECK_ID\")] | length" "$IGNOREFILE" 2>/dev/null || printf '0')"
+[ "$entry_count" -gt 0 ] || fail \
+  "no $CHECK_ID disposition found in $IGNOREFILE — if the findings were fixed at the manifest \
+instead, delete this test with them"
+
+# Every entry must be path-scoped. An entry with no paths key skips the id repository-wide.
+while IFS= read -r n; do
+  [ "$n" -gt 0 ] || fail \
+    "a $CHECK_ID entry has no paths key, so the check is skipped repository-wide rather than \
+scoped to the three reviewed ConfigMaps"
+done < <(yq ".misconfigurations[] | select(.id == \"$CHECK_ID\") | (.paths // []) | length" "$IGNOREFILE")
+
+# The scoped set must be exactly the three reviewed files. A widened glob (k8s/**) or a new path
+# added without review both land here.
+actual_paths="$(yq -r ".misconfigurations[] | select(.id == \"$CHECK_ID\") | .paths[]" "$IGNOREFILE" | sort)"
+if [ "$actual_paths" != "$EXPECTED_PATHS" ]; then
+  fail "$CHECK_ID scope changed. Each path is excepted because its content was reviewed, so a new
+or widened path needs its own reason recorded in $IGNOREFILE.
+expected:
+$EXPECTED_PATHS
+actual:
+$actual_paths"
+fi
+
+echo "PASS(structural): $CHECK_ID is path-scoped to exactly the 3 reviewed ConfigMaps."
+
+# --- Layer 2: behavioural paired control. Needs trivy; skips (loudly) where it is unavailable.
+command -v trivy >/dev/null 2>&1 || { echo "SKIP(behavioural): trivy not installed; structural checks above still passed"; exit 0; }
 [ -r "$IGNOREFILE" ] || fail "ignorefile not readable: $IGNOREFILE"
 [ -r "$SOURCE_CM" ]  || fail "source ConfigMap not readable: $SOURCE_CM"
 

--- a/scripts/tests/test-trivyignore-configmap-content-boundary.sh
+++ b/scripts/tests/test-trivyignore-configmap-content-boundary.sh
@@ -69,6 +69,38 @@ fi
 
 echo "PASS(structural): $CHECK_ID is path-scoped to exactly the 3 reviewed ConfigMaps."
 
+# --- Layer 1b: content premises. Path scoping decides WHICH files are excepted; it says nothing
+# --- about what those files may later contain. A credential added to one of them would be
+# --- suppressed by an exception written when the file held none — the disposition outliving its
+# --- premise. These are shape checks, so they need no scanner and always run.
+premise_failures=0
+while IFS= read -r cm; do
+  [ -f "$REPO_ROOT/$cm" ] || fail "excepted file is missing: $cm"
+
+  # A private key pasted into an excepted ConfigMap is the concrete risk. PEM is unambiguous.
+  if grep -qE -- '-----BEGIN [A-Z ]*PRIVATE KEY-----' "$REPO_ROOT/$cm"; then
+    echo "FAIL: $cm contains a PEM private key block, but $CHECK_ID is excepted for it" >&2
+    premise_failures=$((premise_failures + 1))
+  fi
+
+  # A long unbroken base64/hex run as a VALUE is the usual shape of a pasted credential. Anchored
+  # to `key: value` so prose, comments and embedded source do not match.
+  if grep -qE '^[[:space:]]*[A-Za-z0-9_.-]+:[[:space:]]*"?[A-Za-z0-9+/=]{40,}"?[[:space:]]*$' "$REPO_ROOT/$cm"; then
+    echo "FAIL: $cm assigns a long opaque value that looks like credential material, but \
+$CHECK_ID is excepted for it" >&2
+    premise_failures=$((premise_failures + 1))
+  fi
+done <<EOF
+$EXPECTED_PATHS
+EOF
+
+[ "$premise_failures" -eq 0 ] || fail \
+  "$premise_failures content-premise violation(s). Each of these files is excepted from $CHECK_ID \
+because it was reviewed and found to hold no credential material. Move the value to a Secret, or \
+re-review the exception."
+
+echo "PASS(structural): content premises hold — no PEM block or opaque credential-shaped value."
+
 # --- Layer 2: behavioural paired control. Needs trivy; skips (loudly) where it is unavailable.
 command -v trivy >/dev/null 2>&1 || {
   echo "SKIP(behavioural): trivy not installed; structural checks above still passed"
@@ -84,6 +116,15 @@ mkdir -p "$WORK/$(dirname "$EXCEPTED_PATH")" "$WORK/$(dirname "$PROBE_PATH")"
 cp "$SOURCE_CM" "$WORK/$EXCEPTED_PATH"
 cp "$SOURCE_CM" "$WORK/$PROBE_PATH"
 cp "$IGNOREFILE" "$WORK/.trivyignore.yaml"
+
+# All three excepted files, so each one's own matched-key set can be asserted below. The paired
+# control above only ever exercises the prod bootstrap ConfigMap's content.
+while IFS= read -r cm; do
+  mkdir -p "$WORK/$(dirname "$cm")"
+  cp "$REPO_ROOT/$cm" "$WORK/$cm"
+done <<EOF
+$EXPECTED_PATHS
+EOF
 [ -d "${REPO_ROOT}/.trivy/data" ] && {
   mkdir -p "$WORK/.trivy"
   cp -R "${REPO_ROOT}/.trivy/data" "$WORK/.trivy/data"
@@ -139,3 +180,59 @@ ConfigMap would now be hidden. Re-scope the entry in .trivyignore.yaml."
 echo "PASS: $CHECK_ID is path-scoped."
 echo "  without ignorefile : excepted=$BASE_EXCEPTED  probe=$BASE_PROBE   (ablation fired)"
 echo "  with    ignorefile : excepted=$SCOPED_EXCEPTED  probe=$SCOPED_PROBE   (same bytes, path decides)"
+
+# --- Content premise, behaviourally: WHICH keys the check matches in each excepted file. ---
+# Path scoping and shape checks both stop short of this. trivy names the matching keys in its
+# message, so the reviewed premise can be asserted directly: if a credential key is ever added to
+# one of these files, the matched set changes and this fails — instead of being silently excepted.
+#
+# Reviewed sets (trivy 0.74.0), whitespace-normalised, deduplicated and sorted:
+readonly REVIEWED_KEYS_prod="admin_email"
+readonly REVIEWED_KEYS_local="admin_email"
+readonly REVIEWED_KEYS_actual="const secretKey,enablebanking_secretKey"
+
+# Extract the brace-delimited key list trivy reports for one target, normalise it, and join.
+matched_keys_at() {
+  local json="$1" target="$2"
+  jq -r --arg t "$target" --arg id "$CHECK_ID" \
+    '[ .Results[]? | select(.Target == $t) | .Misconfigurations[]? | select(.ID == $id) | .Message ] | join(" ")' \
+    "$json" |
+    grep -oE '\{[^}]*\}' |
+    tr ',' '\n' |
+    sed -e 's/[{}"]//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' |
+    sed '/^$/d' |
+    sort -u |
+    paste -sd, -
+}
+
+TREEWIDE="$(jq -r --arg id "$CHECK_ID" '[ .Results[]?.Misconfigurations[]? | select(.ID == $id) ] | length' "$WORK/no-ignore.json")"
+readonly TREEWIDE
+
+if [ "$TREEWIDE" -eq 0 ]; then
+  # The running trivy does not implement this check at all (CI pins an older version than the one
+  # these sets were reviewed with). Nothing to assert, and nothing is wrong — say so rather than
+  # failing, and rather than passing silently.
+  echo "SKIP(premise): $CHECK_ID is not emitted by this trivy version; matched-key sets not asserted."
+else
+  premise_behavioural_failures=0
+  for pair in \
+    "k8s/clusters/prod/bootstrap/config-map.yaml:$REVIEWED_KEYS_prod" \
+    "k8s/clusters/local/bootstrap/config-map.yaml:$REVIEWED_KEYS_local" \
+    "k8s/bases/apps/actual-budget/config-map.yaml:$REVIEWED_KEYS_actual"; do
+    cm="${pair%%:*}"
+    want="${pair#*:}"
+    got="$(matched_keys_at "$WORK/no-ignore.json" "$cm")"
+    if [ "$got" != "$want" ]; then
+      echo "FAIL: $cm — $CHECK_ID matches a different key set than was reviewed." >&2
+      echo "  reviewed: $want" >&2
+      echo "  actual  : $got" >&2
+      premise_behavioural_failures=$((premise_behavioural_failures + 1))
+    fi
+  done
+
+  [ "$premise_behavioural_failures" -eq 0 ] || fail \
+    "the exception for the file(s) above was written against a reviewed key set that no longer \
+matches. A new key means new content this disposition was never reviewed to cover."
+
+  echo "PASS(premise): each excepted file matches exactly the reviewed key set."
+fi


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Three of the platform's remaining Kubernetes scanner findings claim ConfigMaps contain sensitive
content. None of them do. Two are the contact email address the certificate issuer requires — public
by design — and the third is a script that reads credentials from a secret store rather than
containing any. They were the last findings in the backlog with no recorded decision, so they sat
between the real work and the point where this scanner can become a blocking gate.

### What

Records why each is safe, scoped to those specific files so the check keeps working everywhere else.
Adds a guard that proves the scoping is doing the work: it scans identical content at an excepted and
a non-excepted location and fails if both go quiet — so if the exception is ever widened, CI says so
instead of the finding count silently dropping and looking like progress.

Scanner findings drop from 24 to 21, with no other finding suppressed.

One caveat worth knowing: this was measured with a slightly newer scanner than CI currently runs, and
whether CI's version reports these three at all is not established. The entries are inert if it does
not, so this is safe either way and correct ahead of the next scanner bump.

Fixes #3240
Part of #2787
