### PR TITLE
feat(observability): cover every Crossplane managed kind

### DIFF
--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
@@ -1,16 +1,80 @@
-# Read-only, and scoped to the one managed-resource kind this exporter reads.
-# It is deliberately not `apiGroups: ["*"]`: a metrics exporter that could read
-# every custom resource in the cluster would also be able to read the spec of
-# resources that carry provider configuration.
+# Read-only, and scoped one-for-one to the managed-resource kinds this exporter
+# describes. It is deliberately not `apiGroups: ["*"]` or `resources: ["*"]`:
+# provider configuration and a newly installed kind stay unreadable until their
+# least-privilege entry is deliberately reviewed.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: crossplane-sync-exporter
 rules:
   - apiGroups:
+      - actions.github.m.upbound.io
+    resources:
+      - repositorypermissions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dns.unifi.m.crossplane.io
+    resources:
+      - records
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - enterprise.github.m.upbound.io
+    resources:
+      - organizationrulesets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - iam.aws.m.upbound.io
+    resources:
+      - openidconnectproviders
+      - policies
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - repo.github.m.upbound.io
     resources:
+      - branchprotections
+      - defaultbranches
+      - issuelabels
       - repositories
+      - repositoryrulesets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - route.unifi.m.crossplane.io
+    resources:
+      - trafficroutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - team.github.m.upbound.io
+    resources:
+      - teams
+      - teammemberships
+      - teamrepositories
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - vpn.unifi.m.crossplane.io
+    resources:
+      - clients
     verbs:
       - get
       - list

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
@@ -4,6 +4,55 @@ metadata:
   name: crossplane-sync-exporter
   namespace: observability
 data:
+  # The alerter compares this closed inventory with live CRDs carrying the
+  # `managed` category. A provider addition therefore alerts before this
+  # exporter receives access to the new kind.
+  managed-resources.tsv: |
+    actions.github.m.upbound.io	v1alpha1	RepositoryPermissions	repositorypermissions
+    dns.unifi.m.crossplane.io	v1alpha1	Record	records
+    enterprise.github.m.upbound.io	v1alpha1	OrganizationRuleset	organizationrulesets
+    iam.aws.m.upbound.io	v1beta1	OpenIDConnectProvider	openidconnectproviders
+    iam.aws.m.upbound.io	v1beta1	Policy	policies
+    iam.aws.m.upbound.io	v1beta1	Role	roles
+    repo.github.m.upbound.io	v1alpha1	BranchProtection	branchprotections
+    repo.github.m.upbound.io	v1alpha1	DefaultBranch	defaultbranches
+    repo.github.m.upbound.io	v1alpha1	IssueLabels	issuelabels
+    repo.github.m.upbound.io	v1alpha1	Repository	repositories
+    repo.github.m.upbound.io	v1alpha1	RepositoryRuleset	repositoryrulesets
+    route.unifi.m.crossplane.io	v1alpha1	TrafficRoute	trafficroutes
+    team.github.m.upbound.io	v1alpha1	Team	teams
+    team.github.m.upbound.io	v1alpha1	TeamMembership	teammemberships
+    team.github.m.upbound.io	v1alpha1	TeamRepository	teamrepositories
+    vpn.unifi.m.crossplane.io	v1alpha1	Client	clients
+
+  # Reads a Kubernetes CustomResourceDefinitionList on stdin and prints every
+  # installed Crossplane managed kind whose configured version is not served.
+  # This catches both a newly installed kind and an API-version migration that
+  # would otherwise leave an exact kube-state-metrics collector silent.
+  managed-coverage-gaps.jq: |
+    ($configured
+      | split("\n")
+      | map(select(length > 0) | split("\t"))
+      | map({group: .[0], version: .[1], kind: .[2]})) as $inventory
+    | [
+        .items[]
+        | select(any(.spec.names.categories[]?; . == "managed"))
+        | .spec.group as $group
+        | .spec.names.kind as $kind
+        | [.spec.versions[]? | select(.served) | .name] as $served
+        | select(
+            any(
+              $inventory[];
+              .group == $group
+                and .kind == $kind
+                and (.version as $version | any($served[]; . == $version))
+            )
+            | not
+          )
+        | "\($group)/\($kind)"
+      ]
+    | unique[]
+
   # kube-state-metrics has no built-in knowledge of Crossplane managed
   # resources, so their conditions are described here as custom resource state.
   #
@@ -11,20 +60,302 @@ data:
   # this exporter exists to surface is a resource reporting Ready=True while
   # Synced=False, and an alert can only express that pair if both series exist.
   #
-  # groupVersionKind is exact — CustomResourceStateMetrics accepts no wildcard
-  # and no `categories: managed` selector — so each managed-resource kind must be
-  # listed. This component starts with Repository alone, which is the kind that
-  # carries the observed failure and therefore both a positive and a negative
-  # fixture. Extending the list to the remaining managed kinds is tracked
-  # separately; until then the exporter's coverage is explicitly partial.
+  # groupVersionKind is exact so the configuration and RBAC grant stay in
+  # one-to-one correspondence. The runtime sentinel above compares this list
+  # with live managed CRDs and alerts on drift instead of widening access.
   custom-resource-state.yaml: |
     kind: CustomResourceStateMetrics
     spec:
       resources:
         - groupVersionKind:
+            group: actions.github.m.upbound.io
+            version: v1alpha1
+            kind: RepositoryPermissions
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: dns.unifi.m.crossplane.io
+            version: v1alpha1
+            kind: Record
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: enterprise.github.m.upbound.io
+            version: v1alpha1
+            kind: OrganizationRuleset
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: iam.aws.m.upbound.io
+            version: v1beta1
+            kind: OpenIDConnectProvider
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: iam.aws.m.upbound.io
+            version: v1beta1
+            kind: Policy
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: iam.aws.m.upbound.io
+            version: v1beta1
+            kind: Role
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: repo.github.m.upbound.io
+            version: v1alpha1
+            kind: BranchProtection
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: repo.github.m.upbound.io
+            version: v1alpha1
+            kind: DefaultBranch
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: repo.github.m.upbound.io
+            version: v1alpha1
+            kind: IssueLabels
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
             group: repo.github.m.upbound.io
             version: v1alpha1
             kind: Repository
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: repo.github.m.upbound.io
+            version: v1alpha1
+            kind: RepositoryRuleset
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: route.unifi.m.crossplane.io
+            version: v1alpha1
+            kind: TrafficRoute
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: team.github.m.upbound.io
+            version: v1alpha1
+            kind: Team
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: team.github.m.upbound.io
+            version: v1alpha1
+            kind: TeamMembership
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: team.github.m.upbound.io
+            version: v1alpha1
+            kind: TeamRepository
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+        - groupVersionKind:
+            group: vpn.unifi.m.crossplane.io
+            version: v1alpha1
+            kind: Client
           metricNamePrefix: crossplane
           labelsFromPath:
             name: [metadata, name]

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/kustomization.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/kustomization.yaml
@@ -6,10 +6,10 @@
 # keyed on Ready reads the fleet as healthy. Nothing in the cluster observes the
 # Synced condition today, so that state is silent.
 #
