### PR TITLE
security(vault-backup): harden primary group identity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -575,9 +575,10 @@ jobs:
 
       - name: 🧱 Validate vault-backup identity disposition boundary
         if: needs.changes.outputs.k8s == 'true'
-        # Same per-container premise as vault-config, on the two workloads that pin the same
-        # openbao digest. This guard also asserts an ABSENCE: KSV-0021 must stay reported on
-        # them, because the mirror inherits that gid rather than having it image-defined.
+        # The two workloads pin the same openbao digest: only snapshot may use its image-baked
+        # UID/GID 100:1000, while mirror keeps the high pod default and receives group 1000 only
+        # through fsGroup. The guard keeps both identity dispositions path-scoped and requires an
+        # identical unlisted probe to stay reported.
         run: |
           shellcheck scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh
           bash scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -175,21 +175,16 @@ DISABLE_ERRORS_LINTERS:
   # openbao containers that legitimately remain — the same image-defined identity the KSV-0020
   # entry above rests on, one field over. The same per-container boundary test asserts both.
   #
-  # It then went 6 -> 4 when KSV-0020 on the two vault-backup workloads was dispositioned (#3202):
-  # the openbao snapshot container's image-defined uid 100, the same premise as the vault-config
-  # entry above and on the same pinned digest, guarded per container by
-  # scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh.
+  # The vault-backup identity pair is guarded per container by
+  # scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh. The pod and mirror use the
+  # high 65532 primary GID; only the digest-pinned openbao snapshot container selects its defined
+  # 100:1000 identity. fsGroup 1000 gives the mirror supplementary read access to the 0640 snapshot
+  # without a low pod-wide primary GID. The path-scoped KSV-0020/KSV-0021 dispositions are coupled
+  # to an identical unlisted probe, so another low-identity workload still fails the scan.
   #
-  # The residual 4 is fully accounted for: 2 KSV-0021 on each of the two vault-backup workloads --
-  # the snapshot container's image-defined gid AND the mirror container, which INHERITS gid 1000
-  # from the pod rather than having it image-defined. That second one is why the KSV-0020 premise
-  # does not carry over. The residual stays live under #2787 until a high primary GID plus explicit
-  # group-1000 membership is proven on the PVC path. REPOSITORY_TRIVY cannot leave the list below
-  # until then.
-  #
-  # ⚠️ That 6 is NOT 9 minus this slice. The 9 recorded here was wrong on two independent counts:
-  # KSV-0020 on vault-backup was 2 (one per file), not 4, and the coredns KSV-0011 was already
-  # gone (#3259 closed). Measured on 2026-08-21 with trivy v0.74.0.
+  # The repository scan is at zero and REPOSITORY_TRIVY is a hard gate. Reproduce that claim from
+  # the repository root with scripts/megalinter-scan-counts.sh --trivy-only; the helper keeps the
+  # ignore paths and config-data root aligned with CI.
   #
   # ⚠️ MEASURE FROM THE REPOSITORY ROOT. Scanning k8s/ directly makes trivy report targets relative
   # to it, so this file's k8s/-prefixed ignore paths stop matching and already-dispositioned
@@ -247,7 +242,7 @@ DISABLE_ERRORS_LINTERS:
   # Both vault-backup workloads run the pod and mirror container at UID 65532. The snapshot
   # container overrides that default with the OpenBao image's baked UID 100, from the same pinned
   # digest vault-config reads. Snapshots are widened to 0640, so the high-UID mirror reads them
-  # through the shared primary GID 1000 instead of by owning the file.
+  # through supplementary group 1000 from fsGroup instead of by owning the file.
   #
   # UID 100 is not remapped: the openbao namespace carries no
   # `pod-security.devantler.tech/user-namespaces: enabled` label, so the add-user-namespaces rule
@@ -327,7 +322,6 @@ DISABLE_ERRORS_LINTERS:
   # because merged work and scanner rule-set changes both move them. Re-run the script and correct
   # these figures as part of any slice, rather than reading a stale figure as the current state.
   # #2853 tracks making that drift detectable rather than something a slice has to notice.
