### PR TITLE
docs(vault-backup): describe current UID boundary

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -183,8 +183,9 @@ DISABLE_ERRORS_LINTERS:
   # The residual 4 is fully accounted for: 2 KSV-0021 on each of the two vault-backup workloads --
   # the snapshot container's image-defined gid AND the mirror container, which INHERITS gid 1000
   # from the pod rather than having it image-defined. That second one is why the KSV-0020 premise
-  # does not carry over, and why #3202 stays open: it needs the PVC sharing model established
-  # first. REPOSITORY_TRIVY cannot leave the list below until it does.
+  # does not carry over. The residual stays live under #2787 until a high primary GID plus explicit
+  # group-1000 membership is proven on the PVC path. REPOSITORY_TRIVY cannot leave the list below
+  # until then.
   #
   # ⚠️ That 6 is NOT 9 minus this slice. The 9 recorded here was wrong on two independent counts:
   # KSV-0020 on vault-backup was 2 (one per file), not 4, and the coredns KSV-0011 was already
@@ -236,26 +237,23 @@ DISABLE_ERRORS_LINTERS:
   # asserts, so the exception fails the build if the VM stack ever reaches production.
   #
   # checkov is at 0 failed checks on all three frameworks CI runs. Its last two findings were both
-  # CKV_K8S_40, on the two vault-backup workloads, and #2904 dispositioned them as a scoped
-  # deferred exception on each workload — neither the eleven per-site constraints #2898 claimed nor
-  # the single risk acceptance #2904 proposed, both of which the measurements below rule out.
+  # CKV_K8S_40 on the two vault-backup snapshot containers. Each pod now defaults to UID 65532, while
+  # the snapshot container alone states the OpenBao image's baked `openbao:x:100:1000` identity.
+  # The two resource-level skips are narrow permanent dispositions guarded against covering any
+  # other container; they are not deferred migration markers.
   # Re-derive that from the scan rather than adjusting a number here — every figure in this
   # block is a measurement, and the running arithmetic that used to track it went stale twice.
   #
-  # Both vault-backup workloads run pod-level UID 100, and each of their two containers has its
-  # own reason. The snapshot container's 100 is the openbao image's baked `openbao:x:100:1000`
-  # identity, from the same pinned digest vault-config reads. The mirror container inherits it
-  # because the snapshot lands `-rw-------` owned by `100:1000` while `minio/mc` mounts
-  # /snapshots readOnly and bakes no uid-100 entry of its own, so opening it as its owner is the
-  # only access it has — `fsGroup` fixes the volume's ownership and mode at mount time, not the
-  # mode `bao operator raft snapshot save` writes the file with afterwards.
+  # Both vault-backup workloads run the pod and mirror container at UID 65532. The snapshot
+  # container overrides that default with the OpenBao image's baked UID 100, from the same pinned
+  # digest vault-config reads. Snapshots are widened to 0640, so the high-UID mirror reads them
+  # through the shared primary GID 1000 instead of by owning the file.
   #
-  # Neither UID is remapped: the openbao namespace carries no
+  # UID 100 is not remapped: the openbao namespace carries no
   # `pod-security.devantler.tech/user-namespaces: enabled` label, so the add-user-namespaces rule
-  # does not match, hostUsers stays on, and 100 is a host UID. #3202 removes that residual by
-  # making the snapshot group-readable first and raising the UIDs after. All three
-  # `vault-snapshots` writers move together; the third is the dr-rebuild workflow's helper pod,
-  # which this check does not reach because it is not a committed Kubernetes manifest.
+  # does not match, hostUsers stays on, and 100 is a host UID. The disposition therefore remains
+  # scoped to the container whose image defines that identity; every other writer uses the high
+  # pod default.
   #
   # The user-namespace probes are resolved rather than excepted, because the UID was never the
   # measurement subject: `/proc/self/uid_map` describes the pod's namespace and reads identically

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -572,9 +572,10 @@ misconfigurations:
   # INHERITS a low GID chosen for openbao rather than taking a high default, and `minio/mc` bakes no
   # such identity. vault-config can make that split because its shared paths are emptyDir, where
   # fsGroup's setgid bit carries the group regardless of the writer's primary gid (#3258); the
-  # vault-backup snapshots live on a PVC, where that has not been established — #3281 assumed it
-  # transferred and was withdrawn. The remaining 4 KSV-0021 findings therefore stay reported until
-  # that is measured, rather than being covered by a premise that does not hold. See #3202.
+  # vault-backup snapshots live on a PVC, where a high primary GID plus explicit group-1000
+  # membership has not been established — #3281 assumed the emptyDir premise transferred and was
+  # withdrawn. The remaining 4 KSV-0021 findings therefore stay reported under #2787 rather than
+  # being covered by a premise that does not hold.
   - id: KSV-0020
     paths:
       - k8s/bases/infrastructure/vault-backup/job.yaml

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -162,9 +162,10 @@ spec:
                   # run creates. #3246 made new snapshots 0640, but retention keeps the
                   # newest 14, so every snapshot taken before it is still 0600 — readable
                   # only by its owner. The mirror runs `mc mirror` over the WHOLE directory,