-# This component supplies the missing metric, which is the prerequisite for the
-# alerting rule — the rule cannot be written before the series exists. It does
-# not alert; delivery is a separate change, and so is extending coverage beyond
-# Repository to the remaining managed-resource kinds.
+# This component supplies the condition metric for every managed-resource kind
+# currently installed on production. Alert delivery lives in the Hetzner
+# overlay, where a CRD-inventory sentinel also makes a newly added kind fail
+# loudly until this component receives exact GVK config and read-only RBAC.
 #
 # No CiliumNetworkPolicy is included: the base `allow-coroot` policy
 # (controllers/coroot/cilium-network-policy.yaml, endpointSelector: {}) already

--- a/k8s/providers/hetzner/infrastructure/coroot/cluster-role-binding-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cluster-role-binding-crossplane-sync-alerter.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-sync-alerter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-sync-alerter
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-sync-alerter
+    namespace: observability

--- a/k8s/providers/hetzner/infrastructure/coroot/cluster-role-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cluster-role-crossplane-sync-alerter.yaml
@@ -1,0 +1,13 @@
+# The alerter compares the exporter's closed inventory with CRD definitions.
+# It reads schemas only; no managed-resource spec and no core Secret is exposed.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-sync-alerter
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -1,37 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: crossplane-sync-alerter
-  namespace: observability
-automountServiceAccountToken: true
----
-# The alerter compares the exporter's closed inventory with CRD definitions.
-# It reads schemas only; no managed-resource spec and no core Secret is exposed.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: crossplane-sync-alerter
-rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: crossplane-sync-alerter
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: crossplane-sync-alerter
-subjects:
-  - kind: ServiceAccount
-    name: crossplane-sync-alerter
-    namespace: observability
----
 # Turns the crossplane-sync-exporter's series into an actual notification.
 #
 # The exporter (bases/infrastructure/coroot/components/crossplane-sync-exporter)

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -1,3 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sync-alerter
+  namespace: observability
+automountServiceAccountToken: true
+---
+# The alerter compares the exporter's closed inventory with CRD definitions.
+# It reads schemas only; no managed-resource spec and no core Secret is exposed.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-sync-alerter
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-sync-alerter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-sync-alerter
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-sync-alerter
+    namespace: observability
+---
 # Turns the crossplane-sync-exporter's series into an actual notification.
 #
 # The exporter (bases/infrastructure/coroot/components/crossplane-sync-exporter)
@@ -29,10 +63,10 @@
 # the sensor itself is down or absent, and refuses to interpret an empty result as
 # good news.
 #
-# COVERAGE IS PARTIAL AND SAYS SO. The exporter currently describes only the
-# Repository kind (CustomResourceStateMetrics takes no wildcard), so this alert
-# covers exactly the kinds the exporter lists. That limit is stated in the alert
-# annotation itself rather than left for a reader to infer from a quiet channel.
+# COVERAGE IS MEASURED, NOT ASSUMED. The exporter carries a closed list of exact
+# managed-resource GVKs and matching least-privilege RBAC. This job compares it
+# with live CRDs carrying the `managed` category and alerts on any gap, so a new
+# provider kind cannot remain silently unobserved.
 #
 # PROD-ONLY: Alertmanager and its Slack webhook are wired only in the hetzner
 # overlay, so this lives here, not in the base.
@@ -60,8 +94,10 @@ spec:
             app: crossplane-sync-alerter
         spec:
           restartPolicy: Never
-          # HTTP-only to two in-cluster Services; no Kubernetes API access.
-          automountServiceAccountToken: false
+          serviceAccountName: crossplane-sync-alerter
+          # Required only for the CRD-list coverage check below. The dedicated
+          # role grants no managed-resource reads and no core API access.
+          automountServiceAccountToken: true
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
@@ -88,6 +124,10 @@ spec:
                 limits:
                   cpu: 100m
                   memory: 64Mi
+              volumeMounts:
+                - name: exporter-config
+                  mountPath: /etc/crossplane-sync-exporter
+                  readOnly: true
               command:
                 - /bin/sh
                 - -c
@@ -95,7 +135,12 @@ spec:
                   set -u
                   PROM="http://coroot-prometheus.observability.svc.cluster.local:9090"
                   AM="http://alertmanager.kubescape.svc.cluster.local:9093"
-                  RETRY="-sS --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused --max-time 30"
+                  KUBE_API="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
+                  SA_DIR="/var/run/secrets/kubernetes.io/serviceaccount"
+                  curl_retry() {
+                    curl -sS --retry 5 --retry-delay 2 --retry-all-errors \
+                      --retry-connrefused --max-time 30 "$@"
+                  }
 
                   # Alertmanager expires an alert at endsAt, so every alert this
                   # job posts self-resolves unless a later run re-asserts it.
@@ -113,9 +158,9 @@ spec:
                     *) echo "ERROR: could not compute endsAt (got '$ENDS')"; exit 1 ;;
                   esac
 
-                  q() { curl $RETRY --get --data-urlencode "query=$1" "$PROM/api/v1/query"; }
+                  q() { curl_retry --get --data-urlencode "query=$1" "$PROM/api/v1/query"; }
 
-                  # ---- 1. Is the sensor alive? -------------------------------
+                  # ---- Prometheus sensor measurements -----------------------
                   # `up` is exempt from the exporter's metric_relabel keep, so its
                   # ABSENCE means no scrape has ever been delivered (component not
                   # deployed, remote_write broken) and 0 means the scrape fails.
@@ -145,6 +190,49 @@ spec:
                   alerts='[]'
                   add() { alerts=$(printf '%s' "$alerts" | jq -c --argjson a "$1" '. + [$a]'); }
 
