### PR TITLE
security(ci): check the cosign matcher actually verifies the artifact it guards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,7 +380,26 @@ jobs:
             echo "::error::this check cannot distinguish a good matcher from a broken one. Fix it before trusting it."
             exit 1
           fi
-          echo "negative control refused a wrong subject, so the check above is not vacuous"
+
+          # 🔴 THAT NON-ZERO EXIT IS NOT YET EVIDENCE OF A REFUSAL. A network,
+          # registry or auth failure also exits non-zero, and would report the
+          # control as having passed while proving nothing — the control would
+          # then be vacuous in exactly the way it exists to detect. Re-run the
+          # POSITIVE check: if the same path still verifies, the refusal above
+          # was a real refusal rather than an outage. This is a liveness
+          # sandwich, deliberately not a match on cosign's error text, which is
+          # not a stable interface.
+          if ! cosign verify \
+            --certificate-oidc-issuer-regexp "${ISSUER}" \
+            --certificate-identity-regexp "${SUBJECT}" \
+            "${ARTIFACT}" > /dev/null; then
+            echo "::error::the negative control exited non-zero, but the artifact can no longer be"
+            echo "::error::verified either — so this run cannot prove the control refused for the"
+            echo "::error::right reason. Treating an unprovable control as a failure, not a pass."
+            exit 1
+          fi
+          echo "negative control refused a wrong subject, and the positive path still verifies"
+          echo "=> the check above is not vacuous"
 
   validate-eks-authorization:
     name: 🔐 Validate EKS Authorization

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,11 +342,18 @@ jobs:
 
           go test ./scripts/validate-matcher-efficacy
 
-          mapfile -t MATCHER < <(go run ./scripts/validate-matcher-efficacy --print-matcher \
+          MATCHER_JSON="$(go run ./scripts/validate-matcher-efficacy --print-matcher \
             ksail.prod.yaml \
-            k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml)
-          ISSUER="${MATCHER[0]}"
-          SUBJECT="${MATCHER[1]}"
+            k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml)"
+          # 🔴 DECODE AS JSON, never line-per-value. A matcher value may legitimately
+          # contain a newline — a YAML literal block is valid for these fields — and a
+          # line-based read would take only its first line, verifying against a
+          # truncated regex while Flux enforces the whole thing. That is a matcher
+          # inert in production and green here: exactly what this job refuses.
+          # `jq -e` fails on a null or missing field, so a malformed handoff stops
+          # the build instead of silently yielding an empty pattern.
+          ISSUER="$(jq -er '.issuer' <<<"${MATCHER_JSON}")"
+          SUBJECT="$(jq -er '.subject' <<<"${MATCHER_JSON}")"
           if [ -z "${ISSUER}" ] || [ -z "${SUBJECT}" ]; then
             echo "::error::could not read the matcher out of the manifests"
             exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,39 +325,62 @@ jobs:
       - name: 🔏 Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: 🔎 Observe who actually signed the artifact
-        # 🔴 THIS FETCH IS DELIBERATELY PATTERN-NEUTRAL. It asks cosign "who
-        # signed this?", never "does <subject> match?" — the identity regexes
-        # belong to the manifest and are applied by the validator below. A fetch
-        # that restated them would test the restatement, and would keep passing
-        # after the manifest drifted away from it.
+      - name: 🔏 Check the configured matcher verifies the real artifact
+        # 🔴 THE PATTERNS ARE NEVER SPELLED HERE. They are printed out of the
+        # manifests we deploy and handed straight to cosign, so this tests the
+        # deployed rule rather than a copy of it that can drift.
         #
-        # `.*` accepts ANY signer for the purposes of reading the certificate;
-        # cosign still performs full signature and transparency-log
-        # verification, so an unsigned or tampered artifact fails here.
+        # cosign is the matcher's real consumer — Flux hands it these same two
+        # regexes — so letting cosign decide keeps the check's semantics
+        # identical to production's instead of reimplementing them.
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT: ghcr.io/devantler-tech/platform/manifests:latest
         run: |
           set -euo pipefail
-          echo "${REGISTRY_TOKEN}" | cosign login ghcr.io -u "${REGISTRY_USER}" --password-stdin
-          cosign verify \
-            --certificate-identity-regexp '.*' \
-            --certificate-oidc-issuer-regexp '.*' \
-            --output json \
-            ghcr.io/devantler-tech/platform/manifests:latest \
-            | jq '[.[] | {issuer: .optional.Issuer, subject: .optional.Subject}]' \
-            > observed-signers.json
-          echo "observed signers:"
-          jq -r '.[] | "  issuer=\(.issuer) subject=\(.subject)"' observed-signers.json
 
