### PR TITLE
fix(vault-backup): report how many snapshots the widen actually touched

### DIFF
--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -159,11 +159,14 @@ spec:
                   # owner. Widening them here, while this container still is, is what makes
                   # that move safe; a warning rather than a hard failure so a single odd file
                   # cannot take the nightly backup down.
+                  widened=0
                   for EXISTING in /snapshots/openbao-*.snap; do
                     [ -e "$EXISTING" ] || continue
-                    chmod 0640 "$EXISTING" ||
+                    chmod 0640 "$EXISTING" && widened=$((widened + 1)) ||
                       echo "WARNING: could not widen $EXISTING; the mirror may be unable to read it"
                   done
+                  # Positive evidence: a silent loop cannot be told apart from one that matched nothing.
+                  echo "Widened $widened snapshot(s) on the shared PVC to 0640."
 
                   SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
                   echo "Saving raft snapshot to $SNAP..."

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -154,11 +154,14 @@ spec:
               # owner. Widening them here, while this container still is, is what makes
               # that move safe; a warning rather than a hard failure so a single odd file
               # cannot take the nightly backup down.
+              widened=0
               for EXISTING in /snapshots/openbao-*.snap; do
                 [ -e "$EXISTING" ] || continue
-                chmod 0640 "$EXISTING" ||
+                chmod 0640 "$EXISTING" && widened=$((widened + 1)) ||
                   echo "WARNING: could not widen $EXISTING; the mirror may be unable to read it"
               done
+              # Positive evidence: a silent loop cannot be told apart from one that matched nothing.
+              echo "Widened $widened snapshot(s) on the shared PVC to 0640."
 
               # Skip if the nightly CronJob already produced a snapshot today —
               # this job only guarantees a baseline exists.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The snapshot widen shipped in #3265 is silent when it succeeds, so its log cannot distinguish
"widened every snapshot on the volume" from "matched nothing and did nothing". I verified #3265
against production on exactly that evidence — no warnings — which was weaker than I claimed at the
time.

It matters because the next step of #3202 is deliberately sequenced behind *observing* this run, and
that observation was not actually available.

### What

The widen now counts what it touched and says so, so the log carries positive evidence either way.
A file it cannot widen still warns and is excluded from the count.

Part of #3202
