### PR TITLE
security(supply-chain): compute which publish-workflow revisions must stay trusted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,16 @@ jobs:
       - name: 🔐 Validate shared publish workflows are pinned
         run: ./scripts/guard-shared-publish-workflow-pin.sh
 
+      # The guard above proves every matcher pins A revision. It cannot say WHICH, and
+      # narrowing them to approved revisions (#2818) needs that fact for each consumer.
+      # This runs the hermetic half of the report that computes it: the network resolver
+      # is stubbed, so nothing here depends on another repository's release cadence.
+      - name: 🔐 Validate the publish-revision report
+        run: |
+          shellcheck scripts/report-publish-workflow-signing-revisions.sh
+          shellcheck scripts/tests/test-publish-workflow-signing-revisions.sh
+          bash scripts/tests/test-publish-workflow-signing-revisions.sh
+
       # Dropping a framework from the Kubescape gate REMOVES findings, so the
       # compliance score RISES and every check stays green — a coverage
       # regression that looks like an improvement. That is what un-gated 59

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -96,6 +96,20 @@ jobs:
       - name: 🔐 Validate shared publish workflows are pinned
         run: ./scripts/guard-shared-publish-workflow-pin.sh
 
+      # Which revision SIGNED what is deployed, against what each consumer pins now
+      # (#3048). Reported on main rather than gated on a PR: it reads five other
+      # repositories over the network, so a transient API failure here must never block
+      # an unrelated pull request. Its hermetic half runs in ci.yaml on every PR.
+      - name: 🔐 Report publish-workflow signing revisions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # `set -o pipefail` is load-bearing: Actions' default shell does not set it, so
+          # a bare pipe into `tee` would report TEE's status and a failed report would
+          # read as a passing step.
+          set -o pipefail
+          ./scripts/report-publish-workflow-signing-revisions.sh | tee -a "$GITHUB_STEP_SUMMARY"
+
   kubescape-baseline:
     name: 🛡️ Publish Kubescape Baseline
     runs-on: ubuntu-latest

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -645,18 +645,18 @@ deployed_tag() {
     # `2.0.0` also `2`), while `2.1.3` cannot be shortened at all.
     local partial_re="" p_major p_minor p_patch partial_hit
     case "$bare" in
-    *.*.*)
-      p_major="${bare%%.*}"
-      p_patch="${bare##*.}"
-      p_minor="${bare#*.}"
-      p_minor="${p_minor%%.*}"
-      if [ "$p_patch" = "0" ]; then
-        partial_re="${p_major}\\.${p_minor}"
-        if [ "$p_minor" = "0" ]; then
-          partial_re="${partial_re}|${p_major}"
+      *.*.*)
+        p_major="${bare%%.*}"
+        p_patch="${bare##*.}"
+        p_minor="${bare#*.}"
+        p_minor="${p_minor%%.*}"
+        if [ "$p_patch" = "0" ]; then
+          partial_re="${p_major}\\.${p_minor}"
+          if [ "$p_minor" = "0" ]; then
+            partial_re="${partial_re}|${p_major}"
+          fi
         fi
-      fi
-      ;;
+        ;;
     esac
     if [ -n "$partial_re" ]; then
       partial_hit="$(printf '%s\n' "$tags" | grep -E "^v?(${partial_re})$" | sort -u || true)"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -566,11 +566,17 @@ deployed_tag() {
   # to 2.5.0 and v2 to 2.0.0. A pattern requiring three components matched neither the strict
   # filter nor this one, so such a tag was dropped from BOTH sets: the walk stepped silently
   # to an older release and reported ITS signing revision, omitting the actual signer from
-  # the allow-list. Prereleases are here for the same reason -- Flux accepts v2.0.0-rc.1, and
-  # ordering it against a release is exactly the Flux-compatible precedence this script does
-  # not implement. Four-component tags and non-numeric ones stay out: Flux rejects them too
+  # the allow-list. Four-component tags and non-numeric ones stay out: Flux rejects them too
   # (measured), so they cannot be selected and refusing on them would be noise.
-  local loose_re='^v?[0-9]+(\.[0-9]+){0,2}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]*)?$'
+  #
+  # PRERELEASES stay out for the same reason, and the guarantee comes from this script:
+  # `effective_version` REFUSES any constraint carrying a prerelease bound by name, so every
+  # consumer that reaches this walk has a constraint with no prerelease comparator -- and
+  # Masterminds excludes prereleases from exactly those. A prerelease therefore cannot be
+  # selected no matter how it orders, so treating one as an unrankable ambiguity refused a
+  # consumer Flux resolves unambiguously: an `v2.0.0-rc.1` above the newest stable made every
+  # run red until the RC tag was deleted or a stable release was cut.
+  local loose_re='^v?[0-9]+(\.[0-9]+){0,2}(\+[0-9A-Za-z.-]*)?$'
   candidates="$(printf '%s\n' "$tags" | grep -E "$strict_re" |
     sed -e 's/^v//' -e 's/+.*$//' | sort -V -r -u || true)"
   [ -n "$candidates" ] || return 1
@@ -661,6 +667,27 @@ deployed_tag() {
         return 1
       fi
       if [ "$walk_pub" -eq 0 ]; then
+        # The early refusal above compares against the highest STRICT tag, which is not
+        # necessarily the one being reported: when that tag never published, the walk steps
+        # past it to an older release, and a loose tag sitting between the two was cleared
+        # by a comparison against a version nobody selects. Flux coerces such a tag -- `v2.5`
+        # resolves to 2.5.0 -- so it can be selected ahead of the release reported here, and
+        # the run would emit the wrong signing revision. Re-check the set against the version
+        # actually being returned, which is the only one the answer depends on.
+        if [ -n "$unrankable" ]; then
+          local late_bad late_core late_high
+          while IFS= read -r late_bad; do
+            [ -n "$late_bad" ] || continue
+            late_core="$(printf '%s' "$late_bad" | sed -e 's/^v//' -e 's/+.*$//')"
+            [ -n "$late_core" ] || continue
+            late_high="$(printf '%s\n%s\n' "$late_core" "$variants" | sort -V -r | head -1)"
+            if [ "$late_high" = "$late_core" ]; then
+              printf 'tag %s is not valid SemVer yet Flux would coerce it to rank at or above the reported release %s, so it may be the artifact Flux selected; choosing needs Flux-compatible ordering, which this script does not implement\n' \
+                "$late_bad" "$variants" >&2
+              return 1
+            fi
+          done <<<"$unrankable"
+        fi
         printf '%s\tinferred\n' "$candidate"
         return 0
       fi

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -337,7 +337,13 @@ effective_version() {
 # The `uses:` pin for one shared workflow, as it stands at one ref of one consumer.
 pin_at_ref() {
   local repo="$1" workflow="$2" ref="$3" body sha
-  body="$(gh_retry api "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml?ref=${ref}" \
+  # The ref goes through as a PARAMETER, exactly as the runs lookup does. A selected
+  # tag may carry SemVer build metadata (v2.0.0+build.1), and a raw + in a query string
+  # is decoded as a SPACE on the wire -- measured with GH_DEBUG=api: interpolation sends
+  # `+`, --raw-field sends `%2B`. The workflow body then fails to load and a healthy
+  # consumer reports UNRESOLVED.
+  body="$(gh_retry api --method GET "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml" \
+    --raw-field "ref=${ref}" \
     -H "Accept: application/vnd.github.raw")" || return 1
   [ -n "$body" ] || return 1
   # 🔴 PARSE THE YAML, NOT THE TEXT. An unanchored `grep … | head -1` selects a COMMENTED-OUT
@@ -466,9 +472,35 @@ deployed_tag() {
     [ "$checked" -le 5 ] || break
     # Every tag standing at this SemVer precedence. Build metadata is IGNORED for
     # precedence, so `2.0.0` and `2.0.0+build.1` rank equally and the set can hold more
-    # than one tag; the `v` spellings fold together because they are the same version
-    # written two ways, which is not ambiguity.
+    # than one tag. The `v` spellings are folded for PRECEDENCE, but folding them for
+    # IDENTITY would hide a real ambiguity -- see the duality refusal immediately below.
     core_re="$(printf '%s' "$bare" | sed 's/[.]/\\./g')"
+    # BOTH SPELLINGS OF ONE VERSION ARE TWO DISTINCT GIT REFS. Stripping the `v` before
+    # `sort -u` folds `1.2.3` and `v1.2.3` into one variant, so the tie check below sees
+    # no ambiguity -- but the two refs can point at different commits and therefore at
+    # different publish-workflow pins, and the loop that follows unconditionally prefers
+    # the `v` form. That reports the `v` ref's signing revision even when the other ref
+    # produced the deployed artifact: a confident wrong answer, which is exactly what the
+    # tie refusal exists to prevent one line down.
+    #
+    # The fold is only safe when one spelling is published. When both are, refuse by name
+    # like every other ambiguity here rather than picking the one this repository happens
+    # to favour.
+    local raw_variants dual=""
+    raw_variants="$(printf '%s\n' "$tags" | grep -E "^v?${core_re}(\+[0-9A-Za-z.-]+)?$" | sort -u || true)"
+    while IFS= read -r stripped; do
+      [ -n "$stripped" ] || continue
+      if printf '%s\n' "$raw_variants" | grep -qxF -- "$stripped" &&
+        printf '%s\n' "$raw_variants" | grep -qxF -- "v${stripped}"; then
+        dual="$stripped"
+        break
+      fi
+    done <<<"$(printf '%s\n' "$raw_variants" | sed 's/^v//' | sort -u)"
+    if [ -n "$dual" ]; then
+      printf 'version %s is published as BOTH "%s" and "v%s"; those are distinct git refs that can point at different commits and therefore different workflow pins, so choosing between them needs Flux-compatible ordering, which this script does not implement\n' \
+        "$bare" "$dual" "$dual" >&2
+      return 1
+    fi
     variants="$(printf '%s\n' "$tags" | grep -E "^v?${core_re}(\+[0-9A-Za-z.-]+)?$" |
       sed 's/^v//' | sort -u || true)"
     variant_count="$(printf '%s\n' "$variants" | grep -c . || true)"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -253,6 +253,21 @@ effective_version() {
             "$expr" >&2
           return 1
           ;;
+        # A lower bound carrying a PRERELEASE component. A range whose bound has none
+        # excludes prerelease versions, but one that carries a bound like `>=1.0.0-0`
+        # ADMITS them, so Flux can select `2.0.0-rc.1`. The tag walk below orders only
+        # release versions, and `sort -V` is not SemVer precedence for a prerelease
+        # anyway, so treating this as unbounded would walk back to an older stable tag
+        # and attribute ITS workflow revision to the deployed artifact.
+        #
+        # It is not caught by the compound-range class above, and cannot be: every
+        # character in `>=1.0.0-0` is one a single lower bound may legitimately contain,
+        # and it begins exactly like the unbounded `>=1.0.0` that IS allowed.
+        *-*)
+          printf 'prerelease semver constraint "%s" needs Flux-compatible prerelease selection, which this script does not implement\n' \
+            "$expr" >&2
+          return 1
+          ;;
         '>'[0-9]* | '>='[0-9]*)
           printf '%s\n' ''
           return 0
@@ -369,15 +384,44 @@ deployed_tag() {
   # deployed artifact was ever signed by. Bounded, because a consumer whose last several
   # releases all failed is a different problem and should surface as UNRESOLVED rather than
   # send this walking back through its whole history.
+  #
+  # BUILD METADATA is part of a valid release tag and SemVer says it is IGNORED when
+  # determining precedence, so `2.0.0` and `2.0.0+build.1` rank EQUALLY and there is no
+  # defined answer to which one a selector picks. Matching only the bare form would
+  # silently discard `2.0.0+build.1` and walk back to an older release, attributing that
+  # release's workflow revision to the deployed artifact. Both forms are therefore
+  # candidates, keyed on the core version they share, and a core version carrying more
+  # than one distinct tag REFUSES — the same reasoning as the bounded-range refusal:
+  # picking one of two equally-ranked tags is a guess, and a guess here is the confident
+  # wrong answer this report must never produce.
   local candidates checked=0
-  candidates="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' |
-    sed 's/^v//' | sort -V -r || true)"
+  candidates="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]+)?$' |
+    sed -e 's/^v//' -e 's/+.*$//' | sort -V -r -u || true)"
   [ -n "$candidates" ] || return 1
+  local core_re variants variant_count candidate
   while IFS= read -r bare; do
     [ -n "$bare" ] || continue
     checked=$((checked + 1))
     [ "$checked" -le 5 ] || break
-    for candidate in "v${bare}" "$bare"; do
+    # Every tag standing at this SemVer precedence. Build metadata is IGNORED for
+    # precedence, so `2.0.0` and `2.0.0+build.1` rank equally and the set can hold more
+    # than one tag; the `v` spellings fold together because they are the same version
+    # written two ways, which is not ambiguity.
+    core_re="$(printf '%s' "$bare" | sed 's/[.]/\\./g')"
+    variants="$(printf '%s\n' "$tags" | grep -E "^v?${core_re}(\+[0-9A-Za-z.-]+)?$" |
+      sed 's/^v//' | sort -u || true)"
+    variant_count="$(printf '%s\n' "$variants" | grep -c . || true)"
+    if [ "$variant_count" -gt 1 ]; then
+      printf 'version %s is carried by more than one tag (%s); build metadata ties their SemVer precedence, so choosing between them needs Flux-compatible ordering, which this script does not implement\n' \
+        "$bare" "$(printf '%s\n' "$variants" | tr '\n' ' ')" >&2
+      return 1
+    fi
+    # The real tag comes from the tag list, never from reconstructing `bare`: a version
+    # published only as `2.0.0+build.1` has no bare spelling to rebuild, so rebuilding
+    # would find nothing, walk silently back to an older release, and attribute THAT
+    # release's workflow revision to the deployed artifact. The `v` form is preferred
+    # only because these repositories use it.
+    for candidate in "v${variants}" "$variants"; do
       printf '%s\n' "$tags" | grep -qxF -- "$candidate" || continue
       plausible_ref "$candidate" || continue
       if tag_was_published "$repo" "$candidate"; then

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Compute, per consumer, WHICH revision of a shared devantler-tech/actions publish
+# workflow signed the artifact that is currently deployed, and which revision that
+# consumer pins today.
+#
+# WHY THIS EXISTS (#3048, under #2818)
+# `guard-shared-publish-workflow-pin.sh` proves every cosign matcher pins a FIXED
+# revision. It says nothing about WHICH revision, and it says so itself: a superseded
+# actions SHA still matches `[0-9a-f]{40}`. Narrowing those matchers to approved
+# revisions is the open half, and it needs one fact nothing computes today — the
+# relationship between "what signed what is running" and "what we pin now".
+#
+# That relationship is not decorative. Measured on #2818, five artifacts were signed by
+# five different revisions, and TWO of them were signed by a revision their consumer no
+# longer pins. An allow-list generated from current pins alone would therefore have
+# stopped verifying two artifacts that are deployed right now — and the failure mode is
+# an OCIRepository that quietly stops reconciling while every check in CI stays green.
+#
+# So this REPORTS; it does not gate. Divergence is the expected state today, and a check
+# that failed on it would fail on the known-good configuration on its first run — which
+# is how a control gets switched off, taking its real coverage with it. What it DOES
+# fail on is not being able to see: a consumer that went missing from discovery, or a
+# revision it could not resolve. Those are the states in which a silent "no divergence"
+# would be a lie.
+#
+# WHAT IT DOES NOT DO
+# Narrowing any matcher, generating one, and deciding how long a superseded revision
+# stays accepted all stay on #2818, and should be designed against this output.
+#
+# THE RESOLVER IS A SEAM, ON PURPOSE
+# Resolving a revision needs the network. Tests inject PUBLISH_REVISION_RESOLVER so the
+# comparison logic is provable without it. Discovery is deliberately NOT injectable in
+# the same way: it reads this repository's real manifests, because a stub there could
+# hide exactly the regression the floor below exists to catch.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+
+# Matches the subject spelling `guard-shared-publish-workflow-pin.sh` validates. Kept
+# textually parallel to that guard: if one moves, the other should be looked at.
+readonly SUBJECT_PATTERN='(subject|subjectRegex|subjectRegExp):[[:space:]]*.?\^?https://github\\?\.com/devantler-tech/actions/\\?\.github/workflows/publish-(app|manifests)\\?\.yaml@'
+
+# A floor, because an empty result from a filtered read is a claim about the FILTER.
+# Five consumer OCIRepositories carry these matchers (wedding-app, ascoachingogvaner,
+# doggy-countdown, github-config/.github, aws). The other three matches are generic —
+# the tenant ResourceGraphDefinition template, the Kyverno image policy and the Talos
+# image config — and name no single consumer, so they are not counted here.
+# Raise this when a consumer is genuinely added.
+readonly EXPECTED_MIN_CONSUMERS=5
+
+fail() {
+  printf 'report-publish-workflow-signing-revisions: %s\n' "$*" >&2
+  exit 1
+}
+
+# The OCI artifact name is USUALLY the source repository's name, but it is not the same
+# thing, and one consumer proves it: `.github` has a leading dot, which is an invalid OCI
+# path component, so that repository publishes its artifact as `github-config`
+# (documented in k8s/bases/apps/github-config/oci-repository.yaml). Deriving the repo
+# from the URL alone therefore resolves a repository that does not exist, and the run
+# would report "could not resolve" for a consumer that is perfectly healthy.
+#
+# This mapping is deliberately an explicit, reviewed table rather than a guess: a name
+# that needs translating is a decision someone should make on purpose, and an entry
+# added here is visible in review. An unmapped name is passed through unchanged, so
+# adding a consumer needs no edit unless its artifact name genuinely differs.
+oci_name_to_repo() {
+  case "$1" in
+  github-config) printf '%s\n' '.github' ;;
+  *) printf '%s\n' "$1" ;;
+  esac
+}
+
+# 🔴 `gh api` WRITES ITS ERROR BODY TO STDOUT, so `2>/dev/null || true` does not make a
+# failed call empty — it makes it a JSON blob that every downstream `[ -n ... ]` test
+# reads as a perfectly good answer. That is how an earlier revision of this script
+# reported healthy consumers as UNRESOLVED: a 404 body became the "tag", and the pin
+# lookup then ran against a ref named `{"message":"Not Found",...}`.
+#
+# The failure was silent and self-consistent, which is the dangerous shape: nothing
+# errored, and the report simply attributed the wrong state to a repository that was
+# fine. So exit status is checked directly, and every ref is shape-checked before use —
+# a ref cannot contain whitespace or a brace, which is enough to reject an error body
+# without pretending to validate git's full ref grammar.
+plausible_ref() {
+  local ref="$1"
+  [ -n "$ref" ] || return 1
+  case "$ref" in
+  *[[:space:]]* | *'{'* | *'}'* | *'"'*) return 1 ;;
+  esac
+  return 0
+}
+
+# Print "<repo>\t<workflow>\t<deployed-version-or-empty>" for every consumer whose
+# artifact is verified by a shared publish-workflow matcher.
+#
+# The consumer repository is derived from the OCIRepository's own `spec.url`, never from
+# the file path — a path is a naming convention, and a renamed directory would silently
+# change which repository a revision is attributed to.
+#
+# The deployed version comes from `spec.ref.tag` where the OCIRepository pins one. That
+# is the single most load-bearing field here: it names the artifact the cluster is
+# ACTUALLY running, which is the whole question. Where the consumer uses a semver RANGE
+# instead, no fixed version exists in the manifest and the resolver falls back to the
+# newest published version tag.
+discover_consumers() {
+  local root="$1" file url repo workflow version
+  [ -d "$root" ] || return 0
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    # Only a real OCIRepository names a consumer. The RGD template, the Kyverno policy
+    # and the Talos config match the subject pattern too but describe no single repo.
+    url="$(yq eval -r 'select(.kind == "OCIRepository") | .spec.url // ""' "$file" 2>/dev/null | grep -m1 . || true)"
+    [ -n "$url" ] || continue
+    case "$url" in
+    oci://ghcr.io/devantler-tech/*) ;;
+    *) continue ;;
+    esac
+    repo="${url#oci://ghcr.io/devantler-tech/}"
+    repo="${repo%%/*}"
+    [ -n "$repo" ] || continue
+    repo="$(oci_name_to_repo "$repo")"
+    workflow="$(grep -oE 'publish-(app|manifests)' "$file" | head -1 || true)"
+    [ -n "$workflow" ] || continue
+    version="$(yq eval -r 'select(.kind == "OCIRepository") | .spec.ref.tag // ""' "$file" 2>/dev/null | grep -m1 . || true)"
+    printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
+  done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
+}
+
+# The `uses:` pin for one shared workflow, as it stands at one ref of one consumer.
+pin_at_ref() {
+  local repo="$1" workflow="$2" ref="$3" body sha
+  body="$(gh api "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml?ref=${ref}" \
+    -H "Accept: application/vnd.github.raw" 2>/dev/null)" || return 1
+  [ -n "$body" ] || return 1
+  sha="$(printf '%s\n' "$body" |
+    grep -oE "devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}" |
+    head -1 || true)"
+  [ -n "$sha" ] || return 1
+  printf '%s\n' "${sha##*@}"
+}
+
+# The tag that produced the DEPLOYED artifact.
+#
+# 🔴 A GitHub RELEASE is the obvious source for this and it is the WRONG one. Releases
+# and the artifact stream are different surfaces that can drift apart without anything
+# breaking: `.github` last cut a Release (`v1.4.2`) in June 2026, while the artifact its
+# OCIRepository is running today is `1.23.0` — a tag with no Release object at all. An
+# earlier revision of this script resolved that consumer at `v1.4.2` and reported it
+# against a `cd.yaml` that predated an entire workflow migration, producing a confident
+# answer about a revision nobody is running. `aws` fails the same way from the other
+# direction: it publishes from tags and cuts no Releases, so `releases/latest` 404s.
+#
+# So the tag stream is authoritative and Releases are not consulted at all. Where the
+# OCIRepository pins an exact version, that version IS the deployed artifact and is used
+# directly; a semver range names no single version, so the newest published tag is the
+# closest honest answer. `sort -V` rather than the API's order, because the tags endpoint
+# promises no version ordering and the wrong tag here attributes a signature to the wrong
+# revision — a quietly incorrect answer, which is worse than none.
+deployed_tag() {
+  local repo="$1" version="$2" tags
+  tags="$(gh api "repos/devantler-tech/${repo}/tags?per_page=100" --jq '.[].name' 2>/dev/null)" || return 1
+  if [ -n "$version" ]; then
+    # The manifest's version may or may not carry the `v` the tag uses.
+    local candidate
+    for candidate in "$version" "v${version}"; do
+      if printf '%s\n' "$tags" | grep -qxF "$candidate"; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done
+    return 1
+  fi
+  local newest
+  newest="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)"
+  plausible_ref "$newest" || return 1
+  printf '%s\n' "$newest"
+}
+
+# Default resolver: "<signing revision>\t<current pin>".
+default_resolver() {
+  local repo="$1" workflow="$2" version="${3:-}" branch tag signing current
+  branch="$(gh api "repos/devantler-tech/${repo}" --jq .default_branch 2>/dev/null)" || return 1
+  plausible_ref "$branch" || return 1
+  tag="$(deployed_tag "$repo" "$version")" || return 1
+  current="$(pin_at_ref "$repo" "$workflow" "$branch")" || return 1
+  signing="$(pin_at_ref "$repo" "$workflow" "$tag")" || return 1
+  printf '%s\t%s\n' "$signing" "$current"
+}
+
+main() {
+  local root="${PUBLISH_CONSUMER_ROOT:-$REPO_ROOT}"
+  local consumers count
+  consumers="$(discover_consumers "$root")"
+  count="$(printf '%s' "$consumers" | grep -c . || true)"
+
+  if [ "${1:-}" = "--list-consumers" ]; then
+    [ "$count" -ge "$EXPECTED_MIN_CONSUMERS" ] ||
+      fail "discovered ${count} consumer(s), expected at least ${EXPECTED_MIN_CONSUMERS}"
+    printf '%s\n' "$consumers"
+    return 0
+  fi
+
+  # Fail closed on a shrunken discovery. Without this the loop below would iterate zero
+  # times and the report would read "no divergence" over a repository it never looked at.
+  if [ "$count" -lt "$EXPECTED_MIN_CONSUMERS" ]; then
+    printf 'discovered %d consumer(s), expected at least %d.\n' \
+      "$count" "$EXPECTED_MIN_CONSUMERS" >&2
+    printf 'The scan, not the repository, is the likely cause: these OCIRepositories may have\n' >&2
+    printf 'moved, been renamed, or adopted a subject spelling this pattern does not match.\n' >&2
+    printf 'Verify by hand, then fix the pattern or lower EXPECTED_MIN_CONSUMERS with the reason.\n' >&2
+    exit 1
+  fi
+
+  local resolver="${PUBLISH_REVISION_RESOLVER:-}"
+  local repo workflow version answer signing current diverged=0 unresolved=""
+
+  printf 'Shared publish-workflow revisions, per consumer (#3048)\n'
+  printf '%s\n' '-------------------------------------------------------'
+
+  while IFS=$'\t' read -r repo workflow version; do
+    [ -n "$repo" ] || continue
+    if [ -n "$resolver" ]; then
+      answer="$("$resolver" "$repo" "$workflow" "$version" 2>/dev/null || true)"
+    else
+      answer="$(default_resolver "$repo" "$workflow" "$version" || true)"
+    fi
+    signing="$(printf '%s' "$answer" | cut -f1)"
+    current="$(printf '%s' "$answer" | cut -f2)"
+    if [ -z "$signing" ] || [ -z "$current" ]; then
+      # An unresolvable consumer is NOT "no divergence". Collect it and fail at the end,
+      # so one lookup failure does not hide the consumers that did resolve.
+      unresolved="${unresolved}  ${repo} (${workflow})
+"
+      printf 'UNRESOLVED %-22s %-18s could not resolve both revisions\n' "$repo" "$workflow"
+      continue
+    fi
+    if [ "$signing" = "$current" ]; then
+      printf 'IN-SYNC    %-22s %-18s signed=%s pinned=%s\n' \
+        "$repo" "$workflow" "$signing" "$current"
+      printf '           allow-list must accept: %s\n' "$signing"
+    else
+      diverged=$((diverged + 1))
+      printf 'DIVERGED   %-22s %-18s signed=%s pinned=%s\n' \
+        "$repo" "$workflow" "$signing" "$current"
+      # AC4: an allow-list narrowed to the current pin alone would stop verifying the
+      # deployed artifact. Naming BOTH is the actionable output of this whole script.
+      printf '           allow-list must accept: %s AND %s\n' "$signing" "$current"
+    fi
+  done <<<"$consumers"
+
+  printf '%s\n' '-------------------------------------------------------'
+  printf '%d consumer(s) examined, %d diverged.\n' "$count" "$diverged"
+
+  if [ -n "$unresolved" ]; then
+    printf '\nCould not resolve both revisions for:\n%s' "$unresolved" >&2
+    printf 'A consumer whose revisions cannot be read is not evidence of agreement, so this\n' >&2
+    printf 'run fails rather than reporting a clean portfolio it could not see.\n' >&2
+    exit 1
+  fi
+
+  if [ "$diverged" -gt 0 ]; then
+    printf '\nDivergence is REPORTED, not failed: an allow-list on #2818 must accept both\n'
+    printf 'revisions for each diverged consumer, or it will stop verifying a deployed artifact.\n'
+  fi
+}
+
+main "$@"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -5,33 +5,25 @@
 #
 # WHY THIS EXISTS (#3048, under #2818)
 # `guard-shared-publish-workflow-pin.sh` proves every cosign matcher pins a FIXED
-# revision. It says nothing about WHICH revision, and it says so itself: a superseded
-# actions SHA still matches `[0-9a-f]{40}`. Narrowing those matchers to approved
-# revisions is the open half, and it needs one fact nothing computes today — the
-# relationship between "what signed what is running" and "what we pin now".
+# revision. It says nothing about WHICH, and it says so itself: a superseded actions SHA
+# still matches `[0-9a-f]{40}`. Narrowing those matchers to approved revisions is the open
+# half, and it needs the one fact nothing computed — the relationship between "what signed
+# what is running" and "what we pin now".
 #
-# That relationship is not decorative. Measured on #2818, five artifacts were signed by
-# five different revisions, and TWO of them were signed by a revision their consumer no
-# longer pins. An allow-list generated from current pins alone would therefore have
-# stopped verifying two artifacts that are deployed right now — and the failure mode is
-# an OCIRepository that quietly stops reconciling while every check in CI stays green.
+# Measured on #2818, five artifacts were signed by five different revisions and TWO were
+# signed by a revision their consumer no longer pins. An allow-list generated from current
+# pins alone would therefore have stopped verifying two artifacts that are deployed right
+# now, and the failure mode is an OCIRepository that quietly stops reconciling while every
+# check in CI stays green.
 #
 # So this REPORTS; it does not gate. Divergence is the expected state today, and a check
