### PR TITLE
fix(ci): paginate MegaLinter run lookup

### DIFF
--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -122,7 +122,7 @@ extract_one() {
 
 resolve_log() {
   command -v gh >/dev/null 2>&1 || die_unverifiable 'gh is not installed'
-  local dest="$1" run_id job_id runs page page_runs
+  local dest="$1" run_id job_id page page_runs head_sha saw_managed
 
   # This repository must NOT define the managed workflow itself. If it ever does, the path stops
   # being proof of org-managed provenance — an in-repo file could then be edited to emit whatever
@@ -179,8 +179,9 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
 
   # Select by the managed workflow's PATH, not the run's display name, then by job name within it.
   # Fetch explicit pages rather than `--paginate`: this keeps the API cost bounded while still
-  # preserving newest-first order across pages for the candidate loop below.
-  runs=''
+  # preserving newest-first order. Process each page before fetching the next so valid evidence is
+  # returned immediately and cannot be discarded by a later, unnecessary API failure.
+  saw_managed=no
   page=1
   while [ "$page" -le "$MAX_RUN_PAGES" ]; do
     page_runs="$(gh api \
@@ -189,43 +190,36 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
       2>/dev/null)" ||
       die_unverifiable "could not list recent runs page $page for $REPO"
     if [ -n "$page_runs" ]; then
-      if [ -n "$runs" ]; then
-        runs="$runs
-$page_runs"
-      else
-        runs="$page_runs"
+      saw_managed=yes
+    fi
+    while read -r run_id head_sha; do
+      [ -n "$run_id" ] || continue
+      if ! managed_path_absent_at "$head_sha"; then
+        printf 'Skipping run %s: %s is not provably absent at its revision %s, so that run is not\n' \
+          "$run_id" "$MANAGED_WORKFLOW_PATH" "$head_sha" >&2
+        printf '  org-managed and its log is not evidence of anything.\n' >&2
+        continue
       fi
-    fi
-    page=$((page + 1))
-  done
-  [ -n "$runs" ] ||
-    die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
-
-  local head_sha
-  while read -r run_id head_sha; do
-    [ -n "$run_id" ] || continue
-    if ! managed_path_absent_at "$head_sha"; then
-      printf 'Skipping run %s: %s is not provably absent at its revision %s, so that run is not\n' \
-        "$run_id" "$MANAGED_WORKFLOW_PATH" "$head_sha" >&2
-      printf '  org-managed and its log is not evidence of anything.\n' >&2
-      continue
-    fi
-    # A skipped job states no versions, so require one that actually executed.
-    job_id="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
-      --jq ".jobs[]
+      # A skipped job states no versions, so require one that actually executed.
+      job_id="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
+        --jq ".jobs[]
             | select(.name | test(\"$MEGALINTER_JOB_MATCH\"))
             | select(.conclusion == \"success\" or .conclusion == \"failure\")
             | .id" 2>/dev/null | head -1)" || continue
-    if [ -n "$job_id" ]; then
-      printf 'Reading mega-linter job %s (run %s of %s) in %s\n' \
-        "$job_id" "$run_id" "$MANAGED_WORKFLOW_PATH" "$REPO" >&2
-      fetch_log "$job_id" "$dest" ||
-        die_unverifiable "could not download the log for job $job_id"
-      return 0
-    fi
-  done <<EOF
-$runs
+      if [ -n "$job_id" ]; then
+        printf 'Reading mega-linter job %s (run %s of %s) in %s\n' \
+          "$job_id" "$run_id" "$MANAGED_WORKFLOW_PATH" "$REPO" >&2
+        fetch_log "$job_id" "$dest" ||
+          die_unverifiable "could not download the log for job $job_id"
+        return 0
+      fi
+    done <<EOF
+$page_runs
 EOF
+    page=$((page + 1))
+  done
+  [ "$saw_managed" = yes ] ||
+    die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
   die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job from a provably org-managed run in the
 last $MAX_RUNS runs of $REPO"
 }

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -37,11 +37,13 @@ set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-devantler-tech/platform}"
 MEGALINTER_JOB_MATCH='mega-linter'
-# Use GitHub's full single-page capacity. A burst of dependency updates can emit several workflows
-# per pull request; 40 repository-wide runs buried a valid MegaLinter job even though it was less
-# than an hour old (observed 2026-08-22). Keep this bounded to one request while making every result
-# that request can return available to the provenance filter below.
-MAX_RUNS=100
+# A burst of dependency updates can emit several workflows per pull request; 40 repository-wide
+# runs buried a valid MegaLinter job even though it was less than an hour old (observed 2026-08-22),
+# and one full 100-result page can be exhausted just as easily. Walk a bounded three pages in newest-
+# first order. The cap prevents an unbounded historical scan; exhausting it still fails closed below.
+RUNS_PER_PAGE=100
+MAX_RUN_PAGES=3
+MAX_RUNS=$((RUNS_PER_PAGE * MAX_RUN_PAGES))
 
 # The org-managed workflow that runs mega-linter for this repository. Binding to it is a PROVENANCE
 # check, not decoration: the job is selected out of arbitrary recent runs, and a job's display name
@@ -120,7 +122,7 @@ extract_one() {
 
 resolve_log() {
   command -v gh >/dev/null 2>&1 || die_unverifiable 'gh is not installed'
-  local dest="$1" run_id job_id runs
+  local dest="$1" run_id job_id runs page page_runs
 
   # This repository must NOT define the managed workflow itself. If it ever does, the path stops
   # being proof of org-managed provenance — an in-repo file could then be edited to emit whatever
@@ -176,10 +178,26 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
   }
 
   # Select by the managed workflow's PATH, not the run's display name, then by job name within it.
-  runs="$(gh api "repos/$REPO/actions/runs?per_page=$MAX_RUNS" \
-    --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha)\"" \
-    2>/dev/null)" ||
-    die_unverifiable "could not list recent runs for $REPO"
+  # Fetch explicit pages rather than `--paginate`: this keeps the API cost bounded while still
+  # preserving newest-first order across pages for the candidate loop below.
+  runs=''
+  page=1
+  while [ "$page" -le "$MAX_RUN_PAGES" ]; do
+    page_runs="$(gh api \
+      "repos/$REPO/actions/runs?per_page=$RUNS_PER_PAGE&page=$page" \
+      --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha)\"" \
+      2>/dev/null)" ||
+      die_unverifiable "could not list recent runs page $page for $REPO"
+    if [ -n "$page_runs" ]; then
+      if [ -n "$runs" ]; then
+        runs="$runs
+$page_runs"
+      else
+        runs="$page_runs"
+      fi
+    fi
+    page=$((page + 1))
+  done
   [ -n "$runs" ] ||
     die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
 

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -37,7 +37,11 @@ set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-devantler-tech/platform}"
 MEGALINTER_JOB_MATCH='mega-linter'