+                  # ---- 1. Does the inventory cover every managed kind? ------
+                  # A newly installed provider or kind must not silently inherit
+                  # broad RBAC. Compare CRD discovery with the exact inventory;
+                  # a gap alerts until its GVK and read permission are reviewed.
+                  if ! CRDS=$(curl_retry --fail \
+                    --cacert "$SA_DIR/ca.crt" \
+                    -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
+                    "$KUBE_API/apis/apiextensions.k8s.io/v1/customresourcedefinitions"); then
+                    echo "ERROR: Kubernetes CRD discovery failed"
+                    exit 1
+                  fi
+                  if [ "$(printf '%s' "$CRDS" | jq -r '.kind // ""')" != "CustomResourceDefinitionList" ]; then
+                    echo "ERROR: Kubernetes CRD discovery returned an unexpected response"
+                    exit 1
+                  fi
+                  if ! missing=$(printf '%s' "$CRDS" | jq -r \
+                    --rawfile configured /etc/crossplane-sync-exporter/managed-resources.tsv \
+                    -f /etc/crossplane-sync-exporter/managed-coverage-gaps.jq); then
+                    echo "ERROR: could not compare managed CRDs with exporter inventory"
+                    exit 1
+                  fi
+                  if [ -n "$missing" ]; then
+                    missing_text=$(printf '%s\n' "$missing" | jq -Rsr '
+                      split("\n") | map(select(length > 0)) | join(", ")
+                    ')
+                    add "$(jq -nc --arg e "$ENDS" --arg missing "$missing_text" '{
+                      labels: {
+                        alertname: "CrossplaneSyncExporterCoverageGap",
+                        severity: "warning",
+                        namespace: "observability",
+                        job: "crossplane-sync-exporter"
+                      },
+                      annotations: {
+                        summary: "Crossplane sync exporter is missing managed-resource kinds",
+                        description: "Installed managed CRDs are absent from the exporter inventory: \($missing). Their Synced failures are unobserved until exact GVK config and least-privilege RBAC entries are reviewed.",
+                        runbook: "Compare managed-resources.tsv with kubectl api-resources --categories=managed, then add only the missing exact kinds."
+                      },
+                      endsAt: $e
+                    }')"
+                    echo "coverage gap: $missing_text"
+                  fi
+
+                  # ---- 2. Is the sensor alive? -------------------------------
                   if [ "$up_n" -eq 0 ] || [ "$up_ok" -eq 0 ] || [ "$cov_n" -eq 0 ]; then
                     if [ "$up_n" -eq 0 ]; then
                       reason="no up series"
@@ -170,7 +258,7 @@ spec:
                     echo "sensor down: $reason"
                   fi
 
-                  # ---- 2. Managed resources that stopped reconciling ---------
+                  # ---- 3. Managed resources that stopped reconciling ---------
                   # Synced=False is the signal; Ready is reported alongside it so
                   # the notification carries the Ready=True/Synced=False pair that
                   # makes this failure mode invisible in kubectl's usual columns.
@@ -198,11 +286,13 @@ spec:
                   #      the alert fires after ~12m while its own text claims 15m of
                   #      continuous failure. The offset anchors the claim.
                   #
-                  # History is aggregated `by (name, namespace)` and joined `on
-                  # (name, namespace)` because `reason` is part of the series
-                  # identity: a resource that changes reason leaves an obsolete
-                  # all-zero series behind, which would keep satisfying the window
-                  # on its own labels long after the live series recovered.
+                  # History is aggregated by the full GVK/name identity and
+                  # joined on that identity because `reason` is part of the
+                  # series identity: a resource that changes reason leaves an
+                  # obsolete all-zero series behind, which would keep satisfying
+                  # the window on its own labels long after the live series
+                  # recovered. Name/namespace alone is insufficient now that
+                  # multiple kinds can legitimately reuse both values.
                   #
                   #   4. `sum by (...) (count_over_time(...[15m])) >= 12` -- the window is
                   #      COVERED, not merely bounded. `max_over_time` ignores
@@ -233,7 +323,7 @@ spec:
                   # reconciliation. Keep paused series in COV above so they still
                   # prove the exporter is alive, but exclude them from every
                   # selector participating in this joined history predicate.
-                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"} == 0 and on (name, namespace) (max by (name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) == 0) and on (name, namespace) (count by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[3m] offset 15m)) > 0) and on (name, namespace) (sum by (name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) >= 12)')
+                  STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"} == 0 and on (customresource_group, customresource_version, customresource_kind, name, namespace) (max by (customresource_group, customresource_version, customresource_kind, name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) == 0) and on (customresource_group, customresource_version, customresource_kind, name, namespace) (count by (customresource_group, customresource_version, customresource_kind, name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[3m] offset 15m)) > 0) and on (customresource_group, customresource_version, customresource_kind, name, namespace) (sum by (customresource_group, customresource_version, customresource_kind, name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) >= 12)')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
                   fi
@@ -245,14 +335,17 @@ spec:
                     name=$(printf '%s' "$m" | jq -r '.name // "unknown"')
                     ns=$(printf '%s' "$m" | jq -r '.namespace // ""')
                     why=$(printf '%s' "$m" | jq -r '.reason // "unknown"')
+                    group=$(printf '%s' "$m" | jq -r '.customresource_group // "unknown"')
+                    version=$(printf '%s' "$m" | jq -r '.customresource_version // "unknown"')
+                    kind=$(printf '%s' "$m" | jq -r '.customresource_kind // "unknown"')
                     # `reason` is deliberately NOT a label. Alertmanager keys the
                     # identity of an alert on its label set, so a resource that
                     # stays unsynced while Crossplane changes the reason would fire
                     # a SECOND alert under a new fingerprint while the first stayed
                     # active until its endsAt -- one broken resource, repeated Slack
                     # notifications. The history query already joins on
-                    # (name, namespace) without reason for the same underlying
-                    # cause, so keeping it out of the identity makes the two agree.
+                    # the full GVK/name identity without reason for the same
+                    # underlying cause, so keeping it out makes the two agree.
                     # The current reason still reaches the reader as an annotation,
                     # which updates in place instead of forking.
                     #
@@ -260,25 +353,28 @@ spec:
                     # program below. That program is a single-quoted shell string,
                     # so an apostrophe in a comment inside it closes the quote and
                     # breaks the whole script.
