### PR TITLE
docs(security): correct the coredns KSV-0011 coverage claim

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -280,7 +280,11 @@ misconfigurations:
       ceiling so the DNS datapath never throttles under burst, and CPU is compressible so a
       limit does not affect scheduling. This is the same premise the file's own
       checkov.io/skip3 already carries for CKV_K8S_11, which scripts/guard-limitrange-premise.sh
-      checks; that guard reads checkov annotations only, so this entry is not itself covered.
+      checks; that guard matches on checkov.io/skipN annotation values, so on its own it
+      vouches for this file's checkov skip rather than for this entry. What binds the two is
+      scripts/tests/test-trivyignore-vendored-operator-boundary.sh, which lists this id/path
+      pair in reviewed_admission_pairs and requires a passing guard verdict naming this file:
+      drop the annotation while keeping this entry and that test fails.
   - id: KSV-0018
     paths:
       - k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

One of our accepted security findings describes itself as resting on a premise that nothing checks. That has not been true for a while — a test does check it — so the note understates our own coverage.

That matters because it invites wasted work: a reviewer reading it concludes there is an unchecked residual and sets out to build the missing guard, which already exists. That is exactly what happened on a recent pass.

### What

Rewrites the closing sentence of the CoreDNS `KSV-0011` disposition to say which test binds the entry to a passing guard verdict, and what happens if someone removes the annotation it depends on. No policy, manifest, or suppression changes — the accepted finding and its scope are untouched.

Verified by ablation rather than by reading: removing the annotation while keeping the entry fails the boundary test, and restoring it passes.