-MAX_RUNS=40
+# Use GitHub's full single-page capacity. A burst of dependency updates can emit several workflows
+# per pull request; 40 repository-wide runs buried a valid MegaLinter job even though it was less
+# than an hour old (observed 2026-08-22). Keep this bounded to one request while making every result
+# that request can return available to the provenance filter below.
+MAX_RUNS=100
 
 # The org-managed workflow that runs mega-linter for this repository. Binding to it is a PROVENANCE
 # check, not decoration: the job is selected out of arbitrary recent runs, and a job's display name

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -192,6 +192,9 @@ case "$args" in
           page="${page%% *}"
           ;;
       esac
+      if [ "${GH_STUB_FAIL_RUNS_PAGE:-}" = "$page" ]; then
+        exit 1
+      fi
       if [ -n "${GH_STUB_RUN_PAGES_DIR:-}" ]; then
         page_file="$GH_STUB_RUN_PAGES_DIR/$page"
         [ ! -f "$page_file" ] || cat "$page_file"
@@ -297,6 +300,24 @@ else
   printf 'ok: a genuine run remains reachable on the second workflow-run page\n'
 fi
 unset GH_STUB_RUN_PAGES_DIR
+
+# Once a usable candidate on page one has passed every provenance check, later pages are irrelevant.
+# A transient failure fetching page two must not discard that already-validated evidence. The eager
+# collector does exactly that; processing each page before requesting the next one returns first.
+printf '111 %s\n' "$genuine_sha" >"$scratch/run-pages/1"
+: >"$scratch/run-pages/2"
+GH_STUB_RUN_PAGES_DIR="$scratch/run-pages"
+GH_STUB_FAIL_RUNS_PAGE=2
+export GH_STUB_RUN_PAGES_DIR GH_STUB_FAIL_RUNS_PAGE
+run_live
+if [ "$rc" -ne 0 ]; then
+  printf 'FAIL: early usable run — later page failure discarded valid evidence, got %d\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a usable page-one run prevents unnecessary later page requests\n'
+fi
+unset GH_STUB_RUN_PAGES_DIR GH_STUB_FAIL_RUNS_PAGE
 
 # Discrimination: the newest candidate is tainted, the next is genuine. The guard must SKIP the
 # first and use the second. Consuming the first reports drift (exit 1) and aborting on it fails

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -180,7 +180,12 @@ case "$args" in
     run="${args##*actions/runs/}"
     run="${run%%/jobs*}"
     printf 'job%s\n' "$run" ;;
-  *actions/runs*per_page*) cat "$GH_STUB_RUNS" ;;
+  *actions/runs*per_page*)
+    per_page="${args#*per_page=}"
+    per_page="${per_page%% *}"
+    if [ "$per_page" -ge "${GH_STUB_MIN_PER_PAGE:-0}" ]; then
+      cat "$GH_STUB_RUNS"
+    fi ;;
   *contents/.github/workflows/validate-go-project.yaml*)
     sha="${args##*ref=}"
     if grep -qxF -- "$sha" "$GH_STUB_TAINTED"; then
@@ -201,6 +206,7 @@ export GH_STUB_LOGDIR="$scratch/logs"
 export GH_STUB_RUNS="$scratch/runs.txt"
 export GH_STUB_TAINTED="$scratch/tainted.txt"
 export GH_STUB_UNRESOLVABLE="$scratch/unresolvable.txt"
