### PR TITLE
security(vault-backup): make the raft snapshot group-readable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,10 @@ jobs:
               - 'scripts/tests/test-kyverno-umami-mutation-rbac.sh'
               - 'scripts/tests/test-tenant-route-hostname-boundary.sh'
               - 'scripts/tests/test-umami-provisioning-bootstrap.sh'
+              # The snapshot manifests and this test are one contract: the
+              # mirror may only stop depending on OWNING the snapshot while
+              # both writers keep making it group-readable (#3202).
+              - 'scripts/tests/test-vault-snapshot-group-readable.sh'
               - 'scripts/tests/test-kyverno-admission-vpa.sh'
               - 'scripts/tests/kyverno-admission-vpa-rules.yaml'
               # The image-verifier liveness checker and its test are one
@@ -487,6 +491,12 @@ jobs:
         run: |
           shellcheck scripts/tests/test-umami-provisioning-bootstrap.sh
           bash scripts/tests/test-umami-provisioning-bootstrap.sh
+
+      - name: 🔐 Validate vault snapshots stay group-readable
+        if: needs.changes.outputs.k8s == 'true'
+        run: |
+          shellcheck scripts/tests/test-vault-snapshot-group-readable.sh
+          bash scripts/tests/test-vault-snapshot-group-readable.sh
 
       - name: ⚖️ Validate cluster policies
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -44,7 +44,7 @@ metadata:
     # is a host UID. That residual is what #3202 removes: it makes the
     # snapshot group-readable first, then raises the UIDs, which the three
     # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC"
+    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the snapshot is chmod 0640 so the mirror reads it on the shared group 1000 -- only the UID migration itself is outstanding"
 spec:
   schedule: "30 3 * * *"
   # Pin the cron evaluation to UTC instead of inheriting kube-controller-manager's
@@ -154,12 +154,13 @@ spec:
                   SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
                   echo "Saving raft snapshot to $SNAP..."
                   bao operator raft snapshot save "$SNAP"
-                  # Group-readable so the off-cluster mirror can open it as GROUP
-                  # (both containers already run fsGroup/runAsGroup 1000) instead of
-                  # as OWNER, which is what currently pins every vault-snapshots
-                  # writer to one low host UID (CKV_K8S_40, #3202). An explicit
-                  # chmod, NOT a umask: umask can only clear permission bits, so it
-                  # cannot widen the 0600 that `bao` creates the snapshot with.
+                  # The mirror opens the snapshot as GROUP: both containers run
+                  # fsGroup/runAsGroup 1000, and the kernel checks access on the numeric
+                  # GID, so reading it needs no matching owner UID. An explicit chmod,
+                  # NOT a umask: umask can only clear permission bits, so it cannot
+                  # widen the 0600 `bao` creates the file with. The writers' UIDs stay
+                  # pinned until the migration in #3202 (CKV_K8S_40); this removes the
+                  # access coupling that blocked it.
                   chmod 0640 "$SNAP"
                   ls -l "$SNAP"
 

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -154,6 +154,13 @@ spec:
                   SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
                   echo "Saving raft snapshot to $SNAP..."
                   bao operator raft snapshot save "$SNAP"
+                  # Group-readable so the off-cluster mirror can open it as GROUP
+                  # (both containers already run fsGroup/runAsGroup 1000) instead of
+                  # as OWNER, which is what currently pins every vault-snapshots
+                  # writer to one low host UID (CKV_K8S_40, #3202). An explicit
+                  # chmod, NOT a umask: umask can only clear permission bits, so it
+                  # cannot widen the 0600 that `bao` creates the snapshot with.
+                  chmod 0640 "$SNAP"
                   ls -l "$SNAP"
 
                   # Retention: keep the newest 14 snapshots

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -46,7 +46,7 @@ metadata:
     # is a host UID. That residual is what #3202 removes: it makes the
     # snapshot group-readable first, then raises the UIDs, which the three
     # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the mirror container must match it to read the -rw------- snapshot from the shared RWO PVC"
+    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the snapshot is chmod 0640 so the mirror reads it on the shared group 1000 -- only the UID migration itself is outstanding"
 spec:
   # No ttlSecondsAfterFinished (intentional). This is a one-shot "snapshot at
   # deploy/change time" Job (see header) -- it must run ONCE per vault-backup