-                    add "$(jq -nc --arg e "$ENDS" --arg name "$name" --arg ns "$ns" --arg why "$why" '{
+                    add "$(jq -nc --arg e "$ENDS" --arg name "$name" --arg ns "$ns" --arg why "$why" --arg group "$group" --arg version "$version" --arg kind "$kind" '{
                       labels: ({
                         alertname: "CrossplaneManagedResourceNotSynced",
                         severity: "warning",
-                        resource: $name
+                        resource: $name,
+                        resource_group: $group,
+                        resource_version: $version,
+                        resource_kind: $kind
                       } + (if $ns == "" then {} else {namespace: $ns} end)),
                       annotations: {
                         reason: $why,
-                        summary: "Crossplane is no longer reconciling \($name)",
-                        description: "The managed resource has reported Synced=False continuously for at least 15 minutes (reason: \($why)), so this is not a transient retry. Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Coverage note: the exporter describes only the managed kinds listed in its CustomResourceStateMetrics config, so other kinds are NOT watched by this alert.",
+                        summary: "Crossplane is no longer reconciling \($kind) \($name)",
+                        description: "The managed resource has reported Synced=False continuously for at least 15 minutes (reason: \($why)), so this is not a transient retry. Crossplane has stopped applying its spec to the external system, so the resource can still report Ready=True while drifting from Git. Exporter coverage is checked separately against every live managed CRD.",
                         runbook: "kubectl describe the resource and read its Synced condition message; a provider credential or API error is the usual cause."
                       },
                       endsAt: $e
                     }')"
-                    echo "not synced: $name ($why)"
+                    echo "not synced: $group/$version $kind $name ($why)"
                     i=$((i + 1))
                   done
 
-                  # ---- 3. Post ------------------------------------------------
+                  # ---- 4. Post ------------------------------------------------
                   n=$(printf '%s' "$alerts" | jq -r 'length')
                   if [ "$n" -eq 0 ]; then
                     echo "all watched managed resources are syncing; exporter healthy"
@@ -290,10 +386,14 @@ spec:
                   # exactly like a healthy fleet, which is the failure mode this
                   # whole CronJob exists to remove. It also lets --retry-all-errors
                   # retry a 5xx instead of accepting it.
-                  if curl $RETRY --fail -X POST -H 'Content-Type: application/json' \
+                  if curl_retry --fail -X POST -H 'Content-Type: application/json' \
                        -d "$alerts" "$AM/api/v2/alerts" >/dev/null; then
                     echo "posted $n alert(s) to alertmanager"
                   else
                     echo "ERROR: alertmanager rejected the POST; $n alert(s) NOT delivered"
                     exit 1
                   fi
+          volumes:
+            - name: exporter-config
+              configMap:
+                name: crossplane-sync-exporter

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -41,6 +41,8 @@ kind: CronJob
 metadata:
   name: crossplane-sync-alerter
   namespace: observability
+  annotations:
+    checkov.io/skip1: "CKV_K8S_38=the alerter reads its SA token to list CRD schemas in bounded pages for exporter coverage"
 spec:
   # 5m: fast enough that a stuck resource surfaces well inside the 4h Slack
   # repeat_interval, slow enough to stay far below Alertmanager's cost of
@@ -105,7 +107,7 @@ spec:
                   SA_DIR="/var/run/secrets/kubernetes.io/serviceaccount"
                   curl_retry() {
                     curl -sS --retry 5 --retry-delay 2 --retry-all-errors \
-                      --retry-connrefused --max-time 30 "$@"
+                      --retry-connrefused --max-time 30 --retry-max-time 30 "$@"
                   }
 
                   # Alertmanager expires an alert at endsAt, so every alert this
@@ -160,23 +162,47 @@ spec:
                   # A newly installed provider or kind must not silently inherit
                   # broad RBAC. Compare CRD discovery with the exact inventory;
                   # a gap alerts until its GVK and read permission are reviewed.