-  - REPOSITORY_TRIVY
   # jscpd (17): all in test files — scripts/validate-eks-ci-role-policy/main_test.go (#2777) and
   # two scripts/tests/*.py files that are themselves migration targets off Python (#2778).
   - COPYPASTE_JSCPD

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -567,15 +567,6 @@ misconfigurations:
   # entries rest on is NOT available here and is not borrowed. This stands on the image-defined
   # identity alone.
   #
-  # ⚠️ DELIBERATELY UID-ONLY. KSV-0021 stays live on both workloads and is NOT dispositioned here,
-  # because its premise is false today: the pod default runAsGroup is 1000, so the mirror container
-  # INHERITS a low GID chosen for openbao rather than taking a high default, and `minio/mc` bakes no
-  # such identity. vault-config can make that split because its shared paths are emptyDir, where
-  # fsGroup's setgid bit carries the group regardless of the writer's primary gid (#3258); the
-  # vault-backup snapshots live on a PVC, where a high primary GID plus explicit group-1000
-  # membership has not been established — #3281 assumed the emptyDir premise transferred and was
-  # withdrawn. The remaining 4 KSV-0021 findings therefore stay reported under #2787 rather than
-  # being covered by a premise that does not hold.
   - id: KSV-0020
     paths:
       - k8s/bases/infrastructure/vault-backup/job.yaml
@@ -590,8 +581,33 @@ misconfigurations:
       pod default is 65532 and the minio/mc mirror container takes that high default. Because trivy
       scopes by path rather than by resource,
       scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh asserts that per container so
-      this entry cannot silently cover a future low-UID container. KSV-0021 is deliberately not
-      dispositioned on these workloads.
+      this entry cannot silently cover a future low-UID container.
+
+  # KSV-0021 "runs with GID <= 10000" on the vault-backup Job and CronJob — one finding per file.
+  #
+  # Only the openbao `snapshot` container keeps primary GID 1000, the group defined by the same
+  # digest-pinned image whose UID disposition is recorded above. The pod default primary GID is the
+  # high 65532, so the minio/mc mirror does not inherit an identity chosen for openbao. It can still
+  # read each 0640 snapshot because fsGroup 1000 adds that group to every container as a
+  # supplementary group; process membership is independent of the PVC's setgid behavior.
+  #
+  # The ignorefile is path-scoped rather than container-scoped, so the paired boundary test asserts
+  # that exactly the snapshot container has a low effective primary GID, that it still uses the
+  # measured openbao digest, that the mirror inherits the high pod default, and that fsGroup 1000
+  # remains present. Identical bytes copied to an unlisted probe path must continue to report.
+  - id: KSV-0021
+    paths:
+      - k8s/bases/infrastructure/vault-backup/job.yaml
+      - k8s/bases/infrastructure/vault-backup/cron-job.yaml
+    statement: >-
+      Primary GID 1000 is the group the digest-pinned openbao image defines for its snapshot
+      container: /etc/passwd carries openbao:x:100:1000 and /etc/group carries openbao:x:1000.
+      The pod default is 65532:65532, so the minio/mc mirror keeps a high primary GID and receives
+      group 1000 only as supplementary membership through fsGroup. That membership lets it read the
+      snapshot container's explicitly group-readable 0640 files without sharing the low primary GID
+      or depending on a PVC setgid bit. Because this path-scoped entry could otherwise hide another
+      low-GID container, scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh asserts the
+      image, effective GID, high pod default, fsGroup, and an unsuppressed identical-path control.
 
   # KSV-0021 "runs with GID <= 10000" on the vault-config Job — 2 findings, both LOW.
   #

--- a/k8s/bases/infrastructure/vault-backup/cron-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cron-job.yaml
@@ -35,11 +35,11 @@ metadata:
     # its own and mounts /snapshots readOnly — takes that rather than a UID
     # chosen for openbao.
     #
-    # The mirror still reads the snapshot because it shares the primary GROUP,
-    # not the owner: runAsGroup/fsGroup 1000 apply to every container, and the
-    # snapshot script chmods the file 0640 after `bao operator raft snapshot
-    # save` writes it. Access therefore rests on group membership, which is a
-    # pod-level property, rather than on the volume's setgid bit.
+    # The mirror still reads the snapshot through supplementary group 1000:
+    # fsGroup adds that group to every container, while only the openbao
+    # snapshot container selects its image-defined primary GID 1000. The
+    # snapshot script chmods the file 0640 after writing it. Access therefore
+    # does not depend on a low pod-wide primary GID or the volume's setgid bit.
     #
     # UID 100 is not remapped. The openbao namespace carries no
     # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
