### PR TITLE
security(vault-backup): raise the snapshot writers off the host UID

### DIFF
--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -426,6 +426,11 @@ jobs:
                     fi
                     echo "Fetching $NEWEST..."
                     mc cp "backup/$R2_BUCKET/openbao-snapshots/$NEWEST" "/snapshots/$NEWEST"
+                    # The restore reads this file as openbao (uid 100, gid 1000), so it must
+                    # be group-readable. mc creates it owned by THIS pod's high uid, and the
+                    # group entry is the only path left — an explicit chmod rather than a
+                    # reliance on mc's umask, matching what the snapshot writers do.
+                    chmod 0640 "/snapshots/$NEWEST"
                     ls -l /snapshots/
           POD
           if ! kubectl -n openbao wait pod/dr-snapshot-fetch \

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -362,7 +362,7 @@ jobs:
             restartPolicy: Never
             securityContext:
               runAsNonRoot: true
-              runAsUser: 100
+              runAsUser: 65532
               runAsGroup: 1000
               fsGroup: 1000
               seccompProfile:

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -27,24 +27,25 @@ metadata:
   namespace: openbao
   annotations:
     checkov.io/skip1: "CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth"
-    # Both containers run the pod's UID 100, for two different reasons.
-    # The snapshot container's 100 IS the openbao image's baked identity:
-    # the image carries `openbao:x:100:1000` in its own /etc/passwd (the
-    # same pinned digest vault-config reads), which runAsUser/runAsGroup
-    # restate. The mirror container inherits it because the snapshot it
-    # uploads lands `-rw-------` owned by 100:1000, so `minio/mc` — which
-    # bakes no uid-100 entry of its own and mounts /snapshots readOnly —
-    # can open it only as its owner. fsGroup fixes the volume's ownership
-    # and mode at mount time, not the mode `bao operator raft snapshot
-    # save` creates the file with afterwards.
+    # Only the snapshot container runs UID 100, and that IS the openbao image's
+    # baked identity: the image carries `openbao:x:100:1000` in its own
+    # /etc/passwd (the same pinned digest vault-config reads), which
+    # runAsUser/runAsGroup restate. The pod default is the high, unprivileged
+    # 65532, so the mirror container — `minio/mc`, which bakes no identity of
+    # its own and mounts /snapshots readOnly — takes that rather than a UID
+    # chosen for openbao.
     #
-    # Neither UID is remapped. The openbao namespace carries no
+    # The mirror still reads the snapshot because it shares the primary GROUP,
+    # not the owner: runAsGroup/fsGroup 1000 apply to every container, and the
+    # snapshot script chmods the file 0640 after `bao operator raft snapshot
+    # save` writes it. Access therefore rests on group membership, which is a
+    # pod-level property, rather than on the volume's setgid bit.
+    #
+    # UID 100 is not remapped. The openbao namespace carries no
     # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
-    # add-user-namespaces rule does not match, hostUsers stays on, and 100
-    # is a host UID. That residual is what #3202 removes: it makes the
-    # snapshot group-readable first, then raises the UIDs, which the three
-    # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the snapshot is chmod 0640 so the mirror reads it on the shared group 1000 -- only the UID migration itself is outstanding"
+    # add-user-namespaces rule does not match and hostUsers stays on; 100 is a
+    # host UID, now scoped to the single container whose image defines it.
+    checkov.io/skip2: "CKV_K8S_40=UID 100 is the openbao image's baked `openbao:x:100:1000` user, which runAsUser/runAsGroup restate; only the snapshot container runs it and the pod default is 65532"
 spec:
   schedule: "30 3 * * *"
   # Pin the cron evaluation to UTC instead of inheriting kube-controller-manager's
@@ -80,7 +81,7 @@ spec:
           # add-security-context Kyverno mutation) so the pod stays hardened
           # even when created before the webhook is active on fresh bring-up.
           securityContext:
-            runAsUser: 100
+            runAsUser: 65532
             runAsGroup: 1000
             fsGroup: 1000
             runAsNonRoot: true
@@ -103,6 +104,12 @@ spec:
             - name: snapshot
               image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
               securityContext:
+                # UID 100 is the openbao image's own baked identity (`openbao:x:100:1000`
+                # in its /etc/passwd) — see the checkov.io/skip2 rationale. Only this
+                # container overrides the pod's high default; the mirror takes 65532
+                # and reads the snapshot on the shared primary group 1000.
+                runAsUser: 100
+                runAsGroup: 1000
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -29,24 +29,25 @@ metadata:
     # Jobs are immutable; let Flux delete-and-recreate on spec change.
     kustomize.toolkit.fluxcd.io/force: enabled
     checkov.io/skip1: "CKV_K8S_38=the snapshot container reads its SA JWT to log in via OpenBao Kubernetes auth"