-# that failed on it would fail on the known-good configuration on its first run — which
-# is how a control gets switched off, taking its real coverage with it. What it DOES
-# fail on is not being able to see: a consumer that went missing from discovery, or a
-# revision it could not resolve. Those are the states in which a silent "no divergence"
-# would be a lie.
+# that failed on it would fail on the known-good configuration on its first run — which is
+# how a control gets switched off, taking its real coverage with it. What it DOES fail on
+# is not being able to SEE.
 #
-# WHAT IT DOES NOT DO
-# Narrowing any matcher, generating one, and deciding how long a superseded revision
-# stays accepted all stay on #2818, and should be designed against this output.
-#
-# THE RESOLVER IS A SEAM, ON PURPOSE
-# Resolving a revision needs the network. Tests inject PUBLISH_REVISION_RESOLVER so the
-# comparison logic is provable without it. Discovery is deliberately NOT injectable in
-# the same way: it reads this repository's real manifests, because a stub there could
-# hide exactly the regression the floor below exists to catch.
+# EVERY FAILURE MODE HERE IS "REPORTS CLEAN WHILE HAVING CHECKED NOTHING"
+# That is the only way this script can do harm, so each guard below exists against one
+# measured instance of it. They are noted where they sit rather than listed here.
 
 set -euo pipefail
 
@@ -42,13 +34,19 @@ readonly REPO_ROOT
 # textually parallel to that guard: if one moves, the other should be looked at.
 readonly SUBJECT_PATTERN='(subject|subjectRegex|subjectRegExp):[[:space:]]*.?\^?https://github\\?\.com/devantler-tech/actions/\\?\.github/workflows/publish-(app|manifests)\\?\.yaml@'
 
-# A floor, because an empty result from a filtered read is a claim about the FILTER.
-# Five consumer OCIRepositories carry these matchers (wedding-app, ascoachingogvaner,
-# doggy-countdown, github-config/.github, aws). The other three matches are generic —
-# the tenant ResourceGraphDefinition template, the Kyverno image policy and the Talos
-# image config — and name no single consumer, so they are not counted here.
-# Raise this when a consumer is genuinely added.
-readonly EXPECTED_MIN_CONSUMERS=5
+# 🔴 AN IDENTITY FLOOR, NOT A COUNT. A count answers "did I find five things?", which is
+# not the question — "did I find THESE five?" is. With a bare count, one consumer moving
+# out of the pattern while any other file moves in leaves the total at five, the floor
+# passes, and the vanished consumer's revision is never checked. Verified by deleting
+# wedding-app's manifest and adding an unrelated matching file: five consumers reported,
+# exit 0, wedding-app silently absent. Add a name here when a consumer is genuinely added.
+readonly EXPECTED_CONSUMERS=(
+  '.github'
+  'ascoachingogvaner'
+  'aws'
+  'doggy-countdown'
+  'wedding-app'
+)
 
 fail() {
   printf 'report-publish-workflow-signing-revisions: %s\n' "$*" >&2
@@ -57,15 +55,13 @@ fail() {
 
 # The OCI artifact name is USUALLY the source repository's name, but it is not the same
 # thing, and one consumer proves it: `.github` has a leading dot, which is an invalid OCI
-# path component, so that repository publishes its artifact as `github-config`
-# (documented in k8s/bases/apps/github-config/oci-repository.yaml). Deriving the repo
-# from the URL alone therefore resolves a repository that does not exist, and the run
-# would report "could not resolve" for a consumer that is perfectly healthy.
+# path component, so that repository publishes its artifact as `github-config` (documented
+# in k8s/bases/apps/github-config/oci-repository.yaml). Deriving the repo from the URL
+# alone therefore names a repository that does not exist, and every lookup for a perfectly
+# healthy consumer fails.
 #
-# This mapping is deliberately an explicit, reviewed table rather than a guess: a name
-# that needs translating is a decision someone should make on purpose, and an entry
-# added here is visible in review. An unmapped name is passed through unchanged, so
-# adding a consumer needs no edit unless its artifact name genuinely differs.
+# An explicit reviewed table rather than a guess: a name that needs translating is a
+# decision someone should make on purpose. An unmapped name passes through unchanged.
 oci_name_to_repo() {
   case "$1" in
     github-config) printf '%s\n' '.github' ;;
@@ -74,16 +70,10 @@ oci_name_to_repo() {
 }
 
 # 🔴 `gh api` WRITES ITS ERROR BODY TO STDOUT, so `2>/dev/null || true` does not make a
-# failed call empty — it makes it a JSON blob that every downstream `[ -n ... ]` test
-# reads as a perfectly good answer. That is how an earlier revision of this script
-# reported healthy consumers as UNRESOLVED: a 404 body became the "tag", and the pin
-# lookup then ran against a ref named `{"message":"Not Found",...}`.
-#
-# The failure was silent and self-consistent, which is the dangerous shape: nothing
-# errored, and the report simply attributed the wrong state to a repository that was
-# fine. So exit status is checked directly, and every ref is shape-checked before use —
-# a ref cannot contain whitespace or a brace, which is enough to reject an error body
-# without pretending to validate git's full ref grammar.
+# failed call empty — it makes it a JSON blob every `[ -n ... ]` test reads as a good
+# answer. An earlier revision resolved a healthy consumer against a ref named
+# `{"message":"Not Found",...}`: nothing errored, and the report was confidently wrong.
+# Exit status is therefore checked directly, and every value is shape-checked before use.
 plausible_ref() {
   local ref="$1"
   [ -n "$ref" ] || return 1
@@ -93,158 +83,222 @@ plausible_ref() {
   return 0
 }
 
-# Print "<repo>\t<workflow>\t<deployed-version-or-empty>" for every consumer whose
-# artifact is verified by a shared publish-workflow matcher.
+# A repository name flows into an API path, so it is shape-checked too rather than
+# trusted: a manifest URL of `oci://ghcr.io/devantler-tech/../foo/manifests` would
+# otherwise yield `..`.
+plausible_repo() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] && [ "$1" != '.' ] && [ "$1" != '..' ]
+}
+
+# A revision is reported to a human who will build an allow-list from it, so it must be a
+# commit SHA and nothing else.
+is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
+
+# A transient 5xx or secondary rate limit must not make main red on a REPORT: a control
+# that goes red for reasons unrelated to what it checks is one people learn to ignore.
+# Bounded, so a genuine outage still fails rather than hanging.
+gh_retry() {
+  local attempt out
+  for attempt in 1 2 3; do
+    if out="$(gh "$@" 2>/dev/null)"; then
+      printf '%s' "$out"
+      return 0
+    fi
+    [ "$attempt" -eq 3 ] || sleep $((attempt * 3))
+  done
+  return 1
+}
+
+# Print "<repo>\t<workflow>\t<pinned-version-or-empty>" per consumer.
 #
-# The consumer repository is derived from the OCIRepository's own `spec.url`, never from
-# the file path — a path is a naming convention, and a renamed directory would silently
-# change which repository a revision is attributed to.
+# 🔴 ITERATES DOCUMENTS, NOT FILES. Reading one value per FILE drops every consumer after
+# the first in a multi-document manifest, and — worse — pairs fields across documents: with
+# two matching documents `yq` emits `---` separators, so a first document using a semver
+# range and a second carrying a tag yielded the literal `---` as the version. Emitting
+# url, tag and subject together as one row per document is what keeps them from the same
+# document by construction.
 #
-# The deployed version comes from `spec.ref.tag` where the OCIRepository pins one. That
-# is the single most load-bearing field here: it names the artifact the cluster is
-# ACTUALLY running, which is the whole question. Where the consumer uses a semver RANGE
-# instead, no fixed version exists in the manifest and the resolver falls back to the
-# newest published version tag.
+# The workflow is read from the document's own cosign SUBJECT, never from a whole-file
+# grep: an unanchored grep matches prose, so a comment mentioning the other workflow
+# reattributed a consumer — and where a consumer's cd.yaml calls both shared workflows
+# that returns the wrong revision silently.
 discover_consumers() {
-  local root="$1" file url repo workflow version
+  local root="$1" file url version subjects repo workflow workflows
   [ -d "$root" ] || return 0
   while IFS= read -r file; do
     [ -n "$file" ] || continue
-    # Only a real OCIRepository names a consumer. The RGD template, the Kyverno policy
-    # and the Talos config match the subject pattern too but describe no single repo.
-    url="$(yq eval -r 'select(.kind == "OCIRepository") | .spec.url // ""' "$file" 2>/dev/null | grep -m1 . || true)"
-    [ -n "$url" ] || continue
-    case "$url" in
-      oci://ghcr.io/devantler-tech/*) ;;
-      *) continue ;;
-    esac
-    repo="${url#oci://ghcr.io/devantler-tech/}"
-    repo="${repo%%/*}"
-    [ -n "$repo" ] || continue
-    repo="$(oci_name_to_repo "$repo")"
-    workflow="$(grep -oE 'publish-(app|manifests)' "$file" | head -1 || true)"
-    [ -n "$workflow" ] || continue
-    version="$(yq eval -r 'select(.kind == "OCIRepository") | .spec.ref.tag // ""' "$file" 2>/dev/null | grep -m1 . || true)"
-    printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
+    while IFS=$'\t' read -r url subjects version; do
+      # 🔴 TAB IS IFS WHITESPACE, so `read` COLLAPSES consecutive tabs and an empty MIDDLE
+      # field silently shifts every later field left. Two consumers pin no `spec.ref.tag`,
+      # so their row was `url\t\tsubject` and the subject landed in `version` — both
+      # vanished from discovery. Every field is emitted with a `-` placeholder instead of
+      # empty, so no field is ever blank and no collapse is possible.
+      [ "$version" = "-" ] && version=""
+      [ "$subjects" = "-" ] && subjects=""
+      [ -n "$url" ] || continue
+      case "$url" in
+        oci://ghcr.io/devantler-tech/*) ;;
+        *) continue ;;
+      esac
+      # Exactly one shared publish workflow per document, or the attribution is ambiguous
+      # and a guess would be worse than a failure.
+      workflows="$(printf '%s\n' "$subjects" |
+        grep -oE 'publish-(app|manifests)\\?\.yaml@' | sed 's/\\\{0,1\}\.yaml@$//' | sort -u || true)"
+      [ -n "$workflows" ] || continue
+      if [ "$(printf '%s\n' "$workflows" | grep -c .)" -ne 1 ]; then
+        printf 'ambiguous: %s names more than one shared publish workflow\n' "$url" >&2
+        continue
+      fi
+      workflow="$workflows"
+      repo="${url#oci://ghcr.io/devantler-tech/}"
+      repo="${repo%%/*}"
+      [ -n "$repo" ] || continue
+      repo="$(oci_name_to_repo "$repo")"
+      plausible_repo "$repo" || continue
+      printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
+    done < <(yq eval -r '
+      select(.kind == "OCIRepository") |
+      [(.spec.url // "-"),
+       ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | join(" ") | select(. != "") // "-"),
+       (.spec.ref.tag // "-")] | @tsv
+    ' "$file" 2>/dev/null || true)
   done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
 }
 
 # The `uses:` pin for one shared workflow, as it stands at one ref of one consumer.
 pin_at_ref() {
   local repo="$1" workflow="$2" ref="$3" body sha
-  body="$(gh api "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml?ref=${ref}" \
-    -H "Accept: application/vnd.github.raw" 2>/dev/null)" || return 1
+  body="$(gh_retry api "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml?ref=${ref}" \
+    -H "Accept: application/vnd.github.raw")" || return 1
   [ -n "$body" ] || return 1
   sha="$(printf '%s\n' "$body" |
     grep -oE "devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}" |
     head -1 || true)"
-  [ -n "$sha" ] || return 1
-  printf '%s\n' "${sha##*@}"
+  sha="${sha##*@}"
+  is_sha "$sha" || return 1
+  printf '%s\n' "$sha"
 }
 
 # The tag that produced the DEPLOYED artifact.
 #
-# 🔴 A GitHub RELEASE is the obvious source for this and it is the WRONG one. Releases
-# and the artifact stream are different surfaces that can drift apart without anything
-# breaking: `.github` last cut a Release (`v1.4.2`) in June 2026, while the artifact its
-# OCIRepository is running today is `1.23.0` — a tag with no Release object at all. An
-# earlier revision of this script resolved that consumer at `v1.4.2` and reported it
-# against a `cd.yaml` that predated an entire workflow migration, producing a confident
-# answer about a revision nobody is running. `aws` fails the same way from the other
-# direction: it publishes from tags and cuts no Releases, so `releases/latest` 404s.
+# 🔴 A GitHub RELEASE is the obvious source and the WRONG one. Releases and the artifact
+# stream drift apart without anything breaking: `.github` last cut a Release (`v1.4.2`) in
+# June 2026 while the artifact its OCIRepository runs today is `1.23.0`, a tag with no
+# Release object; `aws` publishes from tags and cuts no Releases at all. Releases are
+# therefore not consulted.
 #
-# So the tag stream is authoritative and Releases are not consulted at all. Where the
-# OCIRepository pins an exact version, that version IS the deployed artifact and is used
-# directly; a semver range names no single version, so the newest published tag is the
-# closest honest answer. `sort -V` rather than the API's order, because the tags endpoint
-# promises no version ordering and the wrong tag here attributes a signature to the wrong
-# revision — a quietly incorrect answer, which is worse than none.
+# Prints "<tag>\t<exact|inferred>". `exact` means the OCIRepository pins that version, so
+# it IS what is deployed. `inferred` means the consumer uses a semver RANGE, so the newest
+# published tag is the closest honest answer — and the caller marks the row, because an
+# inferred revision must not be mistaken for a measured one when an allow-list is built
+# from this output.
 deployed_tag() {
-  local repo="$1" version="$2" tags
-  tags="$(gh api "repos/devantler-tech/${repo}/tags?per_page=100" --jq '.[].name' 2>/dev/null)" || return 1
+  local repo="$1" version="$2" tags candidate newest
+  # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
+  # Past the cap an un-paginated read returns an arbitrary subset, which either misses a
+  # real tag (false UNRESOLVED) or picks the newest of a truncated page (silently wrong).
+  tags="$(gh_retry api --paginate "repos/devantler-tech/${repo}/tags?per_page=100" --jq '.[].name')" || return 1
+  [ -n "$tags" ] || return 1
   if [ -n "$version" ]; then
-    # The manifest's version may or may not carry the `v` the tag uses.
-    local candidate
     for candidate in "$version" "v${version}"; do
-      if printf '%s\n' "$tags" | grep -qxF "$candidate"; then
-        printf '%s\n' "$candidate"
+      if printf '%s\n' "$tags" | grep -qxF -- "$candidate"; then
+        printf '%s\texact\n' "$candidate"
         return 0
       fi
     done
     return 1
   fi
-  local newest
-  newest="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)"
-  plausible_ref "$newest" || return 1
-  printf '%s\n' "$newest"
+  # Strip the optional `v` before ordering: `sort -V` compares it as text, so a mixed list
+  # orders `v1.23.0` above `1.24.0`. Sort on the bare version, then recover the real tag.
+  newest="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' |
+    sed 's/^v//' | sort -V | tail -1 || true)"
+  [ -n "$newest" ] || return 1
+  for candidate in "v${newest}" "$newest"; do
+    if printf '%s\n' "$tags" | grep -qxF -- "$candidate"; then
+      plausible_ref "$candidate" || return 1
+      printf '%s\tinferred\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
 }
 
-# Default resolver: "<signing revision>\t<current pin>".
+# Default resolver: "<signing revision>\t<current pin>\t<exact|inferred>".
 default_resolver() {
-  local repo="$1" workflow="$2" version="${3:-}" branch tag signing current
-  branch="$(gh api "repos/devantler-tech/${repo}" --jq .default_branch 2>/dev/null)" || return 1
+  local repo="$1" workflow="$2" version="${3:-}" branch tagline tag origin signing current
+  branch="$(gh_retry api "repos/devantler-tech/${repo}" --jq .default_branch)" || return 1
   plausible_ref "$branch" || return 1
-  tag="$(deployed_tag "$repo" "$version")" || return 1
+  tagline="$(deployed_tag "$repo" "$version")" || return 1
+  IFS=$'\t' read -r tag origin <<<"$tagline"
   current="$(pin_at_ref "$repo" "$workflow" "$branch")" || return 1
   signing="$(pin_at_ref "$repo" "$workflow" "$tag")" || return 1
-  printf '%s\t%s\n' "$signing" "$current"
+  printf '%s\t%s\t%s\n' "$signing" "$current" "$origin"
 }
 
 main() {
   local root="${PUBLISH_CONSUMER_ROOT:-$REPO_ROOT}"
-  local consumers count
+  local consumers found missing=""
   consumers="$(discover_consumers "$root")"
-  count="$(printf '%s' "$consumers" | grep -c . || true)"
+  found="$(printf '%s' "$consumers" | cut -f1 | sort -u)"
+
+  local expected
+  for expected in "${EXPECTED_CONSUMERS[@]}"; do
+    printf '%s\n' "$found" | grep -qxF -- "$expected" || missing="${missing} ${expected}"
+  done
+
+  if [ -n "$missing" ]; then
+    printf 'expected consumer(s) not discovered:%s\n' "$missing" >&2
+    printf 'The scan, not the repository, is the likely cause: those OCIRepositories may have\n' >&2
+    printf 'moved, been renamed, or adopted a subject spelling this pattern does not match.\n' >&2
+    printf 'Verify by hand, then fix the pattern or amend EXPECTED_CONSUMERS with the reason.\n' >&2
+    exit 1
+  fi
 
   if [ "${1:-}" = "--list-consumers" ]; then
-    [ "$count" -ge "$EXPECTED_MIN_CONSUMERS" ] ||
-      fail "discovered ${count} consumer(s), expected at least ${EXPECTED_MIN_CONSUMERS}"
     printf '%s\n' "$consumers"
     return 0
   fi
 
-  # Fail closed on a shrunken discovery. Without this the loop below would iterate zero
-  # times and the report would read "no divergence" over a repository it never looked at.
-  if [ "$count" -lt "$EXPECTED_MIN_CONSUMERS" ]; then
-    printf 'discovered %d consumer(s), expected at least %d.\n' \
-      "$count" "$EXPECTED_MIN_CONSUMERS" >&2
-    printf 'The scan, not the repository, is the likely cause: these OCIRepositories may have\n' >&2
-    printf 'moved, been renamed, or adopted a subject spelling this pattern does not match.\n' >&2
-    printf 'Verify by hand, then fix the pattern or lower EXPECTED_MIN_CONSUMERS with the reason.\n' >&2
-    exit 1
-  fi
-
   local resolver="${PUBLISH_REVISION_RESOLVER:-}"
-  local repo workflow version answer signing current diverged=0 unresolved=""
+  local repo workflow version answer signing current origin
+  local diverged=0 unresolved=0 examined=0
 
   printf 'Shared publish-workflow revisions, per consumer (#3048)\n'
   printf '%s\n' '-------------------------------------------------------'
 
   while IFS=$'\t' read -r repo workflow version; do
     [ -n "$repo" ] || continue
+    examined=$((examined + 1))
     if [ -n "$resolver" ]; then
-      answer="$("$resolver" "$repo" "$workflow" "$version" 2>/dev/null || true)"
+      answer="$("$resolver" "$repo" "$workflow" "$version")" || answer=""
     else
-      answer="$(default_resolver "$repo" "$workflow" "$version" || true)"
+      answer="$(default_resolver "$repo" "$workflow" "$version")" || answer=""
     fi
-    signing="$(printf '%s' "$answer" | cut -f1)"
-    current="$(printf '%s' "$answer" | cut -f2)"
-    if [ -z "$signing" ] || [ -z "$current" ]; then
-      # An unresolvable consumer is NOT "no divergence". Collect it and fail at the end,
-      # so one lookup failure does not hide the consumers that did resolve.
-      unresolved="${unresolved}  ${repo} (${workflow})
-"
-      printf 'UNRESOLVED %-22s %-18s could not resolve both revisions\n' "$repo" "$workflow"
+    # 🔴 `cut -f2` WITHOUT `-s` ECHOES THE WHOLE LINE when the delimiter is absent, so a
+    # resolver emitting one tab-free line (an error body — the very shape warned about
+    # above) set signing == current and reported IN-SYNC for every consumer with exit 0.
+    # `read` splits on tabs only, and both values must then be commit SHAs: an
+    # unparseable answer is UNRESOLVED, never agreement.
+    IFS=$'\t' read -r signing current origin <<<"$answer"
+    if ! is_sha "${signing:-}" || ! is_sha "${current:-}"; then
+      unresolved=$((unresolved + 1))
+      printf 'UNRESOLVED %-22s %-18s could not resolve both revisions to a commit SHA\n' \
+        "$repo" "$workflow"
       continue
     fi
+    local mark=''
+    # A revision inferred from the newest tag is not a measurement of what is deployed.
+    # Saying so is the difference between an allow-list built on evidence and one built
+    # on a guess that reads identically.
+    [ "${origin:-}" = 'inferred' ] && mark=' (deployed version inferred from newest tag)'
     if [ "$signing" = "$current" ]; then
-      printf 'IN-SYNC    %-22s %-18s signed=%s pinned=%s\n' \
-        "$repo" "$workflow" "$signing" "$current"
+      printf 'IN-SYNC    %-22s %-18s signed=%s pinned=%s%s\n' \
+        "$repo" "$workflow" "$signing" "$current" "$mark"
       printf '           allow-list must accept: %s\n' "$signing"
     else
       diverged=$((diverged + 1))
-      printf 'DIVERGED   %-22s %-18s signed=%s pinned=%s\n' \
-        "$repo" "$workflow" "$signing" "$current"
+      printf 'DIVERGED   %-22s %-18s signed=%s pinned=%s%s\n' \
+        "$repo" "$workflow" "$signing" "$current" "$mark"
       # AC4: an allow-list narrowed to the current pin alone would stop verifying the
       # deployed artifact. Naming BOTH is the actionable output of this whole script.
       printf '           allow-list must accept: %s AND %s\n' "$signing" "$current"
@@ -252,13 +306,17 @@ main() {
   done <<<"$consumers"
 
   printf '%s\n' '-------------------------------------------------------'
-  printf '%d consumer(s) examined, %d diverged.\n' "$count" "$diverged"
+  # `unresolved` is in the tally deliberately. The failure detail below also goes to
+  # stdout: `tee` into the step summary captures stdout only, so a stderr-only diagnostic
+  # left a human reading `0 diverged` as the last line of a run that had FAILED.
+  printf '%d consumer(s) examined, %d diverged, %d unresolved.\n' \
+    "$examined" "$diverged" "$unresolved"
 
-  if [ -n "$unresolved" ]; then
-    printf '\nCould not resolve both revisions for:\n%s' "$unresolved" >&2
-    printf 'A consumer whose revisions cannot be read is not evidence of agreement, so this\n' >&2
-    printf 'run fails rather than reporting a clean portfolio it could not see.\n' >&2
-    exit 1
+  if [ "$unresolved" -gt 0 ]; then
+    printf '\nFAILED: %d consumer(s) could not be resolved. A consumer whose revisions cannot\n' "$unresolved"
+    printf 'be read is not evidence of agreement, so this run fails rather than reporting a\n'
+    printf 'clean portfolio it could not see.\n'
+    return 1
   fi
 
   if [ "$diverged" -gt 0 ]; then

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -177,16 +177,16 @@ discover_consumers() {
       repo="$(oci_name_to_repo "$repo")"
       plausible_repo "$repo" || continue
       printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
-    # 🔴 FLUX RESOLVES `spec.ref` AS digest > semver > tag, AND AN OMITTED `ref` MEANS
-    # `latest`. Reading `tag` first inverts that: a document carrying BOTH a tag and a
-    # digest (or a tag and a semver) would be attributed to a tag Flux never serves, and
-    # the real signer would be omitted from the proposed allow-list — a confident wrong
-    # answer, which is the one outcome this report must never produce. A digest or an
-    # omitted ref also collapsed to the meaningless `semver:`, which `effective_version`
-    # then refused as a bounded constraint, so a resolvable consumer read as UNRESOLVED.
-    #
-    # These live OUTSIDE the single-quoted yq program deliberately: a backtick inside it
-    # reads as a command substitution to shellcheck (SC2016), so prose belongs out here.
+      # 🔴 FLUX RESOLVES `spec.ref` AS digest > semver > tag, AND AN OMITTED `ref` MEANS
+      # `latest`. Reading `tag` first inverts that: a document carrying BOTH a tag and a
+      # digest (or a tag and a semver) would be attributed to a tag Flux never serves, and
+      # the real signer would be omitted from the proposed allow-list — a confident wrong
+      # answer, which is the one outcome this report must never produce. A digest or an
+      # omitted ref also collapsed to the meaningless `semver:`, which `effective_version`
+      # then refused as a bounded constraint, so a resolvable consumer read as UNRESOLVED.
+      #
+      # These live OUTSIDE the single-quoted yq program deliberately: a backtick inside it
+      # reads as a command substitution to shellcheck (SC2016), so prose belongs out here.
     done < <(yq eval -r '
       select(.kind == "OCIRepository") |
       [(.spec.url // "-"),

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -171,10 +171,19 @@ pin_at_ref() {
   body="$(gh_retry api "repos/devantler-tech/${repo}/contents/.github/workflows/cd.yaml?ref=${ref}" \
     -H "Accept: application/vnd.github.raw")" || return 1
   [ -n "$body" ] || return 1
-  sha="$(printf '%s\n' "$body" |
-    grep -oE "devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}" |
-    head -1 || true)"
-  sha="${sha##*@}"
+  # 🔴 PARSE THE YAML, NOT THE TEXT. An unanchored `grep … | head -1` selects a COMMENTED-OUT
+  # old call if it sits above the active one, and the SHA it yields still passes `is_sha` — so
+  # both revisions get confidently misreported and the real signer is omitted from the
+  # allow-list. Reading `.jobs[].uses` sees only calls that actually run.
+  #
+  # Exactly one matching call, or the attribution is ambiguous: zero means this consumer does
+  # not call that workflow at that ref, and more than one means a guess would be needed.
+  local matches count
+  matches="$(printf '%s\n' "$body" | yq eval -r '.jobs[].uses // ""' - 2>/dev/null |
+    grep -E "^devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}$" || true)"
+  count="$(printf '%s' "$matches" | grep -c . || true)"
+  [ "$count" -eq 1 ] || return 1
+  sha="${matches##*@}"
   is_sha "$sha" || return 1
   printf '%s\n' "$sha"
 }
@@ -194,7 +203,11 @@ pin_at_ref() {
 # #3048 set for it.
 tag_was_published() {
   local repo="$1" tag="$2" runs
-  runs="$(gh_retry api "repos/devantler-tech/${repo}/actions/runs?per_page=100&event=push")" || return 1
+  # Scoped to this tag rather than fetching the newest 100 runs of the whole repository: on a
+  # repository with frequent pushes a candidate release's run falls off that first page, every
+  # retry re-fetches the same incomplete page, and a healthy consumer stays UNRESOLVED until the
+  # next release. Filtering by ref makes the result set small enough that one page is complete.
+  runs="$(gh_retry api "repos/devantler-tech/${repo}/actions/runs?branch=${tag}&event=push&per_page=100")" || return 1
   printf '%s' "$runs" |
     jq -r --arg t "$tag" '
       [.workflow_runs[]
@@ -226,6 +239,13 @@ deployed_tag() {
   if [ -n "$version" ]; then
     for candidate in "$version" "v${version}"; do
       if printf '%s\n' "$tags" | grep -qxF -- "$candidate"; then
+        # 🔴 A PINNED TAG EXISTING IS NOT THE SAME AS ITS ARTIFACT HAVING BEEN PUBLISHED. The
+        # publication check was reachable only from the semver branch, so the two exact-tag
+        # consumers returned as soon as the git tag existed. If that tag's cd.yaml failed, the
+        # previous artifact is still applied and this would name the unpublishing tag's pin as
+        # the signer of what is deployed. A pinned-but-unpublished version is an anomaly worth
+        # surfacing, so it is UNRESOLVED rather than silently walked back to an older tag.
+        tag_was_published "$repo" "$candidate" || return 1
         printf '%s\texact\n' "$candidate"
         return 0
       fi
@@ -283,6 +303,28 @@ main() {
   for expected in "${EXPECTED_CONSUMERS[@]}"; do
     printf '%s\n' "$found" | grep -qxF -- "$expected" || missing="${missing} ${expected}"
   done
+
+  # Both directions. Checking only that every EXPECTED name was found accepts an unregistered
+  # sixth consumer — and that one can later move or change its subject spelling, disappear, and
+  # leave all five registered names present so the report exits clean. That is exactly the silent
+  # disappearance this floor exists to prevent, just one consumer along. Requiring registration
+  # makes adding a consumer a deliberate, reviewed act.
+  local discovered unregistered=""
+  while IFS= read -r discovered; do
+    [ -n "$discovered" ] || continue
+    local known=0 e
+    for e in "${EXPECTED_CONSUMERS[@]}"; do
+      [ "$e" = "$discovered" ] && known=1 && break
+    done
+    [ "$known" -eq 1 ] || unregistered="${unregistered} ${discovered}"
+  done <<<"$found"
+
+  if [ -n "$unregistered" ]; then
+    printf 'discovered consumer(s) not registered in EXPECTED_CONSUMERS:%s\n' "$unregistered" >&2
+    printf 'A consumer this script does not know about is one it cannot notice the LOSS of later.\n' >&2
+    printf 'Add it to EXPECTED_CONSUMERS so its disappearance would fail this run.\n' >&2
+    exit 1
+  fi
 
   if [ -n "$missing" ]; then
     printf 'expected consumer(s) not discovered:%s\n' "$missing" >&2

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -187,11 +187,17 @@ discover_consumers() {
 effective_version() {
   local raw="$1" expr
   case "$raw" in
-    '-' | '') printf '%s\n' ''; return 0 ;;
+    '-' | '')
+      printf '%s\n' ''
+      return 0
+      ;;
     semver:*)
       expr="${raw#semver:}"
       case "$expr" in
-        '*' | '>='[0-9]*) printf '%s\n' ''; return 0 ;;
+        '*' | '>='[0-9]*)
+          printf '%s\n' ''
+          return 0
+          ;;
         *)
           printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
             "$expr" >&2
@@ -199,7 +205,10 @@ effective_version() {
           ;;
       esac
       ;;
-    *) printf '%s\n' "$raw"; return 0 ;;
+    *)
+      printf '%s\n' "$raw"
+      return 0
+      ;;
   esac
 }
 

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -165,6 +165,44 @@ discover_consumers() {
   done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
 }
 
+# 🔴 A SEMVER RANGE IS A CONSTRAINT, NOT "WHATEVER IS NEWEST". Discovery carries the
+# expression through as `semver:<expr>` instead of discarding it, because the two are
+# interchangeable only for an UNBOUNDED lower bound. All three range consumers use
+# `>=1.0.0` today, so the newest published tag is exactly what Flux resolves — but a
+# bounded selector such as `~1.4` or `<2.0.0` would make the report pick a tag Flux would
+# never serve, attribute its workflow revision to the deployed artifact, and omit the real
+# signer from the proposed allow-list.
+#
+# Resolving a bounded range correctly needs Flux-compatible semver selection, which this
+# script deliberately does not implement, so it REFUSES rather than guesses.
+#
+# This is decided from the MANIFEST, before any resolver is consulted — the constraint is a
+# property of what is written down, not of anything the network can tell us. Keeping it out
+# of `deployed_tag` is also what lets the test suite prove it without network access; when
+# this lived inside the resolver, the only way to reach it was to let the real resolver run,
+# which made the case non-hermetic and it failed in CI for an unrelated reason.
+#
+# Prints the effective version (empty means "newest published"), or fails naming the
+# constraint.
+effective_version() {
+  local raw="$1" expr
+  case "$raw" in
+    '-' | '') printf '%s\n' ''; return 0 ;;
+    semver:*)
+      expr="${raw#semver:}"
+      case "$expr" in
+        '*' | '>='[0-9]*) printf '%s\n' ''; return 0 ;;
+        *)
+          printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
+            "$expr" >&2
+          return 1
+          ;;
+      esac
+      ;;
+    *) printf '%s\n' "$raw"; return 0 ;;
+  esac
+}
+
 # The `uses:` pin for one shared workflow, as it stands at one ref of one consumer.
 pin_at_ref() {
   local repo="$1" workflow="$2" ref="$3" body sha
@@ -234,35 +272,6 @@ tag_was_published() {
 # from this output.
 deployed_tag() {
   local repo="$1" version="$2" tags candidate bare
-  # 🔴 A SEMVER RANGE IS A CONSTRAINT, NOT "WHATEVER IS NEWEST". Discovery carries the
-  # expression through as `semver:<expr>` instead of discarding it, because the two are
-  # interchangeable only for an UNBOUNDED lower bound. All three range consumers use
-  # `>=1.0.0` today, so the newest published tag is exactly what Flux resolves — but a
-  # bounded selector such as `~1.4` or `<2.0.0` would make this pick a tag Flux would never
-  # serve, attribute its workflow revision to the deployed artifact, and omit the real
-  # signer from the proposed allow-list.
-  #
-  # Resolving a bounded range correctly needs Flux-compatible semver selection, which this
-  # script deliberately does not implement — so it REFUSES rather than guesses. That is the
-  # same fail-closed choice made everywhere else here: a wrong answer about which revision
-  # signed production is worse than no answer.
-  local constraint=""
-  case "${version}" in
-    semver:*)
-      constraint="${version#semver:}"
-      version=""
-      case "${constraint}" in
-        '*' | '>='[0-9]*) : ;;
-        *)
-          printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
-            "${constraint}" >&2
-          return 1
-          ;;
-      esac
-      ;;
-    '-') version="" ;;
-  esac
-
   # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
   # Past the cap an un-paginated read returns an arbitrary subset, which either misses a
   # real tag (false UNRESOLVED) or picks the newest of a truncated page (silently wrong).