@@ -82,7 +82,7 @@ spec:
           # even when created before the webhook is active on fresh bring-up.
           securityContext:
             runAsUser: 65532
-            runAsGroup: 1000
+            runAsGroup: 65532
             fsGroup: 1000
             runAsNonRoot: true
             seccompProfile:
@@ -106,8 +106,8 @@ spec:
               securityContext:
                 # UID 100 is the openbao image's own baked identity (`openbao:x:100:1000`
                 # in its /etc/passwd) — see the checkov.io/skip2 rationale. Only this
-                # container overrides the pod's high default; the mirror takes 65532
-                # and reads the snapshot on the shared primary group 1000.
+                # container overrides the pod's high defaults; the mirror takes
+                # 65532:65532 and reads through fsGroup 1000 as a supplementary group.
                 runAsUser: 100
                 runAsGroup: 1000
                 allowPrivilegeEscalation: false
@@ -179,9 +179,9 @@ spec:
                   SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
                   echo "Saving raft snapshot to $SNAP..."
                   bao operator raft snapshot save "$SNAP"
-                  # The mirror opens the snapshot as GROUP: pod runAsGroup/fsGroup 1000
-                  # makes 1000 its primary group while it inherits the pod's high UID 65532.
-                  # The snapshot container alone uses the OpenBao image's UID 100. An explicit chmod,
+                  # The mirror opens the snapshot as GROUP: fsGroup 1000 gives it
+                  # supplementary membership while its primary identity stays 65532:65532.
+                  # The snapshot container alone uses OpenBao's image UID/GID 100:1000. An explicit chmod,
                   # NOT a umask: umask can only clear permission bits, so it cannot
                   # widen the 0600 `bao` creates the file with. The 0640 mode decouples
                   # mirror access from the image-defined owner UID.

--- a/k8s/bases/infrastructure/vault-backup/job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/job.yaml
@@ -37,11 +37,11 @@ metadata:
     # its own and mounts /snapshots readOnly — takes that rather than a UID
     # chosen for openbao.
     #
-    # The mirror still reads the snapshot because it shares the primary GROUP,
-    # not the owner: runAsGroup/fsGroup 1000 apply to every container, and the
-    # snapshot script chmods the file 0640 after `bao operator raft snapshot
-    # save` writes it. Access therefore rests on group membership, which is a
-    # pod-level property, rather than on the volume's setgid bit.
+    # The mirror still reads the snapshot through supplementary group 1000:
+    # fsGroup adds that group to every container, while only the openbao
+    # snapshot container selects its image-defined primary GID 1000. The
+    # snapshot script chmods the file 0640 after writing it. Access therefore
+    # does not depend on a low pod-wide primary GID or the volume's setgid bit.
     #
     # UID 100 is not remapped. The openbao namespace carries no
     # `pod-security.devantler.tech/user-namespaces: enabled` label, so the
@@ -80,7 +80,7 @@ spec:
       # even when created before the webhook is active on fresh bring-up.
       securityContext:
         runAsUser: 65532
-        runAsGroup: 1000
+        runAsGroup: 65532
         fsGroup: 1000
         runAsNonRoot: true
         seccompProfile:
@@ -104,8 +104,8 @@ spec:
           securityContext:
             # UID 100 is the openbao image's own baked identity (`openbao:x:100:1000`
             # in its /etc/passwd) — see the checkov.io/skip2 rationale. Only this
-            # container overrides the pod's high default; the mirror takes 65532
-            # and reads the snapshot on the shared primary group 1000.
+            # container overrides the pod's high defaults; the mirror takes
+            # 65532:65532 and reads through fsGroup 1000 as a supplementary group.
             runAsUser: 100
             runAsGroup: 1000
             allowPrivilegeEscalation: false
@@ -181,9 +181,9 @@ spec:
               SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
               echo "Saving initial raft snapshot to $SNAP..."
               bao operator raft snapshot save "$SNAP"