-    # Both containers run the pod's UID 100, for two different reasons.
-    # The snapshot container's 100 IS the openbao image's baked identity:
-    # the image carries `openbao:x:100:1000` in its own /etc/passwd (the
-    # same pinned digest vault-config reads), which runAsUser/runAsGroup
-    # restate. The mirror container inherits it because the snapshot it
-    # uploads lands `-rw-------` owned by 100:1000, so `minio/mc` — which
-    # bakes no uid-100 entry of its own and mounts /snapshots readOnly —
-    # can open it only as its owner. fsGroup fixes the volume's ownership
-    # and mode at mount time, not the mode `bao operator raft snapshot
-    # save` creates the file with afterwards.
+    # Only the snapshot container runs UID 100, and that IS the openbao image's
+    # baked identity: the image carries `openbao:x:100:1000` in its own
+    # /etc/passwd (the same pinned digest vault-config reads), which
+    # runAsUser/runAsGroup restate. The pod default is the high, unprivileged
+    # 65532, so the mirror container — `minio/mc`, which bakes no identity of
+    # its own and mounts /snapshots readOnly — takes that rather than a UID
+    # chosen for openbao.
     #
-    # Neither UID is remapped. The openbao namespace carries no
+    # The mirror still reads the snapshot because it shares the primary GROUP,
+    # not the owner: runAsGroup/fsGroup 1000 apply to every container, and the
+    # snapshot script chmods the file 0640 after `bao operator raft snapshot
+    # save` writes it. Access therefore rests on group membership, which is a
+    # pod-level property, rather than on the volume's setgid bit.
+    #
+    # UID 100 is not remapped. The openbao namespace carries no
     # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
-    # add-user-namespaces rule does not match, hostUsers stays on, and 100
-    # is a host UID. That residual is what #3202 removes: it makes the
-    # snapshot group-readable first, then raises the UIDs, which the three
-    # writers sharing this one RWO PVC have to do together.
-    checkov.io/skip2: "CKV_K8S_40=deferred to #3202 -- the snapshot container's 100 is the openbao image's baked `openbao:x:100:1000` user, and the snapshot is chmod 0640 so the mirror reads it on the shared group 1000 -- only the UID migration itself is outstanding"
+    # add-user-namespaces rule does not match and hostUsers stays on; 100 is a
+    # host UID, now scoped to the single container whose image defines it.
+    checkov.io/skip2: "CKV_K8S_40=UID 100 is the openbao image's baked `openbao:x:100:1000` user, which runAsUser/runAsGroup restate; only the snapshot container runs it and the pod default is 65532"
 spec:
   # No ttlSecondsAfterFinished (intentional). This is a one-shot "snapshot at
   # deploy/change time" Job (see header) -- it must run ONCE per vault-backup
@@ -78,7 +79,7 @@ spec:
       # add-security-context Kyverno mutation) so the pod stays hardened
       # even when created before the webhook is active on fresh bring-up.
       securityContext:
-        runAsUser: 100
+        runAsUser: 65532
         runAsGroup: 1000
         fsGroup: 1000
         runAsNonRoot: true
@@ -101,6 +102,12 @@ spec:
         - name: snapshot
           image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
           securityContext:
+            # UID 100 is the openbao image's own baked identity (`openbao:x:100:1000`
+            # in its /etc/passwd) — see the checkov.io/skip2 rationale. Only this
+            # container overrides the pod's high default; the mirror takes 65532
+            # and reads the snapshot on the shared primary group 1000.
+            runAsUser: 100
+            runAsGroup: 1000
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -209,7 +209,7 @@ while IFS= read -r line; do
     [0-7][0-7][0-7] | [0-7][0-7][0-7][0-7]) ;;
     *) fail "${dr_workflow}: chmod mode '${mode}' is not a 3- or 4-digit octal mode" ;;
   esac