@@ -156,12 +156,13 @@ spec:
               SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
               echo "Saving initial raft snapshot to $SNAP..."
               bao operator raft snapshot save "$SNAP"
-              # Group-readable so the off-cluster mirror can open it as GROUP
-              # (both containers already run fsGroup/runAsGroup 1000) instead of
-              # as OWNER, which is what currently pins every vault-snapshots
-              # writer to one low host UID (CKV_K8S_40, #3202). An explicit
-              # chmod, NOT a umask: umask can only clear permission bits, so it
-              # cannot widen the 0600 that `bao` creates the snapshot with.
+              # The mirror opens the snapshot as GROUP: both containers run
+              # fsGroup/runAsGroup 1000, and the kernel checks access on the numeric
+              # GID, so reading it needs no matching owner UID. An explicit chmod,
+              # NOT a umask: umask can only clear permission bits, so it cannot
+              # widen the 0600 `bao` creates the file with. The writers' UIDs stay
+              # pinned until the migration in #3202 (CKV_K8S_40); this removes the
+              # access coupling that blocked it.
               chmod 0640 "$SNAP"
               ls -l "$SNAP"
               echo "Initial snapshot complete."

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -156,6 +156,13 @@ spec:
               SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
               echo "Saving initial raft snapshot to $SNAP..."
               bao operator raft snapshot save "$SNAP"
+              # Group-readable so the off-cluster mirror can open it as GROUP
+              # (both containers already run fsGroup/runAsGroup 1000) instead of
+              # as OWNER, which is what currently pins every vault-snapshots
+              # writer to one low host UID (CKV_K8S_40, #3202). An explicit
+              # chmod, NOT a umask: umask can only clear permission bits, so it
+              # cannot widen the 0600 that `bao` creates the snapshot with.
+              chmod 0640 "$SNAP"
               ls -l "$SNAP"
               echo "Initial snapshot complete."
       containers:

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -69,6 +69,14 @@ for target in "${targets[@]}"; do
   [ -n "${chmod_line}" ] ||
     fail "${manifest}: the snapshot script never chmods the snapshot; the mirror still depends on owning it (#3202)"
 
+  # Bind the chmod side too. Checking only the FIRST chmod would let a later,
+  # narrowing `chmod 0600 "$SNAP"` re-close the file while this test still
+  # passed on the earlier widening one — the same unbound-assertion trap the
+  # save operand is guarded against above.
+  chmod_count="$(printf '%s\n' "${chmod_line}" | grep -c . || true)"
+  [ "${chmod_count}" -eq 1 ] ||
+    fail "${manifest}: expected exactly 1 chmod in the snapshot script, found ${chmod_count} — the final mode is ambiguous"
+
   chmod_mode="$(printf '%s\n' "${chmod_line}" | head -1 | awk '{print $2}')"
   chmod_operand="$(printf '%s\n' "${chmod_line}" | head -1 | awk '{print $3}' | tr -d '"'"'"'')"
 

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -48,8 +48,9 @@ for target in "${targets[@]}"; do
   [ -f "${path}" ] || fail "${manifest}: not found"
 
   script="$(yq "${query}" "${path}")"
-  [ -n "${script}" ] && [ "${script}" != "null" ] ||
+  if [ -z "${script}" ] || [ "${script}" = "null" ]; then
     fail "${manifest}: could not read the snapshot container's script"
+  fi
 
   # The save operand is the binding key. More than one save makes "the snapshot"
   # ambiguous, so refuse rather than guess which one the chmod should match.

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# The off-cluster mirror must not depend on being the snapshot's OWNER.
+# The off-cluster mirror reads the snapshot as GROUP, not as its OWNER.
 #
-# `bao operator raft snapshot save` creates the file at the process umask and it
-# lands `-rw-------` (0600), owned by the snapshot container's UID. `minio/mc`
-# bakes no matching passwd entry and mounts /snapshots readOnly, so today it can
-# open the snapshot only because it happens to run the same UID. That coupling is
-# what pins all three vault-snapshots writers to a low host UID (checkov
-# CKV_K8S_40, deferred to #3202).
+# `bao` creates the snapshot `-rw-------` (0600), owned by the snapshot
+# container's UID. The kernel decides file access by comparing numeric UID and
+# GID values, so an owner-only mode forces the mirror to run the same UID as the
+# writer. That coupling is what pins every vault-snapshots writer to one low host
+# UID (checkov CKV_K8S_40, whose migration is deferred to #3202).
 #
