### PR TITLE
fix(openbao): keep the hcloud volumes off autoscaler nodes

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -102,6 +102,9 @@ components:
   # - cilium/components/ebpf-host-routing/
 patches:
   - path: openbao/patches/store-data-on-hcloud.yaml
+  # Prod-only: HARD-pin OpenBao to the static baseline workers so its hcloud
+  # block volumes never ride a node the autoscaler can reclaim (#2363) — see file.
+  - path: openbao/patches/keep-off-autoscale-nodes.yaml
   # Umami's Namespace moved into the preceding controllers layer with its
   # Kyverno Role; keep the prod-only user-namespace label with its new owner.
   - path: kyverno/patches/enable-user-namespaces.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
@@ -1,0 +1,76 @@
+# Prod-only: keep OpenBao's pods — and therefore its hcloud block volumes — OFF
+# the ephemeral autoscaler nodes, with a HARD (required) node affinity.
+#
+# WHY A HARD RULE HERE, when prefer-baseline-nodes.yaml deliberately uses a SOFT
+# one: that policy's softness is a FinOps choice ("a hard nodeAffinity would
+# defeat burst"), and it is the right default for ordinary, stateless workloads
+# that can be rescheduled freely. OpenBao is neither. Its `data-` and `audit-`
+# PVCs are `hcloud` block volumes, and an hcloud volume attaches to exactly ONE
+# node at a time with no force-detach when that node departs — so a pod that
+# burst onto an autoscaler node leaves its volume stranded the moment the
+# autoscaler reclaims that node.
+#
+# The failure this prevents is measured, not theoretical (#2363): on 2026-07-01
+# `data-openbao-0` stayed attached to a departed node for ~9h
+# (`FailedAttachVolume ... volume is attached`, ~26,632 retries). With OpenBao
+# down, the one-shot `Job/openbao/vault-config` hit its `activeDeadlineSeconds`,
+# the `infrastructure` Kustomization went `Ready=False`, `apps` blocked on it,
+# and EVERY `merge_group` deploy was evicted — the prod merge queue was wedged
+# for the whole 9h. A single stranded volume takes all of prod delivery down.
+#
+# The soft bias alone does not prevent it, measured on prod 2026-08-21: the
+# rendered spec carried the weight-100 `DoesNotExist` preference from
+# prefer-baseline-nodes and `openbao-0` was running on
+# `autoscale-cx43-6406b46e4820452e` anyway, with both its `data-` and `audit-`
+# hcloud volumes attached there. A preference yields under request pressure, and
+# nothing moves the pod back afterwards.
+#
+# This mirrors the split the cluster already makes for the OTHER storage class:
+# restrict-storage-to-baseline-workers.yaml hard-guards Longhorn replicas off
+# these nodes for the same durability reason. hcloud volumes had no equivalent —
+# even though their failure mode is worse, because Longhorn replicates across
+# nodes and an hcloud volume does not.
+#
+# SCHEDULABILITY: the chart's own podAntiAffinity is `required` on
+# `kubernetes.io/hostname`, so the 3 replicas already need 3 distinct nodes; the
+# 3 static workers supply exactly that. If a baseline worker is down or cordoned
+# the third replica goes Pending instead of bursting onto an autoscaler node.
+# That is the intended trade: OpenBao is raft-HA and keeps quorum at 2/3, so a
+# Pending third replica is a degraded-but-serving cluster, whereas a stranded
+# volume is a multi-hour outage of all prod delivery.
+#
+# The chart's `server.affinity` is a TEMPLATED STRING (it interpolates
+# `openbao.name`/`Release.Name`), not a map, so this restates the chart's default
+# podAntiAffinity verbatim rather than merging into it — dropping it would put
+# two raft peers on one host and lose the anti-affinity the HA setup depends on.
+#
+# RESIDUAL (shared with prefer-baseline-nodes, tracked in #3178): the
+# discriminator is `DoesNotExist`, so an autoscaler node created before KSail
+# began stamping `ksail.io/autoscaled` (ksail#5113) carries no label and is
+# still treated as baseline. Node affinity matches label values and supports no
+# wildcard, so the name-based `autoscale-*` discriminator the Longhorn policies
+# use is not expressible here. Every autoscaler node currently in the pool is
+# labelled; the durable fix is to not leave stranded nodes running.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openbao
+  namespace: openbao
+spec:
+  values:
+    server:
+      affinity: |
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: {{ template "openbao.name" . }}
+                  app.kubernetes.io/instance: "{{ .Release.Name }}"
+                  component: server
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: ksail.io/autoscaled
+                    operator: DoesNotExist

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1125,7 +1125,44 @@ const (
 // unapproved — kubectl v1.36.1 against an approved v1.36.2, so
 // validateRendererVersion fails closed and cannot corroborate. The same
 // single-renderer caveat as the value it replaces.
-const expectedRenderedSurfaceSHA = "3fda03fc7bdccf0a4a9d9057609ea20c0853af6d619523b94d56d21bca77fa71"
+// This value additionally covers pinning OpenBao off the autoscaler nodes
+// (#2363, PR #3286): a required nodeAffinity on the openbao HelmRelease's
+// `server.affinity`, so its single-attach hcloud volumes cannot ride a node the
+// autoscaler may delete.
+//
+// NOTHING grant-bearing moved. Membership is 77 -> 77 and set-IDENTICAL in both
+// directions (Role 11, ClusterRole 23, RoleBinding 16, ClusterRoleBinding 11,
+// ServiceAccount 16) — added-set EMPTY, removed-set EMPTY. Beyond membership,
+// the 77 documents' full canonical CONTENT hashes identically on both trees
+// (4932afd49d173ea6), so no rule, subject or verb changed inside an object whose
+// name stayed the same.
+//
+// Across all five authorization overlays — 1093 rendered documents — EXACTLY ONE
+// document differs: helm.toolkit.fluxcd.io/v2 HelmRelease openbao/openbao,
+// 4812 -> 5334 bytes, the added affinity value. That per-document diff firing on
+// openbao and nowhere else is its own positive control for the comparison.
+//
+// No identity, binding, verb, policy document, ServiceAccount or `aws`-bearing
+// line is touched: the 223 aws/eks/sts-bearing lines hash identically on both
+// trees (e00b36ee90f0d5e8), and a PLANTED extra `sts:AssumeRole` line was
+// confirmed to make that same comparison FIRE, so the identical result is a
+// measurement rather than a vacuous pass.
+//
+// The previous approved digest is recorded here in full, so replacing the
+// constant does not lose it:
+//
+//	3fda03fc7bdccf0a4a9d9057609ea20c0853af6d619523b94d56d21bca77fa71
+//
+// The new fingerprint was read from the required job's own output on the
+// approved renderer (run 32484160592, job 96776995320). UNLIKE the two values
+// above, it is NOT single-renderer: the local toolchain is still refused as
+// unapproved (kubectl v1.36.1 against the approved v1.36.2, so
+// validateRendererVersion fails closed), yet running this same validator locally
+// produced the IDENTICAL fingerprint. The two kubectl patch releases therefore
+// render this surface byte-identically, which corroborates the value rather than
+// resting on one renderer. The conservation figures above were computed with the
+// SAME local renderer on both trees, so that comparison is unaffected by the pin.
+const expectedRenderedSurfaceSHA = "1b7ab5daabc4d5540597a0de180b6f92b4bfb70ef7805eb7e97cf6755a2b92d3"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

OpenBao stores its data on Hetzner block volumes, which can only be attached to one machine at a time and are not released automatically when that machine goes away. Nothing was firmly stopping OpenBao from running on the *autoscaler* machines — the ones the cluster deletes on purpose when load drops — so its storage could be left stranded on a machine that no longer exists. That has already cost us a full outage: on 2026-07-01 a stranded volume took OpenBao down, which blocked the whole delivery pipeline and **wedged the prod merge queue for about 9 hours**.

This was not hypothetical today: OpenBao was found running on an autoscaler machine right now, with both of its volumes attached there. The existing safeguard is only a *preference*, and preferences get overruled when the cluster is busy.

### What

Pins OpenBao to the three permanent worker machines, so its storage can never end up on a machine the cluster is going to delete. This is the same hard rule the cluster already applies to its other storage system; block volumes had been left out.

The trade-off, stated plainly: if a permanent worker is down, one of OpenBao's three copies waits instead of moving to a temporary machine. OpenBao keeps working on the remaining two, which is a much better outcome than a multi-hour delivery outage.

Part of #2363