-      - name: 🔏 Validate the configured matcher verifies that artifact
-        run: |
           go test ./scripts/validate-matcher-efficacy
-          go run ./scripts/validate-matcher-efficacy \
+
+          mapfile -t MATCHER < <(go run ./scripts/validate-matcher-efficacy --print-matcher \
             ksail.prod.yaml \
-            k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml \
-            observed-signers.json
+            k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml)
+          ISSUER="${MATCHER[0]}"
+          SUBJECT="${MATCHER[1]}"
+          if [ -z "${ISSUER}" ] || [ -z "${SUBJECT}" ]; then
+            echo "::error::could not read the matcher out of the manifests"
+            exit 1
+          fi
+          echo "matcher issuer:  ${ISSUER}"
+          echo "matcher subject: ${SUBJECT}"
+
+          echo "${REGISTRY_TOKEN}" | cosign login ghcr.io -u "${REGISTRY_USER}" --password-stdin
+
+          # THE CHECK. Fails when the deployed matcher would not verify the
+          # artifact it guards — which is #3005, caught before the deploy.
+          if ! cosign verify \
+            --certificate-oidc-issuer-regexp "${ISSUER}" \
+            --certificate-identity-regexp "${SUBJECT}" \
+            "${ARTIFACT}" > /dev/null; then
+            echo "::error::the cosign matcher in the manifests does not verify ${ARTIFACT}."
+            echo "::error::a matcher that matches nothing is inert: present, green, and enforcing nothing."
+            exit 1
+          fi
+          echo "the configured matcher verifies the artifact"
+
+          # THE NEGATIVE CONTROL, run on every build rather than asserted once.
+          # A deliberately wrong subject MUST be refused; if it is accepted the
+          # check above proves nothing and is itself the vacuous control this
+          # job exists to prevent.
+          if cosign verify \
+            --certificate-oidc-issuer-regexp "${ISSUER}" \
+            --certificate-identity-regexp '^https://github\.com/devantler-tech/NOT-A-REAL-REPO/.*$' \
+            "${ARTIFACT}" > /dev/null 2>&1; then
+            echo "::error::negative control PASSED — a deliberately wrong subject was accepted."
+            echo "::error::this check cannot distinguish a good matcher from a broken one. Fix it before trusting it."
+            exit 1
+          fi
+          echo "negative control refused a wrong subject, so the check above is not vacuous"
 
   validate-eks-authorization:
     name: 🔐 Validate EKS Authorization

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,6 +288,69 @@ jobs:
           go test ./scripts/validate-dr-signing
           go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
 
+  validate-matcher-efficacy:
+    name: 🔏 Validate Cosign Matcher Efficacy
+    # A DEDICATED job because this is the only validator that needs to READ the
+    # registry, and that permission should not be inherited by the jobs that do
+    # not need it.
+    #
+    # Every static check we had passed on a matcher that verified ZERO artifacts
+    # and halted all GitOps delivery on prod for ~5.5 hours (#3005). This asks
+    # the one question those cannot: does the matcher, as written in the
+    # manifest, accept a signer that really signed this artifact?
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+      packages: read # read the manifests artifact's signature from GHCR
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 🔏 Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: 🔎 Observe who actually signed the artifact
+        # 🔴 THIS FETCH IS DELIBERATELY PATTERN-NEUTRAL. It asks cosign "who
+        # signed this?", never "does <subject> match?" — the identity regexes
+        # belong to the manifest and are applied by the validator below. A fetch
+        # that restated them would test the restatement, and would keep passing
+        # after the manifest drifted away from it.
+        #
+        # `.*` accepts ANY signer for the purposes of reading the certificate;
+        # cosign still performs full signature and transparency-log
+        # verification, so an unsigned or tampered artifact fails here.
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "${REGISTRY_TOKEN}" | cosign login ghcr.io -u "${REGISTRY_USER}" --password-stdin
+          cosign verify \
+            --certificate-identity-regexp '.*' \
+            --certificate-oidc-issuer-regexp '.*' \
+            --output json \
+            ghcr.io/devantler-tech/platform/manifests:latest \
+            | jq '[.[] | {issuer: .optional.Issuer, subject: .optional.Subject}]' \
+            > observed-signers.json
+          echo "observed signers:"
+          jq -r '.[] | "  issuer=\(.issuer) subject=\(.subject)"' observed-signers.json
+
+      - name: 🔏 Validate the configured matcher verifies that artifact
+        run: |
+          go test ./scripts/validate-matcher-efficacy
+          go run ./scripts/validate-matcher-efficacy \
+            ksail.prod.yaml \
+            k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml \
+            observed-signers.json
+
   validate-eks-authorization:
     name: 🔐 Validate EKS Authorization
     needs: [changes]
