### PR TITLE
security(minio): import the bucket Job's credential from a file instead of the environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,10 @@ jobs:
               - 'scripts/tests/test-crossplane-egress-policy.sh'
               - 'scripts/tests/crossplane-egress-policy-rules.yaml'
               - 'scripts/tests/test-cnpg-degraded-alert.sh'
+              # The Job manifest, the Secret it imports and this test are one
+              # contract: the credential is only out of the environment while all
+              # three agree.
+              - 'scripts/tests/test-minio-create-bucket-credentials.sh'
               # Both halves, so editing the guard alone — or its test alone —
               # still runs the check that covers it.
               - 'scripts/dr-rebuild-supersession-guard.sh'
@@ -583,6 +587,15 @@ jobs:
         # delivery so both silent-zero guards and the credential's handling are
         # pinned by behaviour rather than by schema.
         run: bash scripts/tests/test-cnpg-degraded-alert.sh
+
+      - name: 🔑 Validate the MinIO bucket Job's credential handling
+        if: needs.changes.outputs.k8s == 'true'
+        # checkov CKV_K8S_35 was dispositioned here by moving the root
+        # credential out of the environment and into a mounted file. That
+        # only holds while the Job imports the file, keeps the credential
+        # out of argv, and waits on a command that actually reaches MinIO —
+        # none of which schema validation can see.
+        run: bash scripts/tests/test-minio-create-bucket-credentials.sh
 
       - name: 🧭 Validate the DR rebuild supersession gate
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/docker/infrastructure/controllers/minio/job.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/job.yaml
@@ -6,19 +6,6 @@ kind: Job
 metadata:
   name: minio-create-bucket
   namespace: minio
-  annotations:
-    # A file-based route does exist -- `mc alias import <alias>` reads an alias
-    # definition as JSON on stdin -- so this is deferred, not refused, and the
-    # reason is verification rather than absence. Adopting it restructures this
-    # script's control flow: `alias import` never contacts the server, so the
-    # `until mc alias set ...` loop that currently waits for MinIO to come up
-    # has to move onto the bucket creation instead. Platform CI is static
-    # validation with no full-cluster system test, and maintenance must not run
-    # a cluster, so neither that restructure nor `alias import`'s availability
-    # in this pinned release can be exercised here -- a mistake would surface
-    # only when someone next opted into the local backup test-bed. Tracked with
-    # the rest of the group on #3018. Scoped to this resource and this check.
-    checkov.io/skip1: "CKV_K8S_35=deferred to #3018 -- `mc alias import` is the file-based route, but adopting it restructures this Job's wait loop and no environment here can exercise the result"
 spec:
   backoffLimit: 20
   ttlSecondsAfterFinished: 3600
@@ -32,13 +19,16 @@ spec:
       # constrains the UID: the mc image declares no `User` at all, so it would
       # run as root unedited, and its /etc/passwd has no entry for the UID this
       # ran under before — the client is already running unmapped and does not
-      # care. Its only volume is a `mc-config` emptyDir carrying no `fsGroup`,
-      # so no UID owns it, and `MC_CONFIG_DIR` points mc's state there rather
-      # than at a home directory that would have to exist.
+      # care. `fsGroup` below exists so the mounted credential is
+      # group-readable by that same UID, and `MC_CONFIG_DIR` points
+      # mc's state at the emptyDir rather than at a home directory
+      # that would have to exist.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532
+        # Owns the mounted credential (0440) so UID 65532 can read it.
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -50,19 +40,12 @@ spec:
             capabilities:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
+          # No credential here (checkov CKV_K8S_35). The root credential arrives
+          # as the mounted `credentials.json` below and is read once, by mc
+          # itself. `MC_CONFIG_DIR` carries a path, not a secret.
           env:
             - name: MC_CONFIG_DIR
               value: /tmp/.mc
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: minio-root-credentials
-                  key: rootUser
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: minio-root-credentials
-                  key: rootPassword
           resources:
             requests:
               cpu: 10m
@@ -73,17 +56,43 @@ spec:
           volumeMounts:
             - name: mc-config
               mountPath: /tmp/.mc