-  [ $(( ${mode: -2:1} & 4 )) -eq 4 ] ||
+  [ $((${mode: -2:1} & 4)) -eq 4 ] ||
     fail "${dr_workflow}: chmod mode '${mode}' does not grant GROUP read — the restore cannot open it"
   [ "${mode: -1}" -eq 0 ] ||
     fail "${dr_workflow}: chmod mode '${mode}' grants OTHER access to a vault snapshot"

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -175,4 +175,52 @@ for target in "${uid_targets[@]}"; do
   printf 'ok: %s — pod %s:%s (fsGroup %s); UID 100 scoped to the snapshot container; mirror takes the default\n' \
     "${manifest}" "${pod_uid}" "${pod_gid}" "${pod_fsg}"
 done
+
+# --- The DR fetch writes to the same volume, and it is the leg CI never exercises ---------------
+#
+# The restore reads the fetched snapshot as openbao (uid 100, gid 1000). The fetch pod now runs a
+# high uid, so the group entry is the ONLY remaining path to that file — and mc's umask is not
+# something this repository controls. Assert the explicit chmod instead.
+#
+# Scoped to chmods targeting /snapshots: this workflow also chmods an age private key to 600, which
+# is correct and must not be read as a finding.
+#
+# Text-level rather than yq: the pod spec lives inside a heredoc within a `run:` block, so it is not
+# addressable by a YAML path. Bound the same way as the manifests above — the chmod must name the
+# SAME operand the fetch wrote to, or it could be widening some other file.
+dr_workflow='.github/workflows/dr-rebuild.yaml'
+dr_path="${root_dir}/${dr_workflow}"
+[ -f "${dr_path}" ] || fail "${dr_workflow}: not found"
+
+dr_cp="$(grep -E '^[[:space:]]*mc cp .*/snapshots/' "${dr_path}" || true)"
+[ -n "${dr_cp}" ] || fail "${dr_workflow}: no 'mc cp' onto /snapshots — the fetch step moved or was renamed"
+dr_operand="$(printf '%s\n' "${dr_cp}" | awk '{print $NF}' | tr -d '"')"
+[ -n "${dr_operand}" ] || fail "${dr_workflow}: could not extract the fetch destination"
+
+dr_chmod="$(grep -E '^[[:space:]]*chmod[[:space:]]+[0-7]+[[:space:]]+"?/snapshots/' "${dr_path}" || true)"
+[ -n "${dr_chmod}" ] ||
+  fail "${dr_workflow}: the fetch never chmods the snapshot; the restore depends on mc's umask"
+
+dr_bound=0
+while IFS= read -r line; do
+  [ -n "${line}" ] || continue
+  mode="$(printf '%s\n' "${line}" | awk '{print $2}')"
+  operand="$(printf '%s\n' "${line}" | awk '{print $3}' | tr -d '"')"
+  case "${mode}" in
+    [0-7][0-7][0-7] | [0-7][0-7][0-7][0-7]) ;;
+    *) fail "${dr_workflow}: chmod mode '${mode}' is not a 3- or 4-digit octal mode" ;;
+  esac
+  [ $(( ${mode: -2:1} & 4 )) -eq 4 ] ||
+    fail "${dr_workflow}: chmod mode '${mode}' does not grant GROUP read — the restore cannot open it"
+  [ "${mode: -1}" -eq 0 ] ||
+    fail "${dr_workflow}: chmod mode '${mode}' grants OTHER access to a vault snapshot"
+  [ "${operand}" = "${dr_operand}" ] && dr_bound=1
+done <<DRCHMODS
+${dr_chmod}
+DRCHMODS
+
+[ "${dr_bound}" -eq 1 ] ||
+  fail "${dr_workflow}: no chmod targets the fetched snapshot '${dr_operand}' — the assertion is unbound"
+
+printf 'ok: %s — fetch writes %s and chmods that same path group-readable\n' "${dr_workflow}" "${dr_operand}"
 printf 'PASS: both vault-snapshot writers make the snapshot group-readable, and the UID split holds\n'

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -3,13 +3,14 @@
 #
 # `bao` creates the snapshot `-rw-------` (0600), owned by the snapshot
 # container's UID. The kernel decides file access by comparing numeric UID and
-# GID values, so an owner-only mode forces the mirror to run the same UID as the
-# writer. That coupling is what pins every vault-snapshots writer to one low host
-# UID (checkov CKV_K8S_40, whose migration is deferred to #3202).
+# GID values, so an owner-only mode would force the mirror to run the same UID as
+# the writer. Breaking that coupling is what lets the pods default to the high,
+# unprivileged 65532 and scope UID 100 to the one container whose image bakes it
+# (checkov CKV_K8S_40).
 #