-# Making the snapshot group-readable breaks the coupling: both containers already
-# run runAsGroup/fsGroup 1000, so the mirror can read it as GROUP and the UIDs
-# become free to move independently.
+# Both containers already run runAsGroup/fsGroup 1000, so a group-readable
+# snapshot is readable by the mirror on its GROUP entry alone, leaving the UIDs
+# free to move independently.
 #
 # NOTE ON MECHANISM: this must be an explicit chmod, not a umask. umask can only
 # CLEAR permission bits, never add them — so if `bao` requests 0600 explicitly (the
@@ -52,20 +51,25 @@ for target in "${targets[@]}"; do
     fail "${manifest}: could not read the snapshot container's script"
   fi
 
+  # Comments are prose, not commands: a line that merely MENTIONS a save or a
+  # chmod must not count toward either binding, or adding a note beside the
+  # command would fail the test while the script itself was still correct.
+  commands="$(printf '%s\n' "${script}" | grep -vE '^[[:space:]]*#' || true)"
+
   # The save operand is the binding key. More than one save makes "the snapshot"
   # ambiguous, so refuse rather than guess which one the chmod should match.
-  save_count="$(printf '%s\n' "${script}" | grep -c 'raft snapshot save' || true)"
+  save_count="$(printf '%s\n' "${commands}" | grep -c 'raft snapshot save' || true)"
   [ "${save_count}" -eq 1 ] ||
     fail "${manifest}: expected exactly 1 'raft snapshot save', found ${save_count} — binding is ambiguous"
 
-  save_operand="$(printf '%s\n' "${script}" |
+  save_operand="$(printf '%s\n' "${commands}" |
     sed -n 's/.*raft snapshot save[[:space:]]*//p' |
     head -1 |
     tr -d '"'"'"'')"
   [ -n "${save_operand}" ] || fail "${manifest}: could not extract the snapshot save operand"
 
   # Now require a chmod naming that SAME operand.