+            - name: minio-credentials
+              mountPath: /etc/minio-credentials
+              readOnly: true
           command:
             - /bin/sh
             - -c
             - |
               set -e
-              until mc alias set local http://minio.minio.svc.cluster.local:9000 \
-                    "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+
+              # Read the credential from the mounted Secret rather than the
+              # environment (checkov CKV_K8S_35). `alias import` takes a file
+              # path, so the credential never enters this container's
+              # environment nor mc's argv -- `alias set`, which this replaced,
+              # put both halves in /proc/<pid>/cmdline for the process's life.
+              mc alias import local /etc/minio-credentials/credentials.json
+
+              # `alias import` only writes mc's config; it never contacts the
+              # server, so it cannot double as the readiness gate the way the
+              # old `until mc alias set ...` loop did. Wait on bucket creation
+              # instead, which is the first command that does reach MinIO.
+              # Verified against this pinned mc release: `alias import` returns
+              # success with no server reachable at all.
+              until mc mb --ignore-existing local/platform-backups; do
                 sleep 2
               done
-              mc mb --ignore-existing local/platform-backups
+
               mc ls local/
       volumes:
         - name: mc-config
-          emptyDir: {}
+          # Memory-backed: `alias import` writes the imported credential into
+          # mc's config here, and an emptyDir defaults to node disk.
+          emptyDir:
+            medium: Memory
+        - name: minio-credentials
+          secret:
+            secretName: minio-root-credentials
+            items:
+              - key: credentials.json
+                path: credentials.json
+            defaultMode: 0440

--- a/k8s/providers/docker/infrastructure/controllers/minio/secret.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/secret.yaml
@@ -17,19 +17,25 @@ stringData:
   rootUser: ${r2_access_key_id}
   rootPassword: ${r2_secret_access_key}
   # The same credential in the shape `mc alias import` accepts, for the
-  # bucket-creation Job (checkov CKV_K8S_35, #3018). mc has no *_FILE
-  # convention of its own -- verified against the pinned release, which
-  # documents neither a _FILE suffix nor MC_HOST -- so a JSON document is the
-  # only file-based route it offers, and assembling one inside the container is
-  # not an option either: the mc image ships no jq, sed or awk to quote with.
-  # Building it here keeps the credential out of both the environment and argv.
+  # bucket-creation Job (checkov CKV_K8S_35, #3018).
+  #
+  # `alias import` is the only route that keeps the credential off both the
+  # environment and argv. mc has no *_FILE convention like the server's, and
+  # assembling the document inside the container is not an option either: the
+  # mc image ships no jq, sed or awk to quote with.
+  #
+  # It does honour an undocumented MC_HOST_<alias> variable -- verified against
+  # the pinned release, which mentions it in no help output -- but that carries
+  # the whole credential in the environment, which is the exposure this change
+  # removes. It is the more dangerous shape of the two, because checkov looks
+  # for a secretKeyRef and so would not flag it. scripts/tests/
+  # test-minio-create-bucket-credentials.sh fails the build if it appears.
   #
   # The two values are interpolated into JSON string literals, so a credential
   # containing `"` or `\` would produce a malformed document. That fails loudly