-                  if ! CRDS=$(curl_retry --fail \
-                    --cacert "$SA_DIR/ca.crt" \
-                    -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
-                    "$KUBE_API/apis/apiextensions.k8s.io/v1/customresourcedefinitions"); then
-                    echo "ERROR: Kubernetes CRD discovery failed"
-                    exit 1
-                  fi
-                  if [ "$(printf '%s' "$CRDS" | jq -r '.kind // ""')" != "CustomResourceDefinitionList" ]; then
-                    echo "ERROR: Kubernetes CRD discovery returned an unexpected response"
-                    exit 1
-                  fi
-                  if ! missing=$(printf '%s' "$CRDS" | jq -r \
-                    --rawfile configured /etc/crossplane-sync-exporter/managed-resources.tsv \
-                    -f /etc/crossplane-sync-exporter/managed-coverage-gaps.jq); then
-                    echo "ERROR: could not compare managed CRDs with exporter inventory"
-                    exit 1
-                  fi
+                  # Kubernetes pagination bounds each response so complete CRD
+                  # schemas are never buffered for the whole cluster at once.
+                  CRD_API="$KUBE_API/apis/apiextensions.k8s.io/v1/customresourcedefinitions"
+                  cursor=""
+                  missing=""
+                  while :; do
+                    if [ -n "$cursor" ]; then
+                      CRDS=$(curl_retry --fail --get \
+                        --cacert "$SA_DIR/ca.crt" \
+                        -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
+                        --data-urlencode "limit=25" \
+                        --data-urlencode "continue=$cursor" \
+                        "$CRD_API") || {
+                          echo "ERROR: Kubernetes CRD discovery failed"
+                          exit 1
+                        }
+                    else
+                      CRDS=$(curl_retry --fail --get \
+                        --cacert "$SA_DIR/ca.crt" \
+                        -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
+                        --data-urlencode "limit=25" \
+                        "$CRD_API") || {
+                          echo "ERROR: Kubernetes CRD discovery failed"
+                          exit 1
+                        }
+                    fi
+                    if [ "$(printf '%s' "$CRDS" | jq -r '.kind // ""')" != "CustomResourceDefinitionList" ]; then
+                      echo "ERROR: Kubernetes CRD discovery returned an unexpected response"
+                      exit 1
+                    fi
+                    if ! page_missing=$(printf '%s' "$CRDS" | jq -r \
+                      --rawfile configured /etc/crossplane-sync-exporter/managed-resources.tsv \
+                      -f /etc/crossplane-sync-exporter/managed-coverage-gaps.jq); then
+                      echo "ERROR: could not compare managed CRDs with exporter inventory"
+                      exit 1
+                    fi
+                    missing=$(printf '%s\n%s\n' "$missing" "$page_missing")
+                    cursor=$(printf '%s' "$CRDS" | jq -r '.metadata.continue // ""')
+                    [ -n "$cursor" ] || break
+                  done
+                  missing=$(printf '%s\n' "$missing" | sed '/^$/d' | LC_ALL=C sort -u)
                   if [ -n "$missing" ]; then
                     missing_text=$(printf '%s\n' "$missing" | jq -Rsr '
                       split("\n") | map(select(length > 0)) | join(", ")

--- a/k8s/providers/hetzner/infrastructure/coroot/service-account-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/service-account-crossplane-sync-alerter.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sync-alerter
+  namespace: observability
+automountServiceAccountToken: true

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -57,6 +57,9 @@ resources:
   # notification via Alertmanager, which nothing else consumes. See the file
   # header for why this is a CronJob rather than a PrometheusRule.
   - coroot/cron-job-crossplane-sync-alerter.yaml
+  - coroot/service-account-crossplane-sync-alerter.yaml
+  - coroot/cluster-role-crossplane-sync-alerter.yaml
+  - coroot/cluster-role-binding-crossplane-sync-alerter.yaml
   # Prod-only: the CloudNativePG datastore + backup wiring that lets the Coroot
   # SERVER run HA (replicas: 2 — set in the coroot-patch below). The operator
   # only honours replicas > 1 when spec.postgres is set, so this Postgres is the

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -135,10 +135,8 @@ components:
   # Synced=False — measured on 3 of the 20 Repository resources — and every
   # health check keyed on Ready reads that fleet as healthy while no declared
   # setting is reaching the provider. Referenced here rather than from the
-  # shared Coroot base because Crossplane and the `github-config` app it
-  # observes exist only on this provider.
-  #
-  # The metric is the prerequisite for alerting on it; delivery is #2987.
+  # shared Coroot base because Crossplane exists only on this provider. The
+  # adjacent alerter delivers stuck-resource and coverage-gap notifications.
   - ../../../bases/infrastructure/coroot/components/crossplane-sync-exporter
   # Platform-wide HelmRelease drift detection (mode: enabled) — covers the
   # opencost HelmRelease in this layer. See

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -213,7 +213,7 @@ reject_unexpected_rules() {
       fi
     done
     [ "${matched}" -eq 1 ] ||
-      fail "the exporter must hold no RBAC rule beyond the two it needs (found: ${actual})"
+      fail "the inspected role carries an RBAC rule outside its closed expected set (found: ${actual})"
   done <<<"$(rule_signatures <<<"${cluster_role}")"
 }
 
@@ -301,6 +301,9 @@ require_line \
   "${alerter}" \
   'automountServiceAccountToken: true' \
   'the coverage check must receive the API token it uses'
+[ "$(yq eval -r '.metadata.annotations."checkov.io/skip1"' <<<"${alerter}")" = \
+  'CKV_K8S_38=the alerter reads its SA token to list CRD schemas in bounded pages for exporter coverage' ] ||
+  fail 'the intentional service-account token mount must carry its exact scanner rationale'
 
 coverage_role="$(
   extract_resource ClusterRole crossplane-sync-alerter <<<"${hetzner_rendered}"
@@ -329,6 +332,18 @@ require_text \
   "${alerter_script}" \
   '/apis/apiextensions.k8s.io/v1/customresourcedefinitions' \
   'the alerter must compare its inventory with live CRD discovery'
+require_text \
+  "${alerter_script}" \
+  '--data-urlencode "limit=25"' \
+  'the alerter must bound each CRD response instead of buffering the whole discovery surface'
+require_text \
+  "${alerter_script}" \
+  '.metadata.continue // ""' \
+  'the bounded CRD discovery loop must follow every Kubernetes continuation token'
+require_text \
+  "${alerter_script}" \
+  '--retry-max-time 30' \
+  'each five-attempt curl operation must remain bounded inside the job deadline'
 require_text \
   "${alerter_script}" \
   'managed-coverage-gaps.jq' \
@@ -428,7 +443,7 @@ actual_managed_gvks="$(
     .spec.resources[]
     | [.groupVersionKind.group, .groupVersionKind.version, .groupVersionKind.kind]
     | @tsv
-  ' <<<"${custom_resource_state}" | sort
+  ' <<<"${custom_resource_state}" | LC_ALL=C sort
 )"
 [ "${actual_managed_gvks}" = "${expected_managed_gvks}" ] ||
   fail 'the exporter must describe every installed Crossplane managed-resource GVK'
@@ -437,7 +452,7 @@ expected_managed_resources=$'actions.github.m.upbound.io\tv1alpha1\tRepositoryPe
 configured_managed_resources="$(
   yq eval -r '.data."managed-resources.tsv"' <<<"${config_map}" |
     sed '/^[[:space:]]*$/d' |
-    sort
+    LC_ALL=C sort
 )"
 [ "${configured_managed_resources}" = "${expected_managed_resources}" ] ||
   fail 'the runtime coverage sentinel must share the exporter managed-resource inventory'

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -88,6 +88,16 @@ stuck_query_excludes_only_paused() {
     [ "$(count_literal "${query}" "${unfiltered_selector}")" -eq 0 ]
 }
 
+stuck_query_joins_full_resource_identity() {
+  local query="$1"
+  local identity='customresource_group, customresource_version, customresource_kind, name, namespace'
+
+  [ "$(count_literal "${query}" "on (${identity})")" -eq 3 ] &&
+    [ "$(count_literal "${query}" "max by (${identity})")" -eq 1 ] &&
+    [ "$(count_literal "${query}" "count by (${identity})")" -eq 1 ] &&
+    [ "$(count_literal "${query}" "sum by (${identity})")" -eq 1 ]
+}
+
 # Collapse each `rules[]` entry into one canonical signature line:
 #
 #   apiGroups=[g1,g2] resources=[r1] verbs=[v1,v2]
@@ -283,10 +293,50 @@ require_text \
 alerter="$(
   extract_resource CronJob crossplane-sync-alerter <<<"${hetzner_rendered}"
 )" || fail 'the provider layer must render the Crossplane sync alerter CronJob'