-  chmod_line="$(printf '%s\n' "${script}" | grep -E '^[[:space:]]*chmod[[:space:]]' || true)"
+  chmod_line="$(printf '%s\n' "${commands}" | grep -E '^[[:space:]]*chmod[[:space:]]' || true)"
   [ -n "${chmod_line}" ] ||
     fail "${manifest}: the snapshot script never chmods the snapshot; the mirror still depends on owning it (#3202)"
 

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# The off-cluster mirror must not depend on being the snapshot's OWNER.
+#
+# `bao operator raft snapshot save` creates the file at the process umask and it
+# lands `-rw-------` (0600), owned by the snapshot container's UID. `minio/mc`
+# bakes no matching passwd entry and mounts /snapshots readOnly, so today it can
+# open the snapshot only because it happens to run the same UID. That coupling is
+# what pins all three vault-snapshots writers to a low host UID (checkov
+# CKV_K8S_40, deferred to #3202).
+#
+# Making the snapshot group-readable breaks the coupling: both containers already
+# run runAsGroup/fsGroup 1000, so the mirror can read it as GROUP and the UIDs
+# become free to move independently.
+#
+# NOTE ON MECHANISM: this must be an explicit chmod, not a umask. umask can only
+# CLEAR permission bits, never add them — so if `bao` requests 0600 explicitly (the
+# observed 0600 under a normal 0022 umask says it does), lowering the umask is a
+# silent no-op. chmod is correct under either hypothesis.
+#
+# The assertions below are deliberately BOUND to one another: each manifest's
+# chmod must name the SAME path the snapshot was saved to. Checking "a save
+# exists" and "a chmod exists" independently would pass while the chmod targeted
+# some other file.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to read the snapshot container script'
+
+# manifest:yq-path-to-the-snapshot-container-script
+readonly targets=(
+  "k8s/bases/infrastructure/vault-backup/job.yaml:.spec.template.spec.initContainers[]|select(.name==\"snapshot\")|.command[-1]"
+  "k8s/bases/infrastructure/vault-backup/cron-job.yaml:.spec.jobTemplate.spec.template.spec.initContainers[]|select(.name==\"snapshot\")|.command[-1]"
+)
+
+for target in "${targets[@]}"; do
+  manifest="${target%%:*}"
+  query="${target#*:}"
+  path="${root_dir}/${manifest}"
+
+  [ -f "${path}" ] || fail "${manifest}: not found"
+
+  script="$(yq "${query}" "${path}")"
+  [ -n "${script}" ] && [ "${script}" != "null" ] ||
+    fail "${manifest}: could not read the snapshot container's script"
+
+  # The save operand is the binding key. More than one save makes "the snapshot"
+  # ambiguous, so refuse rather than guess which one the chmod should match.
+  save_count="$(printf '%s\n' "${script}" | grep -c 'raft snapshot save' || true)"
+  [ "${save_count}" -eq 1 ] ||
+    fail "${manifest}: expected exactly 1 'raft snapshot save', found ${save_count} — binding is ambiguous"
+
+  save_operand="$(printf '%s\n' "${script}" |
+    sed -n 's/.*raft snapshot save[[:space:]]*//p' |
+    head -1 |
+    tr -d '"'"'"'')"
+  [ -n "${save_operand}" ] || fail "${manifest}: could not extract the snapshot save operand"
+
+  # Now require a chmod naming that SAME operand.
+  chmod_line="$(printf '%s\n' "${script}" | grep -E '^[[:space:]]*chmod[[:space:]]' || true)"
+  [ -n "${chmod_line}" ] ||
+    fail "${manifest}: the snapshot script never chmods the snapshot; the mirror still depends on owning it (#3202)"
+
+  chmod_mode="$(printf '%s\n' "${chmod_line}" | head -1 | awk '{print $2}')"
+  chmod_operand="$(printf '%s\n' "${chmod_line}" | head -1 | awk '{print $3}' | tr -d '"'"'"'')"
+
+  [ "${chmod_operand}" = "${save_operand}" ] ||
+    fail "${manifest}: chmod targets '${chmod_operand}' but the snapshot is saved to '${save_operand}' — the assertions are unbound"
+
+  # Group must gain read; world must gain nothing (the snapshot is vault data).
+  case "${chmod_mode}" in
+  [0-7][0-7][0-7] | [0-7][0-7][0-7][0-7]) ;;
+  *) fail "${manifest}: chmod mode '${chmod_mode}' is not a 3- or 4-digit octal mode" ;;
+  esac
+  group_digit="${chmod_mode: -2:1}"
+  other_digit="${chmod_mode: -1}"
+  [ $((group_digit & 4)) -eq 4 ] ||
+    fail "${manifest}: chmod mode '${chmod_mode}' does not grant GROUP read — the mirror still needs to be the owner"
+  [ "${other_digit}" -eq 0 ] ||
+    fail "${manifest}: chmod mode '${chmod_mode}' grants OTHER access to a vault snapshot"
+
+  printf 'ok: %s — snapshot saved to %s and chmod %s applied to the same path\n' \
+    "${manifest}" "${save_operand}" "${chmod_mode}"
+done
+
+printf 'PASS: both vault-snapshot writers make the snapshot group-readable\n'

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -76,8 +76,8 @@ for target in "${targets[@]}"; do
 
   # Group must gain read; world must gain nothing (the snapshot is vault data).
   case "${chmod_mode}" in
-  [0-7][0-7][0-7] | [0-7][0-7][0-7][0-7]) ;;
-  *) fail "${manifest}: chmod mode '${chmod_mode}' is not a 3- or 4-digit octal mode" ;;
+    [0-7][0-7][0-7] | [0-7][0-7][0-7][0-7]) ;;
+    *) fail "${manifest}: chmod mode '${chmod_mode}' is not a 3- or 4-digit octal mode" ;;
   esac
   group_digit="${chmod_mode: -2:1}"
   other_digit="${chmod_mode: -1}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Our nightly OpenBao backup writes its snapshot so that **only its owner can read it**. The job that
copies that snapshot off-cluster can therefore only do its work by running as the *same* low user
account — which is the sole reason all three backup workloads are still pinned to a low, host-level
user ID that our security scanner flags.

### Description

Make the snapshot readable by its **group** as well as its owner. The copy job already shares that
group, so it no longer has to impersonate the owner to read the file — which frees those workloads
to move to safe high user IDs in the follow-up step.

Deliberately shipped on its own: the group-readable snapshot has to prove itself on a real nightly
run (and the off-cluster copy has to keep working) before the user IDs move, since that second step
also touches the disaster-recovery restore path.

No behaviour changes today — the copy job still reads the file exactly as before, just no longer
*only* as its owner.

Part of #3202