-              # The mirror opens the snapshot as GROUP: pod runAsGroup/fsGroup 1000
-              # makes 1000 its primary group while it inherits the pod's high UID 65532.
-              # The snapshot container alone uses the OpenBao image's UID 100. An explicit chmod,
+              # The mirror opens the snapshot as GROUP: fsGroup 1000 gives it
+              # supplementary membership while its primary identity stays 65532:65532.
+              # The snapshot container alone uses OpenBao's image UID/GID 100:1000. An explicit chmod,
               # NOT a umask: umask can only clear permission bits, so it cannot
               # widen the 0600 `bao` creates the file with. The 0640 mode decouples
               # mirror access from the image-defined owner UID.

--- a/scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh
+++ b/scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# The KSV-0020 disposition on the vault-backup Job and CronJob is PATH-scoped, and this test is what
-# keeps it honest.
+# The KSV-0020/KSV-0021 dispositions on the vault-backup Job and CronJob are PATH-scoped, and this
+# test is what keeps them honest.
 #
 # WHY THIS EXISTS
 # Each workload runs two containers. `snapshot` sets `runAsUser: 100`, which is the openbao image's
@@ -25,12 +25,10 @@
 # operator dispositions is NOT available here and is not borrowed. The disposition stands on the
 # image-defined identity alone — which is exactly why that identity is asserted rather than trusted.
 #
-# ⚠️ UID ONLY, DELIBERATELY. KSV-0021 is NOT dispositioned on these workloads: the pod default
-# runAsGroup is 1000, so the mirror INHERITS a low GID chosen for openbao instead of taking a high
-# default. vault-config can make that split because its shared paths are emptyDir, where fsGroup's
-# setgid bit carries the group whatever gid the writer runs as (#3258); these snapshots live on a
-# PVC, where that is not established — #3281 assumed it transferred and was withdrawn. This test
-# asserts that absence, so a later run cannot quietly borrow the UID premise for the GID half.
+# KSV-0021 rests on a separate, narrower premise: the pod default primary GID is high, while only
+# the openbao snapshot container selects the image-defined GID 1000. The mirror still receives
+# supplementary group 1000 from fsGroup, so it can read the snapshot's 0640 group entry without a
+# low primary GID. This is process membership and does not depend on a PVC setgid bit.
 #
 # Four layers, which fail for different reasons:
 #
@@ -38,10 +36,8 @@
 #   two workloads. Also reciprocal: any OTHER KSV-0020 path must be one of the reviewed sets, so
 #   this file and its sibling boundary tests cannot drift apart.
 #
-#   ABSENCE (always) — KSV-0021 is NOT scoped to either workload.
-#
-#   PREMISE (always) — per container: each pod default UID is high, and the only container below
-#   10000 is the openbao `snapshot` one. This is the layer the ignorefile cannot express.
+#   PREMISE (always) — per container: each pod default UID/GID is high, and the only container below
+#   10001 is the openbao `snapshot` one. This is the layer the ignorefile cannot express.
 #
 #   BEHAVIOUR (when trivy is installed) — the same workload bytes at the dispositioned path and at a
 #   probe path, scanned with and without the ignorefile. The ablation must fire, or the suppression
@@ -51,6 +47,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly REPO_ROOT
 readonly IGNOREFILE="$REPO_ROOT/.trivyignore.yaml"
+readonly MEGALINTER_CONFIG="$REPO_ROOT/.mega-linter.yml"
 readonly UID_CHECK_ID='KSV-0020'
 readonly GID_CHECK_ID='KSV-0021'
 readonly JOB_PATH='k8s/bases/infrastructure/vault-backup/job.yaml'
@@ -70,6 +67,7 @@ readonly EXPECTED_OPENBAO_IMAGE='quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca
 # precisely the boundary it exists to police.
 readonly LOW_ID_FLOOR=10001
 readonly EXPECTED_LOW_UID=100
+readonly EXPECTED_LOW_GID=1000
 readonly EXPECTED_LOW_CONTAINERS=1
 readonly EXPECTED_LOW_CONTAINER_NAME='snapshot'
 
