### PR TITLE
fix(observability): recover Crossplane sync alerting

### DIFF
--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -35,6 +35,12 @@ spec:
         app.kubernetes.io/name: crossplane-sync-exporter
         app.kubernetes.io/part-of: coroot
         app.kubernetes.io/component: metrics-exporter
+      annotations:
+        # kube-state-metrics reports a successful in-process config reload, but
+        # the multi-GVK rollout reset its metric handler to an empty response.
+        # Pin the ConfigMap data checksum here so every config change gets a new
+        # pod and loads the final collector set during process startup.
+        platform.devantler.tech/config-checksum: "2762015805-13322"
     spec:
       serviceAccountName: crossplane-sync-exporter
       # kube-state-metrics reads the managed resources through the API server.

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -43,6 +43,11 @@ metadata:
   namespace: observability
   annotations:
     checkov.io/skip1: "CKV_K8S_38=the alerter reads its SA token to list CRD schemas in bounded pages for exporter coverage"
+    # KUBERNETES_SERVICE_HOST/PORT_HTTPS below are pod environment variables,
+    # not Flux inputs. The infrastructure Kustomization runs post-build
+    # substitution, which otherwise blanks both references and deploys
+    # KUBE_API="https://:". This resource has no Flux substitutions of its own.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   # 5m: fast enough that a stuck resource surfaces well inside the 4h Slack
   # repeat_interval, slow enough to stay far below Alertmanager's cost of

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -431,6 +431,12 @@ rendered="$(kubectl kustomize "${exporter_component}")" ||
 config_map="$(
   extract_resource ConfigMap crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter ConfigMap'
+config_checksum="$(
+  yq eval -o=json '.data' <<<"${config_map}" |
+    jq -cS . |
+    cksum |
+    awk '{ print $1 "-" $2 }'
+)" || fail 'the exporter ConfigMap data checksum must be computable'
 
 custom_resource_state="$(
   yq eval -r '.data."custom-resource-state.yaml"' <<<"${config_map}"
@@ -584,6 +590,9 @@ require_line \
 deployment="$(
   extract_resource Deployment crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter Deployment'
+[ "$(yq eval -r '.spec.template.metadata.annotations."platform.devantler.tech/config-checksum"' \
+  <<<"${deployment}")" = "${config_checksum}" ] ||
+  fail 'the exporter pod template checksum must force a rollout whenever its ConfigMap data changes'
 require_line \
   "${deployment}" \
   'serviceAccountName: crossplane-sync-exporter' \

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -304,6 +304,9 @@ require_line \
 [ "$(yq eval -r '.metadata.annotations."checkov.io/skip1"' <<<"${alerter}")" = \
   'CKV_K8S_38=the alerter reads its SA token to list CRD schemas in bounded pages for exporter coverage' ] ||
   fail 'the intentional service-account token mount must carry its exact scanner rationale'
+[ "$(yq eval -r '.metadata.annotations."kustomize.toolkit.fluxcd.io/substitute"' <<<"${alerter}")" = \
+  'disabled' ] ||
+  fail 'Flux substitution must stay disabled so the pod receives its Kubernetes service environment references'
 
 coverage_role="$(
   extract_resource ClusterRole crossplane-sync-alerter <<<"${hetzner_rendered}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Read-only post-deploy verification of #3052 found two fail-open paths on current main `2dc642957fd7d1589985b76d48fdc9ac01adc15d`:

- Flux post-build substitution blanked the pod-owned `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT_HTTPS` references, so every new alerter Job received `KUBE_API="https://:"` and failed before it could report sensor state.
- kube-state-metrics reported a successful hot reload of all 16 configured GVKs, but its metrics endpoint reset to an empty HTTP 200 response. Prometheus still had `up=1` while no `crossplane_managed_resource_condition` series existed.

## What

- Disable Flux substitution for the alerter CronJob, which consumes no Flux variables.
- Bind the exporter pod template to a deterministic checksum of the ConfigMap data so every collector change starts a fresh process.
- Extend the exporter contract test to pin both safeguards.

## Proof

- RED: `FAIL: Flux substitution must stay disabled so the pod receives its Kubernetes service environment references`
- RED: `FAIL: the exporter pod template checksum must force a rollout whenever its ConfigMap data changes`
- GREEN: `PASS: the activated Crossplane sync exporter keeps its least-privilege metric contract`
- `shellcheck scripts/tests/test-crossplane-sync-exporter.sh`
- `kubectl kustomize k8s/clusters/local/`
- `kubectl kustomize k8s/clusters/prod/`
- `kubectl apply --dry-run=client` for both changed workloads

## Rollout

This stays draft and uses `Part of #3052`: the issue remains open until merge-group deployment proves a fresh exporter pod emits non-Repository groups and the alerter completes successfully against live CRD discovery.

Part of #3052