@@ -381,6 +390,14 @@ main() {
   while IFS=$'\t' read -r repo workflow version; do
     [ -n "$repo" ] || continue
     examined=$((examined + 1))
+    # Classify from the manifest first: a bounded range is refused before any resolver is
+    # consulted, because the constraint is written down rather than discovered remotely.
+    if ! version="$(effective_version "$version")"; then
+      unresolved=$((unresolved + 1))
+      printf 'UNRESOLVED %-22s %-18s bounded semver constraint — not resolvable here\n' \
+        "$repo" "$workflow"
+      continue
+    fi
     if [ -n "$resolver" ]; then
       answer="$("$resolver" "$repo" "$workflow" "$version")" || answer=""
     else

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -633,6 +633,39 @@ deployed_tag() {
         "$bare" "$dual" "$dual" >&2
       return 1
     fi
+    # A PARTIAL TAG COERCES TO THIS SAME PRECEDENCE, and it is invisible to every check
+    # above. Flux reads `v2.0` as 2.0.0, so it TIES `v2.0.0` and may be the ref Flux
+    # selects -- but `sort -V` orders `2.0.0` ABOVE `2.0`, so the partial reads as safely
+    # lower, and its spelling matches neither the three-component core pattern nor the
+    # duality fold. The walk below then considers only the strict tag and can report ITS
+    # signing revision for an artifact the partial tag produced: a confident wrong answer,
+    # which is the same failure the build-metadata tie refusal exists to prevent.
+    #
+    # Only a trailing-zero core has a partial spelling: `2.0.0` can be written `2.0` (and
+    # `2.0.0` also `2`), while `2.1.3` cannot be shortened at all.
+    local partial_re="" p_major p_minor p_patch partial_hit
+    case "$bare" in
+    *.*.*)
+      p_major="${bare%%.*}"
+      p_patch="${bare##*.}"
+      p_minor="${bare#*.}"
+      p_minor="${p_minor%%.*}"
+      if [ "$p_patch" = "0" ]; then
+        partial_re="${p_major}\\.${p_minor}"
+        if [ "$p_minor" = "0" ]; then
+          partial_re="${partial_re}|${p_major}"
+        fi
+      fi
+      ;;
+    esac
+    if [ -n "$partial_re" ]; then
+      partial_hit="$(printf '%s\n' "$tags" | grep -E "^v?(${partial_re})$" | sort -u || true)"
+      if [ -n "$partial_hit" ]; then
+        printf 'version %s is also published as a PARTIAL tag (%s); Flux coerces the partial spelling to the same SemVer precedence, so the two tie and can point at different commits and therefore different workflow pins, and choosing between them needs Flux-compatible ordering, which this script does not implement\n' \
+          "$bare" "$(printf '%s\n' "$partial_hit" | tr '\n' ' ')" >&2
+        return 1
+      fi
+    fi
     variants="$(printf '%s\n' "$tags" | grep -E "^v?${core_re}(\+[0-9A-Za-z.-]+)?$" |
       sed 's/^v//' | sort -u || true)"
     variant_count="$(printf '%s\n' "$variants" | grep -c . || true)"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -287,9 +287,26 @@ effective_version() {
             "$expr" >&2
           return 1
           ;;
-        '>='[0-9]*)
-          printf '%s\n' ''
-          return 0
+        # The WHOLE selector must BE an inclusive lower bound, not merely start like one.
+        # The previous `'>='[0-9]*` matched any trailing text: `>=1.0.0=bad` and
+        # `>=1.0.0>=2.0.0` were both read as UNBOUNDED, so the walk returned the newest
+        # published tag and attributed its workflow revision to an artifact Flux would
+        # never have selected — a confident wrong answer from a selector Flux itself
+        # rejects. No character class catches them: every character in both is one a
+        # legitimate single lower bound may contain, which is why this is anchored on the
+        # whole string instead.
+        #
+        # One to three numeric components, so a legitimate `>=1.0` is not newly refused.
+        # Anything richer (prerelease, build metadata, a second bound) is handled by the
+        # arms above or refused here.
+        '>='*)
+          if [[ "$expr" =~ ^\>=[0-9]+(\.[0-9]+){0,2}$ ]]; then
+            printf '%s\n' ''
+            return 0
+          fi
+          printf 'malformed or unsupported semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
+            "$expr" >&2
+          return 1
           ;;
         # A STRICT lower bound is not the same as an inclusive one. `>=1.0.0` admits
         # 1.0.0, so treating it as unbounded and taking the newest published tag is

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -160,7 +160,7 @@ discover_consumers() {
       select(.kind == "OCIRepository") |
       [(.spec.url // "-"),
        ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | join(" ") | select(. != "") // "-"),
-       (.spec.ref.tag // "-")] | @tsv
+       (.spec.ref.tag // ("semver:" + (.spec.ref.semver // "")) // "-")] | @tsv
     ' "$file" 2>/dev/null || true)
   done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
 }
@@ -234,6 +234,35 @@ tag_was_published() {
 # from this output.
 deployed_tag() {
   local repo="$1" version="$2" tags candidate bare
+  # 🔴 A SEMVER RANGE IS A CONSTRAINT, NOT "WHATEVER IS NEWEST". Discovery carries the
+  # expression through as `semver:<expr>` instead of discarding it, because the two are
+  # interchangeable only for an UNBOUNDED lower bound. All three range consumers use
+  # `>=1.0.0` today, so the newest published tag is exactly what Flux resolves — but a
+  # bounded selector such as `~1.4` or `<2.0.0` would make this pick a tag Flux would never
+  # serve, attribute its workflow revision to the deployed artifact, and omit the real
+  # signer from the proposed allow-list.
+  #
+  # Resolving a bounded range correctly needs Flux-compatible semver selection, which this
+  # script deliberately does not implement — so it REFUSES rather than guesses. That is the
+  # same fail-closed choice made everywhere else here: a wrong answer about which revision
+  # signed production is worse than no answer.
+  local constraint=""
+  case "${version}" in
+    semver:*)
+      constraint="${version#semver:}"
+      version=""
+      case "${constraint}" in
+        '*' | '>='[0-9]*) : ;;
+        *)
+          printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
+            "${constraint}" >&2
+          return 1
+          ;;
+      esac
+      ;;
+    '-') version="" ;;
+  esac
+
   # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
   # Past the cap an un-paginated read returns an arbitrary subset, which either misses a
   # real tag (false UNRESOLVED) or picks the newest of a truncated page (silently wrong).

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -176,11 +176,14 @@ pin_at_ref() {
   # both revisions get confidently misreported and the real signer is omitted from the
   # allow-list. Reading `.jobs[].uses` sees only calls that actually run.
   #
-  # Exactly one matching call, or the attribution is ambiguous: zero means this consumer does
-  # not call that workflow at that ref, and more than one means a guess would be needed.
+  # Exactly one DISTINCT revision, or the attribution is ambiguous. Deduplicate first: two jobs
+  # calling the same shared workflow at the same revision is not ambiguity, and counting call
+  # SITES rather than revisions would report a perfectly unambiguous consumer as UNRESOLVED and
+  # fail the run. Zero means this consumer does not call that workflow at that ref.
   local matches count
   matches="$(printf '%s\n' "$body" | yq eval -r '.jobs[].uses // ""' - 2>/dev/null |
-    grep -E "^devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}$" || true)"
+    grep -E "^devantler-tech/actions/\\.github/workflows/${workflow}\\.yaml@[0-9a-f]{40}$" |
+    sort -u || true)"
   count="$(printf '%s' "$matches" | grep -c . || true)"
   [ "$count" -eq 1 ] || return 1
   sha="${matches##*@}"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -179,6 +179,30 @@ pin_at_ref() {
   printf '%s\n' "$sha"
 }
 
+# Did this tag's release actually PUBLISH an artifact?
+#
+# 🔴 A GIT TAG IS NOT A PUBLISHED ARTIFACT. For the three consumers pinning a semver RANGE
+# there is no version in the manifest, so the newest tag stands in for "what is deployed" —
+# and if that tag's CD run failed or was skipped, no artifact was pushed, Flux is still
+# serving the PREVIOUS one, and this script would read a workflow pin from a release that
+# never signed anything and print it as a SHA the allow-list "must accept". That omits the
+# revision which actually signed the running artifact — the exact outage #3048 exists to
+# prevent, one level in.
+#
+# The publish outcome is public Actions data on the consumer's own repository, so this
+# needs no package read and no cluster access, which keeps the check inside the scope
+# #3048 set for it.
+tag_was_published() {
+  local repo="$1" tag="$2" runs
+  runs="$(gh_retry api "repos/devantler-tech/${repo}/actions/runs?per_page=100&event=push")" || return 1
+  printf '%s' "$runs" |
+    jq -r --arg t "$tag" '
+      [.workflow_runs[]
+       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml")
+       | .conclusion] | .[]' 2>/dev/null |
+    grep -qx 'success'
+}
+
 # The tag that produced the DEPLOYED artifact.
 #
 # 🔴 A GitHub RELEASE is the obvious source and the WRONG one. Releases and the artifact
@@ -193,7 +217,7 @@ pin_at_ref() {
 # inferred revision must not be mistaken for a measured one when an allow-list is built
 # from this output.
 deployed_tag() {
-  local repo="$1" version="$2" tags candidate newest
+  local repo="$1" version="$2" tags candidate bare
   # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
   # Past the cap an un-paginated read returns an arbitrary subset, which either misses a
   # real tag (false UNRESOLVED) or picks the newest of a truncated page (silently wrong).
@@ -210,16 +234,30 @@ deployed_tag() {
   fi
   # Strip the optional `v` before ordering: `sort -V` compares it as text, so a mixed list
   # orders `v1.23.0` above `1.24.0`. Sort on the bare version, then recover the real tag.
-  newest="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' |
-    sed 's/^v//' | sort -V | tail -1 || true)"
-  [ -n "$newest" ] || return 1
-  for candidate in "v${newest}" "$newest"; do
-    if printf '%s\n' "$tags" | grep -qxF -- "$candidate"; then
-      plausible_ref "$candidate" || return 1
-      printf '%s\tinferred\n' "$candidate"
-      return 0
-    fi
-  done
+  #
+  # Walk NEWEST-FIRST to the newest tag that actually published. Stopping at the newest tag
+  # regardless of its release outcome is what would attribute a signature to a revision no
+  # deployed artifact was ever signed by. Bounded, because a consumer whose last several
+  # releases all failed is a different problem and should surface as UNRESOLVED rather than
+  # send this walking back through its whole history.
+  local candidates checked=0
+  candidates="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' |
+    sed 's/^v//' | sort -V -r || true)"
+  [ -n "$candidates" ] || return 1
+  while IFS= read -r bare; do
+    [ -n "$bare" ] || continue
+    checked=$((checked + 1))
+    [ "$checked" -le 5 ] || break
+    for candidate in "v${bare}" "$bare"; do
+      printf '%s\n' "$tags" | grep -qxF -- "$candidate" || continue
+      plausible_ref "$candidate" || continue
+      if tag_was_published "$repo" "$candidate"; then
+        printf '%s\tinferred\n' "$candidate"
+        return 0
+      fi
+      break
+    done
+  done <<<"$candidates"
   return 1
 }
 
@@ -287,10 +325,10 @@ main() {
       continue
     fi
     local mark=''
-    # A revision inferred from the newest tag is not a measurement of what is deployed.
-    # Saying so is the difference between an allow-list built on evidence and one built
-    # on a guess that reads identically.
-    [ "${origin:-}" = 'inferred' ] && mark=' (deployed version inferred from newest tag)'
+    # An inferred revision is the newest tag whose release actually published; it is still
+    # not a measurement of what Flux has APPLIED. Saying so is the difference between an
+    # allow-list built on evidence and one built on a guess that reads identically.
+    [ "${origin:-}" = 'inferred' ] && mark=' (deployed version inferred from newest PUBLISHED tag)'
     if [ "$signing" = "$current" ]; then
       printf 'IN-SYNC    %-22s %-18s signed=%s pinned=%s%s\n' \
         "$repo" "$workflow" "$signing" "$current" "$mark"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -233,7 +233,27 @@ effective_version() {
     semver:*)
       expr="${raw#semver:}"
       case "$expr" in
-        '*' | '>='[0-9]*)
+        '*')
+          printf '%s\n' ''
+          return 0
+          ;;
+        # ANY character a single lower bound cannot contain means the range is COMPOUND,
+        # and therefore bounded. This is a character class rather than a prefix because
+        # the previous form was `'>='[0-9]*`, whose trailing `*` swallowed the upper
+        # bound of `>=1.0.0 <2.0.0`: that selector begins exactly like the unbounded
+        # `>=1.0.0` which IS legitimately allowed, so a prefix test accepted it, dropped
+        # the `<2.0.0`, and would resolve to a 2.x tag Flux never serves — attributing
+        # that tag's workflow revision to the deployed artifact and omitting the real
+        # signer from the allow-list.
+        #
+        # `>` and `=` are quoted so the shell does not read them as a redirection inside
+        # the pattern, and `-` is last inside the class so it stays literal.
+        *[!0-9A-Za-z.+'>='-]*)
+          printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
+            "$expr" >&2
+          return 1
+          ;;
+        '>'[0-9]* | '>='[0-9]*)
           printf '%s\n' ''
           return 0
           ;;

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -379,8 +379,27 @@ pin_at_ref() {
 # The publish outcome is public Actions data on the consumer's own repository, so this
 # needs no package read and no cluster access, which keeps the check inside the scope
 # #3048 set for it.
+# The commit a tag currently points at.
+#
+# 🔴 A TAG IS MUTABLE. `tag_was_published` matches a run by REF NAME, and `pin_at_ref` reads
+# cd.yaml at the ref's CURRENT commit — two different commits whenever a release tag has been
+# moved or deleted and recreated after an older successful run. The report would then pair a
+# workflow revision read from the NEW commit with a publish proved by the OLD one, and print
+# it as a SHA the allow-list "must accept": a confident wrong answer built from two facts that
+# are individually true. Resolving the tag once and binding the run to it is what keeps the
+# publish evidence and the pin evidence on the same commit.
+tag_commit() {
+  local repo="$1" tag="$2" sha
+  sha="$(gh_retry api "repos/devantler-tech/${repo}/commits/${tag}" --jq .sha)" || return 1
+  is_sha "$sha" || return 1
+  printf '%s\n' "$sha"
+}
+
 tag_was_published() {
-  local repo="$1" tag="$2" runs
+  local repo="$1" tag="$2" sha="$3" runs
+  # The commit is REQUIRED, never defaulted: an empty expected SHA would make the match below
+  # vacuous and restore exactly the moved-tag hole this argument exists to close.
+  is_sha "$sha" || return 1
   # Scoped to this tag rather than fetching the newest 100 runs of the whole repository: on a
   # repository with frequent pushes a candidate release's run falls off that first page, every
   # retry re-fetches the same incomplete page, and a healthy consumer stays UNRESOLVED until the
@@ -393,12 +412,35 @@ tag_was_published() {
   # --raw-field sends `branch=v2.0.0%2Bbuild.1`.
   runs="$(gh_retry api --method GET "repos/devantler-tech/${repo}/actions/runs" \
     --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)" || return 1
-  printf '%s' "$runs" |
-    jq -r --arg t "$tag" '
+  # `head_sha` pins the run to the commit the tag resolves to TODAY. A historical run for a
+  # since-moved tag still carries the old commit and no longer counts as evidence that the
+  # artifact the current commit describes was ever published.
+  if printf '%s' "$runs" |
+    jq -r --arg t "$tag" --arg s "$sha" '
       [.workflow_runs[]
-       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml")
+       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml"
+                and .head_sha == $s)
        | .conclusion] | .[]' 2>/dev/null |
-    grep -qx 'success'
+    grep -qx 'success'; then
+    return 0
+  fi
+  # 🔴 A MOVED TAG IS NOT THE SAME AS AN UNPUBLISHED ONE, and collapsing them would swap one
+  # wrong answer for another. "Never published" is ordinary — the walk steps to the previous
+  # release. But a tag with a successful run at a DIFFERENT commit has published something,
+  # just not what it now points at; walking silently past it would report an older release's
+  # workflow revision as the signer of what is deployed, which is the confident wrong answer
+  # this report exists to avoid. It is an anomaly, so it is surfaced by name (exit 2) and the
+  # caller refuses rather than guessing which commit the deployed artifact came from.
+  if printf '%s' "$runs" |
+    jq -r --arg t "$tag" --arg s "$sha" '
+      [.workflow_runs[]
+       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml"
+                and .head_sha != null and .head_sha != $s)
+       | .conclusion] | .[]' 2>/dev/null |
+    grep -qx 'success'; then
+    return 2
+  fi
+  return 1
 }
 
 # The tag that produced the DEPLOYED artifact.