@@ -103,6 +101,13 @@ for path in "${WORKLOAD_PATHS[@]}"; do
     printf 'workload not readable: %s\n' "$path" >&2
     exit 1
   }
+done
+
+for path in "${WORKLOAD_PATHS[@]}"; do
+  entries="$(yq "[.misconfigurations[] | select(.id == \"$GID_CHECK_ID\") | select((.paths // []) | contains([\"$path\"]))] | length" "$IGNOREFILE" 2>/dev/null || printf '0')"
+  entries="${entries:-0}"
+  [ "$entries" -ge 1 ] || fail \
+    "MISSING DISPOSITION: $GID_CHECK_ID has no entry scoped to $path in .trivyignore.yaml"
 done
 
 # Each enumeration below is CAPTURED and its status checked BEFORE its loop runs. A process
@@ -169,15 +174,38 @@ else
   query_failed "the path counts for $UID_CHECK_ID"
 fi
 
-# ------------------------------------------------------------------ absence --
-# The GID half is deliberately NOT dispositioned here. Asserting that keeps a later run from
-# borrowing the UID premise for a claim the PVC sharing model has not established (#3202, #3281).
-for path in "${WORKLOAD_PATHS[@]}"; do
-  gid_entries="$(yq "[.misconfigurations[] | select(.id == \"$GID_CHECK_ID\") | select((.paths // []) | contains([\"$path\"]))] | length" "$IGNOREFILE" 2>/dev/null || printf '1')"
-  gid_entries="${gid_entries:-1}"
-  [ "$gid_entries" -eq 0 ] || fail \
-    "UNJUSTIFIED WIDENING: $GID_CHECK_ID is now scoped to $path. The mirror container inherits GID 1000 from the pod and minio/mc bakes no such identity, so the image-defined premise that carries $UID_CHECK_ID does NOT carry this. Establish how the mirror reads the snapshots on the PVC first (#3202)."
-done
+# Reciprocal GID boundary: every path this check is scoped to must be guarded here or by a sibling.
+if paths_out="$(run_yq ".misconfigurations[] | select(.id == \"$GID_CHECK_ID\") | (.paths // [])[]" "$IGNOREFILE" "the paths $GID_CHECK_ID is scoped to")"; then
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    reviewed=0
+    for known in "${WORKLOAD_PATHS[@]}" "${REVIEWED_ELSEWHERE[@]}"; do
+      [ "$path" = "$known" ] && reviewed=1 && break
+    done
+    [ "$reviewed" -eq 1 ] || fail \
+      "UNREVIEWED DISPOSITION: $GID_CHECK_ID is scoped to $path, which no premises test guards"
+  done <<PATHS
+$paths_out
+PATHS
+else
+  query_failed "the paths $GID_CHECK_ID is scoped to"
+fi
+
+if lens_out="$(run_yq ".misconfigurations[] | select(.id == \"$GID_CHECK_ID\") | (.paths // []) | length" "$IGNOREFILE" "the path counts for $GID_CHECK_ID")"; then
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    [ "$n" -gt 0 ] || fail \
+      "UNSCOPED SKIP: an entry for $GID_CHECK_ID has no paths, which suppresses it on every workload"
+  done <<LENS
+$lens_out
+LENS
+else
+  query_failed "the path counts for $GID_CHECK_ID"
+fi
+
+disabled="$(yq '[.DISABLE_ERRORS_LINTERS[]? | select(. == "REPOSITORY_TRIVY")] | length' "$MEGALINTER_CONFIG" 2>/dev/null || printf '1')"
+[ "${disabled:-1}" -eq 0 ] || fail \
+  'GATE STILL SOFT: REPOSITORY_TRIVY remains in DISABLE_ERRORS_LINTERS'
 
 # ------------------------------------------------------------------ premise --
 for path in "${WORKLOAD_PATHS[@]}"; do
@@ -190,6 +218,23 @@ for path in "${WORKLOAD_PATHS[@]}"; do
   elif [ "$pod_uid" -lt "$LOW_ID_FLOOR" ]; then
     fail "PREMISE BROKEN: the pod default runAsUser in $path is $pod_uid, which KSV-0020 counts as low (<= 10000). The disposition states that only the openbao snapshot container runs low and that everything else takes a HIGH default."
   fi
+
+  if ! pod_gid="$(run_yq "$POD_SPEC.securityContext.runAsGroup // \"unset\"" "$REPO_ROOT/$path" "the pod-level runAsGroup of $path")"; then
+    query_failed "the pod-level runAsGroup of $path"
+    pod_gid="unset"
+  fi
+  if [ "$pod_gid" = "unset" ]; then
+    fail "PREMISE BROKEN: $path sets no pod-level runAsGroup, so containers without overrides inherit an unconstrained primary GID"
+  elif [ "$pod_gid" -lt "$LOW_ID_FLOOR" ]; then
+    fail "PREMISE BROKEN: the pod default runAsGroup in $path is $pod_gid, which KSV-0021 counts as low (<= 10000). Only the openbao snapshot container may use the image-defined low GID."
+  fi
+
+  if ! fs_group="$(run_yq "$POD_SPEC.securityContext.fsGroup // \"unset\"" "$REPO_ROOT/$path" "the fsGroup of $path")"; then
+    query_failed "the fsGroup of $path"
+    fs_group="unset"
+  fi
+  [ "$fs_group" = "$EXPECTED_LOW_GID" ] || fail \
+    "PREMISE BROKEN: fsGroup in $path is $fs_group, not $EXPECTED_LOW_GID; the high-GID mirror would lose supplementary access to 0640 snapshots"
 
   low=0
   if containers_out="$(run_yq "[$POD_SPEC.initContainers[]?, $POD_SPEC.containers[]?] | .[] | .name + \"|\" + .image + \"|\" + ((.securityContext.runAsUser // \"unset\")|tostring)" "$REPO_ROOT/$path" "the containers of $path")"; then
@@ -213,10 +258,31 @@ CONTAINERS
   else
     query_failed "the containers of $path"
   fi
+  low_gid=0
+  if containers_out="$(run_yq "[$POD_SPEC.initContainers[]?, $POD_SPEC.containers[]?] | .[] | .name + \"|\" + .image + \"|\" + ((.securityContext.runAsGroup // ($POD_SPEC.securityContext.runAsGroup // \"unset\"))|tostring)" "$REPO_ROOT/$path" "the effective container GIDs of $path")"; then
+    while IFS='|' read -r name image gid; do
+      [ -n "$name" ] || continue
+      [ "$gid" = "unset" ] && continue
+      [ "$gid" -ge "$LOW_ID_FLOOR" ] && continue
+      low_gid=$((low_gid + 1))
+      [ "$name" = "$EXPECTED_LOW_CONTAINER_NAME" ] || fail \
+        "PREMISE BROKEN: container '$name' in $path has low effective GID $gid; only '$EXPECTED_LOW_CONTAINER_NAME' is justified"
+      [ "$image" = "$EXPECTED_OPENBAO_IMAGE" ] || fail \
+        "PREMISE BROKEN: low-GID container '$name' in $path does not use the measured openbao image"
+      [ "$gid" -eq "$EXPECTED_LOW_GID" ] || fail \
+        "PREMISE BROKEN: openbao container '$name' in $path uses GID $gid, not image-defined $EXPECTED_LOW_GID"
+    done <<CONTAINERS
+$containers_out
+CONTAINERS
+    [ "$low_gid" -eq "$EXPECTED_LOW_CONTAINERS" ] || fail \
+      "PREMISE BROKEN: $low_gid container(s) in $path have a low effective primary GID; expected only the openbao snapshot container"
+  else
+    query_failed "the effective container GIDs of $path"
+  fi
 done
 
 [ "$status" -eq 0 ] || exit "$status"
