### PR TITLE
security(docker-provider): ship the LimitRange the CoreDNS skip already assumes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,6 +215,9 @@ jobs:
               # still runs the check that covers it.
               - 'scripts/guard-checkov-skip-reasons.sh'
               - 'scripts/tests/test-guard-checkov-skip-reasons.sh'
+              # Both halves, for the same reason as the guard above.
+              - 'scripts/guard-limitrange-premise.sh'
+              - 'scripts/tests/test-guard-limitrange-premise.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -672,6 +675,23 @@ jobs:
         run: |
           bash scripts/guard-checkov-skip-reasons.sh k8s
           bash scripts/tests/test-guard-checkov-skip-reasons.sh
+
+      - name: 📐 Validate LimitRange-premised suppressions actually have a LimitRange
+        if: needs.changes.outputs.k8s == 'true'
+        # Several skips here are dispositioned not as accepted risk but as "the check
+        # is blind to an admission-time default" — sound reasoning that holds only
+        # where the LimitRange actually applies. The natural justification is that a
+        # LimitRange is a base resource and so reaches every overlay, which is an
+        # inference about REACHABILITY that reads as obviously true and is not: an
+        # overlay that cherry-picks named base directories does not get it. Nothing
+        # then fails — the suppression keeps suppressing and the workload runs with no
+        # limit in exactly the overlay whose goal was prod-like admission. The guard
+        # walks each provider's kustomize graph and pins its verdict in all three
+        # directions, including the two anti-vacuity cases where a matcher that
+        # matched nothing would otherwise look like a healthy tree.
+        run: |
+          bash scripts/guard-limitrange-premise.sh k8s
+          bash scripts/tests/test-guard-limitrange-premise.sh
 
       - name: 📋 Validate Kubescape finding summary
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/docker/infrastructure/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../../bases/infrastructure/cluster-secret-stores/ # ESO ↔ OpenBao
   - ../../../bases/infrastructure/external-secrets/ # ExternalSecrets (velero one is pruned below)
   - ../../../bases/infrastructure/gateway/ # central Gateway + HTTP→HTTPS redirect
