### PR TITLE
feat(kubescape): add posture exception oracle

### DIFF
--- a/docs/kubescape-exception-oracle.md
+++ b/docs/kubescape-exception-oracle.md
@@ -59,8 +59,8 @@ go run ./scripts/kubescape-backlog-bridge \
 Each raw failed pair produces one deterministic row:
 
 ```text
-excepted	control=C-0016	component=app/Job/nightly	policies=batch-workloads
-unexcepted	control=C-0016	component=app/Deployment/api	policies=-
+excepted control=C-0016 component=app/Job/nightly policies=batch-workloads
+unexcepted control=C-0016 component=app/Deployment/api policies=-
 ```
 
 `excepted` means at least one named policy matches both the control and the

--- a/docs/kubescape-exception-oracle.md
+++ b/docs/kubescape-exception-oracle.md
@@ -56,11 +56,12 @@ go run ./scripts/kubescape-backlog-bridge \
   "${oracle_args[@]}"
 ```
 
-Each raw failed pair produces one deterministic row:
+Each raw failed pair produces one deterministic, tab-separated row. The
+`[TAB]` markers below make those delimiters visible:
 
 ```text
-excepted control=C-0016 component=app/Job/nightly policies=batch-workloads
-unexcepted control=C-0016 component=app/Deployment/api policies=-
+excepted[TAB]control=C-0016[TAB]component=app/Job/nightly[TAB]policies=batch-workloads
+unexcepted[TAB]control=C-0016[TAB]component=app/Deployment/api[TAB]policies=-
 ```
 
 `excepted` means at least one named policy matches both the control and the

--- a/docs/kubescape-exception-oracle.md
+++ b/docs/kubescape-exception-oracle.md
@@ -1,0 +1,101 @@
+# Kubescape posture exception oracle
+
+The Kubescape storage API holds raw posture findings. It does not apply the
+platform's `ClusterSecurityException` resources, so a stored `failed` status is
+not evidence that an exception is ineffective. Use the client-side oracle to
+combine those raw findings with the generated exception artifact and explain
+the decision for each workload/control pair.
+
+The oracle is read-only. It changes neither the cluster nor the committed
+exception resources.
+
+## Collect hydrated posture summaries
+
+Kubescape strips `spec.controls` from LIST responses and ignores server-side
+label selectors. Use LIST only to enumerate object identities, then GET every
+object individually. Run this from the repository root with Bash:
+
+```bash
+set -euo pipefail
+
+oracle_dir="$(mktemp -d)"
+mkdir -p "${oracle_dir}/posture"
+
+kubectl --context=admin@prod \
+  get workloadconfigurationscansummaries -A -o json \
+  | jq -r '.items[] | [.metadata.namespace, .metadata.name] | @tsv' \
+  | while IFS=$'\t' read -r namespace name; do
+      kubectl --context=admin@prod \
+        get workloadconfigurationscansummaries "${name}" \
+        --namespace "${namespace}" -o json \
+        >"${oracle_dir}/posture/${namespace}__${name}.json"
+    done
+
+go run ./scripts/generate-kubescape-exceptions \
+  -o "${oracle_dir}/exceptions.json"
+```
+
+The command fails closed if any supplied summary is still a stripped LIST
+skeleton, has an incomplete workload identity, or carries malformed control
+data.
+
+## Explain every failed pair
+
+Build the repeated posture arguments from the collected directory so the
+command receives every hydrated object:
+
+```bash
+oracle_args=()
+for file in "${oracle_dir}"/posture/*.json; do
+  oracle_args+=( -posture "${file}" )
+done
+
+go run ./scripts/kubescape-backlog-bridge \
+  -mode oracle \
+  -exceptions "${oracle_dir}/exceptions.json" \
+  "${oracle_args[@]}"
+```
+
+Each raw failed pair produces one deterministic row:
+
+```text
+excepted	control=C-0016	component=app/Job/nightly	policies=batch-workloads
+unexcepted	control=C-0016	component=app/Deployment/api	policies=-
+```
+
+`excepted` means at least one named policy matches both the control and the
+component. `unexcepted` means the raw finding remains actionable. The component
+identity comes from the `kubescape.io/workload-namespace`,
+`kubescape.io/workload-kind`, and `kubescape.io/workload-name` labels. The
+oracle does not parse identity from `wlid`.
+
+The answer covers only the objects supplied to the command. A cluster-wide
+statement requires the complete collection loop above to finish successfully.
+
+## Prove the oracle discriminates
+
+A policy-specific verification removes that policy from a local copy of the
+artifact and evaluates the same raw inputs again. This does not alter the
+deployed exception:
+
+```bash
+policy=controller-rbac
+jq -e --arg policy "${policy}" \
+  'any(.[]; .name == $policy)' \
+  "${oracle_dir}/exceptions.json" >/dev/null
+
+jq --arg policy "${policy}" \
+  '[.[] | select(.name != $policy)]' \
+  "${oracle_dir}/exceptions.json" \
+  >"${oracle_dir}/exceptions-without-${policy}.json"
+
+go run ./scripts/kubescape-backlog-bridge \
+  -mode oracle \
+  -exceptions "${oracle_dir}/exceptions-without-${policy}.json" \
+  "${oracle_args[@]}"
+```
+
+For a pair covered only by that policy, the row changes from `excepted` with
+the policy name to `unexcepted` with `policies=-`. If no row changes, the
+supplied findings do not demonstrate that policy's effect; do not infer that
+the exception works from an unchanged aggregate count.

--- a/k8s/bases/infrastructure/cluster-security-exceptions/controller-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/controller-rbac.yaml
@@ -78,9 +78,13 @@ spec:
     # Read the effect off THIS scan only. The kubescape-operator's stored scan
     # resources apply no exceptions at all — their appliedIgnoreRules is empty —
     # so a count taken there says nothing about whether an exception works
-    # (#2823). Headlamp is fixed at the root (SA scoped to read-only
-    # cluster-reader); Flux and Velero are exempted by-design in
-    # wildcard-rbac.yaml.
+    # (#2823). To explain whether a raw in-cluster finding is covered, use the
+    # read-only client-side oracle in docs/kubescape-exception-oracle.md. It
+    # hydrates each summary with an individual GET and matches the generated
+    # exception artifact against the kubescape.io/workload-* labels; it does
+    # not parse kind or name out of wlid. Headlamp is fixed at the root (SA
+    # scoped to read-only cluster-reader); Flux and Velero are exempted
+    # by-design in wildcard-rbac.yaml.
     - controlID: C-0188
       action: ignore
   match:

--- a/scripts/kubescape-backlog-bridge/doc.go
+++ b/scripts/kubescape-backlog-bridge/doc.go
@@ -10,9 +10,14 @@
 // # Modes
 //
 // `-mode=report` (the default) prints the themes it would file and writes
-// nothing. `-mode=write` reconciles them into GitHub issues in `-repo`, which
-// is the default-off half: reporting stays the default, so enabling writes is
-// an explicit, reversible step rather than something a run falls into.
+// nothing. `-mode=oracle` prints one row per raw failed posture pair and names
+// every declared exception policy that matches it. It is the read-only
+// exception oracle documented in docs/kubescape-exception-oracle.md: locally
+// removing one policy from the generated artifact changes the same row from
+// `excepted` to `unexcepted`, without changing the cluster. `-mode=write`
+// reconciles themes into GitHub issues in `-repo`, which is the default-off
+// half: reporting stays the default, so enabling writes is an explicit,
+// reversible step rather than something a run falls into.
 //
 // # Write mode must be serialized
 //
@@ -215,6 +220,14 @@
 //	  -exceptions exceptions.json \
 //	  -posture ns-a-workload.json -posture ns-b-workload.json \
 //	  -cve ns-a-workload-image-1.json -cve ns-a-workload-image-2.json
+//
+// To explain exactly which policy accepts each raw failed posture pair, pass
+// the same hydrated posture inputs to oracle mode. The component identity is
+// read from the `kubescape.io/workload-*` labels, never parsed from `wlid`:
+//
+//	go run ./scripts/kubescape-backlog-bridge \
+//	  -mode oracle -exceptions exceptions.json \
+//	  -posture ns-a-workload.json -posture ns-b-workload.json
 //
 // The same invocation reconciling issues, once a sweep really did pass every
 // object — `-inputs-complete` is what authorises closing and updating, so it

--- a/scripts/kubescape-backlog-bridge/exceptions.go
+++ b/scripts/kubescape-backlog-bridge/exceptions.go
@@ -146,6 +146,22 @@ func (e exception) covers(controlID string, c component) bool {
 	return false
 }
 
+// matchingExceptionNames reports every declared policy that accepts this
+// finding. The names make the match explainable for oracle mode.
+func matchingExceptionNames(exceptions []exception, controlID string, c component) []string {
+	var names []string
+
+	for _, e := range exceptions {
+		if e.covers(controlID, c) {
+			names = append(names, e.name)
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
 // excepted reports whether any declared exception accepts this finding.
 func excepted(exceptions []exception, controlID string, c component) bool {
 	for _, e := range exceptions {
@@ -635,6 +651,10 @@ func analyse(r *syntax.Regexp) (matchable, consumes bool) {
 
 func compilePolicy(p rawPolicy, path string) (exception, error) {
 	e := exception{name: p.Name}
+	if strings.TrimSpace(p.Name) == "" {
+		return exception{}, fmt.Errorf("%w: %s: a policy has no name; an exception match without "+
+			"an audit identity cannot be explained or safely ablated", errBadExceptions, path)
+	}
 
 	// The action is what makes a policy an exception at all. The generator emits
 	// exactly ["alertOnly"] for every policy it writes, so anything else did not

--- a/scripts/kubescape-backlog-bridge/main.go
+++ b/scripts/kubescape-backlog-bridge/main.go
@@ -867,7 +867,9 @@ func run(args []string, out io.Writer) error {
 	fs.Var(&cvePaths, "cve",
 		"path to a per-object vulnerabilitymanifestsummary JSON (repeatable)")
 
-	mode := fs.String("mode", "report", "report (default, prints what it would file) or write (reconciles issues)")
+	mode := fs.String("mode", "report",
+		"report (default, prints what it would file), oracle (explains posture exception matches), "+
+			"or write (reconciles issues)")
 	exceptionsPath := fs.String("exceptions", "",
 		"path to the generated Kubescape exceptions JSON "+
 			"(`go run ./scripts/generate-kubescape-exceptions`); accepted posture controls are not backlog work")
@@ -892,8 +894,8 @@ func run(args []string, out io.Writer) error {
 			errInvalidInvocation, fs.Arg(0))
 	}
 
-	if *mode != "report" && *mode != "write" {
-		return fmt.Errorf("%w: unknown -mode %q (want report or write)", errInvalidInvocation, *mode)
+	if *mode != "report" && *mode != "oracle" && *mode != "write" {
+		return fmt.Errorf("%w: unknown -mode %q (want report, oracle, or write)", errInvalidInvocation, *mode)
 	}
 
 	if *mode == "write" && strings.TrimSpace(*repo) == "" {
@@ -920,6 +922,16 @@ func run(args []string, out io.Writer) error {
 		return fmt.Errorf("%w: -mode=write with -posture requires -exceptions "+
 			"(`go run ./scripts/generate-kubescape-exceptions`); without it every accepted "+
 			"control is filed as backlog work", errWritesNotEnabled)
+	}
+
+	if *mode == "oracle" && strings.TrimSpace(*exceptionsPath) == "" {
+		return fmt.Errorf("%w: -mode=oracle needs -exceptions so every raw posture finding can be "+
+			"evaluated against the declared policy set", errInvalidInvocation)
+	}
+
+	if *mode == "oracle" && len(cvePaths) > 0 {
+		return fmt.Errorf("%w: -mode=oracle accepts posture input only; "+
+			"ClusterSecurityExceptions do not filter the CVE surface", errInvalidInvocation)
 	}
 
 	if len(posturePaths) == 0 && len(cvePaths) == 0 {
@@ -950,6 +962,10 @@ func run(args []string, out io.Writer) error {
 		postureItems, err := readSurface(posturePaths, surfacePosture)
 		if err != nil {
 			return err
+		}
+
+		if *mode == "oracle" {
+			return reportExceptionOracle(postureItems, exceptions, out)
 		}
 
 		derived, n, acceptedKeys, err := derivePosture(postureItems, exceptions)
@@ -990,6 +1006,85 @@ func run(args []string, out io.Writer) error {
 	}
 
 	return report(themes, examined, len(exceptions) > 0, suppressed, out)
+}
+
+// oracleRow is one raw failed posture pair and the declared exception policies
+// that match it. It deliberately carries the same sanitized component string
+// used by backlog rendering, so node identities and wlid internals never enter
+// the output.
+type oracleRow struct {
+	control   string
+	component string
+	policies  []string
+}
+
+// reportExceptionOracle explains the exact client-side exception decision for
+// every failed posture pair in the supplied per-object GETs.
+//
+// derivePosture runs first as the single validation gate for workload identity,
+// status, severity and control-ID consistency. The reporting pass then observes
+// the same validated fields without maintaining a second, weaker validator.
+func reportExceptionOracle(items []item, exceptions []exception, out io.Writer) error {
+	if _, _, _, err := derivePosture(items, exceptions); err != nil {
+		return err
+	}
+
+	var rows []oracleRow
+
+	for _, it := range items {
+		controls, err := it.controls()
+		if err != nil {
+			return err
+		}
+
+		component := it.component()
+		for key, ctrl := range controls {
+			failed, _ := controlFailed(ctrl.Status.Status)
+			if !failed {
+				continue
+			}
+
+			if ctrl.ControlID != "" {
+				key = ctrl.ControlID
+			}
+
+			rows = append(rows, oracleRow{
+				control:   key,
+				component: component.String(),
+				policies:  matchingExceptionNames(exceptions, key, component),
+			})
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].control != rows[j].control {
+			return rows[i].control < rows[j].control
+		}
+
+		return rows[i].component < rows[j].component
+	})
+
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(out, "no failed posture findings in the supplied per-object input(s)")
+
+		return err
+	}
+
+	for _, row := range rows {
+		status := "unexcepted"
+		policies := "-"
+		if len(row.policies) > 0 {
+			status = "excepted"
+			policies = strings.Join(row.policies, ",")
+		}
+
+		if _, err := fmt.Fprintf(out, "%s\tcontrol=%s\tcomponent=%s\tpolicies=%s\n",
+			status, row.control, row.component, policies); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // reconcile lists what this command already tracks, plans the difference, and

--- a/scripts/kubescape-backlog-bridge/main.go
+++ b/scripts/kubescape-backlog-bridge/main.go
@@ -114,10 +114,11 @@ const nodeIdentityDigestLen = 8
 // is rendered with an explicit "cluster" scope marker rather than an empty
 // leading segment, so a reader cannot mistake it for a missing value.
 //
-// This is the ONLY place a component becomes a public string — acc.add is its
-// single call site, and exception designators match the structured fields
-// instead — which is what makes it the right place to enforce the exclusion the
-// package documents, rather than a second rule that rendering has to remember.
+// This is the ONLY place a component becomes a public string — both backlog
+// aggregation and oracle reporting call it, while exception designators match
+// the structured fields instead. That makes it the right place to enforce the
+// exclusion the package documents, rather than a second rule each output path
+// has to remember.
 //
 // A `Node` is the one kind whose NAME is itself the reachability evidence the
 // package excludes. For every other kind the name is a workload identity and

--- a/scripts/kubescape-backlog-bridge/oracle_test.go
+++ b/scripts/kubescape-backlog-bridge/oracle_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeOracleFixture(t *testing.T, exceptionJSON, postureJSON string) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	exceptionsPath := filepath.Join(dir, "exceptions.json")
+	posturePath := filepath.Join(dir, "posture.json")
+	writeRaw(t, exceptionsPath, exceptionJSON)
+	writeBare(t, posturePath, postureJSON)
+
+	return exceptionsPath, posturePath
+}
+
+// The production break this catches is reporting a finding as excepted while
+// leaving policies= blank. An unnamed policy cannot provide the audit identity
+// oracle mode exists to expose, so the artifact must be rejected instead.
+func TestOracleRejectsAnUnnamedMatchingPolicy(t *testing.T) {
+	exceptionsPath, posturePath := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("", []string{"C-0016"}, `{"kind":"^Job$"}`)),
+		postureDoc("app", "Job", "nightly", map[string]string{"C-0016": "failed"}),
+	)
+
+	var out bytes.Buffer
+	err := run([]string{
+		"-mode=oracle", "-exceptions", exceptionsPath, "-posture", posturePath,
+	}, &out)
+	if !errors.Is(err, errBadExceptions) {
+		t.Fatalf("want errBadExceptions, got %v", err)
+	}
+
+	if out.Len() != 0 {
+		t.Fatalf("an unnamed policy must not produce an oracle verdict, got %q", out.String())
+	}
+}
+
+// The production break this catches is an oracle that filters a finding but
+// never identifies which declared policy made that decision. An aggregate
+// suppression count cannot verify one exception or support a local ablation.
+func TestOracleNamesTheMatchingException(t *testing.T) {
+	exceptionsPath, posturePath := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("batch-workloads", []string{"C-0016"}, `{"kind":"^Job$"}`)),
+		postureDoc("app", "Job", "nightly", map[string]string{"C-0016": "failed"}),
+	)
+
+	var out bytes.Buffer
+	if err := run([]string{
+		"-mode=oracle",
+		"-exceptions", exceptionsPath,
+		"-posture", posturePath,
+	}, &out); err != nil {
+		t.Fatalf("run oracle: %v", err)
+	}
+
+	want := "excepted\tcontrol=C-0016\tcomponent=app/Job/nightly\tpolicies=batch-workloads\n"
+	if got := out.String(); got != want {
+		t.Fatalf("oracle output mismatch\nwant: %q\n got: %q", want, got)
+	}
+}
+
+// The production break this catches is a non-discriminating oracle: removing
+// the policy locally must change the answer for the exact same raw finding.
+func TestOracleAblationChangesTheAnswer(t *testing.T) {
+	posture := postureDoc("app", "Job", "nightly", map[string]string{"C-0016": "failed"})
+	matchingPath, posturePath := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("batch-workloads", []string{"C-0016"}, `{"kind":"^Job$"}`)),
+		posture,
+	)
+	ablatedPath, _ := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("unrelated", []string{"C-0999"}, `{"kind":"^Job$"}`)),
+		posture,
+	)
+
+	var withPolicy bytes.Buffer
+	if err := run([]string{
+		"-mode=oracle", "-exceptions", matchingPath, "-posture", posturePath,
+	}, &withPolicy); err != nil {
+		t.Fatalf("run with matching policy: %v", err)
+	}
+
+	var withoutPolicy bytes.Buffer
+	if err := run([]string{
+		"-mode=oracle", "-exceptions", ablatedPath, "-posture", posturePath,
+	}, &withoutPolicy); err != nil {
+		t.Fatalf("run with policy ablated: %v", err)
+	}
+
+	if !strings.HasPrefix(withPolicy.String(), "excepted\t") {
+		t.Fatalf("matching policy must report excepted, got %q", withPolicy.String())
+	}
+
+	wantAblated := "unexcepted\tcontrol=C-0016\tcomponent=app/Job/nightly\tpolicies=-\n"
+	if got := withoutPolicy.String(); got != wantAblated {
+		t.Fatalf("ablated output mismatch\nwant: %q\n got: %q", wantAblated, got)
+	}
+
+	if withPolicy.String() == withoutPolicy.String() {
+		t.Fatal("ablating the matching policy must change the oracle's answer")
+	}
+}
+
+// The production break this catches is matching the kind parsed out of wlid
+// instead of the workload identity labels the generated exception artifact
+// names. The two intentionally disagree in this fixture.
+func TestOracleMatchesWorkloadKindLabelInsteadOfWLID(t *testing.T) {
+	posture := strings.Replace(
+		postureDoc("app", "Job", "nightly", map[string]string{"C-0016": "failed"}),
+		`"spec":{`,
+		`"spec":{"wlid":"wlid://cluster-app/namespace-app/deployment-nightly",`,
+		1,
+	)
+	exceptionsPath, posturePath := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("batch-workloads", []string{"C-0016"}, `{"kind":"^Job$"}`)),
+		posture,
+	)
+
+	var out bytes.Buffer
+	if err := run([]string{
+		"-mode=oracle", "-exceptions", exceptionsPath, "-posture", posturePath,
+	}, &out); err != nil {
+		t.Fatalf("run oracle: %v", err)
+	}
+
+	if !strings.HasPrefix(out.String(), "excepted\t") {
+		t.Fatalf("the Job label must decide the match despite the Deployment wlid, got %q", out.String())
+	}
+}
+
+// Oracle mode is opt-in. The default report remains the backlog view rather
+// than exposing per-finding policy decisions in every ordinary run.
+func TestDefaultReportDoesNotEmitOracleRows(t *testing.T) {
+	exceptionsPath, posturePath := writeOracleFixture(t,
+		exceptionsDoc(policyDoc("batch-workloads", []string{"C-0016"}, `{"kind":"^Job$"}`)),
+		postureDoc("app", "Job", "nightly", map[string]string{"C-0016": "failed"}),
+	)
+
+	var out bytes.Buffer
+	if err := run([]string{
+		"-exceptions", exceptionsPath, "-posture", posturePath,
+	}, &out); err != nil {
+		t.Fatalf("run default report: %v", err)
+	}
+
+	if strings.Contains(out.String(), "policies=") {
+		t.Fatalf("default report must not emit oracle rows, got %q", out.String())
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Motivation

Kubescape stores raw posture findings without applying the platforms declared exceptions. Maintainers therefore need a repeatable way to tell a justified exception from an inert one without mutating production or waiting through another scan cycle.

## What

- Add an explicit, default-off oracle mode that explains each failed workload/control pair and names every matching exception policy.
- Keep workload identity anchored to the scanner workload labels rather than wlid internals.
- Document a full hydrated collection and local policy-ablation workflow, and point the controller RBAC guidance at it.
- Reject an unnamed policy because an exception decision without an audit identity cannot be explained safely.

## Security and developer experience

This makes silent no-op and accidentally broad posture exceptions observable while keeping the cluster unchanged. The everyday backlog command remains the default, and the secure verification path is one opt-in mode over the same generated artifact and raw inputs.

Fixes #2946

Part of #2627.