### PR TITLE
security(k8s): rule on the vendored operators' absent resource limits (KSV-0011, KSV-0018)

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -97,7 +97,7 @@ DISABLE_ERRORS_LINTERS:
   # (#3205). Its dispositions are documented below because they are what holds that zero — each one
   # is a scoped, resource-level skip naming its reason, not a disabled check.
   #
-  # trivy (36 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
+  # trivy (15 in the local v0.74.0 reproduction): Kubernetes misconfiguration in k8s/, which the
   # section above explains is NOT covered elsewhere. Tracked by #2787.
   #
   # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore.yaml — 450 of

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -248,6 +248,33 @@ misconfigurations:
       resource-scoped Checkov annotations, and trivy reads the raw committed file, so a kustomize
       patch would change the deployed posture without clearing the finding. They ship only to the
       docker (local/CI) provider and are excluded from the production overlay.
+  - id: KSV-0011
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Neither operator Deployment sets a CPU limit; both set a CPU request (cdi-operator 100m,
+      virt-operator 10m), so both are schedulable and neither is unbounded in the scheduler's view.
+      CPU is a compressible resource, so the residual is contention under saturation rather than
+      eviction, and an omitted CPU limit is upstream's deliberate default for both bundles. The
+      bundles are upstream release artifacts whose SHA-256 is verified on download before this
+      repository adds its resource-scoped Checkov annotations, and trivy reads the raw committed
+      file, so a kustomize patch would change the deployed posture without clearing the finding.
+      They ship only to the docker (local/CI) provider and are excluded from the production overlay.
+  - id: KSV-0018
+    paths:
+      - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+      - k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    statement: >-
+      Neither operator Deployment sets a memory limit; both set a memory request (cdi-operator
+      150Mi, virt-operator 450Mi). Memory is NOT compressible, so unlike the CPU entry above this
+      is a real residual: a leaking operator is bounded only by node capacity and can drive
+      eviction of co-scheduled pods. It is accepted on exactly the premise the KSV-0014, KSV-0020
+      and KSV-0021 entries above rest on, and no wider — these two Deployments never run outside
+      the local/CI provider, so the blast radius is a developer's own kind cluster. The bundles are
+      upstream release artifacts whose SHA-256 is verified on download before this repository adds
+      its resource-scoped Checkov annotations, and trivy reads the raw committed file, so a
+      kustomize patch would change the deployed posture without clearing the finding.
   - id: KSV-0041
     paths:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -271,7 +271,7 @@ misconfigurations:
       is a real residual: a leaking operator is bounded only by node capacity and can drive
       eviction of co-scheduled pods. It is accepted on exactly the premise the KSV-0014, KSV-0020
       and KSV-0021 entries above rest on, and no wider — these two Deployments never run outside
-      the local/CI provider, so the blast radius is a developer's own kind cluster. The bundles are
+      the local/CI provider, so the blast radius is a developer's own local cluster. The bundles are
       upstream release artifacts whose SHA-256 is verified on download before this repository adds
       its resource-scoped Checkov annotations, and trivy reads the raw committed file, so a
       kustomize patch would change the deployed posture without clearing the finding.

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -59,7 +59,7 @@ readonly first_party_pairs=(
 )
 
 # Every check id dispositioned for the vendored bundles. Keep in sync with .trivyignore.yaml.
-readonly checks=(KSV-0014 KSV-0020 KSV-0021 KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
+readonly checks=(KSV-0011 KSV-0014 KSV-0018 KSV-0020 KSV-0021 KSV-0041 KSV-0046 KSV-0053 KSV-0056 KSV-0114)
 
 status=0
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

`#2787` is driving trivy to zero on `k8s/` so the scanner can become a hard gate again instead of a
reported-but-ignored backlog. Four of the nineteen remaining findings say the two vendored VM-stack
operators (CDI and KubeVirt) declare no CPU or memory limits.

Those two bundles are upstream release artifacts whose checksum is verified on download, and three
checks on exactly these files already carry a reviewed disposition on one premise: the VM stack
ships only to the local/CI provider and never to production. I re-verified that premise against the
live production cluster today — no CDI or KubeVirt namespaces, pods or Deployments exist there.

### What

Rules on the last two checks on those files, in the same path-scoped form as the existing three, so
the remaining trivy backlog is the findings that describe production workloads.

The two entries are deliberately not written as equivalent. The CPU one records a compressible
residual against what upstream ships by default. The memory one states its residual plainly — memory
is not compressible, so a leak is bounded only by node capacity — and is accepted **only** because
these Deployments never leave a developer's own cluster.

Backlog moves 19 → 15. Nothing about production posture changes, and both ids stay live on every
other workload in the repository.

No behaviour, manifest or deployed resource is touched.

Part of #2787