### PR TITLE
fix(headlamp): restore Safari OIDC login flow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -223,10 +223,11 @@
       "automerge": false
     },
     {
-      "description": "headlamp chart 0.43.0 is EXCLUDED (k8s/bases/apps/headlamp/helm-release.yaml, reverted to 0.42.0): its in-cluster OIDC login is broken in Safari — the sign-in popup's only close signal is a cross-window localStorage storage event, which Safari ITP suppresses after the popup's cross-site Dex/GitHub hops, so the popup hangs on 'Redirecting to main page…' forever (upstream kubernetes-sigs/headlamp#6353; fix PR #6355 unmerged; tracked in #2438). The negated regex blocks exactly 0.43.0 while letting the NEXT release (>= 0.43.1, minor or major) bump normally — on that bump, verify Safari login end-to-end per #2438 before considering the regression closed, then remove this rule.",
+      "description": "headlamp is HARD-PINNED at 0.42.0 (k8s/bases/apps/headlamp/helm-release.yaml): 0.43.0 introduced an in-cluster OIDC login regression in Safari, and the same broken popup handoff was reproduced after upgrading to 0.44.0 — the session cookie succeeds, but Safari ITP suppresses the cross-window localStorage storage event after the popup's cross-site Dex/GitHub hops, so the popup never redirects its opener (upstream kubernetes-sigs/headlamp#6353; fix PR #6355 unmerged; tracked in #2438). Keep the last Safari-verified release until a released upstream fix is manually verified end-to-end; automerge:false placed last so an unverified Headlamp update cannot inherit the minor/patch automerge defaults above.",
       "matchDatasources": ["helm"],
       "matchPackageNames": ["headlamp"],
-      "allowedVersions": "!/^v?0\\.43\\.0$/"
+      "allowedVersions": "/^v?0\\.42\\.0$/",
+      "automerge": false
     },
     {
       "description": "KubeVirt and CDI ship as VENDORED upstream operator manifests (k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml, .../cdi/cdi-operator.yaml) — thousands of lines of CRDs, RBAC and the operator Deployment vendored as one unit from each release's published asset. The kubernetes manager only sees the `image:` lines inside them, so a Renovate bump rewrites the operator image alone and silently skews it against the CRDs/RBAC vendored next to it; the system-test would still pass bring-up (operators tolerate startup skew) so automerge would land the skew unseen. Keep the update PR as the new-release signal but require a maintainer to re-vendor the full manifest from the matching release before merging. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,8 @@ jobs:
               - 'scripts/tests/test-actual-budget-auth-route.sh'
               - 'scripts/tests/test-pvc-prune-safety.sh'
               - 'scripts/tests/test-headlamp-plugin-removal.sh'
+              - 'scripts/tests/test-headlamp-oidc-version-gate.sh'
+              - '.github/renovate.json'
               - 'scripts/tests/test-github-config-role-activation-parity.sh'
               - 'scripts/tests/test-restrict-tenant-secret-stores.sh'
               # The Homepage layout and the policy's allow-list are one contract:
@@ -621,6 +623,12 @@ jobs:
         # Removing runtime-downloaded plugins must also prune upgrade state and
         # preserve Crossview's authenticated fresh-install entry point.
         run: bash scripts/tests/test-headlamp-plugin-removal.sh
+
+      - name: 🔐 Validate Headlamp OIDC version gate
+        if: needs.changes.outputs.k8s == 'true'
+        run: |
+          shellcheck scripts/tests/test-headlamp-oidc-version-gate.sh
+          bash scripts/tests/test-headlamp-oidc-version-gate.sh
 
       - name: 🔑 Validate github-config Role covers the activated MR kinds
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,13 @@ jobs:
           go test ./scripts/validate-concurrency-queue
           go run ./scripts/validate-concurrency-queue "${workflows[@]}"
 
+      # This guard spans the HelmRelease and Renovate policy, so it must run
+      # without routing policy-only changes into the production k8s deploy path.
+      - name: 🔐 Validate Headlamp OIDC version gate
+        run: |
+          shellcheck scripts/tests/test-headlamp-oidc-version-gate.sh
+          bash scripts/tests/test-headlamp-oidc-version-gate.sh
+
       - name: 🔍 Filter paths
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
@@ -116,8 +123,6 @@ jobs:
               - 'scripts/tests/test-actual-budget-auth-route.sh'
               - 'scripts/tests/test-pvc-prune-safety.sh'
               - 'scripts/tests/test-headlamp-plugin-removal.sh'
-              - 'scripts/tests/test-headlamp-oidc-version-gate.sh'
-              - '.github/renovate.json'
               - 'scripts/tests/test-github-config-role-activation-parity.sh'
               - 'scripts/tests/test-restrict-tenant-secret-stores.sh'
               # The Homepage layout and the policy's allow-list are one contract:
@@ -623,12 +628,6 @@ jobs:
         # Removing runtime-downloaded plugins must also prune upgrade state and
         # preserve Crossview's authenticated fresh-install entry point.
         run: bash scripts/tests/test-headlamp-plugin-removal.sh
-
-      - name: 🔐 Validate Headlamp OIDC version gate
-        if: needs.changes.outputs.k8s == 'true'
-        run: |
-          shellcheck scripts/tests/test-headlamp-oidc-version-gate.sh
-          bash scripts/tests/test-headlamp-oidc-version-gate.sh
 
       - name: 🔑 Validate github-config Role covers the activated MR kinds
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -12,11 +12,11 @@ spec:
   chart:
     spec:
       chart: headlamp
-      # 0.43.0 is reverted: its OIDC popup never closes in Safari (ITP suppresses
-      # the cross-window storage event the opener waits for) — upstream
-      # kubernetes-sigs/headlamp#6353, tracked in #2438. Renovate is gated off
-      # exactly 0.43.0 (.github/renovate.json); >= 0.43.1 bumps normally.
-      version: 0.44.0
+      # 0.43.0 introduced a Safari OIDC regression and 0.44.0 still reproduces
+      # it: the session succeeds, but ITP suppresses the cross-window storage
+      # event that redirects the opener. Pin the last Safari-verified release
+      # until upstream #6355 ships and its replacement is verified (#2438).
+      version: 0.42.0
       sourceRef:
         kind: HelmRepository
         name: headlamp
@@ -67,8 +67,8 @@ spec:
   values:
     replicaCount: ${headlamp_replicas:=1}
     # Use chart-native values for the main container's writable directories.
-    # When pluginsManager and its PVC are disabled, chart 0.44.0 renders no
-    # volumes parent at all; JSON post-render appends therefore fail before the
+    # When pluginsManager and its PVC are disabled, the chart renders no volumes
+    # parent at all; JSON post-render appends therefore fail before the
     # Deployment reaches Kubernetes.
     volumes:
       - name: tmp-dir

--- a/scripts/tests/test-headlamp-oidc-version-gate.sh
+++ b/scripts/tests/test-headlamp-oidc-version-gate.sh
@@ -27,6 +27,10 @@ rule_count="$(jq -r 'length' <<<"${headlamp_rules}")"
 
 allowed_versions="$(jq -r '.[0].allowedVersions // ""' <<<"${headlamp_rules}")"
 automerge="$(jq -r 'if .[0] | has("automerge") then .[0].automerge else "unset" end' <<<"${headlamp_rules}")"
+readonly expected_allowed_versions='/^v?0\.42\.0$/'
+
+[[ "${allowed_versions}" == "${expected_allowed_versions}" ]] ||
+  fail "Headlamp allowedVersions must pin exactly 0.42.0, got '${allowed_versions}'"
 
 version_is_allowed() {
   local version="$1"

--- a/scripts/tests/test-headlamp-oidc-version-gate.sh
+++ b/scripts/tests/test-headlamp-oidc-version-gate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly headlamp_release="${root_dir}/k8s/bases/apps/headlamp/helm-release.yaml"
+readonly renovate_config="${root_dir}/.github/renovate.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail 'jq is required to inspect the Renovate policy'
+command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to inspect the Headlamp HelmRelease'
+
+headlamp_rules="$(jq -c '
+  [.packageRules[] |
+    select((.matchDatasources // []) | index("helm")) |
+    select((.matchPackageNames // []) | index("headlamp"))]
+' "${renovate_config}")" || fail 'the Renovate configuration must be valid JSON'
+
+rule_count="$(jq -r 'length' <<<"${headlamp_rules}")"
+[[ "${rule_count}" == '1' ]] ||
+  fail "Renovate must define exactly one Helm package rule for Headlamp, found ${rule_count}"
+
+allowed_versions="$(jq -r '.[0].allowedVersions // ""' <<<"${headlamp_rules}")"
+automerge="$(jq -r 'if .[0] | has("automerge") then .[0].automerge else "unset" end' <<<"${headlamp_rules}")"
+
+version_is_allowed() {
+  local version="$1"
+  local expression
+
+  case "${allowed_versions}" in
+    '!'/*'/')
+      expression="${allowed_versions:2:${#allowed_versions}-3}"
+      [[ ! "${version}" =~ ${expression} ]]
+      ;;
+    /*/)
+      expression="${allowed_versions:1:${#allowed_versions}-2}"
+      [[ "${version}" =~ ${expression} ]]
+      ;;
+    *)
+      fail "Headlamp allowedVersions must be an auditable regex, got '${allowed_versions}'"
+      ;;
+  esac
+}
+
+version_is_allowed '0.42.0' || fail 'Renovate must retain the last Safari-verified Headlamp release'
+version_is_allowed 'v0.42.0' || fail "the Headlamp gate must accept Renovate's optional v prefix"
+
+for unsafe_version in 0.43.0 0.44.0 0.45.0; do
+  if version_is_allowed "${unsafe_version}"; then
+    fail "Renovate must not offer unverified Headlamp ${unsafe_version}"
+  fi
+done
+
+[[ "${automerge}" == 'false' ]] ||
+  fail 'Headlamp updates must require deliberate login verification before merge'
+
+deployed_version="$(yq e -r '.spec.chart.spec.version // ""' "${headlamp_release}")"
+[[ "${deployed_version}" == '0.42.0' ]] ||
+  fail "Headlamp must stay on the last Safari-verified release 0.42.0, got ${deployed_version}"
+version_is_allowed "${deployed_version}" ||
+  fail "the deployed Headlamp version ${deployed_version} must satisfy the Renovate gate"
+
+printf 'PASS: Headlamp stays on the Safari-verified release until a fixed release is verified\n'

--- a/scripts/tests/test-headlamp-oidc-version-gate.sh
+++ b/scripts/tests/test-headlamp-oidc-version-gate.sh
@@ -6,6 +6,7 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly root_dir
 readonly headlamp_release="${root_dir}/k8s/bases/apps/headlamp/helm-release.yaml"
 readonly renovate_config="${root_dir}/.github/renovate.json"
+readonly ci_workflow="${root_dir}/.github/workflows/ci.yaml"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -13,7 +14,24 @@ fail() {
 }
 
 command -v jq >/dev/null 2>&1 || fail 'jq is required to inspect the Renovate policy'
-command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to inspect the Headlamp HelmRelease'
+changes_job="$(awk '
+  /^  changes:$/ { in_changes = 1 }
+  in_changes && /^  [[:alnum:]_-]+:$/ && $0 != "  changes:" { exit }
+  in_changes { print }
+' "${ci_workflow}")"
+k8s_filter="$(awk '
+  $0 == "            k8s:" { in_k8s = 1; next }
+  in_k8s && /^            [[:alpha:]_][[:alnum:]_]*:$/ { exit }
+  in_k8s { print }
+' "${ci_workflow}")"
+
+grep -Fq 'name: 🔐 Validate Headlamp OIDC version gate' <<<"${changes_job}" ||
+  fail 'the Headlamp version gate must run unconditionally in the changes job'
+
+if grep -Fq '.github/renovate.json' <<<"${k8s_filter}" ||
+  grep -Fq 'scripts/tests/test-headlamp-oidc-version-gate.sh' <<<"${k8s_filter}"; then
+  fail 'Headlamp policy-only changes must not enter the production k8s deployment filter'
+fi
 
 headlamp_rules="$(jq -c '
   [.packageRules[] |
@@ -63,7 +81,10 @@ done
 [[ "${automerge}" == 'false' ]] ||
   fail 'Headlamp updates must require deliberate login verification before merge'
 
-deployed_version="$(yq e -r '.spec.chart.spec.version // ""' "${headlamp_release}")"
+deployed_version="$(awk '
+  $1 == "chart:" && $2 == "headlamp" { in_headlamp_chart = 1; next }
+  in_headlamp_chart && $1 == "version:" { print $2; exit }
+' "${headlamp_release}")"
 [[ "${deployed_version}" == '0.42.0' ]] ||
   fail "Headlamp must stay on the last Safari-verified release 0.42.0, got ${deployed_version}"
 version_is_allowed "${deployed_version}" ||


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary
- roll Headlamp back from 0.44.0 to the last Safari-verified chart, 0.42.0
- hard-pin Renovate and disable Headlamp automerge until an upstream-fixed release passes manual Safari login verification
- add an unconditional CI regression contract without coupling policy-only changes to production deployment

## Evidence
The current 0.44.0 deployment reproduces the 0.43.0 popup handoff failure: authentication establishes the session, but Safari suppresses the cross-window storage event, so the opener is not redirected. Reopening the main URL then sees the valid session. Upstream fix kubernetes-sigs/headlamp#6355 remains unmerged.

## Verification
- shellcheck plus Headlamp OIDC version-gate regression tests, including broadened-allow-list and deploy-filter counterexamples
- existing Headlamp plugin-removal regression test
- actionlint on the CI workflow
- local and production kustomize renders
- exact-head GitHub CI: 21 checks passed, including both manifest overlays, Kubescape, CodeQL, and mega-linter

Refs #2438