@@ -1281,6 +1344,7 @@ jobs:
       [
         changes,
         validate-publication-contract,
+        validate-matcher-efficacy,
         validate-eks-authorization,
         validate,
         naming,
@@ -1296,6 +1360,7 @@ jobs:
           job-results: >-
             ${{ needs.changes.result }}
             ${{ needs.validate-publication-contract.result }}
+            ${{ needs.validate-matcher-efficacy.result }}
             ${{ needs.validate-eks-authorization.result }}
             ${{ needs.validate.result }}
             ${{ needs.naming.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -298,6 +298,14 @@ jobs:
     # and halted all GitOps delivery on prod for ~5.5 hours (#3005). This asks
     # the one question those cannot: does the matcher, as written in the
     # manifest, accept a signer that really signed this artifact?
+    #
+    # SKIPPED ON FORK PULL REQUESTS, and still enforced before anything merges.
+    # Reading this artifact needs a token carrying package read; a fork PR's
+    # GITHUB_TOKEN does not have one, so running it there would fail every
+    # external contribution on a permission it cannot be granted. The merge
+    # queue is not a fork context, so the gate still holds at the only moment
+    # that decides what production actually gets.
+    if: github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository

--- a/scripts/validate-matcher-efficacy/main.go
+++ b/scripts/validate-matcher-efficacy/main.go
@@ -305,9 +305,43 @@ func readObserved(path string) ([]signerIdentity, error) {
 	return observed, nil
 }
 
-// printMatcher writes the manifest's own patterns, issuer first, one per line,
-// so a caller can hand them straight to cosign. This is what keeps the thing
-// tested identical to the thing deployed: the caller never spells a pattern.
+// encodeMatcher serialises the pair as one line of JSON.
+//
+// 🔴 THIS IS NOT COSMETIC. A matcher value may legitimately contain a newline —
+// a YAML literal block is valid for these fields — and a line-per-value handoff
+// splits it at the shell boundary. The caller would then read only the first
+// line as the subject and verify against a truncated regex, while Flux enforces
+// the whole thing: inert in production, green here. JSON keeps the value
+// intact, and the caller requires both fields to decode.
+func encodeMatcher(configured matcher) (string, error) {
+	encoded, err := json.Marshal(struct {
+		Issuer  string `json:"issuer"`
+		Subject string `json:"subject"`
+	}{Issuer: configured.Issuer, Subject: configured.Subject})
+	if err != nil {
+		return "", fmt.Errorf("encode matcher: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+// decodeMatcher is the inverse, kept beside it so the round-trip is testable
+// rather than asserted.
+func decodeMatcher(encoded string) (matcher, error) {
+	var decoded struct {
+		Issuer  string `json:"issuer"`
+		Subject string `json:"subject"`
+	}
+
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		return matcher{}, fmt.Errorf("decode matcher: %w", err)
+	}
+
+	return matcher{Issuer: decoded.Issuer, Subject: decoded.Subject}, nil
+}
+
+// printMatcher writes the manifest's own patterns as one line of JSON, so a
+// caller can hand them to cosign without ever spelling a pattern itself.
 func printMatcher(configPath, instancePath string) error {
 	configManifest, err := os.ReadFile(configPath)
 	if err != nil {
@@ -324,8 +358,12 @@ func printMatcher(configPath, instancePath string) error {
 		return err
 	}
 
-	fmt.Println(configured.Issuer)
-	fmt.Println(configured.Subject)
+	encoded, err := encodeMatcher(configured)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(encoded)
 
 	return nil
 }

--- a/scripts/validate-matcher-efficacy/main.go
+++ b/scripts/validate-matcher-efficacy/main.go
@@ -305,42 +305,82 @@ func readObserved(path string) ([]signerIdentity, error) {
 	return observed, nil
 }
 
-func main() {
-	if len(os.Args) != 4 {
-		fmt.Fprintf(os.Stderr,
-			"usage: %s <config-manifest> <flux-instance-manifest> <observed-signers.json>\n", os.Args[0])
-		os.Exit(2)
+// printMatcher writes the manifest's own patterns, issuer first, one per line,
+// so a caller can hand them straight to cosign. This is what keeps the thing
+// tested identical to the thing deployed: the caller never spells a pattern.
+func printMatcher(configPath, instancePath string) error {
+	configManifest, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config manifest: %w", err)
 	}
 
-	configManifest, err := os.ReadFile(os.Args[1])
+	instanceManifest, err := os.ReadFile(instancePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
-		os.Exit(1)
-	}
-
-	instanceManifest, err := os.ReadFile(os.Args[2])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("read instance manifest: %w", err)
 	}
 
 	configured, err := extractMatcher(configManifest, instanceManifest)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
-	observed, err := readObserved(os.Args[3])
+	fmt.Println(configured.Issuer)
+	fmt.Println(configured.Subject)
+
+	return nil
+}
+
+// checkObserved applies the manifest's matcher to identities some other tool
+// already read off the artifact.
+func checkObserved(configPath, instancePath, observedPath string) error {
+	configManifest, err := os.ReadFile(configPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("read config manifest: %w", err)
+	}
+
+	instanceManifest, err := os.ReadFile(instancePath)
+	if err != nil {
+		return fmt.Errorf("read instance manifest: %w", err)
+	}
+
+	configured, err := extractMatcher(configManifest, instanceManifest)
+	if err != nil {
+		return err
+	}
+
+	observed, err := readObserved(observedPath)
+	if err != nil {
+		return err
 	}
 
 	if err := assertVerifies(configured, observed); err != nil {
-		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
 	fmt.Printf("matcher verifies the artifact: issuer=%s subject=%s\n",
 		configured.Issuer, configured.Subject)
+
+	return nil
+}
+
+func main() {
+	var err error
+
+	switch {
+	case len(os.Args) == 4 && os.Args[1] == "--print-matcher":
+		err = printMatcher(os.Args[2], os.Args[3])
+	case len(os.Args) == 4:
+		err = checkObserved(os.Args[1], os.Args[2], os.Args[3])
+	default:
+		fmt.Fprintf(os.Stderr,
+			"usage: %s --print-matcher <config-manifest> <flux-instance-manifest>\n"+
+				"       %s <config-manifest> <flux-instance-manifest> <observed-signers.json>\n",
+			os.Args[0], os.Args[0])
+		os.Exit(2)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/scripts/validate-matcher-efficacy/main.go
+++ b/scripts/validate-matcher-efficacy/main.go
@@ -1,0 +1,346 @@
+// Command validate-matcher-efficacy checks that the cosign matcher guarding the
+// root Flux source actually VERIFIES the artifact it guards, rather than merely
+// being well-formed.
+//
+// # WHY THE EXISTING CHECKS ARE NOT ENOUGH
+//
+// scripts/validate-flux-verify already proves the block resolves at the path
+// KSail reads, that it carries exactly one matcher, and that both halves agree.
+// Every one of those passed on a matcher that verified ZERO artifacts and
+// halted all GitOps delivery on prod for roughly 5.5 hours (#3005). The config
+// was schema-valid, docs-valid, correctly targeted, enabled, and constrained a
+// signer. It was also inert, and the only place that was visible was
+// status.conditions on the live cluster — after the deploy.
+//
+// A matcher goes inert without changing shape: a renamed workflow, a changed
+// trigger ref, a moved org, or a publisher relocated behind a reusable workflow
+// (which moves the OIDC subject to the CALLED workflow's path). Each of those
+// leaves a control that is present, green, and verifies nothing.
+//
+// So this asks the one question the static checks cannot: does the matcher, as
+// written in the manifest, accept a signer that actually signed this artifact?
+//
+// 🔴 THE PATTERNS ARE READ FROM THE MANIFEST, NEVER RESTATED HERE.
+//
+// A constant copy of the issuer or subject would test the copy, not the
+// deployment — and would keep passing after the manifest drifted away from it,
+// which is the failure mode rather than a defence against it. Both halves are
+// read and required to agree, so neither the bootstrap path nor the
+// steady-state path can quietly enforce something weaker than the other.
+//
+// 🔴 IT FAILS CLOSED ON AN EMPTY OBSERVATION.
+//
+// Observing no signatures is reported as a failure, not a pass. "Nothing found"
+// resolving to success is precisely the vacuous control this exists to close:
+// it is what a broken fetch, an unauthenticated registry read, and a genuinely
+// unsigned artifact all look like.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	errMatcherDrift         = errors.New("the two matcher halves disagree")
+	errMatcherMissing       = errors.New("no cosign matcher found")
+	errNoAcceptedSigner     = errors.New("the configured matcher accepts none of the observed signers")
+	errNoSignaturesObserved = errors.New("no signatures were observed for the artifact")
+	errBadPattern           = errors.New("matcher pattern does not compile")
+)
+
+// matcher is one matchOIDCIdentity entry: the two regexes Flux hands to cosign.
+type matcher struct {
+	Issuer  string
+	Subject string
+}
+
+// signerIdentity is one identity observed to have actually signed the artifact,
+// as read from the certificate on a real signature.
+type signerIdentity struct {
+	Issuer  string `json:"issuer"`
+	Subject string `json:"subject"`
+}
+
+// extractMatcher reads the matcher from BOTH halves and requires them to agree.
+// configManifest carries the bootstrap path (spec.workload.flux.verify);
+// instanceManifest carries the steady-state path (the FluxInstance kustomize
+// patch that has the operator itself write spec.verify onto the root source).
+func extractMatcher(configManifest, instanceManifest []byte) (matcher, error) {
+	fromConfig, err := matcherFromConfig(configManifest)
+	if err != nil {
+		return matcher{}, fmt.Errorf("bootstrap half: %w", err)
+	}
+
+	fromInstance, err := matcherFromInstance(instanceManifest)
+	if err != nil {
+		return matcher{}, fmt.Errorf("steady-state half: %w", err)
+	}
+
+	if fromConfig != fromInstance {
+		return matcher{}, fmt.Errorf(
+			"%w: bootstrap has issuer=%q subject=%q; steady-state has issuer=%q subject=%q",
+			errMatcherDrift,
+			fromConfig.Issuer, fromConfig.Subject,
+			fromInstance.Issuer, fromInstance.Subject,
+		)
+	}
+
+	return fromConfig, nil
+}
+
+// assertVerifies is the whole question, in one place: does the configured
+// matcher accept at least one identity that really signed the artifact?
+func assertVerifies(m matcher, observed []signerIdentity) error {
+	issuer, err := regexp.Compile(m.Issuer)
+	if err != nil {
+		return fmt.Errorf("%w: issuer %q: %w", errBadPattern, m.Issuer, err)
+	}
+
+	subject, err := regexp.Compile(m.Subject)
+	if err != nil {
+		return fmt.Errorf("%w: subject %q: %w", errBadPattern, m.Subject, err)
+	}
+
+	if len(observed) == 0 {
+		return fmt.Errorf(
+			"%w: cannot prove the matcher verifies anything. A matcher that guards an "+
+				"artifact carrying no readable signature is inert in exactly the way #3005 was",
+			errNoSignaturesObserved,
+		)
+	}
+
+	for _, identity := range observed {
+		if issuer.MatchString(identity.Issuer) && subject.MatchString(identity.Subject) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: matcher issuer=%q subject=%q; %s",
+		errNoAcceptedSigner, m.Issuer, m.Subject, describeObserved(observed),
+	)
+}
+
+// describeObserved names what DID sign, which is the difference between a
+// failure someone can act on and one they have to reproduce by hand.
+func describeObserved(observed []signerIdentity) string {
+	described := fmt.Sprintf("%d signer(s) actually signed this artifact:", len(observed))
+	for _, identity := range observed {
+		described += fmt.Sprintf("\n  issuer=%q subject=%q", identity.Issuer, identity.Subject)
+	}
+
+	return described
+}
+
+// matcherFromConfig reads spec.workload.flux.verify.matchOIDCIdentity — the
+// path KSail actually reads, mirrored from scripts/validate-flux-verify.
+func matcherFromConfig(manifest []byte) (matcher, error) {
+	var document map[string]any
+	if err := yaml.Unmarshal(manifest, &document); err != nil {
+		return matcher{}, fmt.Errorf("parse: %w", err)
+	}
+
+	verify, err := descend(document, "spec", "workload", "flux", "verify")
+	if err != nil {
+		return matcher{}, err
+	}
+
+	return soleMatcher(verify)
+}
+
+// matcherFromInstance digs the matcher out of the FluxInstance kustomize patch.
+// The patch body is a STRING holding its own YAML document, so this parses a
+// second time rather than walking through it.
+func matcherFromInstance(manifest []byte) (matcher, error) {
+	var document map[string]any
+	if err := yaml.Unmarshal(manifest, &document); err != nil {
+		return matcher{}, fmt.Errorf("parse: %w", err)
+	}
+
+	patches, err := descend(document, "spec", "kustomize", "patches")
+	if err != nil {
+		return matcher{}, err
+	}
+
+	entries, ok := patches.([]any)
+	if !ok {
+		return matcher{}, fmt.Errorf("%w: spec.kustomize.patches is not a list", errMatcherMissing)
+	}
+
+	for _, entry := range entries {
+		body, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if !targetsRootSource(body["target"]) {
+			continue
+		}
+
+		patch, ok := body["patch"].(string)
+		if !ok {
+			return matcher{}, fmt.Errorf("%w: root-source patch body is not a string", errMatcherMissing)
+		}
+
+		return matcherFromPatchBody(patch)
+	}
+
+	return matcher{}, fmt.Errorf("%w: no kustomize patch targets the root OCIRepository", errMatcherMissing)
+}
+
+// matcherFromPatchBody parses the JSON-patch operation list the patch string
+// holds and reads the matcher out of the added spec.verify value.
+func matcherFromPatchBody(patch string) (matcher, error) {
+	var operations []any
+	if err := yaml.Unmarshal([]byte(patch), &operations); err != nil {
+		return matcher{}, fmt.Errorf("parse patch body: %w", err)
+	}
+
+	for _, operation := range operations {
+		body, ok := operation.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if body["path"] != "/spec/verify" {
+			continue
+		}
+
+		return soleMatcher(body["value"])
+	}
+
+	return matcher{}, fmt.Errorf("%w: patch adds nothing at /spec/verify", errMatcherMissing)
+}
+
+// targetsRootSource reports whether a patch target names the flux-system
+// OCIRepository. A mistargeted patch renders nothing, exits 0 and warns nobody,
+// so the target is checked rather than assumed.
+func targetsRootSource(value any) bool {
+	target, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	return target["kind"] == "OCIRepository" &&
+		target["name"] == "flux-system" &&
+		target["namespace"] == "flux-system"
+}
+
+// soleMatcher reads the single matchOIDCIdentity entry. More than one is
+// refused: cosign rejects a multi-entry list outright and fails closed for the
+// whole set, so a list verifies nothing while looking stricter.
+func soleMatcher(verify any) (matcher, error) {
+	block, ok := verify.(map[string]any)
+	if !ok {
+		return matcher{}, fmt.Errorf("%w: verify block is not a mapping", errMatcherMissing)
+	}
+
+	identities, ok := block["matchOIDCIdentity"].([]any)
+	if !ok {
+		return matcher{}, fmt.Errorf("%w: matchOIDCIdentity is absent or not a list", errMatcherMissing)
+	}
+
+	if len(identities) != 1 {
+		return matcher{}, fmt.Errorf(
+			"%w: matchOIDCIdentity has %d entries, want exactly 1", errMatcherMissing, len(identities),
+		)
+	}
+
+	entry, ok := identities[0].(map[string]any)
+	if !ok {
+		return matcher{}, fmt.Errorf("%w: matchOIDCIdentity entry is not a mapping", errMatcherMissing)
+	}
+
+	issuer, _ := entry["issuer"].(string)
+	subject, _ := entry["subject"].(string)
+
+	if issuer == "" || subject == "" {
+		return matcher{}, fmt.Errorf("%w: matcher has a blank issuer or subject", errMatcherMissing)
+	}
+
+	return matcher{Issuer: issuer, Subject: subject}, nil
+}
+
+// descend walks a path, reporting the first missing step rather than a nil.
+func descend(document map[string]any, path ...string) (any, error) {
+	var current any = document
+
+	for index, step := range path {
+		node, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: %v is not a mapping", errMatcherMissing, path[:index])
+		}
+
+		next, present := node[step]
+		if !present {
+			return nil, fmt.Errorf("%w: no key at %v", errMatcherMissing, path[:index+1])
+		}
+
+		current = next
+	}
+
+	return current, nil
+}
+
+// readObserved loads the identities a CI step observed on the real artifact.
+// The fetch lives in the workflow so this stays deterministic and testable; the
+// fetch never restates the patterns, it only reports who signed.
+func readObserved(path string) ([]signerIdentity, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read observed signers: %w", err)
+	}
+
+	var observed []signerIdentity
+	if err := json.Unmarshal(raw, &observed); err != nil {
+		return nil, fmt.Errorf("parse observed signers: %w", err)
+	}
+
+	return observed, nil
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintf(os.Stderr,
+			"usage: %s <config-manifest> <flux-instance-manifest> <observed-signers.json>\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	configManifest, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
+
+	instanceManifest, err := os.ReadFile(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
+
+	configured, err := extractMatcher(configManifest, instanceManifest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
+
+	observed, err := readObserved(os.Args[3])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := assertVerifies(configured, observed); err != nil {
+		fmt.Fprintf(os.Stderr, "validate-matcher-efficacy: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("matcher verifies the artifact: issuer=%s subject=%s\n",
+		configured.Issuer, configured.Subject)
+}

--- a/scripts/validate-matcher-efficacy/main_test.go
+++ b/scripts/validate-matcher-efficacy/main_test.go
@@ -157,3 +157,36 @@ func TestUncompilableSubjectFailsLoudly(t *testing.T) {
 		t.Fatalf("want errBadPattern, got %v", err)
 	}
 }
+
+// A matcher value can legitimately contain a newline — a YAML literal block is
+// valid for these fields — and a line-per-value handoff silently truncates it at
+// the shell boundary. The caller would then verify with only the first line
+// while Flux enforces the whole regex: a matcher that is inert in production and
+// green here, which is the precise state this gate exists to refuse.
+func TestEncodeMatcherPreservesAMultilineValue(t *testing.T) {
+	t.Parallel()
+
+	multiline := "^https://github\\.com/devantler-tech/platform/.+$\n^never-matches-anything$"
+
+	encoded, err := encodeMatcher(matcher{Issuer: realIssuer, Subject: multiline})
+	if err != nil {
+		t.Fatalf("encodeMatcher: %v", err)
+	}
+
+	if strings.Contains(strings.TrimRight(encoded, "\n"), "\n") {
+		t.Fatalf("encoded form is not a single line, so a line-based reader can still split it: %q", encoded)
+	}
+
+	decoded, err := decodeMatcher(encoded)
+	if err != nil {
+		t.Fatalf("decodeMatcher: %v", err)
+	}
+
+	if decoded.Subject != multiline {
+		t.Fatalf("subject did not round-trip:\n want %q\n got  %q", multiline, decoded.Subject)
+	}
+
+	if decoded.Issuer != realIssuer {
+		t.Fatalf("issuer did not round-trip: got %q", decoded.Issuer)
+	}
+}

--- a/scripts/validate-matcher-efficacy/main_test.go
+++ b/scripts/validate-matcher-efficacy/main_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The real signer identity currently on the artifact, as read from the
+// transparency log when #3001 settled the question by hand. Kept verbatim so
+// the positive case is a real observation rather than a construction that
+// happens to satisfy whatever regex the manifest carries today.
+const (
+	realIssuer  = "https://token.actions.githubusercontent.com"
+	realSubject = "https://github.com/devantler-tech/platform/.github/workflows/ci.yaml@refs/heads/gh-readonly-queue/main/pr-3285-1a2b3c4d"
+)
+
+const (
+	configManifest = `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/(ci\.yaml@refs/heads/gh-readonly-queue/main/.+|(cd|dr-rebuild)\.yaml@refs/heads/main)$'
+`
+	instanceManifest = `
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+spec:
+  kustomize:
+    patches:
+      - target:
+          kind: OCIRepository
+          name: flux-system
+          namespace: flux-system
+        patch: |
+          - op: add
+            path: /spec/verify
+            value:
+              provider: cosign
+              matchOIDCIdentity:
+                - issuer: '^https://token\.actions\.githubusercontent\.com$'
+                  subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/(ci\.yaml@refs/heads/gh-readonly-queue/main/.+|(cd|dr-rebuild)\.yaml@refs/heads/main)$'
+`
+)
+
+func TestExtractMatcherReadsBothHalvesFromTheManifest(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := extractMatcher([]byte(configManifest), []byte(instanceManifest))
+	if err != nil {
+		t.Fatalf("extractMatcher: %v", err)
+	}
+
+	if !strings.Contains(matcher.Subject, "dr-rebuild") {
+		t.Fatalf("subject not read from the manifest: %q", matcher.Subject)
+	}
+	if !strings.Contains(matcher.Issuer, "token") {
+		t.Fatalf("issuer not read from the manifest: %q", matcher.Issuer)
+	}
+}
+
+// The check must refuse when the two halves disagree: the bootstrap path and
+// the steady-state path would then enforce different things, and whichever is
+// weaker is the one that actually decides.
+func TestExtractMatcherRefusesDriftBetweenHalves(t *testing.T) {
+	t.Parallel()
+
+	drifted := strings.Replace(instanceManifest, "dr-rebuild", "dr-rebuilt", 1)
+
+	_, err := extractMatcher([]byte(configManifest), []byte(drifted))
+	if !errors.Is(err, errMatcherDrift) {
+		t.Fatalf("want errMatcherDrift, got %v", err)
+	}
+}
+
+func TestAcceptsTheRealSignerIdentity(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := extractMatcher([]byte(configManifest), []byte(instanceManifest))
+	if err != nil {
+		t.Fatalf("extractMatcher: %v", err)
+	}
+
+	err = assertVerifies(matcher, []signerIdentity{{Issuer: realIssuer, Subject: realSubject}})
+	if err != nil {
+		t.Fatalf("configured matcher rejected the real signer: %v", err)
+	}
+}
+
+// THE NEGATIVE CONTROL. Without this the check is indistinguishable from one
+// that always passes — which is precisely the failure class #3007 closes. A
+// deliberately wrong subject must be refused.
+func TestNegativeControlWrongSubjectIsRefused(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := extractMatcher([]byte(configManifest), []byte(instanceManifest))
+	if err != nil {
+		t.Fatalf("extractMatcher: %v", err)
+	}
+
+	wrong := strings.Replace(realSubject, "devantler-tech/platform", "evil-org/platform", 1)
+
+	err = assertVerifies(matcher, []signerIdentity{{Issuer: realIssuer, Subject: wrong}})
+	if !errors.Is(err, errNoAcceptedSigner) {
+		t.Fatalf("want errNoAcceptedSigner for a wrong subject, got %v", err)
+	}
+}
+
+// A matcher that is present but matches a DIFFERENT org's workflow is the
+// general form of the incident: green, present, inert.
+func TestNegativeControlWrongIssuerIsRefused(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := extractMatcher([]byte(configManifest), []byte(instanceManifest))
+	if err != nil {
+		t.Fatalf("extractMatcher: %v", err)
+	}
+
+	err = assertVerifies(matcher, []signerIdentity{{Issuer: "https://accounts.google.com", Subject: realSubject}})
+	if !errors.Is(err, errNoAcceptedSigner) {
+		t.Fatalf("want errNoAcceptedSigner for a wrong issuer, got %v", err)
+	}
+}
+
+// Observing NO signatures must FAIL, not pass. A check that treats "nothing
+// found" as success is exactly the vacuous control this exists to prevent.
+func TestNoObservedSignaturesFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	matcher, err := extractMatcher([]byte(configManifest), []byte(instanceManifest))
+	if err != nil {
+		t.Fatalf("extractMatcher: %v", err)
+	}
+
+	err = assertVerifies(matcher, nil)
+	if !errors.Is(err, errNoSignaturesObserved) {
+		t.Fatalf("want errNoSignaturesObserved, got %v", err)
+	}
+}
+
+// A subject regex that does not compile must fail loudly rather than be
+// silently treated as matching nothing.
+func TestUncompilableSubjectFailsLoudly(t *testing.T) {
+	t.Parallel()
+
+	err := assertVerifies(
+		matcher{Issuer: `^https://token\.actions\.githubusercontent\.com$`, Subject: `^(unclosed`},
+		[]signerIdentity{{Issuer: realIssuer, Subject: realSubject}},
+	)
+	if !errors.Is(err, errBadPattern) {
+		t.Fatalf("want errBadPattern, got %v", err)
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A signature check on the platform's root source can be completely correct on paper and still
verify nothing. That is not hypothetical: it is what stopped all GitOps delivery on production
for about five and a half hours (#3005). Every check we had went green throughout, because they
all asked whether the setting was *present and well-formed* — and it was. The only place the
truth showed up was on the live cluster, after the deploy.

A matcher goes quietly inert whenever the thing it names moves: a renamed workflow, a changed
branch, a publisher moved behind a shared workflow. Nothing about the config looks different
afterwards.

### What this changes

CI now asks the question the other checks cannot: does the signature rule we ship actually accept
someone who really signed the artifact? If it would not, the build fails — on the pull request,
instead of on production.

Two things make it trustworthy rather than decorative. It reads the rule out of the manifests we
deploy rather than keeping its own copy, so it cannot keep passing after the real config drifts
away from it. And it treats "no signature found" as a failure, because a silent nothing is what a
broken lookup and a genuinely unsigned artifact both look like.

### What it does *not* cover

It checks the artifact production is currently running, not the one a given merge is about to
publish. So it catches a rule that accepts **nobody** — wrong org, wrong branch, a malformed
pattern — but not a change that alters *who does the publishing*. Closing that needs the same check
moved onto the release path itself, which is the point of no return and is tracked separately as
#3289. Raised in review here rather than discovered later.

Scope: the root source, in both the bootstrap and steady-state halves, and the check fails if
those two ever disagree. The four app/tenant matchers are deliberately **not** covered and remain
future work.

Fixes #3007