+export GH_STUB_MIN_PER_PAGE=0
 : >"$scratch/unresolvable.txt"
 
 tainted_sha='deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
@@ -242,6 +248,22 @@ if [ "$rc" -ne 0 ]; then
 else
   printf 'ok: control — an untainted candidate is still consumed\n'
 fi
+
+# A dependency-update burst can create more than 40 repository-wide workflow runs between two
+# executed MegaLinter jobs. The live incident that motivated this case buried the newest usable job
+# at ordinal 99 even though it was less than an hour old. The selector must use the API's full
+# single-page capacity so unrelated workflows do not make recent evidence unreachable.
+GH_STUB_MIN_PER_PAGE=100
+printf '111 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 0 ]; then
+  printf 'FAIL: busy repository history — expected recent genuine run to be reachable, got %d\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a genuine run remains reachable after more than 40 unrelated workflow runs\n'
+fi
+GH_STUB_MIN_PER_PAGE=0
 
 # Discrimination: the newest candidate is tainted, the next is genuine. The guard must SKIP the
 # first and use the second. Consuming the first reports drift (exit 1) and aborting on it fails

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -182,9 +182,22 @@ case "$args" in
     printf 'job%s\n' "$run" ;;
   *actions/runs*per_page*)
     per_page="${args#*per_page=}"
+    per_page="${per_page%%&*}"
     per_page="${per_page%% *}"
     if [ "$per_page" -ge "${GH_STUB_MIN_PER_PAGE:-0}" ]; then
-      cat "$GH_STUB_RUNS"
+      page=1
+      case "$args" in
+        *'&page='*)
+          page="${args##*&page=}"
+          page="${page%% *}"
+          ;;
+      esac
+      if [ -n "${GH_STUB_RUN_PAGES_DIR:-}" ]; then
+        page_file="$GH_STUB_RUN_PAGES_DIR/$page"
+        [ ! -f "$page_file" ] || cat "$page_file"
+      elif [ "$page" -eq 1 ]; then
+        cat "$GH_STUB_RUNS"
+      fi
     fi ;;
   *contents/.github/workflows/validate-go-project.yaml*)
     sha="${args##*ref=}"
@@ -264,6 +277,26 @@ else
   printf 'ok: a genuine run remains reachable after more than 40 unrelated workflow runs\n'
 fi
 GH_STUB_MIN_PER_PAGE=0
+
+# One full page of unrelated workflows must not hide the first managed candidate on page two. This
+# is the regression boundary from the review finding: `per_page=100` increases one response but does
+# not paginate it. The page fixture makes the old one-request implementation fail closed, while a
+# bounded multi-page lookup reaches the same genuine, provenance-checked candidate.
+mkdir -p "$scratch/run-pages"
+: >"$scratch/run-pages/1"
+printf '111 %s\n' "$genuine_sha" >"$scratch/run-pages/2"
+: >"$scratch/run-pages/3"
+GH_STUB_RUN_PAGES_DIR="$scratch/run-pages"
+export GH_STUB_RUN_PAGES_DIR
+run_live
+if [ "$rc" -ne 0 ]; then
+  printf 'FAIL: paginated history — expected page-two genuine run to be reachable, got %d\n%s\n' \
+    "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a genuine run remains reachable on the second workflow-run page\n'
+fi
+unset GH_STUB_RUN_PAGES_DIR
 
 # Discrimination: the newest candidate is tainted, the next is genuine. The guard must SKIP the
 # first and use the second. Consuming the first reports drift (exit 1) and aborting on it fails


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Root cause

`Validate Main` selected MegaLinter evidence from only the newest 40 repository-wide workflow runs. A dependency-update burst emits several workflows per PR and buried the newest completed MegaLinter job at ordinal 99, so the guard failed closed even though the evidence was less than an hour old.

The lookup now walks up to three explicit 100-result pages in newest-first order. Each page's candidates are validated before the next request, so the first usable provenance-checked job returns immediately and an unnecessary later-page outage cannot discard valid evidence. The API cost remains bounded at 300 repository-wide runs, every per-candidate commit and workflow-provenance check is preserved, and exhausting the bound still fails closed.

Live incident: https://github.com/devantler-tech/platform/actions/runs/32538327579

## Verification

- strict TDD: a page-two-only fixture failed on the one-page implementation with exit 2, then passed after pagination
- strict TDD: a valid page-one plus failing-page-two fixture failed on the eager collector with exit 2, then passed after early return
- `bash scripts/tests/test-check-megalinter-version-drift.sh`
- `bash -n scripts/check-megalinter-version-drift.sh scripts/tests/test-check-megalinter-version-drift.sh`
- `shellcheck --severity=warning scripts/check-megalinter-version-drift.sh scripts/tests/test-check-megalinter-version-drift.sh`
- live guard read provenance-valid job 96979449467 and matched MegaLinter 10.0.0, Checkov 3.3.9, and Trivy 0.73.0