-                  # so it can need to open any of them, and #3202 step 2 stops it being that
-                  # owner. Widening them here, while this container still is, is what makes
-                  # that move safe; a warning rather than a hard failure so a single odd file
+                  # so it can need to open any of them. The mirror now runs as the pod's high
+                  # UID and reads them through group 1000 instead of ownership. Widening them
+                  # here, while the snapshot container still owns them, preserves that access;
+                  # a warning rather than a hard failure means a single odd file
                   # cannot take the nightly backup down.
                   widened=0
                   for EXISTING in /snapshots/openbao-*.snap; do
@@ -178,13 +179,12 @@ spec:
                   SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
                   echo "Saving raft snapshot to $SNAP..."
                   bao operator raft snapshot save "$SNAP"
-                  # The mirror opens the snapshot as GROUP: both containers run
-                  # fsGroup/runAsGroup 1000, and the kernel checks access on the numeric
-                  # GID, so reading it needs no matching owner UID. An explicit chmod,
+                  # The mirror opens the snapshot as GROUP: pod runAsGroup/fsGroup 1000
+                  # makes 1000 its primary group while it inherits the pod's high UID 65532.
+                  # The snapshot container alone uses the OpenBao image's UID 100. An explicit chmod,
                   # NOT a umask: umask can only clear permission bits, so it cannot
-                  # widen the 0600 `bao` creates the file with. The writers' UIDs stay
-                  # pinned until the migration in #3202 (CKV_K8S_40); this removes the
-                  # access coupling that blocked it.
+                  # widen the 0600 `bao` creates the file with. The 0640 mode decouples
+                  # mirror access from the image-defined owner UID.
                   chmod 0640 "$SNAP"
                   ls -l "$SNAP"
 

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -157,9 +157,10 @@ spec:
               # run creates. #3246 made new snapshots 0640, but retention keeps the
               # newest 14, so every snapshot taken before it is still 0600 — readable
               # only by its owner. The mirror runs `mc mirror` over the WHOLE directory,
-              # so it can need to open any of them, and #3202 step 2 stops it being that
-              # owner. Widening them here, while this container still is, is what makes
-              # that move safe; a warning rather than a hard failure so a single odd file
+              # so it can need to open any of them. The mirror now runs as the pod's high
+              # UID and reads them through group 1000 instead of ownership. Widening them
+              # here, while the snapshot container still owns them, preserves that access;
+              # a warning rather than a hard failure means a single odd file
               # cannot take the nightly backup down.
               widened=0
               for EXISTING in /snapshots/openbao-*.snap; do
@@ -180,13 +181,12 @@ spec:
               SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
               echo "Saving initial raft snapshot to $SNAP..."
               bao operator raft snapshot save "$SNAP"
-              # The mirror opens the snapshot as GROUP: both containers run
-              # fsGroup/runAsGroup 1000, and the kernel checks access on the numeric
-              # GID, so reading it needs no matching owner UID. An explicit chmod,
+              # The mirror opens the snapshot as GROUP: pod runAsGroup/fsGroup 1000
+              # makes 1000 its primary group while it inherits the pod's high UID 65532.
+              # The snapshot container alone uses the OpenBao image's UID 100. An explicit chmod,
               # NOT a umask: umask can only clear permission bits, so it cannot
-              # widen the 0600 `bao` creates the file with. The writers' UIDs stay
-              # pinned until the migration in #3202 (CKV_K8S_40); this removes the
-              # access coupling that blocked it.
+              # widen the 0600 `bao` creates the file with. The 0640 mode decouples
+              # mirror access from the image-defined owner UID.
               chmod 0640 "$SNAP"
               ls -l "$SNAP"
               echo "Initial snapshot complete."

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -106,9 +106,10 @@ readonly CI_MEGALINTER_VERSION='10.0.0'
 # Every framework CI runs is now at zero. The three that were left are all dispositioned with
 # scoped, resource-level skips naming their reason:
 #   CKV_K8S_38  CronJob.umami.umami-provision-tenants         (SA token mounted)   #3198
-#   CKV_K8S_40  CronJob.openbao.vault-snapshot                (high UID)           #2904
-#   CKV_K8S_40  Job.openbao.vault-snapshot-init               (high UID)           #2904
-# The two CKV_K8S_40 skips are DEFERRED, not accepted — #3202 removes them.
+#   CKV_K8S_40  CronJob.openbao.vault-snapshot                (image-defined UID)  #3282
+#   CKV_K8S_40  Job.openbao.vault-snapshot-init               (image-defined UID)  #3282
+# The two CKV_K8S_40 skips are narrow permanent dispositions: each pod defaults to high UID 65532,
+# and the identity-boundary guard permits UID 100 only on the container whose OpenBao image defines it.
 readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:0 github_actions:0)
 
 # A parsing error means a file was NOT analysed, so findings can hide behind it. CI's run has


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The first non-vacuous nightly after the UID migration has now verified that the high-UID mirror can read and upload the group-readable snapshot. Exact main still describes the CKV_K8S_40 dispositions as deferred and says the mirror owns the file, which is no longer true.

### What

- describe the pod and mirror UID 65532 boundary, with UID 100 scoped to the OpenBao image container
- record CKV_K8S_40 as the reviewed narrow image-identity disposition
- keep the four KSV-0021 group findings live under #2787

### Validation

- vault snapshot group-readable invariant test
- vault-backup Trivy identity-boundary test
- Checkov skip-reason guard
- local and production Kustomize renders
- read-only live verification: a new 0640 snapshot, non-zero mirror transfer, and successful remote listing

Both full KSail validations exceeded the bounded local attempt without a result, so that aggregate remains QUERY-UNKNOWN rather than inferred green.

Part of #3202