-printf 'PASS(structure+absence+premise): %s is scoped to the two vault-backup workloads; %s is not.\n' \
+printf 'PASS(structure+premise+gate): %s and %s are path-scoped to the two vault-backup workloads and Trivy is blocking.\n' \
   "$UID_CHECK_ID" "$GID_CHECK_ID"
 
 # ---------------------------------------------------------------- behaviour --
@@ -269,6 +335,11 @@ for path in "${WORKLOAD_PATHS[@]}" "$PROBE_PATH"; do
     printf 'VACUOUS: without the ignorefile, %s does not fire at %s, so suppressing it below would prove nothing (a trivy rule change?).\n' "$UID_CHECK_ID" "$path" >&2
     exit 1
   }
+  gid_base="$(count_at "$WORK/no-ignore.json" "$path" "$GID_CHECK_ID")"
+  [ "$gid_base" -gt 0 ] || {
+    printf 'VACUOUS: without the ignorefile, %s does not fire at %s, so suppressing it below would prove nothing.\n' "$GID_CHECK_ID" "$path" >&2
+    exit 1
+  }
 done
 
 # --- With the ignorefile: the dispositioned paths are suppressed, the probe is NOT. ---
@@ -276,6 +347,11 @@ for path in "${WORKLOAD_PATHS[@]}"; do
   scoped="$(count_at "$WORK/with-ignore.json" "$path" "$UID_CHECK_ID")"
   [ "$scoped" -eq 0 ] || {
     printf 'the %s disposition does not cover %s (%s finding(s) still reported)\n' "$UID_CHECK_ID" "$path" "$scoped" >&2
+    exit 1
+  }
+  gid_scoped="$(count_at "$WORK/with-ignore.json" "$path" "$GID_CHECK_ID")"
+  [ "$gid_scoped" -eq 0 ] || {
+    printf 'the %s disposition does not cover %s (%s finding(s) still reported)\n' "$GID_CHECK_ID" "$path" "$gid_scoped" >&2
     exit 1
   }
 done