@@ -419,7 +461,7 @@ tag_was_published() {
 # manual CD workflow deploys it, so a previously-published tag reads as deployed while the
 # cluster still runs its predecessor — and the proposed allow-list then omits the revision
 # that actually signed the running artifact. Closing that needs an applied Flux revision,
-# which means reading a cluster; this script reads manifests and a registry only.
+# which means reading a cluster; this script reads manifests, git tags and Actions runs only.
 deployed_tag() {
   local repo="$1" version="$2" tags candidate bare
   # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
@@ -428,20 +470,50 @@ deployed_tag() {
   tags="$(gh_retry api --paginate "repos/devantler-tech/${repo}/tags?per_page=100" --jq '.[].name')" || return 1
   [ -n "$tags" ] || return 1
   if [ -n "$version" ]; then
+    # 🔴 BOTH SPELLINGS OF ONE VERSION ARE TWO DISTINCT GIT REFS HERE TOO. The semver walk
+    # below refuses that ambiguity by name, but this branch RETURNED ON THE FIRST MATCH, so
+    # the refusal was unreachable for the two exact-tag consumers — precisely the consumers
+    # whose version is written down and therefore most likely to be spelled either way. When
+    # `1.2.3` and `v1.2.3` both exist they can point at different commits and so at different
+    # publish-workflow pins, and this loop reported whichever spelling it happened to try
+    # first: a confident wrong answer. Decide the ambiguity BEFORE resolving anything.
+    local exact_matches exact_count exact_sha
+    exact_matches=''
     for candidate in "$version" "v${version}"; do
-      if printf '%s\n' "$tags" | grep -qxF -- "$candidate"; then
-        # 🔴 A PINNED TAG EXISTING IS NOT THE SAME AS ITS ARTIFACT HAVING BEEN PUBLISHED. The
-        # publication check was reachable only from the semver branch, so the two exact-tag
-        # consumers returned as soon as the git tag existed. If that tag's cd.yaml failed, the
-        # previous artifact is still applied and this would name the unpublishing tag's pin as
-        # the signer of what is deployed. A pinned-but-unpublished version is an anomaly worth
-        # surfacing, so it is UNRESOLVED rather than silently walked back to an older tag.
-        tag_was_published "$repo" "$candidate" || return 1
-        printf '%s\tpinned\n' "$candidate"
-        return 0
-      fi
+      printf '%s\n' "$tags" | grep -qxF -- "$candidate" || continue
+      exact_matches="${exact_matches}${candidate}"$'\n'
     done
-    return 1
+    # `|| true`: `grep -c` exits 1 on a zero count, and a command substitution's status
+    # becomes the assignment's, so under `set -e` the legitimate not-found case would abort
+    # the run here instead of reaching the return that reports it.
+    exact_count="$(printf '%s' "$exact_matches" | grep -c . || true)"
+    if [ "$exact_count" -gt 1 ]; then
+      printf 'version %s is published as BOTH "%s" and "v%s"; those are distinct git refs that can point at different commits and therefore different workflow pins, so choosing between them needs Flux-compatible ordering, which this script does not implement\n' \
+        "$version" "$version" "$version" >&2
+      return 1
+    fi
+    [ "$exact_count" -eq 1 ] || return 1
+    candidate="$(printf '%s' "$exact_matches" | head -1)"
+    # 🔴 A PINNED TAG EXISTING IS NOT THE SAME AS ITS ARTIFACT HAVING BEEN PUBLISHED. The
+    # publication check was reachable only from the semver branch, so the two exact-tag
+    # consumers returned as soon as the git tag existed. If that tag's cd.yaml failed, the
+    # previous artifact is still applied and this would name the unpublishing tag's pin as
+    # the signer of what is deployed. A pinned-but-unpublished version is an anomaly worth
+    # surfacing, so it is UNRESOLVED rather than silently walked back to an older tag.
+    exact_sha="$(tag_commit "$repo" "$candidate")" || return 1
+    # `|| exact_pub=$?` rather than a bare call: under `set -e` a non-zero return would
+    # abort the run before the exit status could be read, and the moved-tag case (2) needs
+    # to be told apart from the never-published case (1).
+    local exact_pub=0
+    tag_was_published "$repo" "$candidate" "$exact_sha" || exact_pub=$?
+    if [ "$exact_pub" -eq 2 ]; then
+      printf 'tag %s published successfully from a DIFFERENT commit than it points at today, so it has been moved or recreated; the workflow revision read from its current commit did not sign the published artifact\n' \
+        "$candidate" >&2
+      return 1
+    fi
+    [ "$exact_pub" -eq 0 ] || return 1
+    printf '%s\tpinned\n' "$candidate"
+    return 0
   fi
   # Strip the optional `v` before ordering: `sort -V` compares it as text, so a mixed list
   # orders `v1.23.0` above `1.24.0`. Sort on the bare version, then recover the real tag.
@@ -461,10 +533,44 @@ deployed_tag() {
   # than one distinct tag REFUSES — the same reasoning as the bounded-range refusal:
   # picking one of two equally-ranked tags is a guess, and a guess here is the confident
   # wrong answer this report must never produce.
+  #
+  # 🔴 A CHARACTER-CLASS REGEX IS NOT SEMVER VALIDATION. The previous pattern accepted
+  # `v02.0.0` (SemVer forbids leading zeros in a numeric identifier) and `v2.0.0+foo..bar`
+  # or `v2.0.0+.` (a build identifier may not be empty) — measured directly against it. It
+  # then stripped the metadata and ranked what was left: `02.0.0` sorts ABOVE `1.9.0`, so an
+  # invalid tag with a successful CD run could be selected and its workflow pin attributed to
+  # the consumer while Flux, rejecting the tag, resolves an older artifact.
+  #
+  # Candidates are therefore built with a STRICT pattern. Excluding an invalid tag is not on
+  # its own enough, though: silently skipping it walks back to an older release and reports
+  # THAT release's pin, which is the confident wrong answer rather than a refusal. So the
+  # tags this script cannot rank are also detected, and when one of them could outrank the
+  # best valid candidate the run REFUSES by name — the same treatment every other ambiguity
+  # here gets, and deliberately narrower than refusing on the mere existence of a stray tag,
+  # which would park a repository on one ancient malformed release forever.
   local candidates checked=0
-  candidates="$(printf '%s\n' "$tags" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]+)?$' |
+  local strict_re='^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+  local loose_re='^v?[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]*)?$'
+  candidates="$(printf '%s\n' "$tags" | grep -E "$strict_re" |
     sed -e 's/^v//' -e 's/+.*$//' | sort -V -r -u || true)"
   [ -n "$candidates" ] || return 1
+  # Version-like enough to be intended as a release, but not valid SemVer.
+  local unrankable top_valid bad bad_core highest
+  unrankable="$(printf '%s\n' "$tags" | grep -E "$loose_re" | grep -Ev "$strict_re" || true)"
+  if [ -n "$unrankable" ]; then
+    top_valid="$(printf '%s\n' "$candidates" | head -1)"
+    while IFS= read -r bad; do
+      [ -n "$bad" ] || continue
+      bad_core="$(printf '%s' "$bad" | sed -e 's/^v//' -e 's/+.*$//')"
+      [ -n "$bad_core" ] || continue
+      highest="$(printf '%s\n%s\n' "$bad_core" "$top_valid" | sort -V -r | head -1)"
+      if [ "$highest" = "$bad_core" ]; then
+        printf 'tag %s is not valid SemVer (a numeric identifier may not carry a leading zero and a build identifier may not be empty) yet would rank at or above %s; Flux may or may not select it, and choosing needs Flux-compatible ordering, which this script does not implement\n' \
+          "$bad" "$top_valid" >&2
+        return 1
+      fi
+    done <<<"$unrankable"
+  fi
   local core_re variants variant_count candidate
   while IFS= read -r bare; do
     [ -n "$bare" ] || continue
@@ -514,12 +620,21 @@ deployed_tag() {
     # would find nothing, walk silently back to an older release, and attribute THAT
     # release's workflow revision to the deployed artifact. The `v` form is preferred
     # only because these repositories use it.
+    local walk_sha
     for candidate in "v${variants}" "$variants"; do
       printf '%s\n' "$tags" | grep -qxF -- "$candidate" || continue
       plausible_ref "$candidate" || continue
-      if tag_was_published "$repo" "$candidate"; then
+      walk_sha="$(tag_commit "$repo" "$candidate")" || break
+      local walk_pub=0
+      tag_was_published "$repo" "$candidate" "$walk_sha" || walk_pub=$?
+      if [ "$walk_pub" -eq 0 ]; then
         printf '%s\tinferred\n' "$candidate"
         return 0
+      fi
+      if [ "$walk_pub" -eq 2 ]; then
+        printf 'tag %s published successfully from a DIFFERENT commit than it points at today, so it has been moved or recreated; walking past it would attribute an older release workflow revision to the deployed artifact\n' \
+          "$candidate" >&2
+        return 1
       fi
       break
     done
@@ -643,9 +758,14 @@ main() {
     fi
     local mark=''
     # 🔴 NEITHER ORIGIN IS A MEASUREMENT OF WHAT FLUX HAS APPLIED, and both say so. This
-    # script reads manifests and a registry; nothing here reads a cluster. Saying so is the
-    # difference between an allow-list built on evidence and one built on a guess that
-    # reads identically.
+    # script reads manifests, git tags and Actions runs; nothing here reads a cluster, and
+    # nothing here reads the REGISTRY either. Saying so is the difference between an
+    # allow-list built on evidence and one built on a guess that reads identically.
+    #
+    # The registry gap is its own limitation, tracked separately: candidates come only from
+    # git tags, so a GHCR version deleted after a successful run still reads as publishable
+    # while Flux's selector can no longer resolve it. Closing that needs a package read,
+    # which is outside the scope #3048 set for this script.
     #
     # `pinned` was called `exact`, which overclaimed in a way that is reachable rather than
     # theoretical: a version bump landing by DIRECT PUSH to main runs validate-main.yaml

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -410,8 +410,13 @@ tag_was_published() {
   # SPACE. The run for a genuinely published tag is then never matched and a healthy
   # consumer reports UNRESOLVED. Measured: raw interpolation sends `branch=v2.0.0+build.1`,
   # --raw-field sends `branch=v2.0.0%2Bbuild.1`.
+  # 🔴 A FAILED QUERY IS NOT AN ESTABLISHED ABSENCE. Returning 1 here made a rate limit, an
+  # API outage or a tag-list race indistinguishable from "this tag never published", and the
+  # caller's walk then stepped BACKWARD and reported an older release's signing revision as
+  # the signer of what is deployed -- a confident wrong answer built from a transient error.
+  # Exit 3 says the question could not be answered, so the caller refuses instead of guessing.
   runs="$(gh_retry api --method GET "repos/devantler-tech/${repo}/actions/runs" \
-    --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)" || return 1
+    --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)" || return 3
   # `head_sha` pins the run to the commit the tag resolves to TODAY. A historical run for a
   # since-moved tag still carries the old commit and no longer counts as evidence that the
   # artifact the current commit describes was ever published.
@@ -506,6 +511,11 @@ deployed_tag() {
     # to be told apart from the never-published case (1).
     local exact_pub=0
     tag_was_published "$repo" "$candidate" "$exact_sha" || exact_pub=$?
+    if [ "$exact_pub" -eq 3 ]; then
+      printf 'could not read the workflow runs for the pinned tag %s, so whether it published cannot be established\n' \
+        "$candidate" >&2
+      return 1
+    fi
     if [ "$exact_pub" -eq 2 ]; then
       printf 'tag %s published successfully from a DIFFERENT commit than it points at today, so it has been moved or recreated; the workflow revision read from its current commit did not sign the published artifact\n' \
         "$candidate" >&2
@@ -550,7 +560,17 @@ deployed_tag() {
   # which would park a repository on one ancient malformed release forever.
   local candidates checked=0
   local strict_re='^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-  local loose_re='^v?[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]*)?$'
+  # Version-like enough to be intended as a release, but not something this script ranks.
+  # It must cover every form FLUX accepts, not just the malformed ones: Flux parses tags with
+  # Masterminds semver.NewVersion, which COERCES a partial version -- measured, v2.5 resolves
+  # to 2.5.0 and v2 to 2.0.0. A pattern requiring three components matched neither the strict
+  # filter nor this one, so such a tag was dropped from BOTH sets: the walk stepped silently
+  # to an older release and reported ITS signing revision, omitting the actual signer from
+  # the allow-list. Prereleases are here for the same reason -- Flux accepts v2.0.0-rc.1, and
+  # ordering it against a release is exactly the Flux-compatible precedence this script does
+  # not implement. Four-component tags and non-numeric ones stay out: Flux rejects them too
+  # (measured), so they cannot be selected and refusing on them would be noise.
+  local loose_re='^v?[0-9]+(\.[0-9]+){0,2}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]*)?$'
   candidates="$(printf '%s\n' "$tags" | grep -E "$strict_re" |
     sed -e 's/^v//' -e 's/+.*$//' | sort -V -r -u || true)"
   [ -n "$candidates" ] || return 1
@@ -624,9 +644,22 @@ deployed_tag() {
     for candidate in "v${variants}" "$variants"; do
       printf '%s\n' "$tags" | grep -qxF -- "$candidate" || continue
       plausible_ref "$candidate" || continue
-      walk_sha="$(tag_commit "$repo" "$candidate")" || break
+      # A `break` here would leave the OUTER loop free to step to an older version, so a
+      # transient commit lookup failure was reported as that older release's signing
+      # revision. The tag is known to exist -- it came from the tag list two lines up -- so
+      # a failure is the query, never absence, and the run refuses by name.
+      if ! walk_sha="$(tag_commit "$repo" "$candidate")"; then
+        printf 'could not resolve the commit for tag %s, so whether it published cannot be established; walking past it would attribute an older release workflow revision to the deployed artifact\n' \
+          "$candidate" >&2
+        return 1
+      fi
       local walk_pub=0
       tag_was_published "$repo" "$candidate" "$walk_sha" || walk_pub=$?
+      if [ "$walk_pub" -eq 3 ]; then
+        printf 'could not read the workflow runs for tag %s, so whether it published cannot be established; walking past it would attribute an older release workflow revision to the deployed artifact\n' \
+          "$candidate" >&2
+        return 1
+      fi
       if [ "$walk_pub" -eq 0 ]; then
         printf '%s\tinferred\n' "$candidate"
         return 0

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -94,6 +94,27 @@ plausible_repo() {
 # commit SHA and nothing else.
 is_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
 
+# Split one resolver answer into its tab-separated fields, ONE PER LINE, PRESERVING
+# EMPTY FIELDS.
+#
+# 🔴 `IFS=$'\t' read` CANNOT BE USED HERE: tab is IFS WHITESPACE, so bash collapses
+# adjacent tabs and an empty MIDDLE field silently shifts every later field LEFT.
+# Measured: an answer of `SHA<TAB><TAB>SHA` assigns the ORIGIN field to `current`, both
+# halves then pass `is_sha`, and the IN-SYNC/DIVERGED comparison runs on a field that was
+# never `current` at all. That is this script's one forbidden failure mode — reporting a
+# confident answer having compared the wrong thing — arriving through the parser rather
+# than the network. Discovery already carries a `-` placeholder for exactly this reason;
+# a resolver answer has no such guarantee, so it is split explicitly instead.
+answer_fields() {
+  local rest="$1" field tab=$'\t'
+  while :; do
+    field="${rest%%"${tab}"*}"
+    printf '%s\n' "$field"
+    [ "$field" = "$rest" ] && break
+    rest="${rest#*"${tab}"}"
+  done
+}
+
 # A transient 5xx or secondary rate limit must not make main red on a REPORT: a control
 # that goes red for reasons unrelated to what it checks is one people learn to ignore.
 # Bounded, so a genuine outage still fails rather than hanging.
@@ -156,11 +177,21 @@ discover_consumers() {
       repo="$(oci_name_to_repo "$repo")"
       plausible_repo "$repo" || continue
       printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
+    # 🔴 FLUX RESOLVES `spec.ref` AS digest > semver > tag, AND AN OMITTED `ref` MEANS
+    # `latest`. Reading `tag` first inverts that: a document carrying BOTH a tag and a
+    # digest (or a tag and a semver) would be attributed to a tag Flux never serves, and
+    # the real signer would be omitted from the proposed allow-list — a confident wrong
+    # answer, which is the one outcome this report must never produce. A digest or an
+    # omitted ref also collapsed to the meaningless `semver:`, which `effective_version`
+    # then refused as a bounded constraint, so a resolvable consumer read as UNRESOLVED.
+    #
+    # These live OUTSIDE the single-quoted yq program deliberately: a backtick inside it
+    # reads as a command substitution to shellcheck (SC2016), so prose belongs out here.
     done < <(yq eval -r '
       select(.kind == "OCIRepository") |
       [(.spec.url // "-"),
        ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | join(" ") | select(. != "") // "-"),
-       (.spec.ref.tag // ("semver:" + (.spec.ref.semver // "")) // "-")] | @tsv
+       (((.spec.ref.digest // "") | select(. != "") | "digest:" + .) // ((.spec.ref.semver // "") | select(. != "") | "semver:" + .) // ((.spec.ref.tag // "") | select(. != "")) // "latest")] | @tsv
     ' "$file" 2>/dev/null || true)
   done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
 }
@@ -190,6 +221,14 @@ effective_version() {
     '-' | '')
       printf '%s\n' ''
       return 0
+      ;;
+    # A digest pins an exact artifact rather than a version, so the tag-based resolver
+    # cannot answer for it. Refuse by name instead of guessing — the same reasoning as
+    # the bounded-semver refusal below.
+    digest:*)
+      printf 'digest-pinned reference "%s" needs artifact-level resolution, which this script does not implement\n' \
+        "${raw#digest:}" >&2
+      return 1
       ;;
     semver:*)
       expr="${raw#semver:}"
@@ -390,7 +429,7 @@ main() {
   fi
 
   local resolver="${PUBLISH_REVISION_RESOLVER:-}"
-  local repo workflow version answer signing current origin
+  local repo workflow version answer signing current origin field field_count
   local diverged=0 unresolved=0 examined=0
 
   printf 'Shared publish-workflow revisions, per consumer (#3048)\n'
@@ -412,13 +451,34 @@ main() {
     else
       answer="$(default_resolver "$repo" "$workflow" "$version")" || answer=""
     fi
-    # 🔴 `cut -f2` WITHOUT `-s` ECHOES THE WHOLE LINE when the delimiter is absent, so a
-    # resolver emitting one tab-free line (an error body — the very shape warned about
-    # above) set signing == current and reported IN-SYNC for every consumer with exit 0.
-    # `read` splits on tabs only, and both values must then be commit SHAs: an
-    # unparseable answer is UNRESOLVED, never agreement.
-    IFS=$'\t' read -r signing current origin <<<"$answer"
-    if ! is_sha "${signing:-}" || ! is_sha "${current:-}"; then
+    # The one-tab-free-line case that `cut -f2` without `-s` used to accept is covered by
+    # the same shape check below: fewer than two fields is UNRESOLVED, never agreement.
+    # A resolver answer must be EXACTLY one line of two or three tab-separated fields,
+    # each SHA field non-empty. Anything else is UNRESOLVED, never agreement.
+    #
+    # 🔴 `read` IS NOT SAFE HERE, on two independent counts, both measured on this exact
+    # path: it stops at the FIRST LINE, so a valid line followed by trailing output was
+    # accepted unseen; and tab is IFS whitespace, so `SHA<TAB><TAB>SHA` COLLAPSED to two
+    # fields and assigned the ORIGIN field to `current` — both halves then passed
+    # `is_sha` and the comparison ran on a field that was never `current`.
+    field_count=0
+    signing=''
+    current=''
+    origin=''
+    while IFS= read -r field; do
+      case "$field_count" in
+        0) signing="$field" ;;
+        1) current="$field" ;;
+        2) origin="$field" ;;
+      esac
+      field_count=$((field_count + 1))
+    done < <(answer_fields "$answer")
+    # A multi-line answer is rejected outright rather than judged on its first line.
+    case "$answer" in
+      *$'\n'*) field_count=0 ;;
+    esac
+    if [ "$field_count" -lt 2 ] || [ "$field_count" -gt 3 ] ||
+      ! is_sha "${signing:-}" || ! is_sha "${current:-}"; then
       unresolved=$((unresolved + 1))
       printf 'UNRESOLVED %-22s %-18s could not resolve both revisions to a commit SHA\n' \
         "$repo" "$workflow"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -178,12 +178,20 @@ discover_consumers() {
       plausible_repo "$repo" || continue
       printf '%s\t%s\t%s\n' "$repo" "$workflow" "$version"
       # 🔴 FLUX RESOLVES `spec.ref` AS digest > semver > tag, AND AN OMITTED `ref` MEANS
-      # `latest`. Reading `tag` first inverts that: a document carrying BOTH a tag and a
-      # digest (or a tag and a semver) would be attributed to a tag Flux never serves, and
-      # the real signer would be omitted from the proposed allow-list — a confident wrong
-      # answer, which is the one outcome this report must never produce. A digest or an
-      # omitted ref also collapsed to the meaningless `semver:`, which `effective_version`
-      # then refused as a bounded constraint, so a resolvable consumer read as UNRESOLVED.
+      # the mutable `latest` tag. Reading `tag` first inverts that: a document carrying BOTH
+      # a tag and a digest (or a tag and a semver) would be attributed to a tag Flux never
+      # serves, and the real signer would be omitted from the proposed allow-list — a
+      # confident wrong answer, which is the one outcome this report must never produce. A
+      # digest or an omitted ref also collapsed to the meaningless `semver:`, which
+      # `effective_version` then refused as a bounded constraint, so a resolvable consumer
+      # read as UNRESOLVED.
+      #
+      # An omitted ref emits `unpinned`, NOT the literal `latest`, so it stays distinct from
+      # a document that explicitly writes `tag: latest`. The two are different questions: an
+      # explicit tag is a written-down selector this resolver can look up, while an omitted
+      # ref is a mutable pointer with no release version behind it. Emitting `latest` for
+      # both made the omitted case an exact lookup for a tag that is not a release, and
+      # `effective_version` refuses `unpinned` by name instead.
       #
       # These live OUTSIDE the single-quoted yq program deliberately: a backtick inside it
       # reads as a command substitution to shellcheck (SC2016), so prose belongs out here.
@@ -191,7 +199,7 @@ discover_consumers() {
       select(.kind == "OCIRepository") |
       [(.spec.url // "-"),
        ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | join(" ") | select(. != "") // "-"),
-       (((.spec.ref.digest // "") | select(. != "") | "digest:" + .) // ((.spec.ref.semver // "") | select(. != "") | "semver:" + .) // ((.spec.ref.tag // "") | select(. != "")) // "latest")] | @tsv
+       (((.spec.ref.digest // "") | select(. != "") | "digest:" + .) // ((.spec.ref.semver // "") | select(. != "") | "semver:" + .) // ((.spec.ref.tag // "") | select(. != "")) // "unpinned")] | @tsv
     ' "$file" 2>/dev/null || true)
   done < <(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$root" 2>/dev/null | sort -u) | sort -u
 }
@@ -228,6 +236,17 @@ effective_version() {
     digest:*)
       printf 'digest-pinned reference "%s" needs artifact-level resolution, which this script does not implement\n' \
         "${raw#digest:}" >&2
+      return 1
+      ;;
+    # An omitted `spec.ref` tracks the MUTABLE `latest` tag. That is a pointer, not a
+    # release version, so the tag walk below has nothing to select and no published
+    # release corresponds to it — the same shape as the digest refusal above. Walking to
+    # the newest release instead would be a GUESS: `latest` need not point at it, and the
+    # report would then attribute that release's workflow revision to whatever is actually
+    # deployed. Refuse by name, so the cause is diagnosable rather than surfacing as an
+    # opaque lookup miss.
+    unpinned)
+      printf 'unpinned reference (spec.ref omitted) tracks the mutable "latest" tag, which is not a release version this tag-based resolver can attribute; pin the consumer with a tag, semver range, or digest\n' >&2
       return 1
       ;;
     semver:*)

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -522,7 +522,11 @@ deployed_tag() {
       return 1
     fi
     [ "$exact_pub" -eq 0 ] || return 1
-    printf '%s\tpinned\n' "$candidate"
+    # The VERIFIED commit travels with the tag. `pin_at_ref` used to be handed the tag NAME,
+    # which is mutable: if the tag moves after the publication check above and before that
+    # read, publication is verified for this commit while cd.yaml is read from a different
+    # one, and the report emits a confident signing revision that never signed the artifact.
+    printf '%s\tpinned\t%s\n' "$candidate" "$exact_sha"
     return 0
   fi
   # Strip the optional `v` before ordering: `sort -V` compares it as text, so a mixed list
@@ -721,7 +725,7 @@ deployed_tag() {
             fi
           done <<<"$unrankable"
         fi
-        printf '%s\tinferred\n' "$candidate"
+        printf '%s\tinferred\t%s\n' "$candidate" "$walk_sha"
         return 0
       fi
       if [ "$walk_pub" -eq 2 ]; then
@@ -737,13 +741,21 @@ deployed_tag() {
 
 # Default resolver: "<signing revision>\t<current pin>\t<pinned|inferred>".
 default_resolver() {
-  local repo="$1" workflow="$2" version="${3:-}" branch tagline tag origin signing current
+  local repo="$1" workflow="$2" version="${3:-}" branch tagline tag origin tag_sha signing current
   branch="$(gh_retry api "repos/devantler-tech/${repo}" --jq .default_branch)" || return 1
   plausible_ref "$branch" || return 1
   tagline="$(deployed_tag "$repo" "$version")" || return 1
-  IFS=$'\t' read -r tag origin <<<"$tagline"
+  # THREE fields: reading two would leave `origin` holding "pinned<TAB><sha>", which matches
+  # neither `pinned` nor `inferred` in the disclaimer case below, so the row would silently
+  # lose its not-applied-revision disclaimer.
+  IFS=$'\t' read -r tag origin tag_sha <<<"$tagline"
+  # Fail closed rather than fall back to the tag: an empty or malformed third field would
+  # restore exactly the mutable-ref read this change exists to close.
+  is_sha "${tag_sha:-}" || return 1
   current="$(pin_at_ref "$repo" "$workflow" "$branch")" || return 1
-  signing="$(pin_at_ref "$repo" "$workflow" "$tag")" || return 1
+  # The COMMIT, never `$tag`. `$tag` remains the human-facing name and is what the Actions
+  # run query above was scoped to; it is not a stable ref to read file content at.
+  signing="$(pin_at_ref "$repo" "$workflow" "$tag_sha")" || return 1
   printf '%s\t%s\t%s\n' "$signing" "$current" "$origin"
 }
 

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -287,9 +287,21 @@ effective_version() {
             "$expr" >&2
           return 1
           ;;
-        '>'[0-9]* | '>='[0-9]*)
+        '>='[0-9]*)
           printf '%s\n' ''
           return 0
+          ;;
+        # A STRICT lower bound is not the same as an inclusive one. `>=1.0.0` admits
+        # 1.0.0, so treating it as unbounded and taking the newest published tag is
+        # right. `>1.0.0` EXCLUDES 1.0.0 — so when 1.0.0 is the newest published tag
+        # Flux selects nothing there, while the walk below would hand back 1.0.0 and
+        # attribute ITS workflow revision to whatever is actually deployed. The walk
+        # models no lower bound at all, so this refuses by name like every other
+        # constraint whose selection this script does not implement.
+        '>'[0-9]*)
+          printf 'strict lower-bound semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
+            "$expr" >&2
+          return 1
           ;;
         *)
           printf 'bounded semver constraint "%s" needs Flux-compatible selection, which this script does not implement\n' \
@@ -350,7 +362,14 @@ tag_was_published() {
   # repository with frequent pushes a candidate release's run falls off that first page, every
   # retry re-fetches the same incomplete page, and a healthy consumer stays UNRESOLVED until the
   # next release. Filtering by ref makes the result set small enough that one page is complete.
-  runs="$(gh_retry api "repos/devantler-tech/${repo}/actions/runs?branch=${tag}&event=push&per_page=100")" || return 1
+  # The tag goes in as a PARAMETER, not interpolated into the query string. A tag may
+  # carry SemVer build metadata (`v2.0.0+build.1`) and this script resolves such tags as
+  # themselves, so a raw `+` reaches the wire unencoded, where query parsing reads it as a
+  # SPACE. The run for a genuinely published tag is then never matched and a healthy
+  # consumer reports UNRESOLVED. Measured: raw interpolation sends `branch=v2.0.0+build.1`,
+  # --raw-field sends `branch=v2.0.0%2Bbuild.1`.
+  runs="$(gh_retry api --method GET "repos/devantler-tech/${repo}/actions/runs" \
+    --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)" || return 1
   printf '%s' "$runs" |
     jq -r --arg t "$tag" '
       [.workflow_runs[]

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -367,11 +367,17 @@ tag_was_published() {
 # Release object; `aws` publishes from tags and cuts no Releases at all. Releases are
 # therefore not consulted.
 #
-# Prints "<tag>\t<exact|inferred>". `exact` means the OCIRepository pins that version, so
-# it IS what is deployed. `inferred` means the consumer uses a semver RANGE, so the newest
-# published tag is the closest honest answer — and the caller marks the row, because an
-# inferred revision must not be mistaken for a measured one when an allow-list is built
-# from this output.
+# Prints "<tag>\t<pinned|inferred>". `pinned` means the OCIRepository names that version
+# and its artifact was published; `inferred` means the consumer uses a semver RANGE, so the
+# newest published tag is the closest honest answer.
+#
+# 🔴 NEITHER IS EVIDENCE OF WHAT IS APPLIED, and the caller marks BOTH rows for that reason.
+# `pinned` was called `exact` and read as "this IS what is deployed", which it cannot know:
+# a version bump landing by direct push to main is reported by validate-main.yaml before the
+# manual CD workflow deploys it, so a previously-published tag reads as deployed while the
+# cluster still runs its predecessor — and the proposed allow-list then omits the revision
+# that actually signed the running artifact. Closing that needs an applied Flux revision,
+# which means reading a cluster; this script reads manifests and a registry only.
 deployed_tag() {
   local repo="$1" version="$2" tags candidate bare
   # --paginate: the endpoint caps at 100 per page and these repos already carry 50+ tags.
@@ -389,7 +395,7 @@ deployed_tag() {
         # the signer of what is deployed. A pinned-but-unpublished version is an anomaly worth
         # surfacing, so it is UNRESOLVED rather than silently walked back to an older tag.
         tag_was_published "$repo" "$candidate" || return 1
-        printf '%s\texact\n' "$candidate"
+        printf '%s\tpinned\n' "$candidate"
         return 0
       fi
     done
@@ -453,7 +459,7 @@ deployed_tag() {
   return 1
 }
 
-# Default resolver: "<signing revision>\t<current pin>\t<exact|inferred>".
+# Default resolver: "<signing revision>\t<current pin>\t<pinned|inferred>".
 default_resolver() {
   local repo="$1" workflow="$2" version="${3:-}" branch tagline tag origin signing current
   branch="$(gh_retry api "repos/devantler-tech/${repo}" --jq .default_branch)" || return 1
@@ -568,10 +574,23 @@ main() {
       continue
     fi
     local mark=''
-    # An inferred revision is the newest tag whose release actually published; it is still
-    # not a measurement of what Flux has APPLIED. Saying so is the difference between an
-    # allow-list built on evidence and one built on a guess that reads identically.
-    [ "${origin:-}" = 'inferred' ] && mark=' (deployed version inferred from newest PUBLISHED tag)'
+    # 🔴 NEITHER ORIGIN IS A MEASUREMENT OF WHAT FLUX HAS APPLIED, and both say so. This
+    # script reads manifests and a registry; nothing here reads a cluster. Saying so is the
+    # difference between an allow-list built on evidence and one built on a guess that
+    # reads identically.
+    #
+    # `pinned` was called `exact`, which overclaimed in a way that is reachable rather than
+    # theoretical: a version bump landing by DIRECT PUSH to main runs validate-main.yaml
+    # immediately, while that path does not deploy until the manual CD workflow runs. If
+    # that tag's artifact had been published earlier, the row read `exact` — "this IS what
+    # is deployed" — while the cluster was still running the PREVIOUS tag, so the proposed
+    # allow-list could omit the revision that actually signed the running artifact.
+    # `tag_was_published` closes "the tag exists but never published"; it cannot close
+    # "published but not yet applied", and no tag-based check can.
+    case "${origin:-}" in
+      inferred) mark=' (deployed version inferred from newest PUBLISHED tag; not applied-revision evidence)' ;;
+      pinned) mark=' (deployed version is what the manifest PINS and was published; not applied-revision evidence)' ;;
+    esac
     if [ "$signing" = "$current" ]; then
       printf 'IN-SYNC    %-22s %-18s signed=%s pinned=%s%s\n' \
         "$repo" "$workflow" "$signing" "$current" "$mark"

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -796,6 +796,12 @@ main() {
   local resolver="${PUBLISH_REVISION_RESOLVER:-}"
   local repo workflow version answer signing current origin field field_count
   local diverged=0 unresolved=0 examined=0
+  # Scratch for one consumer's refusal diagnostic. A file rather than a process
+  # substitution so the capture works under a plain POSIX-ish shell, and so the
+  # command substitution above still yields `effective_version`'s STDOUT and its exit
+  # status unchanged -- `2>&1` would fold the diagnostic into the version string.
+  local why why_file
+  why_file="$(mktemp)" || return 1
 
   printf 'Shared publish-workflow revisions, per consumer (#3048)\n'
   printf '%s\n' '-------------------------------------------------------'
@@ -805,10 +811,20 @@ main() {
     examined=$((examined + 1))
     # Classify from the manifest first: a bounded range is refused before any resolver is
     # consulted, because the constraint is written down rather than discovered remotely.
-    if ! version="$(effective_version "$version")"; then
+    #
+    # REPORT THE CAUSE THE RESOLVER ACTUALLY GAVE. `effective_version` refuses for five
+    # distinct reasons -- digest-pinned, omitted, prerelease bound, malformed inclusive
+    # bound, strict lower bound -- and writes the specific one to stderr. Printing a fixed
+    # "bounded semver constraint" for all of them told a reader of the step summary the
+    # wrong thing for four of the five, and the summary is stdout-only (see the note at the
+    # tally below), so the real cause was not merely elsewhere -- it was absent.
+    if ! version="$(effective_version "$version" 2>"$why_file")"; then
       unresolved=$((unresolved + 1))
-      printf 'UNRESOLVED %-22s %-18s bounded semver constraint — not resolvable here\n' \
-        "$repo" "$workflow"
+      # One row per consumer: fold the diagnostic to a single line, and fall back to the
+      # generic wording only if the refusal was silent.
+      why="$(tr '\n' ' ' <"$why_file" | sed -E 's/[[:space:]]+/ /g; s/ $//')"
+      [ -n "$why" ] || why='not resolvable here (no diagnostic emitted)'
+      printf 'UNRESOLVED %-22s %-18s %s\n' "$repo" "$workflow" "$why"
       continue
     fi
     if [ -n "$resolver" ]; then
@@ -885,6 +901,7 @@ main() {
       printf '           allow-list must accept: %s AND %s\n' "$signing" "$current"
     fi
   done <<<"$consumers"
+  rm -f "$why_file"
 
   printf '%s\n' '-------------------------------------------------------'
   # `unresolved` is in the tally deliberately. The failure detail below also goes to

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -68,8 +68,8 @@ fail() {
 # adding a consumer needs no edit unless its artifact name genuinely differs.
 oci_name_to_repo() {
   case "$1" in
-  github-config) printf '%s\n' '.github' ;;
-  *) printf '%s\n' "$1" ;;
+    github-config) printf '%s\n' '.github' ;;
+    *) printf '%s\n' "$1" ;;
   esac
 }
 
@@ -88,7 +88,7 @@ plausible_ref() {
   local ref="$1"
   [ -n "$ref" ] || return 1
   case "$ref" in
-  *[[:space:]]* | *'{'* | *'}'* | *'"'*) return 1 ;;
+    *[[:space:]]* | *'{'* | *'}'* | *'"'*) return 1 ;;
   esac
   return 0
 }
@@ -115,8 +115,8 @@ discover_consumers() {
     url="$(yq eval -r 'select(.kind == "OCIRepository") | .spec.url // ""' "$file" 2>/dev/null | grep -m1 . || true)"
     [ -n "$url" ] || continue
     case "$url" in
-    oci://ghcr.io/devantler-tech/*) ;;
-    *) continue ;;
+      oci://ghcr.io/devantler-tech/*) ;;
+      *) continue ;;
     esac
     repo="${url#oci://ghcr.io/devantler-tech/}"
     repo="${repo%%/*}"

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -367,8 +367,104 @@ else
   pass 'a bounded semver constraint refuses by name instead of guessing the newest tag'
 fi
 
+# ---------------------------------------------------------------------------
+# 10. AN EMPTY MIDDLE FIELD MUST NOT SHIFT `origin` INTO `current`. (#3305 review)
+#     Tab is IFS WHITESPACE, so `IFS=$'\t' read -r signing current origin` COLLAPSES
+#     adjacent tabs: an answer of `SHA_A<TAB><TAB>SHA_A` assigned SHA_A to BOTH signing
+#     and current and reported IN-SYNC — a confident wrong answer produced by the parser
+#     rather than the network, which is the one outcome this script must never have.
+#     Written without arrays or `read -d`, so it holds on the Bash 3.2 that ships on macOS.
+# ---------------------------------------------------------------------------
+collapse_resolver="$WORK/resolver-collapse.sh"
+cat >"$collapse_resolver" <<COLLAPSE
+#!/usr/bin/env bash
+# exit 0 on purpose: a FAILING resolver is discarded by the caller, so only a SUCCEEDING
+# one reaches the field-splitting path this case exists to test.
+printf '%s\t\t%s\n' '$SHA_A' '$SHA_A'
+exit 0
+COLLAPSE
+chmod +x "$collapse_resolver"
+collapse_out="$WORK/collapse.out"
+if PUBLISH_REVISION_RESOLVER="$collapse_resolver" "$SCRIPT" >"$collapse_out" 2>&1; then
+  fail 'an answer with an EMPTY MIDDLE FIELD exited 0 — the collapsed field was compared as the current revision'
+else
+  grep -q 'IN-SYNC' "$collapse_out" &&
+    fail 'SHA<TAB><TAB>SHA was reported as IN-SYNC — adjacent tabs collapsed and the origin field became the current one'
+  grep -q 'UNRESOLVED' "$collapse_out" ||
+    fail 'an answer with an empty middle field produced no UNRESOLVED line'
+  pass 'an empty middle field is UNRESOLVED, never a comparison against the shifted field'
+fi
+
+# ---------------------------------------------------------------------------
+# 11. TRAILING OUTPUT AFTER A VALID LINE MUST NOT BE ACCEPTED UNSEEN. (#3305 review)
+#     `read` stops at the first line, so a resolver emitting a good line followed by
+#     anything at all was accepted on the strength of the part that parsed.
+# ---------------------------------------------------------------------------
+extra_resolver="$WORK/resolver-extra.sh"
+cat >"$extra_resolver" <<EXTRA
+#!/usr/bin/env bash
+printf '%s\t%s\nunexpected trailing output\n' '$SHA_A' '$SHA_A'
+exit 0
+EXTRA
+chmod +x "$extra_resolver"
+extra_out="$WORK/extra.out"
+if PUBLISH_REVISION_RESOLVER="$extra_resolver" "$SCRIPT" >"$extra_out" 2>&1; then
+  fail 'a multi-line resolver answer exited 0 — only its first line was ever examined'
+else
+  grep -q 'IN-SYNC' "$extra_out" &&
+    fail 'a valid first line with trailing output was reported as IN-SYNC'
+  grep -q 'UNRESOLVED' "$extra_out" ||
+    fail 'a multi-line resolver answer produced no UNRESOLVED line'
+  pass 'trailing output after a valid line is UNRESOLVED, not accepted on the first line alone'
+fi
+
+# ---------------------------------------------------------------------------
+# 12. FLUX REFERENCE PRECEDENCE: digest > semver > tag, omitted ref means `latest`.
+#     (#3305 review) Reading `tag` first attributed a document carrying both a tag and a
+#     digest to a tag Flux never serves; a digest or an omitted ref collapsed to the
+#     meaningless `semver:`, which `effective_version` then refused as a bounded
+#     constraint, so a resolvable consumer read as UNRESOLVED. Asserted against the
+#     expression itself, because the selector choice is a property of the MANIFEST.
+# ---------------------------------------------------------------------------
+# 🔴 EXTRACTED FROM THE SCRIPT, NEVER RETYPED. A copy of the expression here would assert
+# only that SOME expression is correct, and would keep passing while the one the script
+# actually runs regressed — the test would pin nothing. The extraction is asserted
+# non-empty below, so a rename or reformat fails the case loudly instead of silently
+# testing an empty string.
+# `|| true` is load-bearing: under `set -e` a no-match grep in a command substitution
+# ABORTS the suite at this line, so the guard below never runs and the run dies with exit 1
+# and NO diagnostic — a failure nobody can act on. Measured while ablating this case.
+ref_expr="$(grep -o '(((\.spec\.ref\.digest.*"latest")' "$SCRIPT" || true)"
+[ -n "$ref_expr" ] ||
+  fail 'could not extract the reference-precedence expression from the script — the case would pass vacuously'
+ref_case() { # <name> <ref-yaml-block> <expected>
+  local name="$1" block="$2" expected="$3" doc="$WORK/ref-$1.yaml" got
+  {
+    printf 'kind: OCIRepository\nspec:\n  url: oci://ghcr.io/devantler-tech/x/manifests\n'
+    [ -n "$block" ] && printf '%s\n' "$block"
+  } >"$doc"
+  got="$(yq eval -r "$ref_expr" "$doc" 2>&1)"
+  [ "$got" = "$expected" ] ||
+    fail "reference precedence ($name): expected [$expected], got [$got]"
+}
+ref_case tag '  ref:
+    tag: v1.2.3' 'v1.2.3'
+ref_case semver '  ref:
+    semver: ">=1.0.0"' 'semver:>=1.0.0'
+ref_case digest '  ref:
+    digest: sha256:abcdef' 'digest:sha256:abcdef'
+ref_case tag-and-digest '  ref:
+    tag: v1.2.3
+    digest: sha256:abcdef' 'digest:sha256:abcdef'
+ref_case tag-and-semver '  ref:
+    tag: v1.2.3
+    semver: ">=1.0.0"' 'semver:>=1.0.0'
+ref_case omitted '' 'latest'
+pass 'Flux reference precedence is digest > semver > tag, and an omitted ref means latest'
+
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (9 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (12 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -314,8 +314,58 @@ else
   pass 'an extra unregistered consumer fails closed and is named'
 fi
 
+# ---------------------------------------------------------------------------
+# 9. A BOUNDED SEMVER CONSTRAINT MUST REFUSE, NOT GUESS. An unbounded `>=1.0.0` and
+#    "whatever is newest" happen to agree, which is why discarding the constraint looked
+#    harmless. A bounded selector (`~1.4`, `<2.0.0`) does not agree: the newest published
+#    tag is one Flux would never serve, so its workflow revision would be attributed to
+#    the deployed artifact and the real signer omitted from the allow-list.
+#
+#    Resolving such a range needs Flux-compatible semver selection this script does not
+#    implement, so the honest outcome is a named refusal.
+# ---------------------------------------------------------------------------
+bounded_root="$WORK/bounded"
+mkdir -p "$bounded_root"
+k=0
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  k=$((k + 1))
+  oci="$repo"
+  [ "$repo" = '.github' ] && oci='github-config'
+  # One consumer gets a BOUNDED range; the rest keep an unbounded one, so the refusal
+  # cannot be confused with a wholesale failure of the fixture.
+  if [ "$k" -eq 1 ]; then ref='semver: "~1.4"'; else ref='semver: ">=1.0.0"'; fi
+  cat >"$bounded_root/c-$k.yaml" <<YAML
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: b$k
+spec:
+  ref:
+    $ref
+  url: oci://ghcr.io/devantler-tech/$oci/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\\.actions\\.githubusercontent\\.com\$'
+        subject: '^https://github\\.com/devantler-tech/actions/\\.github/workflows/$workflow\\.yaml@[0-9a-f]{40}\$'
+YAML
+done <<<"$consumers"
+bounded_out="$WORK/bounded.out"
+# No resolver stub: the refusal must happen while RESOLVING the deployed version, which is
+# the default resolver's job, so stubbing it would bypass the very branch under test.
+if PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
+  fail 'a bounded semver constraint was silently resolved to the newest tag instead of refusing'
+else
+  grep -q 'bounded semver constraint' "$bounded_out" ||
+    fail 'the run failed but not because of the bounded constraint — the case is not testing what it claims'
+  grep -q '~1.4' "$bounded_out" ||
+    fail 'the refusal does not name the constraint, so the cause is not diagnosable'
+  pass 'a bounded semver constraint refuses by name instead of guessing the newest tag'
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (8 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (9 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -445,7 +445,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 12. FLUX REFERENCE PRECEDENCE: digest > semver > tag, omitted ref means `latest`.
+# 12. FLUX REFERENCE PRECEDENCE: digest > semver > tag, omitted ref emits `unpinned`.
 #     (#3305 review) Reading `tag` first attributed a document carrying both a tag and a
 #     digest to a tag Flux never serves; a digest or an omitted ref collapsed to the
 #     meaningless `semver:`, which `effective_version` then refused as a bounded
@@ -460,7 +460,7 @@ fi
 # `|| true` is load-bearing: under `set -e` a no-match grep in a command substitution
 # ABORTS the suite at this line, so the guard below never runs and the run dies with exit 1
 # and NO diagnostic — a failure nobody can act on. Measured while ablating this case.
-ref_expr="$(grep -o '(((\.spec\.ref\.digest.*"latest")' "$SCRIPT" || true)"
+ref_expr="$(grep -o '(((\.spec\.ref\.digest.*"unpinned")' "$SCRIPT" || true)"
 [ -n "$ref_expr" ] ||
   fail 'could not extract the reference-precedence expression from the script — the case would pass vacuously'
 ref_case() { # <name> <ref-yaml-block> <expected>
@@ -485,8 +485,8 @@ ref_case tag-and-digest '  ref:
 ref_case tag-and-semver '  ref:
     tag: v1.2.3
     semver: ">=1.0.0"' 'semver:>=1.0.0'
-ref_case omitted '' 'latest'
-pass 'Flux reference precedence is digest > semver > tag, and an omitted ref means latest'
+ref_case omitted '' 'unpinned'
+pass 'Flux reference precedence is digest > semver > tag, and an omitted ref emits unpinned rather than a literal tag'
 
 # ---------------------------------------------------------------------------
 # 13. BUILD METADATA MUST NOT BE DISCARDED, AND A TIE MUST NOT BE GUESSED. (#3305 review)
@@ -597,8 +597,24 @@ else
     fail 'the refusal does not name the tags that tie, so the cause is not diagnosable'
   # A CONTROL: the other four consumers must resolve through the same stub, or this
   # "refusal" could just be the whole fixture failing for an unrelated reason.
-  grep -q 'wedding-app' "$bm_out" ||
-    fail 'the refusal does not name the consumer that ties'
+  #
+  # 🔴 COUNT THE OUTCOME LINES; a name match is NOT a control. The report names every
+  # consumer it discovered, on the UNRESOLVED line as readily as the IN-SYNC one, so
+  # `grep -q wedding-app` matches just as well when ALL FIVE consumers failed — which is
+  # precisely the unrelated-failure case this control exists to exclude. It asserted only
+  # that the tying consumer was mentioned, which the refusal message above already proves.
+  #
+  # `|| true` is load-bearing on both counts: `grep -c` exits 1 when the count is zero, and
+  # a command substitution's status becomes the assignment's, so under `set -e` a legitimate
+  # zero would abort the suite here instead of reaching the comparison that reports it.
+  bm_unresolved="$(grep -c '^UNRESOLVED' "$bm_out" || true)"
+  bm_insync="$(grep -c '^IN-SYNC' "$bm_out" || true)"
+  [ "$bm_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the build-metadata tie), got $bm_unresolved — a different count means the fixture failed for an unrelated reason"
+  [ "$bm_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $bm_insync"
+  grep -qE '^UNRESOLVED +wedding-app' "$bm_out" ||
+    fail 'the unresolved consumer is not the one that ties'
   pass 'a version carried by both a bare and a build-metadata tag refuses instead of guessing'
 fi
 
@@ -636,8 +652,59 @@ else
   pass 'a version published only with build metadata is never silently walked past'
 fi
 
+# ---------------------------------------------------------------------------
+# 15. AN OMITTED `spec.ref` MUST REFUSE, NOT BE LOOKED UP. (#3305 review)
+#     Flux serves the mutable `latest` tag when `spec.ref` is absent. That is a pointer,
+#     not a release version, so there is nothing for the tag walk to select — the same
+#     shape as the digest refusal. Emitting the literal `latest` made it an exact lookup
+#     for a tag that is not a release; walking to the newest release instead would be a
+#     GUESS, since `latest` need not point there, and would attribute that release's
+#     workflow revision to whatever is actually deployed.
+#
+#     Case 12 pins the token the expression emits. This pins what the RESOLVER does with
+#     it, which is the half that decides whether a consumer is misattributed.
+# ---------------------------------------------------------------------------
+up_root="$WORK/unpinned"
+mkdir -p "$up_root"
+k=0
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  k=$((k + 1))
+  oci="$repo"
+  [ "$repo" = '.github' ] && oci='github-config'
+  # Consumer 1 OMITS `ref:` entirely; the rest keep an unbounded range, so the refusal
+  # cannot be confused with a wholesale failure of the fixture.
+  if [ "$k" -eq 1 ]; then ref_block=''; else ref_block='  ref:
+    semver: ">=1.0.0"'; fi
+  {
+    printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: u%s\nspec:\n' "$k"
+    if [ -n "$ref_block" ]; then printf '%s\n' "$ref_block"; fi
+    printf '  url: oci://ghcr.io/devantler-tech/%s/manifests\n' "$oci"
+    printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n'
+    printf "      - issuer: '^https://token\\\\.actions\\\\.githubusercontent\\\\.com\$'\n"
+    printf "        subject: '^https://github\\\\.com/devantler-tech/actions/\\\\.github/workflows/%s\\\\.yaml@[0-9a-f]{40}\$'\n" "$workflow"
+  } >"$up_root/c-$k.yaml"
+done <<<"$consumers"
+
+up_out="$WORK/unpinned.out"
+# Hermetic for the same reason as the bounded-semver case: the refusal is decided from
+# the MANIFEST, before any resolver is consulted, so the stub never has to answer.
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+PUBLISH_CONSUMER_ROOT="$up_root" "$SCRIPT" >"$up_out" 2>&1; then
+  fail 'an omitted spec.ref was silently resolved instead of refusing — a mutable latest pointer has no release version behind it'
+else
+  grep -q 'unpinned reference' "$up_out" ||
+    fail 'the run failed but not because of the unpinned reference — the case is not testing what it claims'
+  # A CONTROL, counted rather than name-matched: the other four consumers keep an
+  # unbounded range and must still resolve, or this "refusal" is just the fixture dying.
+  up_insync="$(grep -c '^IN-SYNC' "$up_out" || true)"
+  [ "$up_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC alongside the refusal, got $up_insync"
+  pass 'an omitted spec.ref refuses by name instead of being looked up as a literal tag'
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (14 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (15 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -357,7 +357,7 @@ bounded_out="$WORK/bounded.out"
 # the real one run — which made this case hit the network and fail in CI for an unrelated
 # reason. A hermetic case that reaches the branch is strictly better than a live one that does.
 if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-  PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
+PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
   fail 'a bounded semver constraint was silently resolved to the newest tag instead of refusing'
 else
   grep -q 'bounded semver constraint' "$bounded_out" ||

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -597,6 +597,14 @@ case "$args" in
       printf 'API rate limit exceeded\n' >&2
       exit 1
     fi
+    # A tag that lives at its OWN commit, as real tags do. The fixture otherwise resolves
+    # every tag to one shared commit, which was observationally fine while the signing pin
+    # was read at the tag NAME. Now that it is read at the VERIFIED COMMIT, giving a tag its
+    # own commit is the only way a case can still observe which tag was selected.
+    if [ -n "${BM_OWNCOMMIT_TAG:-}" ] && [ "$bm_ctag" = "$BM_OWNCOMMIT_TAG" ]; then
+      printf '%s\n' "$BM_SHA_B"
+      exit 0
+    fi
     # The commit a tag currently resolves to. Every tag resolves to BM_TAG_SHA, so the run
     # lookup below matches by default and the existing cases keep exercising their own
     # guards rather than failing for want of this one.
@@ -631,6 +639,8 @@ case "$args" in
     # was moved, while `/commits/<tag>` above reports where it points NOW. Naming a tag in
     # BM_MOVED_TAG reproduces exactly that, and nothing else about the fixture changes.
     bm_run_sha="${BM_TAG_SHA:-$BM_SHA_C}"
+    # Its run carries that same commit, or the tag would read as MOVED and refuse.
+    [ -n "${BM_OWNCOMMIT_TAG:-}" ] && [ "$bm_ref" = "$BM_OWNCOMMIT_TAG" ] && bm_run_sha="$BM_SHA_B"
     [ "$bm_ref" = "${BM_MOVED_TAG:-}" ] && bm_run_sha="$BM_SHA_A"
     printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' "$bm_ref" "$bm_run_sha"
     ;;
@@ -645,7 +655,19 @@ case "$args" in
     # SHA, and that looks exactly like the walk having chosen the older tag.
     bm_pinref="${bm_pinref%% *}"
     bm_pinsha="$BM_SHA_A"
-    [ "$bm_pinref" = 'v2.0.0+build.1' ] && bm_pinsha="$BM_SHA_B"
+    # Keyed on the COMMIT, not the tag name: `pin_at_ref` is handed the verified commit for
+    # the signing read and only ever a BRANCH name otherwise, so a tag-name key here would
+    # never match and the case would silently stop discriminating.
+    [ -n "${BM_OWNCOMMIT_TAG:-}" ] && [ "$bm_pinref" = "$BM_SHA_B" ] && bm_pinsha="$BM_SHA_B"
+    # A tag that MOVES between publication verification and this lookup. Reading cd.yaml at
+    # the mutable tag NAME sees the NEW commit's pin; reading it at the commit SHA that was
+    # verified as published sees the pin that actually signed the artifact. Giving the two
+    # refs different pins is what makes the caller's choice of ref observable at all.
+    [ -n "${BM_TOCTOU_TAG:-}" ] && [ "$bm_pinref" = "$BM_TOCTOU_TAG" ] && bm_pinsha="$BM_SHA_B"
+    # The over-permissiveness control: give the VERIFIED commit a pin that genuinely differs
+    # from main's, so a real divergence must still be reported rather than smoothed into
+    # agreement by a fix that simply reads a different ref.
+    [ -n "${BM_TOCTOU_SHA_PIN:-}" ] && [ "$bm_pinref" = "${BM_TAG_SHA:-$BM_SHA_C}" ] && bm_pinsha="$BM_TOCTOU_SHA_PIN"
     # BOTH shared workflows, because the cd.yaml request carries no workflow name and the
     # five consumers split across publish-app and publish-manifests. The caller filters to
     # the one it asked about, so emitting both is exact rather than lax; a stub emitting
@@ -786,11 +808,12 @@ bm2_out="$WORK/buildmeta-only.out"
 # Only `aws` carries the metadata-only release; every other consumer stays on a plain
 # `v1.9.0`, so nothing else in this fixture can produce a refusal or a divergence.
 #
-# The stub pins `v2.0.0+build.1` to SHA_B and everything else — including the default
-# branch — to SHA_A. Selecting the metadata tag therefore prints SHA_B as the signing
-# revision and reports the consumer as diverged; walking silently past it prints SHA_A
-# and reports it in sync. SHA_B in the output is the whole discrimination.
-if BM_AWS_TAGS='v2.0.0+build.1\nv1.9.0\n' \
+# `v2.0.0+build.1` lives at its own commit (SHA_B) and everything else — including the
+# default branch — resolves to SHA_A. The signing pin is read at the VERIFIED COMMIT, so
+# selecting the metadata tag prints SHA_B as the signing revision and reports the consumer
+# as diverged; walking silently past it prints SHA_A and reports it in sync. SHA_B in the
+# output is the whole discrimination.
+if BM_AWS_TAGS='v2.0.0+build.1\nv1.9.0\n' BM_OWNCOMMIT_TAG='v2.0.0+build.1' \
   BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$bm2_root" "$SCRIPT" >"$bm2_out" 2>&1; then
   grep -qF "$SHA_B" "$bm2_out" ||
@@ -1243,8 +1266,55 @@ else
   fail "the below-rank control failed outright — the SemVer refusal is too broad: $(cat "$iv2_out")"
 fi
 
+# ---------------------------------------------------------------------------
+# 22. THE SIGNING PIN MUST BE READ AT THE VERIFIED COMMIT, NOT THE MUTABLE TAG. (#3305 review)
+#     `deployed_tag` verifies publication against the SHA from `tag_commit`, then returned
+#     only the tag NAME. `default_resolver` passed that name to `pin_at_ref`, so if the tag
+#     moves after the publication check and before the workflow read, the script verifies
+#     publication for the OLD commit and reads cd.yaml from the NEW one — two individually
+#     true reads composed into a confident wrong signing revision.
+#
+#     Case 17 covers a tag ALREADY moved at verification time, which refuses. This is the
+#     narrower race the refusal cannot see: at verification the tag was consistent.
+# ---------------------------------------------------------------------------
+tc_root="$WORK/toctou-root"
+cp -R "$bm_root" "$tc_root"
+tc_out="$WORK/toctou.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_TOCTOU_TAG='v2.0.0' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$tc_root" "$SCRIPT" >"$tc_out" 2>&1; then
+  # The signing revision must be the pin at the VERIFIED commit ($SHA_A), never the pin the
+  # moved tag now resolves to ($SHA_B).
+  grep -qE "^IN-SYNC +wedding-app .*signed=$SHA_A" "$tc_out" ||
+    fail "the signing revision was not read at the verified commit: $(grep -E '^(IN-SYNC|DIVERGED|UNRESOLVED) +wedding-app' "$tc_out")"
+  grep -qE "^(DIVERGED|IN-SYNC) +wedding-app .*signed=$SHA_B" "$tc_out" &&
+    fail 'the signing revision came from the MOVED tag, so a workflow revision that never signed the artifact would enter the allow-list'
+  tc_insync="$(grep -c '^IN-SYNC' "$tc_out" || true)"
+  [ "$tc_insync" -eq 5 ] ||
+    fail "expected all FIVE consumers IN-SYNC through the same stub, got $tc_insync — the fixture failed for an unrelated reason"
+  pass 'the signing pin is read at the commit whose publication was verified, not at the mutable tag'
+else
+  fail "the TOCTOU fixture failed outright, so it proves nothing: $(cat "$tc_out")"
+fi
+
+# CONTROL: a GENUINE divergence at the verified commit must still be reported. Without this
+# the assertion above would be satisfied by any change that makes every consumer read
+# IN-SYNC, which would hide real drift instead of fixing the race.
+tc2_root="$WORK/toctou-control-root"
+cp -R "$bm_root" "$tc2_root"
+tc2_out="$WORK/toctou-control.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_TOCTOU_TAG='v2.0.0' BM_TOCTOU_SHA_PIN="$SHA_B" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$tc2_root" "$SCRIPT" >"$tc2_out" 2>&1; then
+  grep -qE "^DIVERGED +wedding-app .*signed=$SHA_B .*pinned=$SHA_A" "$tc2_out" ||
+    fail "a real divergence at the verified commit was not reported: $(grep -E '^(IN-SYNC|DIVERGED|UNRESOLVED) +wedding-app' "$tc2_out")"
+  pass 'a genuine divergence at the verified commit is still reported, so the fix is not smoothing real drift into agreement'
+else
+  fail "the divergence control failed outright: $(cat "$tc2_out")"
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (21 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (22 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -331,6 +331,7 @@ fi
 bounded_case() {
   bc_label=$1
   bc_selector=$2
+  bc_expect=${3:-bounded semver constraint}
   bc_root="$WORK/bounded-$bc_label"
   mkdir -p "$bc_root"
   k=0
@@ -368,7 +369,7 @@ YAML
   PUBLISH_CONSUMER_ROOT="$bc_root" "$SCRIPT" >"$bc_out" 2>&1; then
     fail "a bounded semver constraint ($bc_selector) was silently resolved to the newest tag instead of refusing"
   else
-    grep -q 'bounded semver constraint' "$bc_out" ||
+    grep -q "$bc_expect" "$bc_out" ||
       fail "the run failed but not because of the bounded constraint ($bc_selector) — the case is not testing what it claims"
     grep -qF "$bc_selector" "$bc_out" ||
       fail "the refusal does not name the constraint ($bc_selector), so the cause is not diagnosable"
@@ -392,6 +393,14 @@ bounded_case compound '>=1.0.0 <2.0.0'
 # every character is one a single lower bound may legitimately contain.
 bounded_case prerelease '>=1.0.0-0'
 bounded_case prerelease_named '>1.2.3-alpha.1'
+
+# A STRICT lower bound. `>=1.0.0` admits 1.0.0, so treating it as unbounded and taking the
+# newest published tag is correct. `>1.0.0` EXCLUDES 1.0.0 — so when 1.0.0 is the newest
+# published tag, Flux selects nothing there while the walk would hand back 1.0.0 and
+# attribute ITS workflow revision to whatever is deployed. It begins exactly like the
+# unbounded `>=1.0.0`, and every character is one a legitimate single lower bound may
+# contain, so no character-class check catches it.
+bounded_case strict_lower '>1.0.0' 'strict lower-bound semver constraint'
 
 # ---------------------------------------------------------------------------
 # 10. AN EMPTY MIDDLE FIELD MUST NOT SHIFT `origin` INTO `current`. (#3305 review)
@@ -511,6 +520,21 @@ cat >"$bm_bin/gh" <<'GHSTUB'
 # anything else exits non-zero, so an unstubbed call surfaces as a failure rather than as
 # an empty string the script might read as data.
 args="$*"
+# The tag must arrive as a PARAMETER, never interpolated into the query string. A tag may
+# carry SemVer build metadata (v2.0.0+build.1), and a raw + in a query string is decoded as
+# a SPACE on the wire, so the run for a genuinely published tag is never matched and a
+# healthy consumer reports UNRESOLVED. This stub receives argv and so cannot observe
+# percent-encoding itself; refusing the old call shape is what pins the fix.
+case "$args" in
+  *"/actions/runs?"*)
+    # gh_retry discards stderr, so a message alone would be invisible and the regression
+    # would surface only as unexplained unresolved consumers. Record it where the suite
+    # can assert on it and name the cause.
+    printf 'interpolated\n' >>"${BM_VIOLATION_LOG:-/dev/null}"
+    printf 'stub: the run lookup interpolated its query string; pass the tag with --raw-field so + survives encoding\n' >&2
+    exit 64
+    ;;
+esac
 case "$args" in
   *"/tags?per_page=100"*)
     # Per-repo tag lists, so each case can put the interesting shape on exactly ONE
@@ -522,12 +546,18 @@ case "$args" in
       *)             printf 'v1.9.0\n' ;;
     esac
     ;;
-  *"/actions/runs?branch="*)
+  *"/actions/runs"*)
     # Echo the requested ref back so every candidate tag reads as published. Pinning this
     # to one tag would make the ablations fail for want of a published release rather than
     # for the guard under test, and the cases would stop discriminating.
+    #
+    # The tag now arrives as a --raw-field PARAMETER rather than interpolated into the
+    # query string, so it is trailed by a SPACE rather than an &. Both are trimmed, so this
+    # stub cannot silently match nothing if the call shape moves again. gh does the
+    # percent-encoding on the wire, so the stub still sees the raw tag.
     bm_ref="${args#*branch=}"
     bm_ref="${bm_ref%%&*}"
+    bm_ref="${bm_ref%% *}"
     printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s"}]}\n' "$bm_ref"
     ;;
   *"/contents/.github/workflows/cd.yaml"*)
@@ -587,7 +617,7 @@ YAML
 done <<<"$consumers"
 
 if BM_WEDDING_TAGS='v2.0.0\nv2.0.0+build.1\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$bm_out" 2>&1; then
   fail 'a version carried by two tags was silently resolved instead of refusing'
 else
@@ -640,7 +670,7 @@ bm2_out="$WORK/buildmeta-only.out"
 # revision and reports the consumer as diverged; walking silently past it prints SHA_A
 # and reports it in sync. SHA_B in the output is the whole discrimination.
 if BM_AWS_TAGS='v2.0.0+build.1\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$bm2_root" "$SCRIPT" >"$bm2_out" 2>&1; then
   grep -qF "$SHA_B" "$bm2_out" ||
     fail 'the newest release exists only as a build-metadata tag, and the report resolved an older one instead — it walked silently past it'
@@ -650,6 +680,16 @@ else
   grep -qF '2.0.0+build.1' "$bm2_out" ||
     fail 'the run neither resolved the metadata-only release nor refused by name'
   pass 'a version published only with build metadata is never silently walked past'
+fi
+
+# The run lookup must pass the tag as a PARAMETER. Checked explicitly because the failure
+# it prevents is invisible otherwise: gh_retry discards stderr, so an interpolated query
+# string surfaces only as unexplained unresolved consumers, and this stub receives argv so
+# it cannot observe percent-encoding itself.
+if [ -s "$WORK/interpolated.log" ]; then
+  fail 'the run lookup interpolated its query string — a + in a build-metadata tag decodes as a space on the wire, so a published tag reads as UNPUBLISHED'
+else
+  pass 'the run lookup passes the tag as a query PARAMETER, so build metadata survives encoding'
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -139,7 +139,7 @@ fi
 # ---------------------------------------------------------------------------
 floor_out="$WORK/floor.out"
 if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-  PUBLISH_CONSUMER_ROOT="$WORK/empty" "$SCRIPT" >"$floor_out" 2>&1; then
+PUBLISH_CONSUMER_ROOT="$WORK/empty" "$SCRIPT" >"$floor_out" 2>&1; then
   fail 'discovery over an EMPTY tree exited 0 — an unreadable repository would report as clean'
 else
   pass 'discovery over an empty tree fails closed instead of reporting a clean portfolio'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -563,6 +563,14 @@ case "$args" in
     esac
     ;;
   *"/commits/"*)
+    # A NAMED tag whose commit lookup fails, the way a rate limit or an API outage does.
+    # Nothing else about the fixture changes, so a case using it isolates the failure path.
+    bm_ctag="${args##*/commits/}"
+    bm_ctag="${bm_ctag%% *}"
+    if [ -n "${BM_COMMIT_FAIL_TAG:-}" ] && [ "$bm_ctag" = "$BM_COMMIT_FAIL_TAG" ]; then
+      printf 'API rate limit exceeded\n' >&2
+      exit 1
+    fi
     # The commit a tag currently resolves to. Every tag resolves to BM_TAG_SHA, so the run
     # lookup below matches by default and the existing cases keep exercising their own
     # guards rather than failing for want of this one.
@@ -580,6 +588,19 @@ case "$args" in
     bm_ref="${args#*branch=}"
     bm_ref="${bm_ref%%&*}"
     bm_ref="${bm_ref%% *}"
+    # The same failure one lookup later: the runs query itself cannot be answered.
+    if [ -n "${BM_RUNS_FAIL_TAG:-}" ] && [ "$bm_ref" = "$BM_RUNS_FAIL_TAG" ]; then
+      printf 'API rate limit exceeded\n' >&2
+      exit 1
+    fi
+    # A tag that was QUERIED SUCCESSFULLY and simply never published: the run exists and
+    # failed. This is the ordinary case the walk is built for, and it is what separates
+    # "the answer is no" from "there is no answer".
+    if [ -n "${BM_UNPUBLISHED_TAG:-}" ] && [ "$bm_ref" = "$BM_UNPUBLISHED_TAG" ]; then
+      printf '{"workflow_runs":[{"name":"CD","conclusion":"failure","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' \
+        "$bm_ref" "${BM_TAG_SHA:-$BM_SHA_C}"
+      exit 0
+    fi
     # A MOVED TAG: the historical run still carries the commit the tag pointed at BEFORE it
     # was moved, while `/commits/<tag>` above reports where it points NOW. Naming a tag in
     # BM_MOVED_TAG reproduces exactly that, and nothing else about the fixture changes.
@@ -1025,6 +1046,112 @@ else
   pass 'a tag that is not valid SemVer and would outrank the best valid candidate refuses by name'
 fi
 
+# ---------------------------------------------------------------------------
+# 20. A TAG FLUX ACCEPTS BUT THIS SCRIPT CANNOT RANK. (#3305 review)
+#     Flux parses tags with Masterminds semver.NewVersion, which COERCES a partial
+#     version: measured, v2.5 resolves to 2.5.0 and v2 to 2.0.0. Both the strict
+#     candidate filter and the unrankable filter required three components, so such
+#     a tag matched NEITHER -- it was silently dropped, the walk stepped to an older
+#     release, and the report named THAT release's signing revision, leaving the
+#     actual signer out of the allow-list.
+# ---------------------------------------------------------------------------
+fx_root="$WORK/flux-loose-root"
+cp -R "$bm_root" "$fx_root"
+fx_out="$WORK/flux-loose.out"
+if BM_WEDDING_TAGS='v2.5\nv2.4.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$fx_root" "$SCRIPT" >"$fx_out" 2>&1; then
+  fail 'a partial-version tag Flux resolves ABOVE every ranked candidate was silently skipped instead of refusing'
+else
+  grep -q 'not valid SemVer' "$fx_out" ||
+    fail 'the run failed but not because of the unrankable tag — the case is not testing what it claims'
+  grep -qF 'v2.5' "$fx_out" ||
+    fail 'the refusal does not name the tag Flux would select, so the cause is not diagnosable'
+  fx_unresolved="$(grep -c '^UNRESOLVED' "$fx_out" || true)"
+  [ "$fx_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the partial-version tag), got $fx_unresolved"
+  pass 'a partial version Flux would rank above the best candidate refuses by name'
+fi
+
+# CONTROL — the same narrowing as case 19: a partial version ranking BELOW the best
+# candidate cannot change what Flux selects, so it must NOT refuse. Without this the
+# case above would be satisfied by refusing whenever any partial tag exists.
+fx2_root="$WORK/flux-loose-below-root"
+cp -R "$bm_root" "$fx2_root"
+fx2_out="$WORK/flux-loose-below.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.5\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$fx2_root" "$SCRIPT" >"$fx2_out" 2>&1; then
+  fx2_insync="$(grep -c '^IN-SYNC' "$fx2_out" || true)"
+  [ "$fx2_insync" -eq 5 ] ||
+    fail "the below-rank control resolved only $fx2_insync of 5 consumers — the partial-version check refuses on mere existence, not on rank"
+  pass 'a partial version ranking below the best candidate does not refuse'
+else
+  fail "the below-rank control failed outright — the partial-version refusal is too broad: $(cat "$fx2_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# 21. A FAILED LOOKUP IS NOT AN ESTABLISHED ABSENCE. (#3305 review)
+#     `tag_commit` returning nonzero only broke the inner spelling loop, so the outer
+#     loop walked on to an OLDER version; and `tag_was_published` returned 1 both for
+#     "queried successfully, never published" and for "the query failed". Either way a
+#     rate limit or a transient outage was reported as an older release's signing SHA
+#     -- a confident wrong answer built from an error, where the honest answer is that
+#     the question could not be answered.
+# ---------------------------------------------------------------------------
+lc_root="$WORK/lookup-commit-root"
+cp -R "$bm_root" "$lc_root"
+lc_out="$WORK/lookup-commit.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_COMMIT_FAIL_TAG='v2.0.0' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$lc_root" "$SCRIPT" >"$lc_out" 2>&1; then
+  fail 'a failed commit lookup walked back to an older release instead of refusing'
+else
+  grep -q 'could not resolve the commit for tag' "$lc_out" ||
+    fail 'the run failed but not because the commit lookup could not be answered — the case is not testing what it claims'
+  grep -qF 'v2.0.0' "$lc_out" ||
+    fail 'the refusal does not name the tag whose lookup failed, so the cause is not diagnosable'
+  lc_unresolved="$(grep -c '^UNRESOLVED' "$lc_out" || true)"
+  [ "$lc_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the failed lookup), got $lc_unresolved"
+  pass 'a commit lookup that cannot be answered refuses instead of walking backward'
+fi
+
+lr_root="$WORK/lookup-runs-root"
+cp -R "$bm_root" "$lr_root"
+lr_out="$WORK/lookup-runs.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_RUNS_FAIL_TAG='v2.0.0' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$lr_root" "$SCRIPT" >"$lr_out" 2>&1; then
+  fail 'a failed workflow-runs query was read as "never published" and walked back to an older release'
+else
+  grep -q 'could not read the workflow runs for' "$lr_out" ||
+    fail 'the run failed but not because the runs query could not be answered — the case is not testing what it claims'
+  grep -qF 'v2.0.0' "$lr_out" ||
+    fail 'the refusal does not name the tag whose runs query failed, so the cause is not diagnosable'
+  lr_unresolved="$(grep -c '^UNRESOLVED' "$lr_out" || true)"
+  [ "$lr_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the failed runs query), got $lr_unresolved"
+  pass 'a runs query that cannot be answered refuses instead of walking backward'
+fi
+
+# CONTROL — a tag that genuinely never published must still WALK, exactly as before.
+# Without this, the two cases above would be satisfied by refusing on every non-zero
+# status, which would turn every ordinary failed release into an UNRESOLVED consumer.
+nw_root="$WORK/never-published-walk-root"
+cp -R "$bm_root" "$nw_root"
+nw_out="$WORK/never-published-walk.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_UNPUBLISHED_TAG='v2.0.0' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$nw_root" "$SCRIPT" >"$nw_out" 2>&1; then
+  nw_insync="$(grep -c '^IN-SYNC' "$nw_out" || true)"
+  [ "$nw_insync" -eq 5 ] ||
+    fail "the never-published control resolved only $nw_insync of 5 consumers — the lookup-failure refusal swallowed the ordinary walk"
+  pass 'a tag that genuinely never published still walks to the previous release'
+else
+  fail "the never-published control failed outright — the lookup-failure refusal is too broad: $(cat "$nw_out")"
+fi
+
 # CONTROL, and the one that pins the NARROWING: an unrankable tag that ranks BELOW the best
 # valid candidate cannot change which tag is selected, so it must NOT refuse. Without this
 # the case above would be satisfied by refusing on the mere existence of a malformed tag,
@@ -1047,4 +1174,4 @@ if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (19 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (21 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -462,7 +462,6 @@ ref_case tag-and-semver '  ref:
 ref_case omitted '' 'latest'
 pass 'Flux reference precedence is digest > semver > tag, and an omitted ref means latest'
 
-
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -402,6 +402,14 @@ bounded_case prerelease_named '>1.2.3-alpha.1'
 # contain, so no character-class check catches it.
 bounded_case strict_lower '>1.0.0' 'strict lower-bound semver constraint'
 
+# MALFORMED selectors that merely START like the inclusive lower bound. The previous
+# prefix test matched any trailing text, so these were read as UNBOUNDED and the walk
+# returned the newest published tag — a confident signing revision for an artifact Flux
+# would never have selected, from a selector Flux itself rejects. Every character in both
+# is one a legitimate single lower bound may contain, so no character class catches them.
+bounded_case malformed_trailing '>=1.0.0=bad' 'malformed or unsupported semver constraint'
+bounded_case malformed_second_bound '>=1.0.0>=2.0.0' 'malformed or unsupported semver constraint'
+
 # ---------------------------------------------------------------------------
 # 10. AN EMPTY MIDDLE FIELD MUST NOT SHIFT `origin` INTO `current`. (#3305 review)
 #     Tab is IFS WHITESPACE, so `IFS=$'\t' read -r signing current origin` COLLAPSES

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -703,8 +703,53 @@ else
   pass 'an omitted spec.ref refuses by name instead of being looked up as a literal tag'
 fi
 
+# ---------------------------------------------------------------------------
+# 16. NEITHER ORIGIN MAY READ AS APPLIED-REVISION EVIDENCE. (#3305 review)
+#     `pinned` was called `exact` and read as "this IS what is deployed". It cannot know
+#     that: a version bump landing by DIRECT PUSH to main is reported by validate-main.yaml
+#     before the manual CD workflow deploys it, so a previously-published tag reads as
+#     deployed while the cluster still runs its predecessor — and the allow-list built from
+#     that row omits the revision which actually signed the running artifact.
+#
+#     This script reads manifests and a registry; nothing in it reads a cluster. So BOTH
+#     origins are marked, and the assertion is on the marks rather than on the token, since
+#     the mark is what a human building an allow-list actually reads.
+# ---------------------------------------------------------------------------
+origin_stub="$WORK/resolver-origin.sh"
+cat >"$origin_stub" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+# \$1=repo \$2=workflow \$3=version. Emit the THIRD origin field, which the two-field
+# stubs above never exercise.
+if [ -n "\${3:-}" ]; then
+  printf '%s\t%s\t%s\n' '$SHA_A' '$SHA_A' 'pinned'
+else
+  printf '%s\t%s\t%s\n' '$SHA_A' '$SHA_A' 'inferred'
+fi
+STUB
+chmod +x "$origin_stub"
+
+origin_out="$WORK/origin.out"
+if PUBLISH_REVISION_RESOLVER="$origin_stub" "$SCRIPT" >"$origin_out" 2>&1; then
+  # Every row must disclaim applied-revision evidence — count them against the IN-SYNC
+  # rows rather than grepping for one consumer, so a partially-marked report fails.
+  origin_insync="$(grep -c '^IN-SYNC' "$origin_out" || true)"
+  origin_marked="$(grep -c 'not applied-revision evidence' "$origin_out" || true)"
+  [ "$origin_insync" -gt 0 ] ||
+    fail 'the origin fixture produced no IN-SYNC rows, so the marks below would pass vacuously'
+  [ "$origin_marked" -eq "$origin_insync" ] ||
+    fail "every resolved row must disclaim applied-revision evidence: $origin_marked marked of $origin_insync rows"
+  grep -q 'what the manifest PINS and was published' "$origin_out" ||
+    fail 'a pinned row does not say that a pin is not proof of what is applied'
+  grep -q 'inferred from newest PUBLISHED tag' "$origin_out" ||
+    fail 'an inferred row lost its existing disclaimer'
+  pass 'a pinned origin is disclaimed as not applied-revision evidence, exactly like an inferred one'
+else
+  fail "the script exited non-zero on the origin fixture: $(cat "$origin_out")"
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (15 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (16 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -332,6 +332,13 @@ bounded_case() {
   bc_label=$1
   bc_selector=$2
   bc_expect=${3:-bounded semver constraint}
+  # How the first consumer's `spec.ref` is written. `semver` is the original shape;
+  # `raw` passes the selector through verbatim (for a digest), and `omit` drops the
+  # `ref:` key entirely -- the unpinned case, which is a refusal with no selector at all.
+  bc_ref_kind=${4:-semver}
+  # For `raw`, the ref LINE and the string the refusal must NAME differ: the script
+  # reports `sha256:...` while the manifest writes `digest: sha256:...`.
+  bc_ref_line=${5:-}
   bc_root="$WORK/bounded-$bc_label"
   mkdir -p "$bc_root"
   k=0
@@ -342,15 +349,22 @@ bounded_case() {
     [ "$repo" = '.github' ] && oci='github-config'
     # One consumer gets the BOUNDED range; the rest keep an unbounded one, so the
     # refusal cannot be confused with a wholesale failure of the fixture.
-    if [ "$k" -eq 1 ]; then ref="semver: \"$bc_selector\""; else ref='semver: ">=1.0.0"'; fi
+    if [ "$k" -eq 1 ]; then
+      case "$bc_ref_kind" in
+      raw) ref_block="  ref:"$'\n'"    $bc_ref_line" ;;
+      omit) ref_block='' ;;
+      *) ref_block="  ref:"$'\n'"    semver: \"$bc_selector\"" ;;
+      esac
+    else
+      ref_block="  ref:"$'\n'"    semver: \">=1.0.0\""
+    fi
     cat >"$bc_root/c-$k.yaml" <<YAML
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: b$k
 spec:
-  ref:
-    $ref
+$ref_block
   url: oci://ghcr.io/devantler-tech/$oci/manifests
   verify:
     provider: cosign
@@ -391,8 +405,20 @@ bounded_case compound '>=1.0.0 <2.0.0'
 # attribute THAT release's workflow revision to the deployed artifact. It starts exactly
 # like the unbounded `>=1.0.0`, so the compound-range character class does not catch it:
 # every character is one a single lower bound may legitimately contain.
-bounded_case prerelease '>=1.0.0-0'
-bounded_case prerelease_named '>1.2.3-alpha.1'
+# THE ROW MUST NAME THE CAUSE THE RESOLVER GAVE. `effective_version` refuses for five
+# distinct reasons and writes the specific one to stderr, but the report printed a fixed
+# "bounded semver constraint" for all of them -- and the step summary is stdout-only, so a
+# digest-pinned or unpinned consumer was not merely described elsewhere, it was described
+# WRONGLY with no other copy to consult. Two causes are asserted here, one of which is not
+# a semver constraint at all, so a regression to any single fixed wording fails.
+bounded_case digest_pinned 'sha256:abcdef' 'digest-pinned reference' raw 'digest: sha256:abcdef'
+bounded_case unpinned_ref 'spec.ref omitted' 'unpinned reference' omit
+
+# These two refuse for the PRERELEASE reason, not the generic bounded-range one, so they
+# assert that specific wording. The row used to print one fixed cause for every refusal,
+# which made the default expectation match here while describing the wrong thing.
+bounded_case prerelease '>=1.0.0-0' 'prerelease semver constraint'
+bounded_case prerelease_named '>1.2.3-alpha.1' 'prerelease semver constraint'
 
 # A STRICT lower bound. `>=1.0.0` admits 1.0.0, so treating it as unbounded and taking the
 # newest published tag is correct. `>1.0.0` EXCLUDES 1.0.0 — so when 1.0.0 is the newest

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -352,9 +352,12 @@ spec:
 YAML
 done <<<"$consumers"
 bounded_out="$WORK/bounded.out"
-# No resolver stub: the refusal must happen while RESOLVING the deployed version, which is
-# the default resolver's job, so stubbing it would bypass the very branch under test.
-if PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
+# The stub is safe here BECAUSE the refusal is decided from the manifest, before any resolver
+# is consulted. When this check lived inside the resolver, the only way to reach it was to let
+# the real one run — which made this case hit the network and fail in CI for an unrelated
+# reason. A hermetic case that reaches the branch is strictly better than a live one that does.
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+  PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
   fail 'a bounded semver constraint was silently resolved to the newest tag instead of refusing'
 else
   grep -q 'bounded semver constraint' "$bounded_out" ||

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -383,6 +383,16 @@ bounded_case simple '~1.4'
 # revision to an artifact Flux would never deploy, and omitting the real signer.
 bounded_case compound '>=1.0.0 <2.0.0'
 
+# A lower bound carrying a PRERELEASE component. Flux/Masterminds excludes prerelease
+# versions from a range whose bound has none, but ADMITS them once the bound carries one
+# — so `>=1.0.0-0` legitimately selects `2.0.0-rc.1`. The tag walk only ever considers
+# `X.Y.Z`, so it would discard that tag, walk back to an older stable release, and
+# attribute THAT release's workflow revision to the deployed artifact. It starts exactly
+# like the unbounded `>=1.0.0`, so the compound-range character class does not catch it:
+# every character is one a single lower bound may legitimately contain.
+bounded_case prerelease '>=1.0.0-0'
+bounded_case prerelease_named '>1.2.3-alpha.1'
+
 # ---------------------------------------------------------------------------
 # 10. AN EMPTY MIDDLE FIELD MUST NOT SHIFT `origin` INTO `current`. (#3305 review)
 #     Tab is IFS WHITESPACE, so `IFS=$'\t' read -r signing current origin` COLLAPSES
@@ -478,8 +488,156 @@ ref_case tag-and-semver '  ref:
 ref_case omitted '' 'latest'
 pass 'Flux reference precedence is digest > semver > tag, and an omitted ref means latest'
 
+# ---------------------------------------------------------------------------
+# 13. BUILD METADATA MUST NOT BE DISCARDED, AND A TIE MUST NOT BE GUESSED. (#3305 review)
+#     SemVer ignores build metadata for precedence, so `2.0.0` and `2.0.0+build.1` rank
+#     equally: a tag walk matching only the bare form silently discards the metadata tag
+#     and walks back to an older release, attributing THAT release's workflow revision to
+#     the deployed artifact. Both forms are candidates; a core version carrying two tags
+#     refuses instead of picking one.
+#
+#     This is the only case that exercises the REAL resolver, so it stubs `gh` on PATH
+#     rather than replacing the resolver: the behaviour under test lives inside
+#     `deployed_tag`, which a resolver stub bypasses entirely.
+# ---------------------------------------------------------------------------
+bm_bin="$WORK/bm-bin"
+mkdir -p "$bm_bin"
+# Quoted delimiter: the stub's own comments mention shell syntax, and an UNQUOTED
+# heredoc runs backticks and expands parameters while WRITING the file — which silently
+# executed fragments of those comments. Values it needs come through the environment.
+cat >"$bm_bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+# Minimal forge stub. Only the four call shapes the default resolver makes are answered;
+# anything else exits non-zero, so an unstubbed call surfaces as a failure rather than as
+# an empty string the script might read as data.
+args="$*"
+case "$args" in
+  *"/tags?per_page=100"*)
+    # Per-repo tag lists, so each case can put the interesting shape on exactly ONE
+    # consumer and leave the rest clean: a refusal or divergence can then only have come
+    # from that consumer.
+    case "$args" in
+      *wedding-app*) printf "${BM_WEDDING_TAGS:-v1.9.0\n}" ;;
+      *aws*)         printf "${BM_AWS_TAGS:-v1.9.0\n}" ;;
+      *)             printf 'v1.9.0\n' ;;
+    esac
+    ;;
+  *"/actions/runs?branch="*)
+    # Echo the requested ref back so every candidate tag reads as published. Pinning this
+    # to one tag would make the ablations fail for want of a published release rather than
+    # for the guard under test, and the cases would stop discriminating.
+    bm_ref="${args#*branch=}"
+    bm_ref="${bm_ref%%&*}"
+    printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s"}]}\n' "$bm_ref"
+    ;;
+  *"/contents/.github/workflows/cd.yaml"*)
+    # The pin DEPENDS ON THE REF, which is what makes the walk's choice observable: the
+    # report prints the signing revision and never the tag it came from, so a case can
+    # only tell which tag was selected by giving that tag a distinct pin.
+    bm_pinref="${args#*ref=}"
+    bm_pinref="${bm_pinref%%&*}"
+    # args is the whole argv joined by spaces, so the ref is trailed by the Accept-header
+    # flags. Without this trim the ref never compares equal, every tag reads as the base
+    # SHA, and that looks exactly like the walk having chosen the older tag.
+    bm_pinref="${bm_pinref%% *}"
+    bm_pinsha="$BM_SHA_A"
+    [ "$bm_pinref" = 'v2.0.0+build.1' ] && bm_pinsha="$BM_SHA_B"
+    # BOTH shared workflows, because the cd.yaml request carries no workflow name and the
+    # five consumers split across publish-app and publish-manifests. The caller filters to
+    # the one it asked about, so emitting both is exact rather than lax; a stub emitting
+    # only one silently made EVERY consumer unresolvable.
+    printf 'jobs:\n  app:\n    uses: devantler-tech/actions/.github/workflows/publish-app.yaml@%s\n  manifests:\n    uses: devantler-tech/actions/.github/workflows/publish-manifests.yaml@%s\n' \
+      "$bm_pinsha" "$bm_pinsha"
+    ;;
+  *"repos/devantler-tech/"*)
+    printf 'main\n'
+    ;;
+  *) exit 1 ;;
+esac
+exit 0
+GHSTUB
+chmod +x "$bm_bin/gh"
+
+bm_out="$WORK/buildmeta.out"
+# No PUBLISH_REVISION_RESOLVER: the default resolver must run for `deployed_tag` to be
+# reached at all. Every consumer keeps an unbounded `>=1.0.0`, so the walk is entered.
+bm_root="$WORK/buildmeta-root"
+mkdir -p "$bm_root"
+k=0
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  k=$((k + 1))
+  oci="$repo"
+  [ "$repo" = '.github' ] && oci='github-config'
+  cat >"$bm_root/c-$k.yaml" <<YAML
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bm$k
+spec:
+  ref:
+    semver: ">=1.0.0"
+  url: oci://ghcr.io/devantler-tech/$oci/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\\.actions\\.githubusercontent\\.com\$'
+        subject: '^https://github\\.com/devantler-tech/actions/\\.github/workflows/$workflow\\.yaml@[0-9a-f]{40}\$'
+YAML
+done <<<"$consumers"
+
+if BM_WEDDING_TAGS='v2.0.0\nv2.0.0+build.1\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$bm_out" 2>&1; then
+  fail 'a version carried by two tags was silently resolved instead of refusing'
+else
+  grep -q 'carried by more than one tag' "$bm_out" ||
+    fail 'the run failed but not because of the build-metadata tie — the case is not testing what it claims'
+  grep -qF '2.0.0+build.1' "$bm_out" ||
+    fail 'the refusal does not name the tags that tie, so the cause is not diagnosable'
+  # A CONTROL: the other four consumers must resolve through the same stub, or this
+  # "refusal" could just be the whole fixture failing for an unrelated reason.
+  grep -q 'wedding-app' "$bm_out" ||
+    fail 'the refusal does not name the consumer that ties'
+  pass 'a version carried by both a bare and a build-metadata tag refuses instead of guessing'
+fi
+
+# ---------------------------------------------------------------------------
+# 14. A VERSION PUBLISHED ONLY WITH BUILD METADATA MUST NOT BE WALKED PAST. (#3305 review)
+#     `2.0.0+build.1` with no bare `2.0.0` is the newest release, and Flux selects it.
+#     A walk that rebuilds the tag from the bare core version finds nothing at that
+#     precedence, drops silently to `1.9.0`, and reports ITS workflow revision as the
+#     signer of the deployed artifact — succeeding, which is worse than refusing.
+#
+#     This is the case the tie refusal alone does NOT cover: with one tag at the newest
+#     precedence there is no tie, so only reading the real tag out of the tag list makes
+#     the run correct here.
+# ---------------------------------------------------------------------------
+bm2_root="$WORK/buildmeta-only-root"
+cp -R "$bm_root" "$bm2_root"
+bm2_out="$WORK/buildmeta-only.out"
+# Only `aws` carries the metadata-only release; every other consumer stays on a plain
+# `v1.9.0`, so nothing else in this fixture can produce a refusal or a divergence.
+#
+# The stub pins `v2.0.0+build.1` to SHA_B and everything else — including the default
+# branch — to SHA_A. Selecting the metadata tag therefore prints SHA_B as the signing
+# revision and reports the consumer as diverged; walking silently past it prints SHA_A
+# and reports it in sync. SHA_B in the output is the whole discrimination.
+if BM_AWS_TAGS='v2.0.0+build.1\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$bm2_root" "$SCRIPT" >"$bm2_out" 2>&1; then
+  grep -qF "$SHA_B" "$bm2_out" ||
+    fail 'the newest release exists only as a build-metadata tag, and the report resolved an older one instead — it walked silently past it'
+  pass 'a version published only with build metadata is resolved as itself, not walked past'
+else
+  # Refusing by name is acceptable; succeeding while naming an older tag is not.
+  grep -qF '2.0.0+build.1' "$bm2_out" ||
+    fail 'the run neither resolved the metadata-only release nor refused by name'
+  pass 'a version published only with build metadata is never silently walked past'
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (12 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (14 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -542,6 +542,14 @@ case "$args" in
     printf 'stub: the run lookup interpolated its query string; pass the tag with --raw-field so + survives encoding\n' >&2
     exit 64
     ;;
+  *"/contents/.github/workflows/cd.yaml?"*)
+    # Same rule for the PIN lookup. The selected tag reaches this call too, so an
+    # interpolated ref loses a + exactly as the run lookup did, and the workflow body then
+    # fails to load -- reporting a healthy consumer UNRESOLVED.
+    printf 'interpolated\n' >>"${BM_VIOLATION_LOG:-/dev/null}"
+    printf 'stub: the pin lookup interpolated its query string; pass the ref with --raw-field so + survives encoding\n' >&2
+    exit 64
+    ;;
 esac
 case "$args" in
   *"/tags?per_page=100"*)
@@ -698,6 +706,61 @@ if [ -s "$WORK/interpolated.log" ]; then
   fail 'the run lookup interpolated its query string — a + in a build-metadata tag decodes as a space on the wire, so a published tag reads as UNPUBLISHED'
 else
   pass 'the run lookup passes the tag as a query PARAMETER, so build metadata survives encoding'
+fi
+
+# ---------------------------------------------------------------------------
+# 14b. A VERSION PUBLISHED UNDER BOTH SPELLINGS MUST REFUSE. (#3305 review)
+#      `2.0.0` and `v2.0.0` are two DISTINCT git refs. They can point at different
+#      commits and therefore at different publish-workflow pins, but the precedence fold
+#      strips the `v` before `sort -u`, so the tie check saw ONE variant and passed. The
+#      loop that follows then unconditionally prefers the `v` form — reporting its
+#      signing revision even when the other ref produced the deployed artifact.
+#
+#      This is NOT the build-metadata tie above: there the two tags differ visibly and
+#      the tie check catches them. Here the fold erases the difference before the check
+#      ever runs, which is why folding for precedence and folding for identity have to be
+#      separated.
+# ---------------------------------------------------------------------------
+vd_root="$WORK/vdual-root"
+cp -R "$bm_root" "$vd_root"
+vd_out="$WORK/vdual.out"
+# Only `wedding-app` publishes both spellings; every other consumer stays on a plain
+# v1.9.0, so a refusal or divergence can only have come from that consumer.
+if BM_WEDDING_TAGS='2.0.0\nv2.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$vd_root" "$SCRIPT" >"$vd_out" 2>&1; then
+  fail 'a version published as both 2.0.0 and v2.0.0 was silently resolved to the v spelling instead of refusing'
+else
+  grep -q 'published as BOTH' "$vd_out" ||
+    fail 'the run failed but not because of the v-spelling duality — the case is not testing what it claims'
+  grep -qF '2.0.0' "$vd_out" ||
+    fail 'the refusal does not name the version published twice, so the cause is not diagnosable'
+  # The same outcome-count control the build-metadata tie uses: a name match alone would
+  # pass just as well if ALL FIVE consumers had failed for an unrelated reason.
+  vd_unresolved="$(grep -c '^UNRESOLVED' "$vd_out" || true)"
+  vd_insync="$(grep -c '^IN-SYNC' "$vd_out" || true)"
+  [ "$vd_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the v-spelling duality), got $vd_unresolved"
+  [ "$vd_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $vd_insync"
+  grep -qE '^UNRESOLVED +wedding-app' "$vd_out" ||
+    fail 'the unresolved consumer is not the one publishing both spellings'
+  pass 'a version published under both the bare and v spellings refuses instead of preferring v'
+fi
+
+# CONTROL: ONE spelling is the normal case and must still resolve. Without this the
+# refusal above could be satisfied by refusing every `v` tag, which would break every
+# real consumer in this repository.
+vd2_root="$WORK/vdual-single-root"
+cp -R "$bm_root" "$vd2_root"
+vd2_out="$WORK/vdual-single.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$vd2_root" "$SCRIPT" >"$vd2_out" 2>&1; then
+  pass 'a version published under only the v spelling still resolves'
+else
+  printf '%s\n' "$(cat "$vd2_out")" >&2
+  fail 'a version published under only the v spelling was refused — the duality check is too broad'
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -2,25 +2,30 @@
 # RED/GREEN coverage for `report-publish-workflow-signing-revisions.sh` (#3048).
 #
 # WHAT IS ACTUALLY BEING PROVED
-# The reported script answers one question per consumer: "is the revision that SIGNED
-# what is deployed the same revision this consumer pins TODAY?" An allow-list built for
-# #2818 has to accept both, so the whole value of the script is that a DIFFERENCE is
-# surfaced and a MATCH is not. Those are the two directions this file pins.
+# The script answers one question per consumer: "is the revision that SIGNED what is
+# deployed the same revision this consumer pins TODAY?" An allow-list built for #2818 has
+# to accept both, so a DIFFERENCE must be surfaced and a MATCH must not.
+#
+# The script's only harmful failure mode is reporting a clean, in-sync portfolio while
+# having checked nothing or the wrong thing — so most cases below are aimed at that, not
+# at the happy path.
 #
 # WHY THERE IS A RESOLVER SEAM
-# Resolving a revision needs the network (release tag -> tag commit -> the pin in that
-# commit's cd.yaml). A test that depended on it would prove nothing repeatable: it would
-# go red when an unrelated repository cut a release, and green when the network was
-# simply unavailable. The script therefore takes its resolver from
-# PUBLISH_REVISION_RESOLVER, and these fixtures supply a stub. Discovery — which
-# consumers exist and whether any went missing — stays REAL, against this repository's
-# own manifests, because that is the half a stub could hide a regression in.
+# Resolving a revision needs the network. A test that depended on it would prove nothing
+# repeatable: red when an unrelated repository cut a release, green when the network was
+# simply unavailable. The script takes its resolver from PUBLISH_REVISION_RESOLVER and
+# these fixtures supply a stub. Discovery stays REAL, against this repository's own
+# manifests, because that is the half a stub could hide a regression in.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly REPO_ROOT
 readonly SCRIPT="$REPO_ROOT/scripts/report-publish-workflow-signing-revisions.sh"
+
+readonly SHA_A='1111111111111111111111111111111111111111'
+readonly SHA_B='2222222222222222222222222222222222222222'
+readonly SHA_C='3333333333333333333333333333333333333333'
 
 failures=0
 fail() {
@@ -32,9 +37,8 @@ pass() { printf 'ok: %s\n' "$*"; }
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# A stub resolver. It is handed <repo> <workflow> and prints "<signing>\t<current>".
-# Each fixture writes its own answers into a table file the stub reads, so one stub
-# covers every case without the fixtures having to generate shell code.
+# A stub resolver, handed <repo> <workflow> <version>, printing "<signing>\t<current>".
+# Each fixture writes its answers into a table the stub reads.
 make_stub() {
   local table="$1" path="$WORK/resolver-$2.sh"
   cat >"$path" <<STUB
@@ -53,128 +57,189 @@ STUB
   printf '%s\n' "$path"
 }
 
-# Every consumer this repository actually carries, resolved from the real manifests, so
-# a fixture cannot silently drift out of step with discovery.
 consumers="$("$SCRIPT" --list-consumers 2>/dev/null || true)"
 if [ -z "$consumers" ]; then
   fail '--list-consumers produced nothing; every case below would pass vacuously'
-  printf '\n%d failure(s)\n' "$((failures + 1))" >&2
+  printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
 
+write_table() { # <path> <special-repo|""> <special-signing> <special-current>
+  local table="$1" special="$2" s_sign="$3" s_cur="$4" repo workflow
+  : >"$table"
+  while IFS=$'\t' read -r repo workflow _version; do
+    [ -n "$repo" ] || continue
+    if [ -n "$special" ] && [ "$repo" = "$special" ]; then
+      printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" "$s_sign" "$s_cur" >>"$table"
+    else
+      printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" "$SHA_A" "$SHA_A" >>"$table"
+    fi
+  done <<<"$consumers"
+}
+
+first_repo="$(printf '%s\n' "$consumers" | head -1 | cut -f1)"
+
 # ---------------------------------------------------------------------------
-# 1. AGREEING: signing revision == current pin for every consumer.
-#    The script must NOT report a divergence.
+# 1. AGREEING: identical revisions must NOT be reported as diverged, and must be
+#    positively reported — a silent no-op would otherwise look the same.
 # ---------------------------------------------------------------------------
 agree_table="$WORK/agree.tsv"
-: >"$agree_table"
-while IFS=$'\t' read -r repo workflow _version; do
-  [ -n "$repo" ] || continue
-  printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
-    "1111111111111111111111111111111111111111" \
-    "1111111111111111111111111111111111111111" >>"$agree_table"
-done <<<"$consumers"
-
+write_table "$agree_table" '' '' ''
 agree_out="$WORK/agree.out"
-if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-  "$SCRIPT" >"$agree_out" 2>&1; then
-  if grep -q 'DIVERGED' "$agree_out"; then
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" "$SCRIPT" >"$agree_out" 2>&1; then
+  grep -q 'DIVERGED' "$agree_out" &&
     fail 'identical revisions were reported as DIVERGED — the check cannot distinguish the two states'
-  else
-    pass 'matching signing revision and current pin are not reported as diverged'
-  fi
-  if ! grep -q 'IN-SYNC' "$agree_out"; then
+  grep -q 'IN-SYNC' "$agree_out" ||
     fail 'the agreeing case produced no IN-SYNC line, so a silent no-op would look identical'
-  else
-    pass 'the agreeing case is positively reported, not merely silent'
-  fi
+  grep -q '0 unresolved' "$agree_out" ||
+    fail 'the agreeing case reports unresolved consumers'
+  [ "$failures" -eq 0 ] && pass 'matching revisions report IN-SYNC and never DIVERGED'
 else
   fail "the script exited non-zero on the all-agreeing fixture: $(cat "$agree_out")"
 fi
 
 # ---------------------------------------------------------------------------
-# 2. DIFFERING: one consumer's deployed artifact was signed by a revision it no
-#    longer pins. This is the measured two-behind case (#3048) in miniature, and
-#    it is the whole reason the script exists.
+# 2. DIFFERING: the measured two-behind case (#3048) in miniature. Both revisions
+#    must be named, because the allow-list has to accept both.
 # ---------------------------------------------------------------------------
-first_repo="$(printf '%s\n' "$consumers" | head -1 | cut -f1)"
 diff_table="$WORK/diff.tsv"
-: >"$diff_table"
-while IFS=$'\t' read -r repo workflow _version; do
-  [ -n "$repo" ] || continue
-  if [ "$repo" = "$first_repo" ]; then
-    printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
-      "2222222222222222222222222222222222222222" \
-      "3333333333333333333333333333333333333333" >>"$diff_table"
-  else
-    printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
-      "1111111111111111111111111111111111111111" \
-      "1111111111111111111111111111111111111111" >>"$diff_table"
-  fi
-done <<<"$consumers"
-
+write_table "$diff_table" "$first_repo" "$SHA_B" "$SHA_C"
 diff_out="$WORK/diff.out"
-if PUBLISH_REVISION_RESOLVER="$(make_stub "$diff_table" diff)" \
-  "$SCRIPT" >"$diff_out" 2>&1; then
+before=$failures
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$diff_table" diff)" "$SCRIPT" >"$diff_out" 2>&1; then
   grep -q 'DIVERGED' "$diff_out" ||
     fail 'a consumer whose signing revision differs from its current pin was NOT reported as DIVERGED'
-  grep -q "$first_repo" "$diff_out" ||
-    fail "the diverged consumer ($first_repo) is not named in the output"
-  # The allow-list this feeds has to accept BOTH revisions, so both must appear.
-  grep -q '2222222222222222222222222222222222222222' "$diff_out" ||
-    fail 'the signing revision is missing from the output, so an allow-list cannot be built from it'
-  grep -q '3333333333333333333333333333333333333333' "$diff_out" ||
-    fail 'the current pin is missing from the output, so an allow-list cannot be built from it'
-  [ "$failures" -eq 0 ] && pass 'a diverged consumer is reported with both revisions named'
+  grep -q -- "$first_repo" "$diff_out" || fail "the diverged consumer ($first_repo) is not named"
+  grep -q "$SHA_B" "$diff_out" ||
+    fail 'the signing revision is missing, so an allow-list cannot be built from it'
+  grep -q "$SHA_C" "$diff_out" ||
+    fail 'the current pin is missing, so an allow-list cannot be built from it'
+  [ "$failures" -eq "$before" ] && pass 'a diverged consumer is reported with both revisions named'
 else
   fail "the script exited non-zero on the diverging fixture: $(cat "$diff_out")"
 fi
 
 # ---------------------------------------------------------------------------
-# 3. DISCOVERY FLOOR. An empty or shrunken result from a filtered read is a claim
-#    about the FILTER, not about the repository. If the manifests move, are
-#    renamed, or adopt a spelling discovery does not match, the script must FAIL
-#    rather than report a clean, empty portfolio — the same fail-closed property
-#    guard-shared-publish-workflow-pin.sh carries for the same reason.
+# 3. DISCOVERY over a real tree that matches NOTHING. An empty result from a filtered
+#    read is a claim about the FILTER. This deliberately uses a populated directory of
+#    non-matching YAML rather than a missing one, so it exercises the "manifests moved,
+#    were renamed, or changed spelling" path and not merely a `[ -d ]` guard.
 # ---------------------------------------------------------------------------
-floor_out="$WORK/floor.out"
+nomatch_root="$WORK/nomatch"
+mkdir -p "$nomatch_root"
+cat >"$nomatch_root/unrelated.yaml" <<'YAML'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nothing-to-see
+data:
+  note: "no cosign subject here"
+YAML
+nomatch_out="$WORK/nomatch.out"
 if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-PUBLISH_CONSUMER_ROOT="$WORK/empty" "$SCRIPT" >"$floor_out" 2>&1; then
-  fail 'discovery over an EMPTY tree exited 0 — an unreadable repository would report as clean'
+  PUBLISH_CONSUMER_ROOT="$nomatch_root" "$SCRIPT" >"$nomatch_out" 2>&1; then
+  fail 'discovery over a tree matching nothing exited 0 — a moved manifest would report as clean'
 else
-  pass 'discovery over an empty tree fails closed instead of reporting a clean portfolio'
+  grep -q 'not discovered' "$nomatch_out" ||
+    fail 'the discovery failure does not say which consumers went missing'
+  pass 'a tree matching nothing fails closed instead of reporting a clean portfolio'
 fi
 
 # ---------------------------------------------------------------------------
-# 4. RESOLUTION FAILURE. A consumer the resolver cannot answer for must fail the
-#    run. Reporting "no divergence" because a lookup errored is the same
-#    fail-open as an empty read, one layer down.
+# 4. RIGHT SIZE, WRONG MEMBERSHIP. This is why the floor is an identity check and not a
+#    count: one real consumer dropping out while any other file drops in leaves the total
+#    unchanged, so a count-based floor passes and the vanished consumer is never checked.
+# ---------------------------------------------------------------------------
+swap_root="$WORK/swap"
+mkdir -p "$swap_root"
+i=0
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  i=$((i + 1))
+  # Substitute an impostor for one real consumer, keeping the total identical.
+  name="$repo"
+  [ "$repo" = "$first_repo" ] && name='impostor-repo'
+  cat >"$swap_root/consumer-$i.yaml" <<YAML
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: c$i
+spec:
+  url: oci://ghcr.io/devantler-tech/$name/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\\.actions\\.githubusercontent\\.com$'
+        subject: '^https://github\\.com/devantler-tech/actions/\\.github/workflows/$workflow\\.yaml@[0-9a-f]{40}\$'
+YAML
+done <<<"$consumers"
+swap_out="$WORK/swap.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+  PUBLISH_CONSUMER_ROOT="$swap_root" "$SCRIPT" >"$swap_out" 2>&1; then
+  fail 'a discovery set of the right SIZE but wrong MEMBERSHIP passed — a consumer can vanish silently'
+else
+  grep -q -- "$first_repo" "$swap_out" ||
+    fail "the missing consumer ($first_repo) is not named in the discovery failure"
+  pass 'a same-size discovery set missing a real consumer fails closed and names it'
+fi
+
+# ---------------------------------------------------------------------------
+# 5. A RESOLVER ANSWER THAT IS NOT TWO SHAs. `cut -f2` without `-s` echoes the WHOLE line
+#    when the delimiter is absent, so a resolver emitting one tab-free line — exactly the
+#    shape of a `gh api` error body — made signing == current and reported IN-SYNC for
+#    every consumer with exit 0. That is the worst failure this script can have.
+# ---------------------------------------------------------------------------
+junk_resolver="$WORK/resolver-junk.sh"
+cat >"$junk_resolver" <<'JUNK'
+#!/usr/bin/env bash
+printf '%s\n' '{"message":"Not Found","status":"404"}'
+exit 1
+JUNK
+chmod +x "$junk_resolver"
+junk_out="$WORK/junk.out"
+if PUBLISH_REVISION_RESOLVER="$junk_resolver" "$SCRIPT" >"$junk_out" 2>&1; then
+  fail 'a resolver emitting a tab-free error body exited 0 — every consumer read as IN-SYNC'
+else
+  grep -q 'IN-SYNC' "$junk_out" &&
+    fail 'an unparseable resolver answer was reported as IN-SYNC rather than UNRESOLVED'
+  grep -q 'UNRESOLVED' "$junk_out" ||
+    fail 'an unparseable resolver answer produced no UNRESOLVED line'
+  grep -q 'FAILED' "$junk_out" ||
+    fail 'the failure explanation is absent from stdout, so the CI step summary would end on a clean-looking tally'
+  pass 'a resolver answer that is not two SHAs is UNRESOLVED, fails the run, and explains itself on stdout'
+fi
+
+# ---------------------------------------------------------------------------
+# 6. ONE UNRESOLVABLE CONSUMER MUST NOT HIDE THE OTHERS. The script collects and fails at
+#    the end precisely so a single lookup failure does not suppress the consumers that did
+#    resolve; nothing proved that until now.
 # ---------------------------------------------------------------------------
 partial_table="$WORK/partial.tsv"
-grep -v "^$first_repo	" "$agree_table" >"$partial_table" || true
+awk -F'\t' -v r="$first_repo" '$1 != r' "$agree_table" >"$partial_table"
+expected_insync=$(($(printf '%s\n' "$consumers" | grep -c .) - 1))
 partial_out="$WORK/partial.out"
-if PUBLISH_REVISION_RESOLVER="$(make_stub "$partial_table" partial)" \
-  "$SCRIPT" >"$partial_out" 2>&1; then
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$partial_table" partial)" "$SCRIPT" >"$partial_out" 2>&1; then
   fail 'a consumer the resolver could not answer for did not fail the run'
 else
-  grep -q "$first_repo" "$partial_out" ||
-    fail 'the unresolvable consumer is not named in the failure, so the cause is not diagnosable'
-  pass 'an unresolvable consumer fails the run and is named'
+  grep -q -- "$first_repo" "$partial_out" ||
+    fail 'the unresolvable consumer is not named, so the cause is not diagnosable'
+  got_insync="$(grep -c '^IN-SYNC' "$partial_out" || true)"
+  [ "$got_insync" -eq "$expected_insync" ] ||
+    fail "one unresolvable consumer suppressed the others: expected $expected_insync IN-SYNC, got $got_insync"
+  pass 'an unresolvable consumer fails the run, is named, and does not hide the consumers that resolved'
 fi
 
 # ---------------------------------------------------------------------------
-# 5. ARTIFACT NAME vs SOURCE REPOSITORY. `.github` cannot be an OCI path component,
-#    so its artifact ships as `github-config`. Deriving the repository from the URL
-#    alone therefore names a repository that does not exist, and every lookup for
-#    that consumer fails — which the report would show as UNRESOLVED, i.e. a healthy
-#    consumer reported as unreadable. Pin the translation so it cannot be dropped.
+# 7. ARTIFACT NAME vs SOURCE REPOSITORY. `.github` cannot be an OCI path component, so its
+#    artifact ships as `github-config`. Deriving the repository from the URL alone names a
+#    repository that does not exist, so every lookup for a healthy consumer fails.
 # ---------------------------------------------------------------------------
-if printf '%s\n' "$consumers" | cut -f1 | grep -qxF '.github'; then
+if printf '%s\n' "$consumers" | cut -f1 | grep -qxF -- '.github'; then
   pass 'the github-config artifact is attributed to its real source repository (.github)'
 else
   fail 'github-config is not mapped to .github — its revisions cannot be resolved at all'
 fi
-if printf '%s\n' "$consumers" | cut -f1 | grep -qxF 'github-config'; then
+if printf '%s\n' "$consumers" | cut -f1 | grep -qxF -- 'github-config'; then
   fail 'the OCI artifact name github-config leaked through as a repository name; no such repository exists'
 fi
 
@@ -182,4 +247,4 @@ if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (5 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (7 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -351,9 +351,9 @@ bounded_case() {
     # refusal cannot be confused with a wholesale failure of the fixture.
     if [ "$k" -eq 1 ]; then
       case "$bc_ref_kind" in
-      raw) ref_block="  ref:"$'\n'"    $bc_ref_line" ;;
-      omit) ref_block='' ;;
-      *) ref_block="  ref:"$'\n'"    semver: \"$bc_selector\"" ;;
+        raw) ref_block="  ref:"$'\n'"    $bc_ref_line" ;;
+        omit) ref_block='' ;;
+        *) ref_block="  ref:"$'\n'"    semver: \"$bc_selector\"" ;;
       esac
     else
       ref_block="  ref:"$'\n'"    semver: \">=1.0.0\""

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -697,6 +697,53 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 13b. A PARTIAL TAG TIES A STRICT ONE, AND IS INVISIBLE TO EVERY OTHER CHECK.
+#
+# Flux coerces `v2.0` to 2.0.0, so it stands at the SAME precedence as `v2.0.0` and may
+# be the ref it selects. But `sort -V` orders `2.0.0` ABOVE `2.0`, so the partial reads
+# as safely lower, and its spelling matches neither the three-component core pattern nor
+# the `v`-duality fold -- so it never entered the variant set and the tie refusal never
+# fired. The walk then considered only the strict tag and could report ITS signing
+# revision for an artifact the partial tag produced.
+partial_tie_out="$WORK/partial-tie.out"
+if BM_WEDDING_TAGS='v2.0.0\nv2.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/partial-tie.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$partial_tie_out" 2>&1; then
+  fail 'a strict version tied by a PARTIAL tag was silently resolved instead of refusing'
+else
+  grep -q 'published as a PARTIAL tag' "$partial_tie_out" ||
+    fail 'the run failed but not because of the partial-tag tie -- the case is not testing what it claims'
+  grep -qF 'v2.0' "$partial_tie_out" ||
+    fail 'the refusal does not name the partial tag, so the cause is not diagnosable'
+  # Same control as the build-metadata tie: count the outcome lines, because the report
+  # names every consumer it discovered on the UNRESOLVED line as readily as the IN-SYNC
+  # one, so a name match would also pass if ALL FIVE consumers had failed.
+  pt_unresolved="$(grep -c '^UNRESOLVED' "$partial_tie_out" || true)"
+  pt_insync="$(grep -c '^IN-SYNC' "$partial_tie_out" || true)"
+  [ "$pt_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the partial tie), got $pt_unresolved -- a different count means the fixture failed for an unrelated reason"
+  [ "$pt_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $pt_insync"
+  pass 'a strict version tied by a partial tag refuses instead of preferring the strict spelling'
+fi
+
+# A MIRROR, and the reason the refusal is conditioned on a trailing-zero core: `2.1.3`
+# has NO partial spelling, so a repository publishing it alongside an unrelated `v2.0`
+# must still resolve. Without this, "refuse when any shorter tag exists" would look
+# identical on the case above while breaking ordinary repositories.
+partial_ok_out="$WORK/partial-ok.out"
+if BM_WEDDING_TAGS='v2.1.3\nv2.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/partial-ok.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$partial_ok_out" 2>&1; then
+  pok_insync="$(grep -c '^IN-SYNC' "$partial_ok_out" || true)"
+  [ "$pok_insync" -eq 5 ] ||
+    fail "a version with no partial spelling must still resolve for all five consumers, got $pok_insync IN-SYNC"
+  pass 'a version that has no partial spelling is unaffected by the partial-tie refusal'
+else
+  fail 'a version with no partial spelling was refused -- the partial-tie check is too broad'
+fi
+
+# ---------------------------------------------------------------------------
 # 14. A VERSION PUBLISHED ONLY WITH BUILD METADATA MUST NOT BE WALKED PAST. (#3305 review)
 #     `2.0.0+build.1` with no bare `2.0.0` is the newest release, and Flux selects it.
 #     A walk that rebuilds the tag from the bare core version finds nothing at that

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# RED/GREEN coverage for `report-publish-workflow-signing-revisions.sh` (#3048).
+#
+# WHAT IS ACTUALLY BEING PROVED
+# The reported script answers one question per consumer: "is the revision that SIGNED
+# what is deployed the same revision this consumer pins TODAY?" An allow-list built for
+# #2818 has to accept both, so the whole value of the script is that a DIFFERENCE is
+# surfaced and a MATCH is not. Those are the two directions this file pins.
+#
+# WHY THERE IS A RESOLVER SEAM
+# Resolving a revision needs the network (release tag -> tag commit -> the pin in that
+# commit's cd.yaml). A test that depended on it would prove nothing repeatable: it would
+# go red when an unrelated repository cut a release, and green when the network was
+# simply unavailable. The script therefore takes its resolver from
+# PUBLISH_REVISION_RESOLVER, and these fixtures supply a stub. Discovery — which
+# consumers exist and whether any went missing — stays REAL, against this repository's
+# own manifests, because that is the half a stub could hide a regression in.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly SCRIPT="$REPO_ROOT/scripts/report-publish-workflow-signing-revisions.sh"
+
+failures=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+pass() { printf 'ok: %s\n' "$*"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A stub resolver. It is handed <repo> <workflow> and prints "<signing>\t<current>".
+# Each fixture writes its own answers into a table file the stub reads, so one stub
+# covers every case without the fixtures having to generate shell code.
+make_stub() {
+  local table="$1" path="$WORK/resolver-$2.sh"
+  cat >"$path" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+while IFS=\$'\t' read -r repo workflow signing current; do
+  [ -n "\$repo" ] || continue
+  if [ "\$repo" = "\$1" ] && [ "\$workflow" = "\$2" ]; then
+    printf '%s\t%s\n' "\$signing" "\$current"
+    exit 0
+  fi
+done <"$table"
+exit 7
+STUB
+  chmod +x "$path"
+  printf '%s\n' "$path"
+}
+
+# Every consumer this repository actually carries, resolved from the real manifests, so
+# a fixture cannot silently drift out of step with discovery.
+consumers="$("$SCRIPT" --list-consumers 2>/dev/null || true)"
+if [ -z "$consumers" ]; then
+  fail '--list-consumers produced nothing; every case below would pass vacuously'
+  printf '\n%d failure(s)\n' "$((failures + 1))" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. AGREEING: signing revision == current pin for every consumer.
+#    The script must NOT report a divergence.
+# ---------------------------------------------------------------------------
+agree_table="$WORK/agree.tsv"
+: >"$agree_table"
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
+    "1111111111111111111111111111111111111111" \
+    "1111111111111111111111111111111111111111" >>"$agree_table"
+done <<<"$consumers"
+
+agree_out="$WORK/agree.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+  "$SCRIPT" >"$agree_out" 2>&1; then
+  if grep -q 'DIVERGED' "$agree_out"; then
+    fail 'identical revisions were reported as DIVERGED — the check cannot distinguish the two states'
+  else
+    pass 'matching signing revision and current pin are not reported as diverged'
+  fi
+  if ! grep -q 'IN-SYNC' "$agree_out"; then
+    fail 'the agreeing case produced no IN-SYNC line, so a silent no-op would look identical'
+  else
+    pass 'the agreeing case is positively reported, not merely silent'
+  fi
+else
+  fail "the script exited non-zero on the all-agreeing fixture: $(cat "$agree_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. DIFFERING: one consumer's deployed artifact was signed by a revision it no
+#    longer pins. This is the measured two-behind case (#3048) in miniature, and
+#    it is the whole reason the script exists.
+# ---------------------------------------------------------------------------
+first_repo="$(printf '%s\n' "$consumers" | head -1 | cut -f1)"
+diff_table="$WORK/diff.tsv"
+: >"$diff_table"
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  if [ "$repo" = "$first_repo" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
+      "2222222222222222222222222222222222222222" \
+      "3333333333333333333333333333333333333333" >>"$diff_table"
+  else
+    printf '%s\t%s\t%s\t%s\n' "$repo" "$workflow" \
+      "1111111111111111111111111111111111111111" \
+      "1111111111111111111111111111111111111111" >>"$diff_table"
+  fi
+done <<<"$consumers"
+
+diff_out="$WORK/diff.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$diff_table" diff)" \
+  "$SCRIPT" >"$diff_out" 2>&1; then
+  grep -q 'DIVERGED' "$diff_out" ||
+    fail 'a consumer whose signing revision differs from its current pin was NOT reported as DIVERGED'
+  grep -q "$first_repo" "$diff_out" ||
+    fail "the diverged consumer ($first_repo) is not named in the output"
+  # The allow-list this feeds has to accept BOTH revisions, so both must appear.
+  grep -q '2222222222222222222222222222222222222222' "$diff_out" ||
+    fail 'the signing revision is missing from the output, so an allow-list cannot be built from it'
+  grep -q '3333333333333333333333333333333333333333' "$diff_out" ||
+    fail 'the current pin is missing from the output, so an allow-list cannot be built from it'
+  [ "$failures" -eq 0 ] && pass 'a diverged consumer is reported with both revisions named'
+else
+  fail "the script exited non-zero on the diverging fixture: $(cat "$diff_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. DISCOVERY FLOOR. An empty or shrunken result from a filtered read is a claim
+#    about the FILTER, not about the repository. If the manifests move, are
+#    renamed, or adopt a spelling discovery does not match, the script must FAIL
+#    rather than report a clean, empty portfolio — the same fail-closed property
+#    guard-shared-publish-workflow-pin.sh carries for the same reason.
+# ---------------------------------------------------------------------------
+floor_out="$WORK/floor.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+  PUBLISH_CONSUMER_ROOT="$WORK/empty" "$SCRIPT" >"$floor_out" 2>&1; then
+  fail 'discovery over an EMPTY tree exited 0 — an unreadable repository would report as clean'
+else
+  pass 'discovery over an empty tree fails closed instead of reporting a clean portfolio'
+fi
+
+# ---------------------------------------------------------------------------
+# 4. RESOLUTION FAILURE. A consumer the resolver cannot answer for must fail the
+#    run. Reporting "no divergence" because a lookup errored is the same
+#    fail-open as an empty read, one layer down.
+# ---------------------------------------------------------------------------
+partial_table="$WORK/partial.tsv"
+grep -v "^$first_repo	" "$agree_table" >"$partial_table" || true
+partial_out="$WORK/partial.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$partial_table" partial)" \
+  "$SCRIPT" >"$partial_out" 2>&1; then
+  fail 'a consumer the resolver could not answer for did not fail the run'
+else
+  grep -q "$first_repo" "$partial_out" ||
+    fail 'the unresolvable consumer is not named in the failure, so the cause is not diagnosable'
+  pass 'an unresolvable consumer fails the run and is named'
+fi
+
+# ---------------------------------------------------------------------------
+# 5. ARTIFACT NAME vs SOURCE REPOSITORY. `.github` cannot be an OCI path component,
+#    so its artifact ships as `github-config`. Deriving the repository from the URL
+#    alone therefore names a repository that does not exist, and every lookup for
+#    that consumer fails — which the report would show as UNRESOLVED, i.e. a healthy
+#    consumer reported as unreadable. Pin the translation so it cannot be dropped.
+# ---------------------------------------------------------------------------
+if printf '%s\n' "$consumers" | cut -f1 | grep -qxF '.github'; then
+  pass 'the github-config artifact is attributed to its real source repository (.github)'
+else
+  fail 'github-config is not mapped to .github — its revisions cannot be resolved at all'
+fi
+if printf '%s\n' "$consumers" | cut -f1 | grep -qxF 'github-config'; then
+  fail 'the OCI artifact name github-config leaked through as a repository name; no such repository exists'
+fi
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+printf '\nPASS: publish-workflow signing-revision report (5 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -324,18 +324,25 @@ fi
 #    Resolving such a range needs Flux-compatible semver selection this script does not
 #    implement, so the honest outcome is a named refusal.
 # ---------------------------------------------------------------------------
-bounded_root="$WORK/bounded"
-mkdir -p "$bounded_root"
-k=0
-while IFS=$'\t' read -r repo workflow _version; do
-  [ -n "$repo" ] || continue
-  k=$((k + 1))
-  oci="$repo"
-  [ "$repo" = '.github' ] && oci='github-config'
-  # One consumer gets a BOUNDED range; the rest keep an unbounded one, so the refusal
-  # cannot be confused with a wholesale failure of the fixture.
-  if [ "$k" -eq 1 ]; then ref='semver: "~1.4"'; else ref='semver: ">=1.0.0"'; fi
-  cat >"$bounded_root/c-$k.yaml" <<YAML
+# Each selector below is bounded and must refuse BY NAME. `~1.4` is the simple form;
+# `>=1.0.0 <2.0.0` is the compound one, which matters because a lower-bound-prefix
+# test accepts it — the upper bound is simply not looked at — and the script would
+# then treat a bounded range as unbounded and resolve it to the newest tag.
+bounded_case() {
+  bc_label=$1
+  bc_selector=$2
+  bc_root="$WORK/bounded-$bc_label"
+  mkdir -p "$bc_root"
+  k=0
+  while IFS=$'\t' read -r repo workflow _version; do
+    [ -n "$repo" ] || continue
+    k=$((k + 1))
+    oci="$repo"
+    [ "$repo" = '.github' ] && oci='github-config'
+    # One consumer gets the BOUNDED range; the rest keep an unbounded one, so the
+    # refusal cannot be confused with a wholesale failure of the fixture.
+    if [ "$k" -eq 1 ]; then ref="semver: \"$bc_selector\""; else ref='semver: ">=1.0.0"'; fi
+    cat >"$bc_root/c-$k.yaml" <<YAML
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -350,22 +357,31 @@ spec:
       - issuer: '^https://token\\.actions\\.githubusercontent\\.com\$'
         subject: '^https://github\\.com/devantler-tech/actions/\\.github/workflows/$workflow\\.yaml@[0-9a-f]{40}\$'
 YAML
-done <<<"$consumers"
-bounded_out="$WORK/bounded.out"
-# The stub is safe here BECAUSE the refusal is decided from the manifest, before any resolver
-# is consulted. When this check lived inside the resolver, the only way to reach it was to let
-# the real one run — which made this case hit the network and fail in CI for an unrelated
-# reason. A hermetic case that reaches the branch is strictly better than a live one that does.
-if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-PUBLISH_CONSUMER_ROOT="$bounded_root" "$SCRIPT" >"$bounded_out" 2>&1; then
-  fail 'a bounded semver constraint was silently resolved to the newest tag instead of refusing'
-else
-  grep -q 'bounded semver constraint' "$bounded_out" ||
-    fail 'the run failed but not because of the bounded constraint — the case is not testing what it claims'
-  grep -q '~1.4' "$bounded_out" ||
-    fail 'the refusal does not name the constraint, so the cause is not diagnosable'
-  pass 'a bounded semver constraint refuses by name instead of guessing the newest tag'
-fi
+  done <<<"$consumers"
+  bc_out="$WORK/bounded-$bc_label.out"
+  # The stub is safe here BECAUSE the refusal is decided from the manifest, before any
+  # resolver is consulted. When this check lived inside the resolver, the only way to
+  # reach it was to let the real one run — which made this case hit the network and fail
+  # in CI for an unrelated reason. A hermetic case that reaches the branch is strictly
+  # better than a live one that does.
+  if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+  PUBLISH_CONSUMER_ROOT="$bc_root" "$SCRIPT" >"$bc_out" 2>&1; then
+    fail "a bounded semver constraint ($bc_selector) was silently resolved to the newest tag instead of refusing"
+  else
+    grep -q 'bounded semver constraint' "$bc_out" ||
+      fail "the run failed but not because of the bounded constraint ($bc_selector) — the case is not testing what it claims"
+    grep -qF "$bc_selector" "$bc_out" ||
+      fail "the refusal does not name the constraint ($bc_selector), so the cause is not diagnosable"
+    pass "a bounded semver constraint refuses by name instead of guessing the newest tag: $bc_selector"
+  fi
+}
+
+bounded_case simple '~1.4'
+# A COMPOUND range beginning with a lower bound. The whole point: it *starts* like the
+# unbounded `>=1.0.0` that is legitimately allowed, so any test looking only at the
+# prefix accepts it and discards the `<2.0.0` — attributing a 2.x tag's workflow
+# revision to an artifact Flux would never deploy, and omitting the real signer.
+bounded_case compound '>=1.0.0 <2.0.0'
 
 # ---------------------------------------------------------------------------
 # 10. AN EMPTY MIDDLE FIELD MUST NOT SHIFT `origin` INTO `current`. (#3305 review)

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -198,8 +198,11 @@ fi
 junk_resolver="$WORK/resolver-junk.sh"
 cat >"$junk_resolver" <<'JUNK'
 #!/usr/bin/env bash
+# exit 0 ON PURPOSE. A FAILING resolver is discarded by the caller (`answer=$(...) || answer=""`),
+# so only a SUCCEEDING resolver reaches the tab-free-answer parsing path this case exists to test.
+# With `exit 1` the case proved only that an EMPTY answer is UNRESOLVED — a different, weaker claim.
 printf '%s\n' '{"message":"Not Found","status":"404"}'
-exit 1
+exit 0
 JUNK
 chmod +x "$junk_resolver"
 junk_out="$WORK/junk.out"

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -178,9 +178,15 @@ if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
 PUBLISH_CONSUMER_ROOT="$swap_root" "$SCRIPT" >"$swap_out" 2>&1; then
   fail 'a discovery set of the right SIZE but wrong MEMBERSHIP passed — a consumer can vanish silently'
 else
-  grep -q -- "$first_repo" "$swap_out" ||
-    fail "the missing consumer ($first_repo) is not named in the discovery failure"
-  pass 'a same-size discovery set missing a real consumer fails closed and names it'
+  # The set comparison runs in BOTH directions, and the unregistered side fires first here: the
+  # impostor is not in EXPECTED_CONSUMERS, which is itself the stronger objection — a consumer this
+  # script does not know about is one whose later disappearance it could not notice. Either half
+  # naming its cause is a pass; silence is not.
+  grep -qE -- "impostor-repo|$first_repo" "$swap_out" ||
+    fail "the discovery failure names neither the unregistered consumer nor the missing one"
+  grep -qE -- 'not registered|not discovered' "$swap_out" ||
+    fail "the discovery failure does not say WHICH direction of the set comparison failed"
+  pass 'a same-size discovery set with an unregistered member fails closed and names the cause'
 fi
 
 # ---------------------------------------------------------------------------
@@ -243,8 +249,70 @@ if printf '%s\n' "$consumers" | cut -f1 | grep -qxF -- 'github-config'; then
   fail 'the OCI artifact name github-config leaked through as a repository name; no such repository exists'
 fi
 
+# ---------------------------------------------------------------------------
+# 8. AN EXTRA, UNREGISTERED CONSUMER. This isolates the OTHER direction of the set
+#    comparison: every expected consumer is present, so the "missing" check cannot fire
+#    and only the unregistered check can. Without this the swap fixture above passes on
+#    either direction and the unregistered half is never actually exercised — which is
+#    exactly what an ablation showed before this case existed.
+#
+#    It matters because an unregistered consumer is one whose later disappearance this
+#    script could not notice: it would drop out and every registered name would still be
+#    present, so the run would exit clean.
+# ---------------------------------------------------------------------------
+extra_root="$WORK/extra"
+mkdir -p "$extra_root"
+j=0
+while IFS=$'\t' read -r repo workflow _version; do
+  [ -n "$repo" ] || continue
+  j=$((j + 1))
+  # `.github` is the artifact name `github-config` on the wire; emit the OCI name so the
+  # script's own mapping reproduces the real repository, exactly as in production.
+  oci="$repo"
+  [ "$repo" = '.github' ] && oci='github-config'
+  cat >"$extra_root/real-$j.yaml" <<YAML
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: r$j
+spec:
+  url: oci://ghcr.io/devantler-tech/$oci/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\\.actions\\.githubusercontent\\.com\$'
+        subject: '^https://github\\.com/devantler-tech/actions/\\.github/workflows/$workflow\\.yaml@[0-9a-f]{40}\$'
+YAML
+done <<<"$consumers"
+cat >"$extra_root/extra.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: newcomer
+spec:
+  url: oci://ghcr.io/devantler-tech/newcomer/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'
+YAML
+extra_out="$WORK/extra.out"
+if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
+PUBLISH_CONSUMER_ROOT="$extra_root" "$SCRIPT" >"$extra_out" 2>&1; then
+  fail 'an unregistered sixth consumer was accepted — its later disappearance could not be noticed'
+else
+  grep -q 'not registered' "$extra_out" ||
+    fail 'the failure does not identify the unregistered direction of the set comparison'
+  grep -q 'newcomer' "$extra_out" ||
+    fail 'the unregistered consumer is not named, so registering it needs guesswork'
+  grep -q 'not discovered' "$extra_out" &&
+    fail 'the run reported a MISSING consumer; this fixture has all five, so the case is not isolating'
+  pass 'an extra unregistered consumer fails closed and is named'
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (7 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (8 cases)\n'

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -137,7 +137,7 @@ data:
 YAML
 nomatch_out="$WORK/nomatch.out"
 if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-  PUBLISH_CONSUMER_ROOT="$nomatch_root" "$SCRIPT" >"$nomatch_out" 2>&1; then
+PUBLISH_CONSUMER_ROOT="$nomatch_root" "$SCRIPT" >"$nomatch_out" 2>&1; then
   fail 'discovery over a tree matching nothing exited 0 — a moved manifest would report as clean'
 else
   grep -q 'not discovered' "$nomatch_out" ||
@@ -175,7 +175,7 @@ YAML
 done <<<"$consumers"
 swap_out="$WORK/swap.out"
 if PUBLISH_REVISION_RESOLVER="$(make_stub "$agree_table" agree)" \
-  PUBLISH_CONSUMER_ROOT="$swap_root" "$SCRIPT" >"$swap_out" 2>&1; then
+PUBLISH_CONSUMER_ROOT="$swap_root" "$SCRIPT" >"$swap_out" 2>&1; then
   fail 'a discovery set of the right SIZE but wrong MEMBERSHIP passed — a consumer can vanish silently'
 else
   grep -q -- "$first_repo" "$swap_out" ||

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -562,6 +562,12 @@ case "$args" in
       *)             printf 'v1.9.0\n' ;;
     esac
     ;;
+  *"/commits/"*)
+    # The commit a tag currently resolves to. Every tag resolves to BM_TAG_SHA, so the run
+    # lookup below matches by default and the existing cases keep exercising their own
+    # guards rather than failing for want of this one.
+    printf '%s\n' "${BM_TAG_SHA:-$BM_SHA_C}"
+    ;;
   *"/actions/runs"*)
     # Echo the requested ref back so every candidate tag reads as published. Pinning this
     # to one tag would make the ablations fail for want of a published release rather than
@@ -574,7 +580,12 @@ case "$args" in
     bm_ref="${args#*branch=}"
     bm_ref="${bm_ref%%&*}"
     bm_ref="${bm_ref%% *}"
-    printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s"}]}\n' "$bm_ref"
+    # A MOVED TAG: the historical run still carries the commit the tag pointed at BEFORE it
+    # was moved, while `/commits/<tag>` above reports where it points NOW. Naming a tag in
+    # BM_MOVED_TAG reproduces exactly that, and nothing else about the fixture changes.
+    bm_run_sha="${BM_TAG_SHA:-$BM_SHA_C}"
+    [ "$bm_ref" = "${BM_MOVED_TAG:-}" ] && bm_run_sha="$BM_SHA_A"
+    printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' "$bm_ref" "$bm_run_sha"
     ;;
   *"/contents/.github/workflows/cd.yaml"*)
     # The pin DEPENDS ON THE REF, which is what makes the walk's choice observable: the
@@ -633,7 +644,7 @@ YAML
 done <<<"$consumers"
 
 if BM_WEDDING_TAGS='v2.0.0\nv2.0.0+build.1\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$bm_out" 2>&1; then
   fail 'a version carried by two tags was silently resolved instead of refusing'
 else
@@ -686,7 +697,7 @@ bm2_out="$WORK/buildmeta-only.out"
 # revision and reports the consumer as diverged; walking silently past it prints SHA_A
 # and reports it in sync. SHA_B in the output is the whole discrimination.
 if BM_AWS_TAGS='v2.0.0+build.1\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$bm2_root" "$SCRIPT" >"$bm2_out" 2>&1; then
   grep -qF "$SHA_B" "$bm2_out" ||
     fail 'the newest release exists only as a build-metadata tag, and the report resolved an older one instead — it walked silently past it'
@@ -727,7 +738,7 @@ vd_out="$WORK/vdual.out"
 # Only `wedding-app` publishes both spellings; every other consumer stays on a plain
 # v1.9.0, so a refusal or divergence can only have come from that consumer.
 if BM_WEDDING_TAGS='2.0.0\nv2.0.0\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$vd_root" "$SCRIPT" >"$vd_out" 2>&1; then
   fail 'a version published as both 2.0.0 and v2.0.0 was silently resolved to the v spelling instead of refusing'
 else
@@ -755,7 +766,7 @@ vd2_root="$WORK/vdual-single-root"
 cp -R "$bm_root" "$vd2_root"
 vd2_out="$WORK/vdual-single.out"
 if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' \
-  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
   PUBLISH_CONSUMER_ROOT="$vd2_root" "$SCRIPT" >"$vd2_out" 2>&1; then
   pass 'a version published under only the v spelling still resolves'
 else
@@ -859,8 +870,181 @@ else
   fail "the script exited non-zero on the origin fixture: $(cat "$origin_out")"
 fi
 
+# ---------------------------------------------------------------------------
+# 17. A MOVED TAG MUST NOT COUNT AS PUBLISHED. (#3305 review)
+#     The run filter matched on ref NAME, path and conclusion only, so a successful run
+#     from BEFORE a tag was moved or recreated still counted. `pin_at_ref` then reads
+#     cd.yaml at the tag's CURRENT commit, so the report pairs a workflow revision from one
+#     commit with a publish proved by another and prints it as a SHA the allow-list "must
+#     accept" — two individually-true facts composed into a confident wrong answer.
+#
+#     It REFUSES rather than walking back: a moved tag HAS published something, just not
+#     what it now points at, so stepping silently to the previous release would attribute
+#     THAT release's revision to the deployed artifact — the same failure one release down.
+# ---------------------------------------------------------------------------
+mv_root="$WORK/moved-root"
+cp -R "$bm_root" "$mv_root"
+mv_out="$WORK/moved.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_MOVED_TAG='v2.0.0' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$mv_root" "$SCRIPT" >"$mv_out" 2>&1; then
+  fail 'a tag whose only successful run belongs to a DIFFERENT commit was accepted as published — the workflow pin would be read from a commit that never signed the artifact'
+else
+  grep -q 'moved or recreated' "$mv_out" ||
+    fail 'the run failed but not because of the moved tag — the case is not testing what it claims'
+  grep -qF 'v2.0.0' "$mv_out" ||
+    fail 'the refusal does not name the moved tag, so the cause is not diagnosable'
+  mv_unresolved="$(grep -c '^UNRESOLVED' "$mv_out" || true)"
+  mv_insync="$(grep -c '^IN-SYNC' "$mv_out" || true)"
+  [ "$mv_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the moved tag), got $mv_unresolved"
+  [ "$mv_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $mv_insync"
+  grep -qE '^UNRESOLVED +wedding-app' "$mv_out" ||
+    fail 'the unresolved consumer is not the one whose tag moved'
+  pass 'a tag whose successful run belongs to another commit refuses instead of being read as published'
+fi
+
+# CONTROL: the SAME tag set with nothing moved must resolve. Without this the refusal above
+# would be satisfied by rejecting every tag, which would break every real consumer — and the
+# only difference between the two runs is BM_MOVED_TAG, so it is the moved-ness under test.
+mv2_root="$WORK/moved-control-root"
+cp -R "$bm_root" "$mv2_root"
+mv2_out="$WORK/moved-control.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$mv2_root" "$SCRIPT" >"$mv2_out" 2>&1; then
+  mv2_insync="$(grep -c '^IN-SYNC' "$mv2_out" || true)"
+  [ "$mv2_insync" -eq 5 ] ||
+    fail "the unmoved control resolved only $mv2_insync of 5 consumers — the moved-tag check is too broad"
+  pass 'an unmoved tag still resolves, so the moved-tag refusal is not rejecting every run'
+else
+  fail "the unmoved control failed outright, so the moved-tag case above proves nothing: $(cat "$mv2_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# 18. AN EXACT PIN MUST REFUSE BOTH SPELLINGS TOO. (#3305 review)
+#     Case 14b proves the semver WALK refuses a version published as both `2.0.0` and
+#     `v2.0.0`. The exact-pin branch returned on the FIRST spelling it found, so that
+#     refusal was unreachable for precisely the consumers whose version is written down —
+#     and the two refs can point at different commits and so at different workflow pins.
+# ---------------------------------------------------------------------------
+# One consumer pins an EXACT tag; the rest keep an unbounded range, so a refusal can only
+# have come from that consumer.
+make_exact_root() { # <dest> <pinned-tag>
+  local dest="$1" pin="$2" k=0 repo workflow oci ref_block
+  mkdir -p "$dest"
+  while IFS=$'\t' read -r repo workflow _version; do
+    [ -n "$repo" ] || continue
+    k=$((k + 1))
+    oci="$repo"
+    [ "$repo" = '.github' ] && oci='github-config'
+    if [ "$repo" = 'wedding-app' ]; then
+      ref_block="    tag: \"$pin\""
+    else
+      ref_block='    semver: ">=1.0.0"'
+    fi
+    {
+      printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: e%s\nspec:\n  ref:\n' "$k"
+      printf '%s\n' "$ref_block"
+      printf '  url: oci://ghcr.io/devantler-tech/%s/manifests\n' "$oci"
+      printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n'
+      printf "      - issuer: '^https://token\\\\.actions\\\\.githubusercontent\\\\.com\$'\n"
+      printf "        subject: '^https://github\\\\.com/devantler-tech/actions/\\\\.github/workflows/%s\\\\.yaml@[0-9a-f]{40}\$'\n" "$workflow"
+    } >"$dest/c-$k.yaml"
+  done <<<"$consumers"
+}
+
+ex_root="$WORK/exact-dual-root"
+make_exact_root "$ex_root" '2.0.0'
+ex_out="$WORK/exact-dual.out"
+if BM_WEDDING_TAGS='2.0.0\nv2.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$ex_root" "$SCRIPT" >"$ex_out" 2>&1; then
+  fail 'an exact pin whose version exists under BOTH spellings resolved to whichever was tried first instead of refusing'
+else
+  grep -q 'published as BOTH' "$ex_out" ||
+    fail 'the run failed but not because of the exact-pin duality — the case is not testing what it claims'
+  ex_unresolved="$(grep -c '^UNRESOLVED' "$ex_out" || true)"
+  ex_insync="$(grep -c '^IN-SYNC' "$ex_out" || true)"
+  [ "$ex_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the exact-pin duality), got $ex_unresolved"
+  [ "$ex_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $ex_insync"
+  grep -qE '^UNRESOLVED +wedding-app' "$ex_out" ||
+    fail 'the unresolved consumer is not the one pinning the doubly-spelled version'
+  pass 'an exact pin refuses when its version exists under both the bare and v spellings'
+fi
+
+# CONTROL: an exact pin with ONE spelling present must still resolve — the pin is written
+# bare while only the `v` form exists, which is the real repository's shape.
+ex2_root="$WORK/exact-single-root"
+make_exact_root "$ex2_root" '2.0.0'
+ex2_out="$WORK/exact-single.out"
+if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$ex2_root" "$SCRIPT" >"$ex2_out" 2>&1; then
+  ex2_insync="$(grep -c '^IN-SYNC' "$ex2_out" || true)"
+  [ "$ex2_insync" -eq 5 ] ||
+    fail "the single-spelling exact-pin control resolved only $ex2_insync of 5 consumers — the duality check is too broad"
+  pass 'an exact pin resolves normally when only one spelling of its version exists'
+else
+  fail "the single-spelling exact-pin control failed outright, so the duality case proves nothing: $(cat "$ex2_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# 19. A TAG THIS SCRIPT CANNOT RANK MUST NOT BE SILENTLY OUTRANKED. (#3305 review)
+#     The candidate filter was a character-class regex, so `v02.0.0` (SemVer forbids a
+#     leading zero in a numeric identifier) and `v2.0.0+foo..bar` (a build identifier may
+#     not be empty) were accepted, stripped and ranked. Measured: `02.0.0` sorts ABOVE
+#     `1.9.0`, so such a tag could be selected and its workflow pin attributed to the
+#     consumer while Flux, rejecting the tag, resolves an older artifact.
+#
+#     Excluding it is not enough on its own — that walks silently back to an older release,
+#     which is the confident wrong answer rather than a refusal. So it refuses BY NAME, and
+#     only when the unrankable tag could actually outrank the best valid candidate.
+# ---------------------------------------------------------------------------
+iv_root="$WORK/invalid-semver-root"
+cp -R "$bm_root" "$iv_root"
+iv_out="$WORK/invalid-semver.out"
+if BM_WEDDING_TAGS='v02.0.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$iv_root" "$SCRIPT" >"$iv_out" 2>&1; then
+  fail 'a tag that is not valid SemVer but outranks every valid candidate was resolved or silently skipped instead of refusing'
+else
+  grep -q 'not valid SemVer' "$iv_out" ||
+    fail 'the run failed but not because of the unrankable tag — the case is not testing what it claims'
+  grep -qF 'v02.0.0' "$iv_out" ||
+    fail 'the refusal does not name the unrankable tag, so the cause is not diagnosable'
+  iv_unresolved="$(grep -c '^UNRESOLVED' "$iv_out" || true)"
+  iv_insync="$(grep -c '^IN-SYNC' "$iv_out" || true)"
+  [ "$iv_unresolved" -eq 1 ] ||
+    fail "expected exactly ONE unresolved consumer (the unrankable tag), got $iv_unresolved"
+  [ "$iv_insync" -eq 4 ] ||
+    fail "expected the other FOUR consumers to resolve IN-SYNC through the same stub, got $iv_insync"
+  pass 'a tag that is not valid SemVer and would outrank the best valid candidate refuses by name'
+fi
+
+# CONTROL, and the one that pins the NARROWING: an unrankable tag that ranks BELOW the best
+# valid candidate cannot change which tag is selected, so it must NOT refuse. Without this
+# the case above would be satisfied by refusing on the mere existence of a malformed tag,
+# which would park a repository on one ancient stray tag forever.
+iv2_root="$WORK/invalid-semver-below-root"
+cp -R "$bm_root" "$iv2_root"
+iv2_out="$WORK/invalid-semver-below.out"
+if BM_WEDDING_TAGS='v2.0.0\nv01.5.0\nv1.9.0\n' \
+  BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" BM_VIOLATION_LOG="$WORK/interpolated.log" PATH="$bm_bin:$PATH" \
+  PUBLISH_CONSUMER_ROOT="$iv2_root" "$SCRIPT" >"$iv2_out" 2>&1; then
+  iv2_insync="$(grep -c '^IN-SYNC' "$iv2_out" || true)"
+  [ "$iv2_insync" -eq 5 ] ||
+    fail "the below-rank control resolved only $iv2_insync of 5 consumers — the SemVer check refuses on mere existence, not on rank"
+  pass 'an unrankable tag ranking below the best valid candidate does not refuse'
+else
+  fail "the below-rank control failed outright — the SemVer refusal is too broad: $(cat "$iv2_out")"
+fi
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (16 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (19 cases)\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

We verify five deployed artifacts against signed-by matchers, and we want to narrow those
matchers to *approved* signers rather than any fixed one. Nobody could do that safely,
because nothing computed which signer actually produced what is running — so narrowing to
"what we pin today" would silently stop verifying artifacts that are live right now, and
the symptom would be an app that quietly stops updating while every check stays green.

### What

Adds a report that works this out per consumer and names both revisions an allow-list has
to accept. It reproduces the known case: two of the five deployed artifacts were signed by
a revision their repo no longer pins. It only reports — it does not block anything — and it
fails loudly when it *cannot see*, so an unreadable consumer is never mistaken for a healthy
one.

Running it surfaced two ways the obvious approach gets a confident wrong answer, both fixed
here: a repo's GitHub Releases can lag its actual artifact stream by months, and a failed
API call returns an error message that reads as a valid answer.

### Security floor / developer experience

**Floor:** the input the approved-signer work needs now exists and is computed rather than
hand-derived, so narrowing a matcher stops being a guess. **Everyday path:** unchanged on
pull requests — only a fast offline test runs there. The live report runs after merge, so a
hiccup talking to another repo can never block someone's PR.

Fixes #3048. Part of #2818.