+require_line \
+  "${alerter}" \
+  'serviceAccountName: crossplane-sync-alerter' \
+  'the coverage check must use its dedicated service account'
+require_line \
+  "${alerter}" \
+  'automountServiceAccountToken: true' \
+  'the coverage check must receive the API token it uses'
+
+coverage_role="$(
+  extract_resource ClusterRole crossplane-sync-alerter <<<"${hetzner_rendered}"
+)" || fail 'the provider layer must render the coverage sentinel ClusterRole'
+require_rule \
+  "${coverage_role}" \
+  'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[list]' \
+  'the coverage sentinel must receive only the CRD-list permission it uses'
+reject_unexpected_rules \
+  "${coverage_role}" \
+  'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[list]'
+extract_resource \
+  ClusterRoleBinding \
+  crossplane-sync-alerter <<<"${hetzner_rendered}" >/dev/null ||
+  fail 'the provider layer must bind the coverage sentinel ClusterRole'
+extract_resource \
+  ServiceAccount \
+  crossplane-sync-alerter <<<"${hetzner_rendered}" >/dev/null ||
+  fail 'the provider layer must render the coverage sentinel ServiceAccount'
 alerter_script="$(
   yq eval -r '.spec.jobTemplate.spec.template.spec.containers[] | select(.name == "alerter") | .command[2]' \
     <<<"${alerter}"
 )" || fail 'the rendered Crossplane sync alerter script must be readable'
+
+require_text \
+  "${alerter_script}" \
+  '/apis/apiextensions.k8s.io/v1/customresourcedefinitions' \
+  'the alerter must compare its inventory with live CRD discovery'
+require_text \
+  "${alerter_script}" \
+  'managed-coverage-gaps.jq' \
+  'the alerter must execute the behavior-tested coverage-gap program'
+require_text \
+  "${alerter_script}" \
+  'CrossplaneSyncExporterCoverageGap' \
+  'an unconfigured managed kind must produce an Alertmanager alert'
 
 # Paused resources are deliberately still evidence that the exporter is alive,
 # so coverage must count them. They are not stuck, though: ReconcilePaused is an
@@ -313,6 +363,8 @@ stuck_query="${stuck_query:1:${#stuck_query}-3}"
 
 stuck_query_excludes_only_paused "${stuck_query}" ||
   fail 'the stuck query must exclude ReconcilePaused from all four metric selectors'
+stuck_query_joins_full_resource_identity "${stuck_query}" ||
+  fail 'the stuck query must keep same-named resources from different GVKs separate'
 
 # Mutation controls keep this from becoming a self-affirming source check. The
 # contract must fail if the pause exemption is removed, and also if a future edit
@@ -324,6 +376,10 @@ fi
 wrong_reason_query="${stuck_query//ReconcilePaused/ReconcileError}"
 if stuck_query_excludes_only_paused "${wrong_reason_query}"; then
   fail 'test control: excluding a real reconciliation error must break the query contract'
+fi
+collapsed_identity_query="${stuck_query//customresource_kind, /}"
+if stuck_query_joins_full_resource_identity "${collapsed_identity_query}"; then
+  fail 'test control: dropping kind identity must break the multi-kind join contract'
 fi
 
 # Negative control, and the load-bearing one. The exporter reads
@@ -357,6 +413,94 @@ rendered="$(kubectl kustomize "${exporter_component}")" ||
 config_map="$(
   extract_resource ConfigMap crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter ConfigMap'