@@ -286,14 +362,10 @@ scoped_probe="$(count_at "$WORK/with-ignore.json" "$PROBE_PATH" "$UID_CHECK_ID")
   exit 1
 }
 
-# The GID half must still be REPORTED on these workloads — the absence layer above checks the
-# ignorefile, this checks what the scanner actually does with it.
-for path in "${WORKLOAD_PATHS[@]}"; do
-  gid_scoped="$(count_at "$WORK/with-ignore.json" "$path" "$GID_CHECK_ID")"
-  [ "$gid_scoped" -gt 0 ] || {
-    printf 'SUPPRESSED WITHOUT A PREMISE: %s no longer reports at %s. It is deliberately not dispositioned there (#3202) — if a fix made it genuinely clean, update this test and the ignorefile comment together.\n' "$GID_CHECK_ID" "$path" >&2
-    exit 1
-  }
-done
+gid_probe="$(count_at "$WORK/with-ignore.json" "$PROBE_PATH" "$GID_CHECK_ID")"
+[ "$gid_probe" -gt 0 ] || {
+  printf 'BOUNDARY BREACHED: identical bytes at the non-dispositioned path %s are also suppressed for %s.\n' "$PROBE_PATH" "$GID_CHECK_ID" >&2
+  exit 1
+}
 
-printf 'PASS(behaviour): %s is path-scoped and %s remains reported.\n' "$UID_CHECK_ID" "$GID_CHECK_ID"
+printf 'PASS(behaviour): %s and %s are path-scoped; identical probe bytes remain reported.\n' "$UID_CHECK_ID" "$GID_CHECK_ID"

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -72,11 +72,13 @@ readonly reviewed_workload_pairs=(
   'KSV-0021:k8s/bases/infrastructure/vault-config/job.yaml'
   # The same openbao image-baked uid 100, on the two vault-backup workloads that pin the identical
   # digest; guarded per container by
-  # scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh (#3202). KSV-0021 is
-  # deliberately NOT paired here — the mirror container inherits that gid rather than having it
-  # image-defined, so that half stays reported.
+  # scripts/tests/test-trivyignore-vault-backup-identity-boundary.sh (#3202, #2787). That guard now
+  # also proves the narrower GID premise: only snapshot uses the image-defined primary GID 1000;
+  # mirror keeps the high pod default and receives group 1000 only through fsGroup.
   'KSV-0020:k8s/bases/infrastructure/vault-backup/job.yaml'
   'KSV-0020:k8s/bases/infrastructure/vault-backup/cron-job.yaml'
+  'KSV-0021:k8s/bases/infrastructure/vault-backup/job.yaml'
+  'KSV-0021:k8s/bases/infrastructure/vault-backup/cron-job.yaml'
 )
 
 # THIRD reviewed category: an ADMISSION verdict — the suppressed field is not absent at runtime, it