-# Both containers already run runAsGroup/fsGroup 1000, so a group-readable
-# snapshot is readable by the mirror on its GROUP entry alone, leaving the UIDs
-# free to move independently.
+# Every container runs runAsGroup/fsGroup 1000, so a group-readable snapshot is
+# readable by the mirror on its GROUP entry alone — a pod-level property, which is
+# why this does not depend on the volume's setgid bit.
 #
 # NOTE ON MECHANISM: this must be an explicit chmod, not a umask. umask can only
 # CLEAR permission bits, never add them — so if `bao` requests 0600 explicitly (the
@@ -123,4 +124,55 @@ CHMODS
     "${manifest}" "${save_operand}" "${chmod_modes}"
 done
 
-printf 'PASS: both vault-snapshot writers make the snapshot group-readable\n'
+
+# --- The UID split that group-readability makes possible ----------------------------------------
+#
+# Asserted here rather than in a separate file because it is the same property from the other end:
+# the chmod above is only half of it. If the mirror were re-pinned to the openbao UID, every
+# assertion above would still pass while the coupling it exists to prevent had quietly returned.
+
+# manifest:yq-path-to-the-pod-spec
+readonly uid_targets=(
+  "k8s/bases/infrastructure/vault-backup/job.yaml:.spec.template.spec"
+  "k8s/bases/infrastructure/vault-backup/cron-job.yaml:.spec.jobTemplate.spec.template.spec"
+)
+
+for target in "${uid_targets[@]}"; do
+  manifest="${target%%:*}"
+  pod="${target#*:}"
+  path="${root_dir}/${manifest}"
+
+  [ -f "${path}" ] || fail "${manifest}: not found"
+
+  pod_uid="$(yq "${pod}.securityContext.runAsUser" "${path}")"
+  pod_gid="$(yq "${pod}.securityContext.runAsGroup" "${path}")"
+  pod_fsg="$(yq "${pod}.securityContext.fsGroup" "${path}")"
+
+  case "${pod_uid}" in
+    '' | null) fail "${manifest}: the pod sets no runAsUser" ;;
+    *[!0-9]*) fail "${manifest}: pod runAsUser '${pod_uid}' is not numeric" ;;
+  esac
+  [ "${pod_uid}" -ge 10000 ] ||
+    fail "${manifest}: pod runAsUser ${pod_uid} is a low host UID (CKV_K8S_40) — the writers are re-coupled"
+
+  # The mirror reads on THIS group. If either value moves, group access stops working and the only
+  # remaining path to the file is ownership, which is the coupling being removed.
+  [ "${pod_gid}" = "1000" ] ||
+    fail "${manifest}: pod runAsGroup is '${pod_gid}', not 1000 — the mirror loses its group entry"
+  [ "${pod_fsg}" = "1000" ] ||
+    fail "${manifest}: pod fsGroup is '${pod_fsg}', not 1000 — the mirror loses its group entry"
+
+  snap_uid="$(yq "${pod}.initContainers[]|select(.name==\"snapshot\")|.securityContext.runAsUser" "${path}")"
+  [ "${snap_uid}" = "100" ] ||
+    fail "${manifest}: the snapshot container's runAsUser is '${snap_uid}', not the image's baked 100"
+
+  # Asserted ABSENT rather than equal to the pod default: an explicit value here is precisely how
+  # the mirror would be re-pinned to the writer's UID.
+  mirror_uid="$(yq "${pod}.containers[]|select(.name==\"mirror\")|.securityContext.runAsUser" "${path}")"
+  [ "${mirror_uid}" = "null" ] ||
+    fail "${manifest}: the mirror pins runAsUser '${mirror_uid}' instead of taking the pod's high default"
+
+  printf 'ok: %s — pod %s:%s (fsGroup %s); UID 100 scoped to the snapshot container; mirror takes the default\n' \
+    "${manifest}" "${pod_uid}" "${pod_gid}" "${pod_fsg}"
+done
+printf 'PASS: both vault-snapshot writers make the snapshot group-readable, and the UID split holds\n'

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -165,6 +165,12 @@ for target in "${uid_targets[@]}"; do
   [ "${snap_uid}" = "100" ] ||
     fail "${manifest}: the snapshot container's runAsUser is '${snap_uid}', not the image's baked 100"
 