+  - ../../../bases/infrastructure/limit-ranges/ # CPU LimitRanges for the namespaces Kyverno cannot reach
   - ../../../bases/infrastructure/vault-config/ # OpenBao configuration Job
   - ../../../bases/infrastructure/vault-seed/ # OpenBao secret seeding
   - cluster-issuers/

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -56,7 +56,13 @@ command -v yq >/dev/null 2>&1 || die 'yq is required but not on PATH'
 # are not filesystem paths and are skipped by the caller.
 canonicalize() { # <dir> <entry>
   local base=$1 entry=$2 combined
-  combined="$base/$entry"
+  # An entry that is already absolute names its target outright. Joining it onto $base
+  # would build a path that names nothing, and the graph walk would then miss a
+  # LimitRange it does reach — a FALSE premise violation, which fails the build.
+  case $entry in
+    /*) combined=$entry ;;
+    *)  combined="$base/$entry" ;;
+  esac
   # No realpath dependency: collapse `.`/`..` textually so the result is stable
   # whether or not the path exists (a dangling entry must not abort the walk).
   printf '%s' "$combined" | awk -F/ -v abs="${combined:0:1}" '{

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -61,7 +61,7 @@ canonicalize() { # <dir> <entry>
   # LimitRange it does reach — a FALSE premise violation, which fails the build.
   case $entry in
     /*) combined=$entry ;;
-    *)  combined="$base/$entry" ;;
+    *) combined="$base/$entry" ;;
   esac
   # No realpath dependency: collapse `.`/`..` textually so the result is stable
   # whether or not the path exists (a dangling entry must not abort the walk).

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -90,6 +90,13 @@ reachable_files() { # <provider-dir>
     dir=$(dirname "$k")
     # yq exits non-zero on a malformed kustomization; that is a real inability to
     # check the graph, not a clean overlay.
+    # A `namespace:` transformer rewrites the namespace of every resource below this
+      # kustomization, so `.metadata.namespace` read from the file would no longer be the
+      # namespace the LimitRange must match. Resolving that properly means reimplementing
+      # kustomize; refusing to answer is the honest alternative to answering wrongly.
+    ns_xform=$(yq -r '.namespace // ""' "$k" 2>/dev/null) || die "could not parse $k"
+    [ -z "$ns_xform" ] ||
+      die "$k sets a kustomize namespace transformer ($ns_xform); this guard cannot resolve the effective namespace"
     entry=$(yq -r '(.resources // []) + (.components // []) | .[]' "$k" 2>/dev/null) ||
       die "could not parse $k"
     while IFS= read -r e; do
@@ -125,13 +132,21 @@ limitrange_namespaces() { # <files...on stdin>
     [ -n "$f" ] || continue
     case $f in *.yaml | *.yml) ;; *) continue ;; esac
     # A file may hold several documents; only LimitRange ones contribute.
-    ns=$(yq -r 'select(.kind == "LimitRange") | .metadata.namespace // ""' "$f" 2>/dev/null) || continue
+    # A parse failure here is an INABILITY TO CHECK, not an absent LimitRange. Skipping
+    # it would let a malformed file contribute no namespace, and the caller would then
+    # report a definite premise violation (exit 1) over input it could not read.
+    ns=$(yq -r 'select(.kind == "LimitRange") | .metadata.namespace // ""' "$f" 2>/dev/null) ||
+      die "could not parse a reachable LimitRange candidate: $f"
     while IFS= read -r n; do
       [ -n "$n" ] && printf '%s\n' "$n"
     done <<EOF
 $ns
 EOF
   done
+  # An explicit success: a `while` loop returns the status of its LAST body command, so a
+  # final line contributing no namespace would otherwise make this function look like it
+  # failed — and the caller now treats that failure as fatal.
+  return 0
 }
 
 annotated=$(grep -rlE 'checkov\.io/skip[0-9]+' --include='*.yaml' --include='*.yml' -- "$root" 2>/dev/null)
@@ -150,7 +165,12 @@ while IFS= read -r p; do
   [ -n "$p" ] || continue
   name=$(basename "$p")
   reachable_files "$p" >"$prov_files_dir/$name.files"
-  limitrange_namespaces <"$prov_files_dir/$name.files" | sort -u >"$prov_files_dir/$name.ns"
+  # Deliberately NOT piped into `sort`: `die` inside a pipeline exits only the subshell,
+  # and the pipeline then reports `sort`'s status, so a fatal parse error would vanish.
+  limitrange_namespaces <"$prov_files_dir/$name.files" >"$prov_files_dir/$name.raw" ||
+    die "could not collect LimitRange namespaces for provider $name"
+  sort -u <"$prov_files_dir/$name.raw" >"$prov_files_dir/$name.ns" ||
+    die "could not sort LimitRange namespaces for provider $name"
 done <<EOF
 $providers
 EOF

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -88,8 +88,6 @@ reachable_files() { # <provider-dir>
     case $'\n'"$seen_k"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
     seen_k="$seen_k$k"$'\n'
     dir=$(dirname "$k")
-    # yq exits non-zero on a malformed kustomization; that is a real inability to
-    # check the graph, not a clean overlay.
     # A `namespace:` transformer rewrites the namespace of every resource below this
     # kustomization, so `.metadata.namespace` read from the file would no longer be the
     # namespace the LimitRange must match. Resolving that properly means reimplementing
@@ -97,6 +95,8 @@ reachable_files() { # <provider-dir>
     ns_xform=$(yq -r '.namespace // ""' "$k" 2>/dev/null) || die "could not parse $k"
     [ -z "$ns_xform" ] ||
       die "$k sets a kustomize namespace transformer ($ns_xform); this guard cannot resolve the effective namespace"
+    # yq exits non-zero on a malformed kustomization; that is a real inability to
+    # check the graph, not a clean overlay.
     entry=$(yq -r '(.resources // []) + (.components // []) | .[]' "$k" 2>/dev/null) ||
       die "could not parse $k"
     while IFS= read -r e; do

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -91,9 +91,9 @@ reachable_files() { # <provider-dir>
     # yq exits non-zero on a malformed kustomization; that is a real inability to
     # check the graph, not a clean overlay.
     # A `namespace:` transformer rewrites the namespace of every resource below this
-      # kustomization, so `.metadata.namespace` read from the file would no longer be the
-      # namespace the LimitRange must match. Resolving that properly means reimplementing
-      # kustomize; refusing to answer is the honest alternative to answering wrongly.
+    # kustomization, so `.metadata.namespace` read from the file would no longer be the
+    # namespace the LimitRange must match. Resolving that properly means reimplementing
+    # kustomize; refusing to answer is the honest alternative to answering wrongly.
     ns_xform=$(yq -r '.namespace // ""' "$k" 2>/dev/null) || die "could not parse $k"
     [ -z "$ns_xform" ] ||
       die "$k sets a kustomize namespace transformer ($ns_xform); this guard cannot resolve the effective namespace"

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Fail when a suppression is justified by "a LimitRange supplies it at admission"
+# in an overlay that does not actually ship a LimitRange into that namespace.
+#
+# THE PREMISE THIS PROTECTS. Several suppressions in this tree are dispositioned not
+# as "we accept the risk" but as "the check is blind to an admission-time default" —
+# the kube-system `default-limitrange` supplies a CPU limit that the stored spec does
+# not state, so checkov, reading the stored spec, reports a finding that is not real.
+# That reasoning is sound, and it is only sound WHERE THE LIMITRANGE ACTUALLY APPLIES.
+#
+# WHY A GUARD RATHER THAN REVIEW. The premise fails silently and asymmetrically. A
+# LimitRange lives in its own base, so the natural way to justify one of these skips
+# is "it is a base resource, therefore it applies to every overlay" — an inference
+# about REACHABILITY that reads as obviously true and is not. An overlay that
+# cherry-picks named base directories, rather than pulling the aggregate, does not
+# get it. Nothing then fails: the suppression keeps suppressing, the scan stays
+# green, and the workload runs with no limit in exactly the overlay whose stated
+# goal was prod-like admission. The suppression still reads as reviewed.
+#
+# WHAT IT CHECKS. For every file carrying a `checkov.io/skipN` whose reason invokes
+# the LimitRange-at-admission premise, this walks the kustomize graph of each
+# provider that actually ships that file and asserts that the same provider also
+# ships a LimitRange into the annotated resource's namespace.
+#
+# WHY REACHABILITY RATHER THAN A RENDER. `kustomize build` is the more direct
+# question, but many roots here pull remote Helm charts and OCI bases, so a
+# render-based guard would need the network and would exit 2 — "could not check" —
+# far more often than it would answer. The graph walk is the same question asked
+# statically: it resolves `resources:` and `components:` exactly as the overlay
+# declares them, which is the precise step the bad inference skipped.
+#
+# Usage: guard-limitrange-premise.sh [root]        (default: k8s)
+# Exit:  0 every LimitRange-premised suppression is in an overlay that ships one
+#        1 at least one is not (each is named, with the overlay that lacks it)
+#        2 the guard could not check — missing tool, unreadable root, parse failure
+#
+# Exit 2 is deliberately distinct from 0. A guard that cannot run must never be
+# indistinguishable from a clean tree.
+
+set -uo pipefail
+
+root=${1:-k8s}
+
+die() {
+  printf 'guard-limitrange-premise: %s\n' "$1" >&2
+  exit 2
+}
+
+command -v yq >/dev/null 2>&1 || die 'yq is required but not on PATH'
+[ -d "$root" ] || die "not a directory: $root"
+[ -d "$root/providers" ] || die "no providers directory under $root"
+
+# Resolve a `resources:`/`components:` entry against the directory of the
+# kustomization that named it. Entries that leave the tree (remote bases, OCI, URLs)
+# are not filesystem paths and are skipped by the caller.
+canonicalize() { # <dir> <entry>
+  local base=$1 entry=$2 combined
+  combined="$base/$entry"
+  # No realpath dependency: collapse `.`/`..` textually so the result is stable
+  # whether or not the path exists (a dangling entry must not abort the walk).
+  printf '%s' "$combined" | awk -F/ -v abs="${combined:0:1}" '{
+    n = 0
+    for (i = 1; i <= NF; i++) {
+      if ($i == "" || $i == ".") continue
+      if ($i == "..") { if (n > 0) n--; continue }
+      parts[++n] = $i
+    }
+    out = ""
+    for (i = 1; i <= n; i++) out = out "/" parts[i]
+    # Preserve an absolute root: dropping the leading slash would make the path
+    # unmatchable against the annotated-file list and read as "no overlay ships it".
+    if (abs == "/") print out; else print substr(out, 2)
+  }'
+}
+
+# Every filesystem path a provider's kustomize graph reaches, one per line.
+reachable_files() { # <provider-dir>
+  local provider=$1 queue seen_k="" files="" k dir entry target
+  # Seed with every kustomization under the provider. Flux applies each layer
+  # separately, so a LimitRange reached by ANY of them lands on that cluster.
+  queue=$(find "$provider" -name kustomization.yaml -type f 2>/dev/null)
+  [ -n "$queue" ] && queue="$queue"$'\n'
+  while [ -n "$queue" ]; do
+    k=${queue%%$'\n'*}
+    if [ "$k" = "$queue" ]; then queue=""; else queue=${queue#*$'\n'}; fi
+    [ -n "$k" ] || continue
+    case $'\n'"$seen_k"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
+    seen_k="$seen_k$k"$'\n'
+    dir=$(dirname "$k")
+    # yq exits non-zero on a malformed kustomization; that is a real inability to
+    # check the graph, not a clean overlay.
+    entry=$(yq -r '(.resources // []) + (.components // []) | .[]' "$k" 2>/dev/null) \
+      || die "could not parse $k"
+    while IFS= read -r e; do
+      [ -n "$e" ] || continue
+      # Remote bases are not filesystem paths; a LimitRange cannot be asserted
+      # through one statically, and none of this tree's limit ranges come that way.
+      case $e in *"://"*|"git@"*) continue ;; esac
+      target=$(canonicalize "$dir" "$e")
+      if [ -d "$target" ]; then
+        if [ -f "$target/kustomization.yaml" ]; then
+          queue="$queue$target/kustomization.yaml"$'\n'
+        fi
+      elif [ -f "$target" ]; then
+        files="$files$target"$'\n'
+      fi
+    done <<EOF
+$entry
+EOF
+  done
+  printf '%s' "$files"
+}
+
+# The reason text that marks a suppression as resting on this premise. Matched on
+# the ANNOTATION VALUE rather than the neighbouring YAML comment: the value is the
+# part checkov actually carries, it is what survives a reformat, and the sibling
+# guard already forces it to be a quoted scalar carrying the whole reason.
+premise_re='limit[ -]?range'
+
+# Namespaces a provider ships a LimitRange into.
+limitrange_namespaces() { # <files...on stdin>
+  local f ns
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case $f in *.yaml|*.yml) ;; *) continue ;; esac
+    # A file may hold several documents; only LimitRange ones contribute.
+    ns=$(yq -r 'select(.kind == "LimitRange") | .metadata.namespace // ""' "$f" 2>/dev/null) || continue
+    while IFS= read -r n; do
+      [ -n "$n" ] && printf '%s\n' "$n"
+    done <<EOF
+$ns
+EOF
+  done
+}
+
+annotated=$(grep -rlE 'checkov\.io/skip[0-9]+' --include='*.yaml' --include='*.yml' -- "$root" 2>/dev/null)
+grep_rc=$?
+if [ "$grep_rc" -gt 1 ]; then
+  die "could not search $root for annotations (grep exit $grep_rc)"
+fi
+
+providers=$(find "$root/providers" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+[ -n "$providers" ] || die "no provider overlays under $root/providers"
+
+# Precompute each provider's reachable file set and LimitRange namespaces once.
+prov_files_dir=$(mktemp -d) || die 'could not create scratch dir'
+trap 'rm -rf "$prov_files_dir"' EXIT
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  name=$(basename "$p")
+  reachable_files "$p" >"$prov_files_dir/$name.files"
+  limitrange_namespaces <"$prov_files_dir/$name.files" | sort -u >"$prov_files_dir/$name.ns"
+done <<EOF
+$providers
+EOF
+
+failures=0
+checked=0
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  values=$(yq -r '.metadata.annotations // {} | to_entries | .[] | select(.key | test("^checkov\\.io/skip[0-9]+$")) | .value' \
+    "$file" 2>/dev/null) || die "could not read annotations from $file"
+  printf '%s' "$values" | grep -qiE "$premise_re" || continue
+
+  ns=$(yq -r '.metadata.namespace // ""' "$file" 2>/dev/null | head -1)
+  [ -n "$ns" ] || die "$file carries a LimitRange-premised skip but states no namespace"
+
+  shipped_by=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    name=$(basename "$p")
+    grep -qxF -- "$file" "$prov_files_dir/$name.files" || continue
+    shipped_by=$((shipped_by + 1))
+    checked=$((checked + 1))
+    if grep -qxF -- "$ns" "$prov_files_dir/$name.ns"; then
+      printf 'ok   %s — provider %s ships a LimitRange into %s\n' "$file" "$name" "$ns"
+    else
+      printf 'FAIL %s\n' "$file" >&2
+      printf '     its skip reason rests on a LimitRange applying at admission, but provider\n' >&2
+      printf '     %s ships NO LimitRange into namespace %s.\n' "$name" "$ns" >&2
+      printf '     Fix: add the limit-ranges base to that overlay, or drop the skip and\n' >&2
+      printf '     state the limit on the workload.\n' >&2
+      failures=$((failures + 1))
+    fi
+  done <<EOF
+$providers
+EOF
+
+  if [ "$shipped_by" -eq 0 ]; then
+    # An unattributable premised suppression is NOT benign. Either the walk failed
+    # to reach a file that is really shipped, or the suppression is dead code — and
+    # from here those are indistinguishable. Both mean the premise went unchecked,
+    # which is precisely the silent pass this guard exists to refuse.
+    die "$file carries a LimitRange-premised skip, but no provider overlay reaches it"
+  fi
+done <<EOF
+$annotated
+EOF
+
+if [ "$checked" -eq 0 ]; then
+  # No premised suppression anywhere is a legitimately clean tree, but it is also
+  # what a broken matcher looks like. Say which it is rather than printing "ok".
+  printf 'limitrange premise: no suppression under %s invokes the premise\n' "$root"
+  exit 0
+fi
+
+if [ "$failures" -gt 0 ]; then
+  printf '\nlimitrange premise: %d premised suppression(s) rest on an overlay that ships none.\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nlimitrange premise: %d premised suppression(s) checked, all shipped with a LimitRange.\n' "$checked"
+exit 0

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -131,17 +131,22 @@ EOF
 # guard already forces it to be a quoted scalar carrying the whole reason.
 premise_re='limit[ -]?range'
 
-# Namespaces a provider ships a LimitRange into.
+# Namespaces a provider ships a CPU-defaulting LimitRange into.
 limitrange_namespaces() { # <files...on stdin>
   local f ns
   while IFS= read -r f; do
     [ -n "$f" ] || continue
     case $f in *.yaml | *.yml) ;; *) continue ;; esac
-    # A file may hold several documents; only LimitRange ones contribute.
+    # A file may hold several documents; only LimitRange ones contribute — and only those
+    # that actually supply the suppressed field. The premise these skips invoke is that a
+    # CPU limit arrives at admission, which is true only of a Container-type limit carrying
+    # `default.cpu`. A range with only `defaultRequest`, only `max`, or only a memory default
+    # leaves the container with no CPU limit, so counting it would satisfy the premise with a
+    # resource that does not supply it.
     # A parse failure here is an INABILITY TO CHECK, not an absent LimitRange. Skipping
     # it would let a malformed file contribute no namespace, and the caller would then
     # report a definite premise violation (exit 1) over input it could not read.
-    ns=$(yq -r 'select(.kind == "LimitRange") | .metadata.namespace // ""' "$f" 2>/dev/null) ||
+    ns=$(yq -r 'select(.kind == "LimitRange") | select([.spec.limits[] | select(.type == "Container" and .default.cpu != null)] | length > 0) | .metadata.namespace // ""' "$f" 2>/dev/null) ||
       die "could not parse a reachable LimitRange candidate: $f"
     while IFS= read -r n; do
       [ -n "$n" ] && printf '%s\n' "$n"
@@ -217,13 +222,15 @@ while IFS= read -r file; do
       shipped_by=$((shipped_by + 1))
       checked=$((checked + 1))
       if grep -qxF -- "$ns" "$prov_files_dir/$name.ns"; then
-        printf 'ok   %s — provider %s ships a LimitRange into %s\n' "$file" "$name" "$ns"
+        printf 'ok   %s — provider %s ships a CPU-defaulting LimitRange into %s\n' "$file" "$name" "$ns"
       else
         printf 'FAIL %s\n' "$file" >&2
         printf '     its skip reason rests on a LimitRange applying at admission, but provider\n' >&2
-        printf '     %s ships NO LimitRange into namespace %s.\n' "$name" "$ns" >&2
-        printf '     Fix: add the limit-ranges base to that overlay, or drop the skip and\n' >&2
-        printf '     state the limit on the workload.\n' >&2
+        printf '     %s ships NO LimitRange supplying a default CPU limit into\n' "$name" >&2
+        printf '     namespace %s. A LimitRange that sets only defaultRequest, only max,\n' "$ns" >&2
+        printf '     or only a memory default does not supply one.\n' >&2
+        printf '     Fix: add (or extend) a Container-type default.cpu in that overlay'"'"'s\n' >&2
+        printf '     limit-ranges base, or drop the skip and state the limit on the workload.\n' >&2
         failures=$((failures + 1))
       fi
     done <<EOF
@@ -256,5 +263,5 @@ if [ "$failures" -gt 0 ]; then
   exit 1
 fi
 
-printf '\nlimitrange premise: %d premised suppression(s) checked, all shipped with a LimitRange.\n' "$checked"
+printf '\nlimitrange premise: %d premised suppression(s) checked, all shipped with a CPU-defaulting LimitRange.\n' "$checked"
 exit 0

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -90,13 +90,13 @@ reachable_files() { # <provider-dir>
     dir=$(dirname "$k")
     # yq exits non-zero on a malformed kustomization; that is a real inability to
     # check the graph, not a clean overlay.
-    entry=$(yq -r '(.resources // []) + (.components // []) | .[]' "$k" 2>/dev/null) \
-      || die "could not parse $k"
+    entry=$(yq -r '(.resources // []) + (.components // []) | .[]' "$k" 2>/dev/null) ||
+      die "could not parse $k"
     while IFS= read -r e; do
       [ -n "$e" ] || continue
       # Remote bases are not filesystem paths; a LimitRange cannot be asserted
       # through one statically, and none of this tree's limit ranges come that way.
-      case $e in *"://"*|"git@"*) continue ;; esac
+      case $e in *"://"* | "git@"*) continue ;; esac
       target=$(canonicalize "$dir" "$e")
       if [ -d "$target" ]; then
         if [ -f "$target/kustomization.yaml" ]; then
@@ -123,7 +123,7 @@ limitrange_namespaces() { # <files...on stdin>
   local f ns
   while IFS= read -r f; do
     [ -n "$f" ] || continue
-    case $f in *.yaml|*.yml) ;; *) continue ;; esac
+    case $f in *.yaml | *.yml) ;; *) continue ;; esac
     # A file may hold several documents; only LimitRange ones contribute.
     ns=$(yq -r 'select(.kind == "LimitRange") | .metadata.namespace // ""' "$f" 2>/dev/null) || continue
     while IFS= read -r n; do

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -209,34 +209,34 @@ while IFS= read -r file; do
     [ -n "$ns" ] ||
       die "$file document $doc carries a LimitRange-premised skip but states no namespace"
 
-  shipped_by=0
-  while IFS= read -r p; do
-    [ -n "$p" ] || continue
-    name=$(basename "$p")
-    grep -qxF -- "$file" "$prov_files_dir/$name.files" || continue
-    shipped_by=$((shipped_by + 1))
-    checked=$((checked + 1))
-    if grep -qxF -- "$ns" "$prov_files_dir/$name.ns"; then
-      printf 'ok   %s — provider %s ships a LimitRange into %s\n' "$file" "$name" "$ns"
-    else
-      printf 'FAIL %s\n' "$file" >&2
-      printf '     its skip reason rests on a LimitRange applying at admission, but provider\n' >&2
-      printf '     %s ships NO LimitRange into namespace %s.\n' "$name" "$ns" >&2
-      printf '     Fix: add the limit-ranges base to that overlay, or drop the skip and\n' >&2
-      printf '     state the limit on the workload.\n' >&2
-      failures=$((failures + 1))
-    fi
-  done <<EOF
+    shipped_by=0
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      name=$(basename "$p")
+      grep -qxF -- "$file" "$prov_files_dir/$name.files" || continue
+      shipped_by=$((shipped_by + 1))
+      checked=$((checked + 1))
+      if grep -qxF -- "$ns" "$prov_files_dir/$name.ns"; then
+        printf 'ok   %s — provider %s ships a LimitRange into %s\n' "$file" "$name" "$ns"
+      else
+        printf 'FAIL %s\n' "$file" >&2
+        printf '     its skip reason rests on a LimitRange applying at admission, but provider\n' >&2
+        printf '     %s ships NO LimitRange into namespace %s.\n' "$name" "$ns" >&2
+        printf '     Fix: add the limit-ranges base to that overlay, or drop the skip and\n' >&2
+        printf '     state the limit on the workload.\n' >&2
+        failures=$((failures + 1))
+      fi
+    done <<EOF
 $providers
 EOF
 
-  if [ "$shipped_by" -eq 0 ]; then
-    # An unattributable premised suppression is NOT benign. Either the walk failed
-    # to reach a file that is really shipped, or the suppression is dead code — and
-    # from here those are indistinguishable. Both mean the premise went unchecked,
-    # which is precisely the silent pass this guard exists to refuse.
-    die "$file document $doc carries a LimitRange-premised skip, but no provider overlay reaches it"
-  fi
+    if [ "$shipped_by" -eq 0 ]; then
+      # An unattributable premised suppression is NOT benign. Either the walk failed
+      # to reach a file that is really shipped, or the suppression is dead code — and
+      # from here those are indistinguishable. Both mean the premise went unchecked,
+      # which is precisely the silent pass this guard exists to refuse.
+      die "$file document $doc carries a LimitRange-premised skip, but no provider overlay reaches it"
+    fi
   done <<EOF
 $records
 EOF

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -186,12 +186,28 @@ checked=0
 
 while IFS= read -r file; do
   [ -n "$file" ] || continue
-  values=$(yq -r '.metadata.annotations // {} | to_entries | .[] | select(.key | test("^checkov\\.io/skip[0-9]+$")) | .value' \
+  # ONE RECORD PER YAML DOCUMENT, pairing that document's namespace with that document's
+  # own premise-bearing annotation values. Reading the values from every document while
+  # taking the namespace from only the first checks a later document against the wrong
+  # namespace — or, when document 0 is a namespaceless cluster-scoped object, against no
+  # namespace at all, which aborts the build on a well-formed file. That is the ordinary
+  # shape of an operator bundle and already the shape of cdi-operator.yaml and
+  # kubevirt-operator.yaml here.
+  # `@tsv` escapes any tab or newline inside a value, so one document is always one line.
+  records=$(yq -r '[(.metadata.namespace // ""), ((.metadata.annotations // {}) | to_entries | map(select(.key | test("^checkov\\.io/skip[0-9]+$")) | .value) | join(" "))] | @tsv' \
     "$file" 2>/dev/null) || die "could not read annotations from $file"
-  printf '%s' "$values" | grep -qiE "$premise_re" || continue
 
-  ns=$(yq -r '.metadata.namespace // ""' "$file" 2>/dev/null | head -1)
-  [ -n "$ns" ] || die "$file carries a LimitRange-premised skip but states no namespace"
+  doc=-1
+  while IFS= read -r record; do
+    doc=$((doc + 1))
+    # Split on the first tab with parameter expansion, NOT `IFS=$'\t' read`: tab is an IFS
+    # whitespace character, so `read` would collapse an empty leading namespace field and
+    # shift the values into it — silently checking against a namespace named after a reason.
+    ns=${record%%$'\t'*}
+    values=${record#*$'\t'}
+    printf '%s' "$values" | grep -qiE "$premise_re" || continue
+    [ -n "$ns" ] ||
+      die "$file document $doc carries a LimitRange-premised skip but states no namespace"
 
   shipped_by=0
   while IFS= read -r p; do
@@ -219,8 +235,11 @@ EOF
     # to reach a file that is really shipped, or the suppression is dead code — and
     # from here those are indistinguishable. Both mean the premise went unchecked,
     # which is precisely the silent pass this guard exists to refuse.
-    die "$file carries a LimitRange-premised skip, but no provider overlay reaches it"
+    die "$file document $doc carries a LimitRange-premised skip, but no provider overlay reaches it"
   fi
+  done <<EOF
+$records
+EOF
 done <<EOF
 $annotated
 EOF

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -108,7 +108,7 @@ expect() { # <case> <expected-rc> <root> [<needle>]
 missing="$scratch/missing"
 make_provider "$missing" dockerlike unshielded-dns kube-system \
   "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" ""
-make_limitrange_base "$missing" kube-system   # present in the tree, but NOT referenced
+make_limitrange_base "$missing" kube-system # present in the tree, but NOT referenced
 expect 'premise-without-limitrange-fails' 1 "$missing" 'unshielded-dns'
 
 # The report must name the overlay that lacks it, not merely the file: the fix

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -235,5 +235,18 @@ make_limitrange_base "$nsxform" kube-system
 printf 'namespace: somewhere-else\n' >>"$nsxform/providers/nsxformlike/infrastructure/kustomization.yaml"
 expect 'namespace-transformer-is-exit-2' 2 "$nsxform" 'namespace transformer'
 
+# --- 12. An ABSOLUTE resources entry still resolves to the file it names ------
+# `canonicalize` joins every entry onto the naming kustomization's directory. An entry
+# that is already absolute must not be joined — the combined path names nothing, the graph
+# walk misses the LimitRange it does reach, and the guard reports a premise violation that
+# is not there. That is a FALSE exit 1: the most expensive verdict this guard can give,
+# because it fails a build over a suppression that is in fact well-founded.
+absentry="$scratch/absentry"
+make_provider "$absentry" absentrylike absolute-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "$scratch/absentry/bases/limit-ranges/"
+make_limitrange_base "$absentry" kube-system
+expect 'absolute-resources-entry-resolves' 0 "$absentry" 'absolute-dns'
+
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ] || exit 1

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -286,5 +286,39 @@ YAML
 make_limitrange_base "$multidoc" multidoc-ns
 expect 'multidoc-namespace-resolves-per-document' 0 "$multidoc" 'bundle-dns'
 
+
+# --- 14. A LimitRange that supplies no default CPU does NOT satisfy the premise ---
+# The suppressed control is CKV_K8S_11 ("CPU limits should be set") and the reason
+# says the limit arrives at admission. Only `.spec.limits[].default.cpu` makes that
+# true: a range carrying only `defaultRequest`, only `max`, or only a memory default
+# leaves admission supplying no CPU limit at all, so the suppression is unfounded
+# while a namespace-only check still calls it satisfied. That is the fail-open this
+# guard exists to prevent, one field in.
+capless="$scratch/capless"
+make_provider "$capless" caplessprov capless-dns capless-ns \
+  'CKV_K8S_11=the capless-ns default-limitrange supplies the CPU limit at admission' \
+  '../../../bases/limit-ranges/'
+mkdir -p "$capless/bases/limit-ranges"
+cat >"$capless/bases/limit-ranges/kustomization.yaml" <<YAML
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - range.yaml
+YAML
+cat >"$capless/bases/limit-ranges/range.yaml" <<YAML
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: capless-ns
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 15m
+      max:
+        memory: 1Gi
+YAML
+expect 'limitrange-without-default-cpu-fails' 1 "$capless" 'capless-dns'
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ] || exit 1

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -286,7 +286,6 @@ YAML
 make_limitrange_base "$multidoc" multidoc-ns
 expect 'multidoc-namespace-resolves-per-document' 0 "$multidoc" 'bundle-dns'
 
-
 # --- 14. A LimitRange that supplies no default CPU does NOT satisfy the premise ---
 # The suppressed control is CKV_K8S_11 ("CPU limits should be set") and the reason
 # says the limit arrives at admission. Only `.spec.limits[].default.cpu` makes that

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -34,10 +34,15 @@ failures=0
 assertions=0
 
 run_guard() { # <root>
-  set +e
-  GUARD_OUT="$("$guard" "$1" 2>&1)"
-  GUARD_RC=$?
-  set -e
+  # Capture the status with `if` rather than toggling `set -e`: this file runs under
+  # `set -uo pipefail` with NO errexit, so `set -e` here would ENABLE a mode the script
+  # never had and let a later setup failure kill the run instead of being reported
+  # through the assertion summary.
+  if GUARD_OUT="$("$guard" "$1" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
 }
 
 # A LimitRange base, shared in shape by every fixture that has one.
@@ -206,6 +211,29 @@ spec:
   replicas: 1
 YAML
 expect 'premised-skip-without-namespace-is-exit-2' 2 "$nons" 'namespaceless'
+
+# --- 10. COULD-NOT-CHECK: a reachable LimitRange candidate that will not parse ---
+# A parse failure is an inability to check. Skipping it would let the file contribute
+# no namespace, and the guard would then report a DEFINITE premise violation over input
+# it could not read — a wrong verdict, not a missing one.
+badrange="$scratch/badrange"
+make_provider "$badrange" badrangelike unparseable-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "../../../bases/limit-ranges/"
+make_limitrange_base "$badrange" kube-system
+printf 'apiVersion: v1\nkind: [ LimitRange\n  bad: yaml: here\n' >"$badrange/bases/limit-ranges/range.yaml"
+expect 'unparseable-reachable-limitrange-is-exit-2' 2 "$badrange" 'range.yaml'
+
+# --- 11. COULD-NOT-CHECK: a kustomize namespace transformer -----------------
+# `namespace:` rewrites every resource below it, so the namespace read from the file is
+# no longer the one that must match. The guard refuses rather than comparing the wrong one.
+nsxform="$scratch/nsxform"
+make_provider "$nsxform" nsxformlike transformed-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "../../../bases/limit-ranges/"
+make_limitrange_base "$nsxform" kube-system
+printf 'namespace: somewhere-else\n' >>"$nsxform/providers/nsxformlike/infrastructure/kustomization.yaml"
+expect 'namespace-transformer-is-exit-2' 2 "$nsxform" 'namespace transformer'
 
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ] || exit 1

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Pins the LimitRange-premise guard's verdict in all THREE directions.
+#
+# The guard's job is to make a suppression that rests on "a LimitRange supplies
+# this at admission" impossible to keep in an overlay that ships no such
+# LimitRange. The cases that matter are therefore:
+#
+#   exit 1  the premise is invoked, and the overlay shipping the file has no
+#           LimitRange in that namespace — the real defect
+#   exit 0  the premise is invoked and the overlay DOES ship one, INCLUDING when
+#           the LimitRange is reached through a nested kustomization rather than
+#           named directly (the graph step the bad inference skipped)
+#   exit 2  the guard could not check — missing root, unparseable kustomization,
+#           or a premised skip on a resource that states no namespace
+#
+# Two of these are anti-vacuity cases rather than behaviours: a tree with no
+# premised suppression, and a suppression whose reason is about something else,
+# must both come back clean WITHOUT being reported as "checked". A matcher that
+# silently matched nothing would otherwise be indistinguishable from a healthy
+# tree — which is the same failure the guard itself exists to prevent.
+#
+# Every fixture carries its OWN provider name, filename and namespace, so an
+# assertion can only be satisfied by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-limitrange-premise.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <root>
+  set +e
+  GUARD_OUT="$("$guard" "$1" 2>&1)"
+  GUARD_RC=$?
+  set -e
+}
+
+# A LimitRange base, shared in shape by every fixture that has one.
+make_limitrange_base() { # <root> <namespace>
+  mkdir -p "$1/bases/limit-ranges"
+  cat >"$1/bases/limit-ranges/kustomization.yaml" <<YAML
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - range.yaml
+YAML
+  cat >"$1/bases/limit-ranges/range.yaml" <<YAML
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: $2
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+YAML
+}
+
+# One provider shipping one annotated workload. <extra> is spliced into the
+# overlay's resource list, so neighbouring cases differ in exactly one line.
+make_provider() { # <root> <provider> <workload-basename> <namespace> <skip-reason> <extra-resource>
+  local root=$1 prov=$2 base=$3 ns=$4 reason=$5 extra=$6
+  mkdir -p "$root/providers/$prov/infrastructure"
+  {
+    printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n'
+    printf '  - %s.yaml\n' "$base"
+    [ -n "$extra" ] && printf '  - %s\n' "$extra"
+  } >"$root/providers/$prov/infrastructure/kustomization.yaml"
+  cat >"$root/providers/$prov/infrastructure/$base.yaml" <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $base
+  namespace: $ns
+  annotations:
+    checkov.io/skip1: "$reason"
+spec:
+  replicas: 1
+YAML
+}
+
+expect() { # <case> <expected-rc> <root> [<needle>]
+  local case_name=$1 want=$2 root=$3 needle=${4-}
+  assertions=$((assertions + 1))
+  run_guard "$root"
+  if [ "$GUARD_RC" -ne "$want" ]; then
+    printf 'FAIL %s: expected exit %s, got %s\n%s\n' "$case_name" "$want" "$GUARD_RC" "$GUARD_OUT" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$GUARD_OUT" | grep -qF -- "$needle"; then
+    printf 'FAIL %s: exit %s was right, but the report never named %s\n%s\n' \
+      "$case_name" "$want" "$needle" "$GUARD_OUT" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s (exit %s)\n' "$case_name" "$want"
+}
+
+# --- 1. THE DEFECT: premise invoked, overlay ships no LimitRange -------------
+missing="$scratch/missing"
+make_provider "$missing" dockerlike unshielded-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" ""
+make_limitrange_base "$missing" kube-system   # present in the tree, but NOT referenced
+expect 'premise-without-limitrange-fails' 1 "$missing" 'unshielded-dns'
+
+# The report must name the overlay that lacks it, not merely the file: the fix
+# lives in the kustomization, not in the annotated workload.
+run_guard "$missing"
+assertions=$((assertions + 1))
+if printf '%s' "$GUARD_OUT" | grep -qF 'dockerlike' && printf '%s' "$GUARD_OUT" | grep -qF 'kube-system'; then
+  printf 'ok   failure-report-names-provider-and-namespace\n'
+else
+  printf 'FAIL failure-report-names-provider-and-namespace\n%s\n' "$GUARD_OUT" >&2
+  failures=$((failures + 1))
+fi
+
+# --- 2. THE FIX: same tree, overlay now references the base -----------------
+shipped="$scratch/shipped"
+make_provider "$shipped" hetznerlike shielded-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "../../../bases/limit-ranges/"
+make_limitrange_base "$shipped" kube-system
+expect 'premise-with-limitrange-passes' 0 "$shipped" 'shielded-dns'
+
+# --- 3. The LimitRange reached only through a NESTED kustomization ----------
+# The whole defect was an inference about reachability, so a guard that only
+# looked one level deep would reproduce it.
+nested="$scratch/nested"
+make_provider "$nested" nestedlike deep-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "../../../bases/aggregate/"
+make_limitrange_base "$nested" kube-system
+mkdir -p "$nested/bases/aggregate"
+cat >"$nested/bases/aggregate/kustomization.yaml" <<YAML
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../limit-ranges/
+YAML
+expect 'limitrange-reached-through-nested-base' 0 "$nested" 'deep-dns'
+
+# --- 4. WRONG NAMESPACE: a LimitRange that does not cover this resource -----
+# Shipping *a* LimitRange is not the claim; shipping one into the annotated
+# resource's namespace is.
+wrongns="$scratch/wrongns"
+make_provider "$wrongns" otherns-like misplaced-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" \
+  "../../../bases/limit-ranges/"
+make_limitrange_base "$wrongns" some-other-namespace
+expect 'limitrange-in-another-namespace-fails' 1 "$wrongns" 'misplaced-dns'
+
+# --- 5. ANTI-VACUITY: a skip whose reason is about something else -----------
+unrelated="$scratch/unrelated"
+make_provider "$unrelated" unrelatedlike plain-dns kube-system \
+  "CKV_K8S_38=CoreDNS resolves cluster DNS by watching Services via the API server" ""
+expect 'unrelated-skip-is-not-matched' 0 "$unrelated" 'no suppression'
+
+# --- 6. ANTI-VACUITY: no suppression at all --------------------------------
+bare="$scratch/bare"
+mkdir -p "$bare/providers/barelike/infrastructure"
+cat >"$bare/providers/barelike/infrastructure/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+YAML
+expect 'empty-tree-reports-nothing-checked' 0 "$bare" 'no suppression'
+
+# --- 7. COULD-NOT-CHECK: unparseable kustomization -------------------------
+broken="$scratch/broken"
+make_provider "$broken" brokenlike broken-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" ""
+printf 'resources: [ this is not\n  valid: yaml: at all\n' \
+  >"$broken/providers/brokenlike/infrastructure/kustomization.yaml"
+expect 'unparseable-kustomization-is-exit-2' 2 "$broken" 'brokenlike'
+
+# --- 8. COULD-NOT-CHECK: no providers directory ----------------------------
+noprov="$scratch/noprov"
+mkdir -p "$noprov/bases"
+expect 'missing-providers-dir-is-exit-2' 2 "$noprov" 'providers'
+
+# --- 9. COULD-NOT-CHECK: premised skip on a namespace-less resource --------
+nons="$scratch/nons"
+mkdir -p "$nons/providers/nonslike/infrastructure"
+cat >"$nons/providers/nonslike/infrastructure/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaceless.yaml
+YAML
+cat >"$nons/providers/nonslike/infrastructure/namespaceless.yaml" <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: namespaceless
+  annotations:
+    checkov.io/skip1: "CKV_K8S_11=the default-limitrange supplies the CPU limit at admission"
+spec:
+  replicas: 1
+YAML
+expect 'premised-skip-without-namespace-is-exit-2' 2 "$nons" 'namespaceless'
+
+printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
+[ "$failures" -eq 0 ] || exit 1

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -248,5 +248,43 @@ make_provider "$absentry" absentrylike absolute-dns kube-system \
 make_limitrange_base "$absentry" kube-system
 expect 'absolute-resources-entry-resolves' 0 "$absentry" 'absolute-dns'
 
+# --- 13. A MULTI-DOCUMENT file resolves the namespace PER DOCUMENT -----------
+# `values` is read from every document in the file, but the namespace was taken from
+# the FIRST one. A file whose annotated document is not document 0 — the ordinary shape
+# of an operator bundle, and already the shape of cdi-operator.yaml and
+# kubevirt-operator.yaml in this repo — is then checked against the wrong namespace, or
+# against no namespace at all when document 0 states none. Both readings are wrong about
+# a file the guard reports as checked.
+#
+# Here document 0 is a namespaceless cluster-scoped object and the annotated Deployment
+# in document 1 states `multidoc-ns`, where the LimitRange is shipped. The correct
+# verdict is exit 0.
+multidoc="$scratch/multidoc"
+mkdir -p "$multidoc/providers/multidoclike/infrastructure"
+{
+  printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n'
+  printf '  - bundle-dns.yaml\n'
+  printf '  - %s\n' "$multidoc/bases/limit-ranges/"
+} >"$multidoc/providers/multidoclike/infrastructure/kustomization.yaml"
+cat >"$multidoc/providers/multidoclike/infrastructure/bundle-dns.yaml" <<'YAML'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-dns-reader
+rules: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bundle-dns
+  namespace: multidoc-ns
+  annotations:
+    checkov.io/skip1: "CKV_K8S_11=the multidoc-ns default-limitrange supplies the CPU limit at admission"
+spec:
+  replicas: 1
+YAML
+make_limitrange_base "$multidoc" multidoc-ns
+expect 'multidoc-namespace-resolves-per-document' 0 "$multidoc" 'bundle-dns'
+
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ] || exit 1


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The local (docker) cluster silently ran every kube-system add-on — CoreDNS, cilium, metrics-server and the rest — with **no CPU limit**, while a merged suppression in the repo asserted that one was being applied. The suppression's reason was that the limit arrives at admission from a shared base resource, "and so applies to both provider overlays". That last step is an assumption about which overlays actually pull that base, and for the docker overlay it was wrong.

Nothing failed as a result, which is the concerning part: the scan stayed green, the suppression kept reading as reviewed, and the local cluster diverged from prod in exactly the area the overlay exists to mirror. A second issue was about to copy the same premise into the trivy configuration.

### What this changes

The docker overlay now actually ships the LimitRange its own suppression depends on, so the stated reason becomes true rather than being quietly dropped. A new guard then makes this class of mistake non-recurring: it checks every suppression justified by "a LimitRange supplies this at admission" against the overlay that really ships that file, and fails if no such LimitRange is there.

The guard refuses to pass when it cannot attribute a suppression to an overlay, rather than treating that as clean — a guard that goes green having checked nothing is the same failure being fixed here.

**Still open on the parent issue:** confirming on a running local cluster that nothing fails to schedule under the added default *requests*. That is the one acceptance criterion this PR does not prove, and it is why the PR is a draft.

Part of #3263
Part of #2787