+
+custom_resource_state="$(
+  yq eval -r '.data."custom-resource-state.yaml"' <<<"${config_map}"
+)" || fail 'the rendered custom-resource-state config must be readable'
+
+# Each configured GVK has a matching exact RBAC resource. The separate plural
+# inventory lets the runtime sentinel compare this closed set with live CRDs,
+# so a provider addition fails loudly without pre-authorising the exporter to
+# read resource kinds that have not been reviewed.
+expected_managed_gvks=$'actions.github.m.upbound.io\tv1alpha1\tRepositoryPermissions\ndns.unifi.m.crossplane.io\tv1alpha1\tRecord\nenterprise.github.m.upbound.io\tv1alpha1\tOrganizationRuleset\niam.aws.m.upbound.io\tv1beta1\tOpenIDConnectProvider\niam.aws.m.upbound.io\tv1beta1\tPolicy\niam.aws.m.upbound.io\tv1beta1\tRole\nrepo.github.m.upbound.io\tv1alpha1\tBranchProtection\nrepo.github.m.upbound.io\tv1alpha1\tDefaultBranch\nrepo.github.m.upbound.io\tv1alpha1\tIssueLabels\nrepo.github.m.upbound.io\tv1alpha1\tRepository\nrepo.github.m.upbound.io\tv1alpha1\tRepositoryRuleset\nroute.unifi.m.crossplane.io\tv1alpha1\tTrafficRoute\nteam.github.m.upbound.io\tv1alpha1\tTeam\nteam.github.m.upbound.io\tv1alpha1\tTeamMembership\nteam.github.m.upbound.io\tv1alpha1\tTeamRepository\nvpn.unifi.m.crossplane.io\tv1alpha1\tClient'
+actual_managed_gvks="$(
+  yq eval -r '
+    .spec.resources[]
+    | [.groupVersionKind.group, .groupVersionKind.version, .groupVersionKind.kind]
+    | @tsv
+  ' <<<"${custom_resource_state}" | sort
+)"
+[ "${actual_managed_gvks}" = "${expected_managed_gvks}" ] ||
+  fail 'the exporter must describe every installed Crossplane managed-resource GVK'
+
+expected_managed_resources=$'actions.github.m.upbound.io\tv1alpha1\tRepositoryPermissions\trepositorypermissions\ndns.unifi.m.crossplane.io\tv1alpha1\tRecord\trecords\nenterprise.github.m.upbound.io\tv1alpha1\tOrganizationRuleset\torganizationrulesets\niam.aws.m.upbound.io\tv1beta1\tOpenIDConnectProvider\topenidconnectproviders\niam.aws.m.upbound.io\tv1beta1\tPolicy\tpolicies\niam.aws.m.upbound.io\tv1beta1\tRole\troles\nrepo.github.m.upbound.io\tv1alpha1\tBranchProtection\tbranchprotections\nrepo.github.m.upbound.io\tv1alpha1\tDefaultBranch\tdefaultbranches\nrepo.github.m.upbound.io\tv1alpha1\tIssueLabels\tissuelabels\nrepo.github.m.upbound.io\tv1alpha1\tRepository\trepositories\nrepo.github.m.upbound.io\tv1alpha1\tRepositoryRuleset\trepositoryrulesets\nroute.unifi.m.crossplane.io\tv1alpha1\tTrafficRoute\ttrafficroutes\nteam.github.m.upbound.io\tv1alpha1\tTeam\tteams\nteam.github.m.upbound.io\tv1alpha1\tTeamMembership\tteammemberships\nteam.github.m.upbound.io\tv1alpha1\tTeamRepository\tteamrepositories\nvpn.unifi.m.crossplane.io\tv1alpha1\tClient\tclients'
+configured_managed_resources="$(
+  yq eval -r '.data."managed-resources.tsv"' <<<"${config_map}" |
+    sed '/^[[:space:]]*$/d' |
+    sort
+)"
+[ "${configured_managed_resources}" = "${expected_managed_resources}" ] ||
+  fail 'the runtime coverage sentinel must share the exporter managed-resource inventory'
+
+coverage_gap_program="$(
+  yq eval -r '.data."managed-coverage-gaps.jq"' <<<"${config_map}"
+)" || fail 'the rendered managed-resource coverage program must be readable'
+[ -n "${coverage_gap_program}" ] && [ "${coverage_gap_program}" != "null" ] ||
+  fail 'the exporter ConfigMap must carry the managed-resource coverage program'
+
+# Exercise the real jq program against a Kubernetes CRD-list fixture. The
+# production change that breaks this is accepting a newly installed managed
+# kind merely because another kind from the same provider is configured.
+coverage_fixture='{
+  "items": [
+    {
+      "spec": {
+        "group": "repo.github.m.upbound.io",
+        "names": {"kind": "Repository", "categories": ["crossplane", "managed"]},
+        "versions": [{"name": "v1alpha1", "served": true}]
+      }
+    },
+    {
+      "spec": {
+        "group": "actions.github.m.upbound.io",
+        "names": {"kind": "RepositoryPermissions", "categories": ["crossplane", "managed"]},
+        "versions": [{"name": "v1alpha1", "served": true}]
+      }
+    },
+    {
+      "spec": {
+        "group": "example.invalid",
+        "names": {"kind": "Ignored", "categories": ["unmanaged"]}
+      }
+    }
+  ]
+}'
+repository_inventory=$'repo.github.m.upbound.io\tv1alpha1\tRepository\trepositories'
+gap="$(
+  jq -r \
+    --rawfile configured <(printf '%s\n' "${repository_inventory}") \
+    "${coverage_gap_program}" <<<"${coverage_fixture}"
+)" || fail 'the managed-resource coverage program must accept a CRD-list response'
+[ "${gap}" = 'actions.github.m.upbound.io/RepositoryPermissions' ] ||
+  fail 'an installed managed kind absent from the inventory must be reported as a coverage gap'
+
+complete_fixture_inventory=$'actions.github.m.upbound.io\tv1alpha1\tRepositoryPermissions\trepositorypermissions\nrepo.github.m.upbound.io\tv1alpha1\tRepository\trepositories'
+gap="$(
+  jq -r \
+    --rawfile configured <(printf '%s\n' "${complete_fixture_inventory}") \
+    "${coverage_gap_program}" <<<"${coverage_fixture}"
+)" || fail 'the managed-resource coverage program must accept a complete inventory'
+[ -z "${gap}" ] ||
+  fail 'configured managed kinds and unmanaged CRDs must not produce coverage gaps'
+
+stale_version_inventory=$'actions.github.m.upbound.io\tv1alpha1\tRepositoryPermissions\trepositorypermissions\nrepo.github.m.upbound.io\tv1beta1\tRepository\trepositories'
+gap="$(
+  jq -r \
+    --rawfile configured <(printf '%s\n' "${stale_version_inventory}") \
+    "${coverage_gap_program}" <<<"${coverage_fixture}"
+)" || fail 'the managed-resource coverage program must evaluate served CRD versions'
+[ "${gap}" = 'repo.github.m.upbound.io/Repository' ] ||
+  fail 'a configured GVK whose version is no longer served must be reported as a coverage gap'
 
 # Coroot's bundled Prometheus exposes no scrape configuration, so remote-write is
 # the only ingest path into the store the alerting rule will query.
@@ -471,8 +615,36 @@ cluster_role="$(
 )" || fail 'the component must render the exporter ClusterRole'
 require_rule \
   "${cluster_role}" \
-  'apiGroups=[repo.github.m.upbound.io] resources=[repositories] verbs=[get,list,watch]' \
-  'the exporter must hold exactly one read-only rule on the managed resource it exports'
+  'apiGroups=[actions.github.m.upbound.io] resources=[repositorypermissions] verbs=[get,list,watch]' \
+  'the exporter must read the GitHub Actions managed resource it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[dns.unifi.m.crossplane.io] resources=[records] verbs=[get,list,watch]' \
+  'the exporter must read the UniFi DNS managed resource it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[enterprise.github.m.upbound.io] resources=[organizationrulesets] verbs=[get,list,watch]' \
+  'the exporter must read the GitHub enterprise managed resource it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[iam.aws.m.upbound.io] resources=[openidconnectproviders,policies,roles] verbs=[get,list,watch]' \
+  'the exporter must read the AWS IAM managed resources it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[repo.github.m.upbound.io] resources=[branchprotections,defaultbranches,issuelabels,repositories,repositoryrulesets] verbs=[get,list,watch]' \
+  'the exporter must read the GitHub repository managed resources it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[route.unifi.m.crossplane.io] resources=[trafficroutes] verbs=[get,list,watch]' \
+  'the exporter must read the UniFi route managed resource it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[team.github.m.upbound.io] resources=[teams,teammemberships,teamrepositories] verbs=[get,list,watch]' \
+  'the exporter must read the GitHub team managed resources it exports'
+require_rule \
+  "${cluster_role}" \
+  'apiGroups=[vpn.unifi.m.crossplane.io] resources=[clients] verbs=[get,list,watch]' \
+  'the exporter must read the UniFi VPN managed resource it exports'
 
 # The DISCOVERY half of the RBAC, and the reason this component shipped dead
 # (#3068). kube-state-metrics resolves a CustomResourceStateMetrics
@@ -500,7 +672,14 @@ require_rule \
 # Closes the set: the two rules above are the ONLY rules this role may carry.
 reject_unexpected_rules \
   "${cluster_role}" \