+  # The group it WRITES with. runAsUser 100 alone is not enough: if this moved, the snapshot
+  # would land with a group the mirror does not share, and chmod 0640 could not help it.
+  snap_gid="$(yq "${pod}.initContainers[]|select(.name==\"snapshot\")|.securityContext.runAsGroup" "${path}")"
+  [ "${snap_gid}" = "1000" ] ||
+    fail "${manifest}: the snapshot container's runAsGroup is '${snap_gid}', not 1000 — it would write the snapshot with a group the mirror does not share"
+
   # Asserted ABSENT rather than equal to the pod default: an explicit value here is precisely how
   # the mirror would be re-pinned to the writer's UID.
   mirror_uid="$(yq "${pod}.containers[]|select(.name==\"mirror\")|.securityContext.runAsUser" "${path}")"
@@ -222,4 +228,29 @@ DRCHMODS
   fail "${dr_workflow}: no chmod targets the fetched snapshot '${dr_operand}' — the assertion is unbound"
 
 printf 'ok: %s — fetch writes %s and chmods that same path group-readable\n' "${dr_workflow}" "${dr_operand}"
+
+# The fetch pod's own identity decides the GROUP of the file it writes, so the chmod above is only
+# half of this leg too: a correct 0640 on a file whose group nobody shares is still unreadable.
+# Bound to the pod's own block — the workflow sets securityContext elsewhere as well.
+dr_pod="$(awk '/name: dr-snapshot-fetch/{f=1} f{print} f && /^[[:space:]]*containers:/{exit}' "${dr_path}")"
+[ -n "${dr_pod}" ] || fail "${dr_workflow}: could not locate the dr-snapshot-fetch pod spec"
+
+dr_field() { printf '%s\n' "${dr_pod}" | sed -n "s/^[[:space:]]*$1:[[:space:]]*//p" | head -1; }
+
+dr_uid="$(dr_field runAsUser)"
+dr_gid="$(dr_field runAsGroup)"
+dr_fsg="$(dr_field fsGroup)"
+
+case "${dr_uid}" in
+  '') fail "${dr_workflow}: the fetch pod sets no runAsUser" ;;
+  *[!0-9]*) fail "${dr_workflow}: fetch pod runAsUser '${dr_uid}' is not numeric" ;;
+esac
+[ "${dr_uid}" -ge 10000 ] ||
+  fail "${dr_workflow}: fetch pod runAsUser ${dr_uid} is a low host UID (CKV_K8S_40) — re-coupled to the writer"
+[ "${dr_gid}" = "1000" ] ||
+  fail "${dr_workflow}: fetch pod runAsGroup is '${dr_gid}', not 1000 — the restore could not read what it fetched"
+[ "${dr_fsg}" = "1000" ] ||
+  fail "${dr_workflow}: fetch pod fsGroup is '${dr_fsg}', not 1000 — the restore could not read what it fetched"
+
+printf 'ok: %s — fetch pod runs %s:%s (fsGroup %s)\n' "${dr_workflow}" "${dr_uid}" "${dr_gid}" "${dr_fsg}"
 printf 'PASS: both vault-snapshot writers make the snapshot group-readable, and the UID split holds\n'

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -124,7 +124,6 @@ CHMODS
     "${manifest}" "${save_operand}" "${chmod_modes}"
 done
 
-
 # --- The UID split that group-readability makes possible ----------------------------------------
 #
 # Asserted here rather than in a separate file because it is the same property from the other end:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The nightly OpenBao backup and its off-cluster mirror both ran as user 100 — a low, unprivileged-looking
number that is nevertheless a real user on the host, because these pods are not user-namespaced. They
had to share it: the snapshot used to land readable only by its owner, so the container uploading it
could only open the file by *being* that owner.

That constraint is gone. The snapshot is now written group-readable, so the uploader can read it as a
group member instead. This takes the last step and moves the backup workloads off the host UID.

### What

The backup pods now default to a high, unprivileged identity, and the low one survives only on the
single container whose image actually defines it. Access between the containers rests on shared group
membership, which Kubernetes guarantees at the pod level, rather than on a volume-level detail that is
harder to reason about.

All three writers move together because they share one disk, and the housekeeping step that widens
older snapshots only works while the same identity owns them.

**Security floor:** the class of "a container process is also a real host user" shrinks from three
workloads to one container that cannot avoid it.
**Everyday path:** unchanged — no new flag, step, or configuration, and the backup behaves identically.

⚠️ **Deliberately left as a draft.** This touches the disaster-recovery restore path, and its final
condition is one that can only be observed on a real nightly cycle — the snapshot running, the mirror
uploading it, and a restore reading both an older snapshot and a new one. Everything checkable ahead
of that is done and recorded in a comment below; the remaining check is named there rather than
assumed.

Part of #3202