-  # rather than silently: `mc alias import` rejects unparseable JSON, the
-  # script runs under `set -e`, and the Job's backoffLimit surfaces it as a
-  # failing workload. The values are R2-style hex keys, which cannot contain
-  # either character.
+  # rather than silently: `mc alias import` rejects unparseable JSON, the script
+  # runs under `set -e`, and the Job's backoffLimit surfaces it as a failing
+  # workload. The values are R2-style hex keys, which cannot contain either.
   credentials.json: |
     {
       "url": "http://minio.minio.svc.cluster.local:9000",

--- a/k8s/providers/docker/infrastructure/controllers/minio/secret.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/secret.yaml
@@ -13,5 +13,28 @@ metadata:
     app.kubernetes.io/name: minio
 type: Opaque
 stringData:
+  # The server reads these two through MINIO_ROOT_USER_FILE / _PASSWORD_FILE.
   rootUser: ${r2_access_key_id}
   rootPassword: ${r2_secret_access_key}
+  # The same credential in the shape `mc alias import` accepts, for the
+  # bucket-creation Job (checkov CKV_K8S_35, #3018). mc has no *_FILE
+  # convention of its own -- verified against the pinned release, which
+  # documents neither a _FILE suffix nor MC_HOST -- so a JSON document is the
+  # only file-based route it offers, and assembling one inside the container is
+  # not an option either: the mc image ships no jq, sed or awk to quote with.
+  # Building it here keeps the credential out of both the environment and argv.
+  #
+  # The two values are interpolated into JSON string literals, so a credential
+  # containing `"` or `\` would produce a malformed document. That fails loudly
+  # rather than silently: `mc alias import` rejects unparseable JSON, the
+  # script runs under `set -e`, and the Job's backoffLimit surfaces it as a
+  # failing workload. The values are R2-style hex keys, which cannot contain
+  # either character.
+  credentials.json: |
+    {
+      "url": "http://minio.minio.svc.cluster.local:9000",
+      "accessKey": "${r2_access_key_id}",
+      "secretKey": "${r2_secret_access_key}",
+      "api": "s3v4",
+      "path": "auto"
+    }

--- a/scripts/tests/test-minio-create-bucket-credentials.sh
+++ b/scripts/tests/test-minio-create-bucket-credentials.sh
@@ -12,9 +12,20 @@
 # document. It was deferred once because it restructures the Job's control flow:
 # `alias import` never contacts the server, so the `until mc alias set ...` loop
 # that waited for MinIO to come up cannot stay where it was. That restructure is
-# what makes the wait assertions below load-bearing rather than cosmetic — a
+# what makes the wait assertion below load-bearing rather than cosmetic — a
 # revert to `alias set` would still create the bucket in a warm cluster and fail
 # only on a cold start, which is exactly when this Job runs.
+#
+# THE ASSERTIONS ARE BOUND TO EACH OTHER ON PURPOSE. Checking the parts
+# separately leaves gaps that each individual check reports as fine:
+#   - reading only `.env` misses `envFrom[].secretRef`, which injects every key
+#     of a Secret into the environment — the same exposure, one field over;
+#   - "the script mentions the mount path" and "the script calls alias import"
+#     can both hold while it imports something else entirely;
+#   - a Secret key, a volume item path and the imported filename can each exist
+#     and still name three different files.
+# So the imported operand is extracted and required to equal the mount path, and
+# the volume item and Secret key are required to match its basename.
 #
 # Assertions are made against the manifest rather than a transcription of it, so
 # this cannot drift into testing a stale copy.
@@ -45,7 +56,8 @@ command -v yq >/dev/null 2>&1 || {
 container_path='.spec.template.spec.containers[0]'
 pod_path='.spec.template.spec'
 
-env_block="$(yq eval "${container_path}.env" "${manifest}")"
+# BOTH environment surfaces. `envFrom` is the one an `.env`-only check misses.
+env_block="$(yq eval "${container_path}.env, ${container_path}.envFrom" "${manifest}")"
 script_body="$(yq eval "${container_path}.command[2]" "${manifest}")"
 volumes="$(yq eval "${pod_path}.volumes" "${manifest}")"
 annotations="$(yq eval '.metadata.annotations' "${manifest}")"
@@ -53,30 +65,33 @@ annotations="$(yq eval '.metadata.annotations' "${manifest}")"
 [ -n "${script_body}" ] && [ "${script_body}" != "null" ] ||
   fail "could not extract the container script from ${manifest}"
 
-# Assertions below are about CODE, not prose. The manifest's inline
-# comments legitimately name `mc alias set` to explain what this Job
-# stopped doing, and a bare match would read that explanation as the
-# defect it describes.
+# Assertions below are about CODE, not prose. The manifest's inline comments
+# legitimately name `mc alias set` to explain what this Job stopped doing, and a
+# bare match would read that explanation as the defect it describes.
 script_code="$(grep -vE '^[[:space:]]*#' <<<"${script_body}")"
 
-# --- CKV_K8S_35: the credential must not arrive as an environment variable ----
-if grep -q 'secretKeyRef' <<<"${env_block}"; then
-  fail "CKV_K8S_35: container env still carries a secretKeyRef; the credential must arrive as a mounted file"
-fi
-pass "no secretKeyRef in the container environment"
+# --- CKV_K8S_35: the credential must not arrive through the environment ------
+# secretKeyRef is the `.env` shape; secretRef is the `envFrom` shape, which
+# injects EVERY key of the Secret and which checkov's CKV_K8S_35 does not flag.
+for ref in secretKeyRef secretRef; do
+  if grep -q "${ref}" <<<"${env_block}"; then
+    fail "CKV_K8S_35: container environment carries a ${ref}; the credential must arrive as a mounted file"
+  fi
+done
+pass "no secretKeyRef or secretRef on either env surface"
 
 # mc also honours an undocumented MC_HOST_<alias> variable carrying the whole
 # credential inline. checkov looks for a secretKeyRef, so it would NOT flag
-# that -- it is the same exposure in a shape the scanner cannot see, which
-# makes it the more likely way for this fix to be quietly undone.
+# that -- the same exposure in a shape the scanner cannot see, which makes it
+# the more likely way for this fix to be quietly undone.
 if grep -qE 'MC_HOST' <<<"${env_block}"; then
   fail "CKV_K8S_35: an MC_HOST_* variable carries the credential in the environment; import it from the mounted file instead"
 fi
 pass "no MC_HOST_* variable in the container environment"
 
-# The check above is also satisfied by simply deleting the credential, which
-# would break the Job instead of hardening it. Assert the Secret still reaches
-# the pod as a volume.
+# --- the credential must actually reach the pod ------------------------------
+# The checks above are also satisfied by deleting the credential outright, which
+# would break the Job rather than harden it.
 grep -q 'minio-root-credentials' <<<"${volumes}" ||
   fail "no volume sourced from the minio-root-credentials Secret"
 pass "minio-root-credentials is mounted as a volume"
@@ -87,11 +102,6 @@ creds_mount_path="$(yq eval \
   fail "the minio-credentials volume is not mounted into the container"
 pass "credentials volume is mounted at ${creds_mount_path}"
 
-# ...and that the script actually reads it, or the mount is decorative.
-grep -q -- "${creds_mount_path}" <<<"${script_code}" ||
-  fail "the script never references ${creds_mount_path}; the mounted credential is unused"
-pass "the script reads the credential from its mount path"
-
 # --- the credential must not reappear in argv --------------------------------
 # `mc alias set <alias> <url> <user> <password>` puts both halves on the command
 # line, where /proc/<pid>/cmdline exposes them to anything in the pod's PID
@@ -101,9 +111,38 @@ if grep -qE 'mc[[:space:]]+alias[[:space:]]+set' <<<"${script_code}"; then
 fi
 pass "no 'mc alias set' — the credential never enters argv"
 
-grep -qE 'mc[[:space:]]+alias[[:space:]]+import' <<<"${script_code}" ||
+# --- the imported file must BE the mounted credential ------------------------
+# Extract the operand rather than merely confirming both strings appear
+# somewhere: "mentions the mount path" and "calls alias import" can both hold
+# while the import reads an entirely different file.
+import_line="$(grep -E 'mc[[:space:]]+alias[[:space:]]+import' <<<"${script_code}" || true)"
+[ -n "${import_line}" ] ||
   fail "the script does not use 'mc alias import'; the file-based route is what removes the exposure"
-pass "the script imports its alias from the mounted file"
+[ "$(grep -cE 'mc[[:space:]]+alias[[:space:]]+import' <<<"${script_code}")" -eq 1 ] ||
+  fail "more than one 'mc alias import' call; this test can only bind a single import to the mount"
+
+imported_path="$(awk '{ for (i = 1; i < NF; i++) if ($i == "import") { print $(i + 2); exit } }' <<<"${import_line}")"
+[ -n "${imported_path}" ] ||
+  fail "could not extract the file operand of 'mc alias import' from: ${import_line}"
+
+case "${imported_path}" in
+  "${creds_mount_path}"/*) ;;
+  *) fail "'mc alias import' reads ${imported_path}, which is not under the mounted credential path ${creds_mount_path}" ;;
+esac
+pass "the imported file (${imported_path}) is under the mounted credential path"
+
+imported_file="${imported_path##*/}"
+
+# --- the volume item and the Secret key must name that same file -------------
+item_path="$(yq eval \
+  "${pod_path}.volumes[] | select(.name == \"minio-credentials\") | .secret.items[] | .path" "${manifest}")"
+[ "${item_path}" = "${imported_file}" ] ||
+  fail "the Secret volume projects '${item_path}' but the script imports '${imported_file}'; nothing would be at that path"
+pass "the volume projects exactly ${imported_file}"
+
+yq eval ".stringData | has(\"${imported_file}\")" "${secret_manifest}" | grep -qx 'true' ||
+  fail "the minio-root-credentials Secret does not define a '${imported_file}' key for the Job to import"
+pass "the Secret supplies ${imported_file}"
 
 # --- the wait loop must have moved off 'alias set' ---------------------------
 # Measured against the pinned mc release: `alias import` returns success with no
@@ -119,13 +158,5 @@ if grep -q 'CKV_K8S_35' <<<"${annotations}"; then
   fail "a CKV_K8S_35 checkov.io/skip annotation is still present; the finding is fixed, so the exception must go"
 fi
 pass "no CKV_K8S_35 skip annotation remains"
-
-# --- the Secret must actually supply the document the Job imports ------------
-creds_key="$(basename "$(yq eval "${container_path}.command[2]" "${manifest}" |
-  grep -oE '/[A-Za-z0-9._/-]*credentials[A-Za-z0-9._/-]*\.json' | head -1)")"
-[ -n "${creds_key}" ] || fail "could not determine the credential filename the script imports"
-yq eval ".stringData | has(\"${creds_key}\")" "${secret_manifest}" | grep -qx 'true' ||
-  fail "the minio-root-credentials Secret does not define a '${creds_key}' key for the Job to import"
-pass "the Secret supplies ${creds_key}"
 
 printf '\nAll minio-create-bucket credential assertions passed.\n'

--- a/scripts/tests/test-minio-create-bucket-credentials.sh
+++ b/scripts/tests/test-minio-create-bucket-credentials.sh
@@ -134,11 +134,35 @@ pass "the imported file (${imported_path}) is under the mounted credential path"
 imported_file="${imported_path##*/}"
 
 # --- the volume item and the Secret key must name that same file -------------
+# Exactly one item: with two, every comparison below would compare a multi-line
+# string and the binding would be ambiguous rather than wrong.
+item_count="$(yq eval \
+  "[${pod_path}.volumes[] | select(.name == \"minio-credentials\") | .secret.items[]] | length" "${manifest}")"
+[ "${item_count}" = "1" ] ||
+  fail "expected exactly 1 minio-credentials volume item, found ${item_count}; the binding would be ambiguous"
+
 item_path="$(yq eval \
   "${pod_path}.volumes[] | select(.name == \"minio-credentials\") | .secret.items[] | .path" "${manifest}")"
+item_key="$(yq eval \
+  "${pod_path}.volumes[] | select(.name == \"minio-credentials\") | .secret.items[] | .key" "${manifest}")"
+
+# The EXACT path, not a prefix plus a basename. The prefix test above accepts
+# anything below the mount and the basename discards the directory, so a nested
+# "<mount>/sub/credentials.json" satisfies both while nothing is projected there.
+[ "${imported_path}" = "${creds_mount_path}/${item_path}" ] ||
+  fail "'mc alias import' reads '${imported_path}', not the projected Secret file '${creds_mount_path}/${item_path}'"
+pass "the imported path is exactly the projected file ${creds_mount_path}/${item_path}"
+
 [ "${item_path}" = "${imported_file}" ] ||
   fail "the Secret volume projects '${item_path}' but the script imports '${imported_file}'; nothing would be at that path"
 pass "the volume projects exactly ${imported_file}"
+
+# The item's KEY, not only its path: an item may map key 'alternate.json' onto
+# path 'credentials.json', so the Secret's own 'credentials.json' key can exist,
+# keep the assertion below green, and still never be the file that is mounted.
+[ "${item_key}" = "${imported_file}" ] ||
+  fail "the volume maps Secret key '${item_key}' onto the imported path, but the imported file is '${imported_file}'; a different key would be mounted"
+pass "the volume projects Secret key ${item_key}"
 
 yq eval ".stringData | has(\"${imported_file}\")" "${secret_manifest}" | grep -qx 'true' ||
   fail "the minio-root-credentials Secret does not define a '${imported_file}' key for the Job to import"

--- a/scripts/tests/test-minio-create-bucket-credentials.sh
+++ b/scripts/tests/test-minio-create-bucket-credentials.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# Contract for the minio-create-bucket Job's credential handling (#3018).
+#
+# checkov CKV_K8S_35 flagged this Job for taking the MinIO root credential as
+# two `secretKeyRef` environment variables. The remediation is only real if the
+# credential reaches `mc` from a mounted file AND does not reappear in argv — a
+# fix that moves it from /proc/self/environ to /proc/<pid>/cmdline has relocated
+# the exposure, not removed it. Both are asserted here.
+#
+# The route is `mc alias import ALIAS <file>`, which reads a JSON credential
+# document. It was deferred once because it restructures the Job's control flow:
+# `alias import` never contacts the server, so the `until mc alias set ...` loop
+# that waited for MinIO to come up cannot stay where it was. That restructure is
+# what makes the wait assertions below load-bearing rather than cosmetic — a
+# revert to `alias set` would still create the bucket in a warm cluster and fail
+# only on a cold start, which is exactly when this Job runs.
+#
+# Assertions are made against the manifest rather than a transcription of it, so
+# this cannot drift into testing a stale copy.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly manifest="${root_dir}/k8s/providers/docker/infrastructure/controllers/minio/job.yaml"
+readonly secret_manifest="${root_dir}/k8s/providers/docker/infrastructure/controllers/minio/secret.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok — %s\n' "$1"
+}
+
+command -v yq >/dev/null 2>&1 || {
+  printf '::error::yq is required to run this contract test.\n' >&2
+  exit 64
+}
+[ -f "${manifest}" ] || fail "manifest not found: ${manifest} (run from the repository root)"
+[ -f "${secret_manifest}" ] || fail "secret manifest not found: ${secret_manifest}"
+
+container_path='.spec.template.spec.containers[0]'
+pod_path='.spec.template.spec'
+
+env_block="$(yq eval "${container_path}.env" "${manifest}")"
+script_body="$(yq eval "${container_path}.command[2]" "${manifest}")"
+volumes="$(yq eval "${pod_path}.volumes" "${manifest}")"
+annotations="$(yq eval '.metadata.annotations' "${manifest}")"
+
+[ -n "${script_body}" ] && [ "${script_body}" != "null" ] ||
+  fail "could not extract the container script from ${manifest}"
+
+# Assertions below are about CODE, not prose. The manifest's inline
+# comments legitimately name `mc alias set` to explain what this Job
+# stopped doing, and a bare match would read that explanation as the
+# defect it describes.
+script_code="$(grep -vE '^[[:space:]]*#' <<<"${script_body}")"
+
+# --- CKV_K8S_35: the credential must not arrive as an environment variable ----
+if grep -q 'secretKeyRef' <<<"${env_block}"; then
+  fail "CKV_K8S_35: container env still carries a secretKeyRef; the credential must arrive as a mounted file"
+fi
+pass "no secretKeyRef in the container environment"
+
+# The check above is also satisfied by simply deleting the credential, which
+# would break the Job instead of hardening it. Assert the Secret still reaches
+# the pod as a volume.
+grep -q 'minio-root-credentials' <<<"${volumes}" ||
+  fail "no volume sourced from the minio-root-credentials Secret"
+pass "minio-root-credentials is mounted as a volume"
+
+creds_mount_path="$(yq eval \
+  "${container_path}.volumeMounts[] | select(.name == \"minio-credentials\") | .mountPath" "${manifest}")"
+[ -n "${creds_mount_path}" ] && [ "${creds_mount_path}" != "null" ] ||
+  fail "the minio-credentials volume is not mounted into the container"
+pass "credentials volume is mounted at ${creds_mount_path}"
+
+# ...and that the script actually reads it, or the mount is decorative.
+grep -q -- "${creds_mount_path}" <<<"${script_code}" ||
+  fail "the script never references ${creds_mount_path}; the mounted credential is unused"
+pass "the script reads the credential from its mount path"
+
+# --- the credential must not reappear in argv --------------------------------
+# `mc alias set <alias> <url> <user> <password>` puts both halves on the command
+# line, where /proc/<pid>/cmdline exposes them to anything in the pod's PID
+# namespace. `alias import` takes a file path instead.
+if grep -qE 'mc[[:space:]]+alias[[:space:]]+set' <<<"${script_code}"; then
+  fail "CKV_K8S_35: 'mc alias set' places the credential in argv; use 'mc alias import <file>'"
+fi
+pass "no 'mc alias set' — the credential never enters argv"
+
+grep -qE 'mc[[:space:]]+alias[[:space:]]+import' <<<"${script_code}" ||
+  fail "the script does not use 'mc alias import'; the file-based route is what removes the exposure"
+pass "the script imports its alias from the mounted file"
+
+# --- the wait loop must have moved off 'alias set' ---------------------------
+# Measured against the pinned mc release: `alias import` returns success with no
+# server reachable at all, so it cannot serve as the readiness gate. Whatever
+# waits for MinIO has to be a command that contacts it.
+if ! grep -qE 'until[[:space:]]+mc[[:space:]]+mb' <<<"${script_code}"; then
+  fail "no 'until mc mb' wait loop; 'alias import' never contacts the server, so nothing waits for MinIO to come up"
+fi
+pass "the readiness wait is on bucket creation, which does contact the server"
+
+# --- the disposition is now a fix, not an exception --------------------------
+if grep -q 'CKV_K8S_35' <<<"${annotations}"; then
+  fail "a CKV_K8S_35 checkov.io/skip annotation is still present; the finding is fixed, so the exception must go"
+fi
+pass "no CKV_K8S_35 skip annotation remains"
+
+# --- the Secret must actually supply the document the Job imports ------------
+creds_key="$(basename "$(yq eval "${container_path}.command[2]" "${manifest}" |
+  grep -oE '/[A-Za-z0-9._/-]*credentials[A-Za-z0-9._/-]*\.json' | head -1)")"
+[ -n "${creds_key}" ] || fail "could not determine the credential filename the script imports"
+yq eval ".stringData | has(\"${creds_key}\")" "${secret_manifest}" | grep -qx 'true' ||
+  fail "the minio-root-credentials Secret does not define a '${creds_key}' key for the Job to import"
+pass "the Secret supplies ${creds_key}"
+
+printf '\nAll minio-create-bucket credential assertions passed.\n'

--- a/scripts/tests/test-minio-create-bucket-credentials.sh
+++ b/scripts/tests/test-minio-create-bucket-credentials.sh
@@ -65,6 +65,15 @@ if grep -q 'secretKeyRef' <<<"${env_block}"; then
 fi
 pass "no secretKeyRef in the container environment"
 
+# mc also honours an undocumented MC_HOST_<alias> variable carrying the whole
+# credential inline. checkov looks for a secretKeyRef, so it would NOT flag
+# that -- it is the same exposure in a shape the scanner cannot see, which
+# makes it the more likely way for this fix to be quietly undone.
+if grep -qE 'MC_HOST' <<<"${env_block}"; then
+  fail "CKV_K8S_35: an MC_HOST_* variable carries the credential in the environment; import it from the mounted file instead"
+fi
+pass "no MC_HOST_* variable in the container environment"
+
 # The check above is also satisfied by simply deleting the credential, which
 # would break the Job instead of hardening it. Assert the Secret still reaches
 # the pod as a volume.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The MinIO bucket-creation Job took its root credential as environment variables. Anything that can inspect the process — `/proc`, a crash dump, most logging middleware — can read a value passed that way, so the scanner flagged it and we deferred the fix, believing the file-based route could not be verified without a live cluster.

That belief was wrong, and checking it was cheap. The client supports the file-based route in the exact version we pin, and a local MinIO exercises the whole thing end to end, including the cold-start case the deferral was actually worried about.

### What this changes

The credential now arrives as a mounted file and is read once, by the client itself — it never enters the container environment or the command line. The temporary deferral is removed rather than re-worded, so the finding is closed by a fix rather than an exception.

A contract test pins the parts a schema check cannot see, and is wired into CI.

Fixes #3247
Part of #3018
Part of #2787