--- a/scripts/tests/test-vault-snapshot-group-readable.sh
+++ b/scripts/tests/test-vault-snapshot-group-readable.sh
@@ -8,9 +8,10 @@
 # unprivileged 65532 and scope UID 100 to the one container whose image bakes it
 # (checkov CKV_K8S_40).
 #
-# Every container runs runAsGroup/fsGroup 1000, so a group-readable snapshot is
-# readable by the mirror on its GROUP entry alone — a pod-level property, which is
-# why this does not depend on the volume's setgid bit.
+# fsGroup 1000 gives every container supplementary group 1000. The snapshot container alone uses
+# the openbao image's primary GID 1000; the mirror keeps the pod's high primary GID and reads the
+# 0640 snapshot through that supplementary group. Process membership does not depend on the
+# volume's setgid bit.
 #
 # NOTE ON MECHANISM: this must be an explicit chmod, not a umask. umask can only
 # CLEAR permission bits, never add them — so if `bao` requests 0600 explicitly (the
@@ -154,10 +155,12 @@ for target in "${uid_targets[@]}"; do
   [ "${pod_uid}" -ge 10000 ] ||
     fail "${manifest}: pod runAsUser ${pod_uid} is a low host UID (CKV_K8S_40) — the writers are re-coupled"
 
-  # The mirror reads on THIS group. If either value moves, group access stops working and the only
-  # remaining path to the file is ownership, which is the coupling being removed.
-  [ "${pod_gid}" = "1000" ] ||
-    fail "${manifest}: pod runAsGroup is '${pod_gid}', not 1000 — the mirror loses its group entry"
+  case "${pod_gid}" in
+    '' | null) fail "${manifest}: the pod sets no runAsGroup" ;;
+    *[!0-9]*) fail "${manifest}: pod runAsGroup '${pod_gid}' is not numeric" ;;
+  esac
+  [ "${pod_gid}" -ge 10001 ] ||
+    fail "${manifest}: pod runAsGroup ${pod_gid} is a low host GID (KSV-0021) — the mirror should use fsGroup 1000 only as a supplementary group"
   [ "${pod_fsg}" = "1000" ] ||
     fail "${manifest}: pod fsGroup is '${pod_fsg}', not 1000 — the mirror loses its group entry"
 
@@ -177,7 +180,11 @@ for target in "${uid_targets[@]}"; do
   [ "${mirror_uid}" = "null" ] ||
     fail "${manifest}: the mirror pins runAsUser '${mirror_uid}' instead of taking the pod's high default"
 
-  printf 'ok: %s — pod %s:%s (fsGroup %s); UID 100 scoped to the snapshot container; mirror takes the default\n' \
+  mirror_gid="$(yq "${pod}.containers[]|select(.name==\"mirror\")|.securityContext.runAsGroup" "${path}")"
+  [ "${mirror_gid}" = "null" ] ||
+    fail "${manifest}: the mirror pins runAsGroup '${mirror_gid}' instead of taking the pod's high default and fsGroup supplementary membership"
+
+  printf 'ok: %s — pod %s:%s (fsGroup %s); image UID/GID scoped to snapshot; mirror takes high defaults plus fsGroup\n' \
     "${manifest}" "${pod_uid}" "${pod_gid}" "${pod_fsg}"
 done
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Closes #2787

## Why

The vault-backup pod gave every container primary GID 1000 solely because the OpenBao snapshot image defines that group. That left the unrelated mirror container on a low host identity and kept Trivy's Kubernetes checks non-blocking.

## What

- Move the pod default and mirror to primary identity `65532:65532` while retaining supplementary group 1000 for read-only snapshot access.
- Keep `100:1000` scoped to the digest-pinned OpenBao snapshot container whose image defines it.
- Narrowly disposition both image-defined identity findings with executable boundary controls, then make repository Trivy findings blocking.

## Security outcome

Before this change, a low pod-wide primary group was shared by two images and repository misconfiguration findings could not fail CI. After it, only the measured OpenBao container uses the low primary identity, an identical workload outside the two reviewed paths still fails, and any new Trivy finding blocks delivery.
