### PR TITLE
security(vault-backup): stop the mirror inheriting a gid chosen for openbao

### DIFF
--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -82,7 +82,19 @@ spec:
           # even when created before the webhook is active on fresh bring-up.
           securityContext:
             runAsUser: 65532
-            runAsGroup: 1000
+            # The pod default gid is the same high 65532, for the same reason the uid is:
+            # `minio/mc` bakes no group of its own, so a pod-level 1000 was an
+            # unjustified low-GID execution for the only container that inherits it. The
+            # snapshot container restates the openbao image's baked 100:1000 explicitly,
+            # so the annotation above covers just the execution its rationale accounts
+            # for rather than one more it does not.
+            #
+            # Reading the snapshot does NOT depend on the mirror's primary gid. fsGroup
+            # stays 1000: Kubernetes adds it to every container's supplementary groups
+            # and sets the setgid bit on the volume, so the 0640 snapshot lands group
+            # 1000 and a gid-65532 reader still opens it. Same mechanism vault-config
+            # relies on, verified there against a paired control (#3258).
+            runAsGroup: 65532
             fsGroup: 1000
             runAsNonRoot: true
             seccompProfile:

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -80,7 +80,19 @@ spec:
       # even when created before the webhook is active on fresh bring-up.
       securityContext:
         runAsUser: 65532
-        runAsGroup: 1000
+        # The pod default gid is the same high 65532, for the same reason the uid is:
+        # `minio/mc` bakes no group of its own, so a pod-level 1000 was an
+        # unjustified low-GID execution for the only container that inherits it. The
+        # snapshot container restates the openbao image's baked 100:1000 explicitly,
+        # so the annotation above covers just the execution its rationale accounts
+        # for rather than one more it does not.
+        #
+        # Reading the snapshot does NOT depend on the mirror's primary gid. fsGroup
+        # stays 1000: Kubernetes adds it to every container's supplementary groups
+        # and sets the setgid bit on the volume, so the 0640 snapshot lands group
+        # 1000 and a gid-65532 reader still opens it. Same mechanism vault-config
+        # relies on, verified there against a paired control (#3258).
+        runAsGroup: 65532
         fsGroup: 1000
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The nightly OpenBao backup pods were running one container under a group ID that was never meant for it. The mirror step uses a different image from the snapshot step, but it inherited the group chosen for OpenBao — so a security scan flagged it, and the existing written justification for that low ID did not actually cover it.

### Changes

Give the backup pods the same high, unprivileged group the rest of the pod already uses, so only the container that genuinely needs OpenBao's built-in identity still runs with it.

The two steps still hand the snapshot file between them exactly as before — that sharing never depended on the group being changed here, and the same arrangement is already proven in the sibling job.

Measured effect on this repository's own security scan: **6 findings → 4**. The four that remain are the OpenBao image's own built-in identity, which is a separate and already-documented decision.

Part of #3202