-  'apiGroups=[repo.github.m.upbound.io] resources=[repositories] verbs=[get,list,watch]' \
+  'apiGroups=[actions.github.m.upbound.io] resources=[repositorypermissions] verbs=[get,list,watch]' \
+  'apiGroups=[dns.unifi.m.crossplane.io] resources=[records] verbs=[get,list,watch]' \
+  'apiGroups=[enterprise.github.m.upbound.io] resources=[organizationrulesets] verbs=[get,list,watch]' \
+  'apiGroups=[iam.aws.m.upbound.io] resources=[openidconnectproviders,policies,roles] verbs=[get,list,watch]' \
+  'apiGroups=[repo.github.m.upbound.io] resources=[branchprotections,defaultbranches,issuelabels,repositories,repositoryrulesets] verbs=[get,list,watch]' \
+  'apiGroups=[route.unifi.m.crossplane.io] resources=[trafficroutes] verbs=[get,list,watch]' \
+  'apiGroups=[team.github.m.upbound.io] resources=[teams,teammemberships,teamrepositories] verbs=[get,list,watch]' \
+  'apiGroups=[vpn.unifi.m.crossplane.io] resources=[clients] verbs=[get,list,watch]' \
   'apiGroups=[apiextensions.k8s.io] resources=[customresourcedefinitions] verbs=[get,list,watch]'
 
 # A metrics exporter able to read every custom resource could also read provider

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1186,7 +1186,42 @@ const (
 // The new fingerprint was read from the required job's approved renderer (run
 // 32537665794, job 96941582102). The local approved renderer independently
 // produced the identical value.
-const expectedRenderedSurfaceSHA = "072296094a73bafe660540b84da2ee94bbe0683d90c7fc9ed97a6d6f9c292d7a"
+//
+// Measured against current main 64c4ba23 before approving this value: the five
+// authorization overlays move from 546 to 549 rendered documents, with no
+// duplicate identities. Set difference in BOTH directions reports exactly
+// three additions and no removals or renames:
+//
+//	v1                               ServiceAccount       observability/crossplane-sync-alerter
+//	rbac.authorization.k8s.io/v1    ClusterRole          crossplane-sync-alerter
+//	rbac.authorization.k8s.io/v1    ClusterRoleBinding   crossplane-sync-alerter
+//
+// The grant-bearing surface moves from 77 to 80 objects: Role stays 11,
+// ClusterRole 23 -> 24, RoleBinding stays 16, ClusterRoleBinding 11 -> 12,
+// and ServiceAccount 16 -> 17. Canonical content comparison of every object
+// reports those three additions plus exactly ONE changed existing identity:
+// `ClusterRole/crossplane-sync-exporter`. That role replaces its Repository-only
+// rule with the exact 16 managed-resource kinds currently installed across
+// eight reviewed API groups. Every grant stays get/list/watch, there is no
+// wildcard, no core-group access and no Secret access; its existing exact
+// get/list/watch on CustomResourceDefinitions is unchanged.
+//
+// The new alerter ClusterRole is narrower still: its sole rule is `list` on
+// `apiextensions.k8s.io/customresourcedefinitions`. Its binding names only the
+// new `observability/crossplane-sync-alerter` ServiceAccount. No EKS CI subject,
+// AWS service account, AWS role, boundary, policy, or individually pinned core
+// authorization identity moved; the validator emitted only this aggregate
+// mismatch and no object-specific mismatch.
+//
+// The previous approved digest remains recorded here:
+//
+//	072296094a73bafe660540b84da2ee94bbe0683d90c7fc9ed97a6d6f9c292d7a
+//
+// The new fingerprint was produced by the required hosted renderer (run
+// 32587236884, job 97065434213). The local kubectl v1.36.1 render used by the
+// tests independently produced the identical value, while the full local CLI
+// correctly refused that renderer because the approved pin is v1.36.2.
+const expectedRenderedSurfaceSHA = "2e5ff04e52117cdbdc88261c35845e51a17ff31b709ed5b7d449b5076c08d8e1"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The production Crossplane sync exporter observes only `repo.github.m.upbound.io/Repository`, while the cluster currently has 16 installed managed-resource kinds. Live read-only evidence also shows paused resources outside that group: 7 UniFi DNS Records, 1 UniFi TrafficRoute, and 1 UniFi VPN Client. Their conditions are absent from Prometheus today.

## What

- describe every currently installed managed-resource GVK with the existing reason-preserving condition metric
- grant the exporter exact read-only access to those resources, with no wildcard and no Secret access
- compare the closed inventory against live managed CRDs and alert on a missing kind or unserved configured version
- page CRD discovery in bounded groups of 25 and cap each retry loop at 30 seconds
- keep same-named resources from different GVKs distinct in the stuck-history query and Alertmanager identity
- add behavior and mutation controls for coverage drift, stale versions, RBAC breadth, and GVK collisions

## Proof

- RED: the contract rejected missing managed kinds
- RED: the contract rejected an inventory that did not compare with live CRD discovery
- RED: the contract rejected a configured version that was no longer served
- RED: the contract rejected a stuck query that collapsed different GVKs onto name/namespace
- GREEN: `bash scripts/tests/test-crossplane-sync-exporter.sh`
- GREEN: `shellcheck scripts/tests/test-crossplane-sync-exporter.sh`
- GREEN: `python3 scripts/validate-naming.py`
- GREEN: `go test ./scripts/validate-eks-ci-role-policy`
- GREEN: focused Checkov scan (85 passed, 0 failed, 1 exact documented skip)
- GREEN: `ksail workload validate` (588 files)
- GREEN: `ksail --config ksail.prod.yaml workload validate` (588 files)
- GREEN: targeted schema validation of the exporter component and production Coroot overlay
- GREEN: `git diff --check`

The EKS authorization fingerprint was updated only after rendering all five
authorization overlays against exact main: 546 -> 549 unique documents, with
the new ServiceAccount, list-only CRD ClusterRole, and its binding as the exact
membership additions. Across grant-bearing objects, the only changed existing
identity is the exporter role's exact managed-kind read list; it has no wildcard,
core-group access, Secret access, or mutating verb.

## Behavioral checkpoint

Live pre-deploy Prometheus currently exposes 20 Repository resources and no condition series for the three paused non-Repository groups above. No natural `ReconcileError` sample exists in the current cluster, so multi-group error notification evidence remains a post-deploy acceptance checkpoint; production was not mutated to manufacture a failure. This PR stays draft until hosted checks, exact-head review, and that behavioral evidence converge.

Part of #3052
