### PR TITLE
fix(security): close three ways the image-verifier liveness check reports OK without checking

### DIFF
--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -966,6 +966,26 @@ if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
 fi
 require_text "${output}" 'disabled_plugins' 'case 24: quoted # is content, not a comment'
 
+# Same class one character along: a ] INSIDE a quoted entry is content, not the
+# array terminator. Ending the array there drops every entry that follows --
+# including ours -- so the script reported disabled=0 and OK while containerd
+# had the verifier switched off. That is a FAIL-OPEN on the one signal meant to
+# mean enforcement is on, which is the failure mode this script exists to catch.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = [
+  'io.containerd.snapshotter.v1.blockfile]notaterminator', 'io.containerd.image-verifier.v1.bindir',
+]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a ] inside a quoted entry must not terminate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: quoted ] is content, not the array terminator'
+
 # A `disabled_plugins` key that belongs to some OTHER table is not the root key
 # and must not disable anything -- otherwise an unrelated setting could switch
 # this whole check off.

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1522,4 +1522,76 @@ printf 'ok — case 27: each config file is read exactly once\n' >/dev/null
 
 reset_node_sequence
 
+# ===========================================================================
+# 28. A MULTILINE BASIC STRING'S BACKSLASH LINE CONTINUATION. (#3320 review)
+#     TOML says a backslash immediately before a physical newline inside a
+#     MULTILINE BASIC string removes the newline AND all leading whitespace of
+#     the next line. So this entry resolves to exactly our plugin id and
+#     containerd switches the verifier off.
+#
+#     The array is joined with a single space, and decode_basic() had no case
+#     for `\` before that join point, so the buffered value kept the backslash
+#     and compared unequal -- disabled=0, and the node reported OK with the
+#     verifier disabled. That is a FAIL-OPEN on the one signal meant to mean
+#     enforcement is on.
+#
+#     🔴 The heredoc MUST be quoted. Unquoted, bash removes the backslash-newline
+#     while WRITING the fixture, collapsing it to the plain identifier -- which
+#     the parser already handles, so the case would pass while testing nothing.
+#     Measured: unquoted yields 1 line and no backslash, quoted yields 2.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1.\
+bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+# The fixture must actually carry the continuation, or this case is vacuous.
+grep -q '\\$' "${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" ||
+  fail 'case 28: the fixture lost its backslash continuation — the case would pass vacuously'
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 28: a line-continued multiline basic string naming our plugin must fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 28: says WHY, so the operator edits the right setting'
+
+# CONTROL 1 — MULTILINE LITERAL strings do NOT apply the continuation rule, so
+# the same text is a DIFFERENT plugin id containerd never matches. Applying the
+# continuation here would alias a foreign id onto ours and fail a node whose
+# verifier is ENABLED — a false alarm on the signal that means enforcement is on.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ['''io.containerd.image-verifier.v1.\
+bindir''']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+grep -q '\\$' "${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" ||
+  fail 'case 28 control: the literal fixture lost its backslash — the control proves nothing'
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 28 control: a multiline LITERAL string does not continue lines, so that entry is a different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 28 control: literal strings keep the backslash verbatim'
+
+# CONTROL 2 — a backslash-continued entry naming SOME OTHER plugin must still
+# not disable ours. Without this, the fix could be satisfied by treating any
+# continued entry as a match.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.snapshotter.v1.\
+blockfile"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 28 control: a continued entry naming another plugin must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 28 control: continuation is decoded, not treated as a wildcard match'
+
+reset_node_sequence
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1819,7 +1819,6 @@ require_text "${output}" 'at least 1' 'case 33 control: 00 is decimal zero, stil
 
 reset_node_sequence
 
-
 # ===========================================================================
 # 34. THE CLOSING-RUN RULE IS NEEDED IN THE ARRAY SCANNER TOO. (#3320 review)
 #     Case 29 fixed the run in the ENTRY comparison. The scanner that decides

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -80,6 +80,7 @@ while [[ "$#" -gt 0 ]]; do
     -n) node="$2"; shift 2 ;;
     read)
       path="$2"
+      printf '%s %s\n' "${node}" "${path}" >>"${FIXTURES}/read-log"
       file="${FIXTURES}/${node}/files/${path//\//_}"
       [[ -f "${file}" ]] || exit 1
       cat "${file}"
@@ -1148,6 +1149,39 @@ if output="$(run_script 2>&1)"; then
   fail 'case 26: a node with no metadata.uid must not be accepted'
 fi
 require_text "${output}" 'no metadata.uid' 'case 26: names the missing identity'
+
+reset_node_sequence
+
+# ===========================================================================
+# Case 27 — ONE read per config file. The disabled verdict and bin_dir describe
+# the same file, so they must come from the same view of it. Two reads could
+# straddle a Talos or containerd update — the fleet workflow uses a different
+# concurrency group from deployments, so it can overlap one — and a replacement
+# that disables the plugin without removing its binaries would then be assembled
+# into an OK verdict from two snapshots that never coexisted. The node UID does
+# not change, so the convergence loop would never retry it.
+#
+# Asserted by COUNTING reads rather than by inspecting the code, so the property
+# survives any future refactor of how the facts are extracted.
+# ===========================================================================
+write_node oneread
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/oneread/files/_etc_cri_conf.d_cri.toml"
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/oneread/files/_etc_containerd_config.toml"
+write_dir oneread /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+rm -f "${fixtures}/read-log"
+run_script TALOS_NODES=oneread >/dev/null 2>&1 ||
+  fail 'case 27 control: the fixture must be a node that PASSES, or the count below proves nothing'
+
+for probed in /etc/cri/conf.d/cri.toml /etc/containerd/config.toml; do
+  reads="$(grep -c "^oneread ${probed}\$" "${fixtures}/read-log" || true)"
+  [[ "${reads}" -eq 1 ]] ||
+    fail "case 27: ${probed} was read ${reads} time(s), expected exactly 1 — the two facts can describe different snapshots"
+done
+printf 'ok — case 27: each config file is read exactly once\n' >/dev/null
 
 reset_node_sequence
 

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1038,6 +1038,37 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a quoted lookalike key must not be aliased onto the root key'
 require_text "${output}" 'OK   disabled' 'case 24: interior characters inside a quoted key are preserved'
 
+# A BASIC (double-quoted) TOML key interprets escapes, so this names our setting and
+# containerd switches the verifier OFF. Comparing the raw text missed it and the node
+# reported OK with no enforcement -- a FAIL-OPEN, the direction that matters here.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+"disabled\u005fplugins" = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: an escaped basic-quoted key must be decoded before comparison'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: TOML basic-string escapes are decoded in a quoted key'
+
+# The LITERAL (single-quoted) spelling of the same text is a DIFFERENT key: literal
+# strings do not interpret escapes, so containerd never reads it. Decoding it too would
+# re-introduce the aliasing this parser exists to avoid. Measured with go-toml.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+'disabled\u005fplugins' = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a literal-quoted key with escape text must not be decoded onto the root key'
+require_text "${output}" 'OK   disabled' 'case 24: literal strings keep escape text verbatim'
+
 # Our identifier appearing only in a trailing TOML COMMENT is not an entry.
 cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
 version = 3

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1594,4 +1594,230 @@ require_text "${output}" 'OK   disabled' 'case 28 control: continuation is decod
 
 reset_node_sequence
 
+
+# ===========================================================================
+# 29. A CLOSING RUN OF FOUR OR FIVE QUOTES. (#3320 review)
+#     TOML reads the FIRST quote of a four-quote run as content and the last
+#     three as the delimiter, so this entry is a plugin id ending in a quote --
+#     a DIFFERENT plugin, and our verifier stays ENABLED. Measured with
+#     go-toml: """id"""" -> `id"` and """id""""" -> `id""`.
+#
+#     Closing at the first three quotes compared the bare id and reported the
+#     node disabled, so a healthy node fails the gate.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1.bindir""""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 29: a four-quote closing run leaves a trailing quote in the value, so that is a different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 29: the first quote of a four-quote run is content'
+
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1.bindir"""""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 29: a five-quote closing run leaves two trailing quotes, so that is a different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 29: the first two quotes of a five-quote run are content'
+
+# CONTROL -- the plain three-quote close still names our plugin and must fail.
+# Without this, the fix could be satisfied by never matching a multiline entry.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 29 control: a three-quote close names our plugin and must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 29 control: the ordinary multiline form is still matched'
+
+reset_node_sequence
+
+# ===========================================================================
+# 30. A LEADING SPACE THAT IS CONTENT, NOT A JOINED LINE BREAK. (#3320 review)
+#     TOML trims a newline that immediately follows the opening delimiter, and
+#     the array's physical lines were joined with a single space -- so the
+#     parser dropped one leading space to represent that trimmed newline.
+#
+#     But a space written on the SAME line is content: go-toml resolves
+#     """ id""" to " id", a DIFFERENT plugin, so our verifier stays ENABLED.
+#     Trimming it unconditionally reported a healthy node as disabled.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = [""" io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 30: a same-line leading space is content, so that entry is a different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 30: only a real line break after the opener is trimmed'
+
+# CONTROL -- a real newline after the opener IS trimmed, so this names our
+# plugin and must fail. This is the half the trim exists for; without it the
+# fix could be satisfied by never trimming anything.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""
+io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 30 control: a newline immediately after the opener is trimmed, so this names our plugin and must fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 30 control: the trimmed-newline form is still matched'
+
+reset_node_sequence
+
+# ===========================================================================
+# 31. A COMMA INSIDE A STRING IS CONTENT, NOT AN ENTRY SEPARATOR. (#3320 review)
+#     Splitting the raw array text at every comma invents a second entry out of
+#     one string. go-toml resolves
+#       ['other, "io.containerd.image-verifier.v1.bindir"']
+#     to a SINGLE string naming a different plugin, so our verifier stays
+#     ENABLED -- but the split produced an apparent entry equal to our id and
+#     reported the healthy node disabled.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ['other, "io.containerd.image-verifier.v1.bindir"']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 31: a comma inside a literal string is content, so that is one different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 31: commas are tokenized with quote state'
+
+# CONTROL -- a GENUINE two-entry array whose second entry is ours must still
+# fail. Without this, the fix could be satisfied by never splitting at all.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ['io.containerd.snapshotter.v1.blockfile', 'io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 31 control: a real second entry naming our plugin must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 31 control: real separators are still split'
+
+reset_node_sequence
+
+# ===========================================================================
+# 32. A CRLF PHYSICAL LINE BOUNDARY. (#3320 review)
+#     A config assembled from fragments with mixed line endings can carry CRLF.
+#     TOML removes that line ending exactly as it removes LF, so both of these
+#     resolve to our plugin id and containerd switches the verifier OFF
+#     (measured with go-toml).
+#
+#     awk splits records on newline only, so each line kept a trailing CR; the
+#     continuation rule recognised space and tab alone, the CR survived into the
+#     buffered value, the comparison failed, and the script printed disabled=0
+#     -- a node reporting OK with no enforcement. That is the FAIL-OPEN this
+#     script exists to catch.
+#
+#     printf writes the CR: a heredoc cannot carry one portably.
+# ===========================================================================
+printf 'version = 3\ndisabled_plugins = ["""io.containerd.image-verifier.v1.\\\r\nbindir"""]\n\n[plugins]\n  [plugins.%s]\n    bin_dir = %s\n' \
+  "'io.containerd.image-verifier.v1.bindir'" "'/opt/containerd/image-verifier/bin'" \
+  >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml"
+# The fixture must actually carry CR before the newline, or the case is vacuous.
+grep -q "$(printf '\\\r$')" "${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" ||
+  fail 'case 32: the fixture lost its CRLF continuation — the case would pass vacuously'
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 32: a CRLF line continuation naming our plugin must fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 32: CRLF boundaries are decoded like LF'
+
+# The same hole at the opener: a CRLF immediately after """ is trimmed too.
+printf 'version = 3\ndisabled_plugins = ["""\r\nio.containerd.image-verifier.v1.bindir"""]\n\n[plugins]\n  [plugins.%s]\n    bin_dir = %s\n' \
+  "'io.containerd.image-verifier.v1.bindir'" "'/opt/containerd/image-verifier/bin'" \
+  >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml"
+grep -q "$(printf '"""\r$')" "${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" ||
+  fail 'case 32: the opener fixture lost its CR — the case would pass vacuously'
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 32: a CRLF immediately after the opening delimiter is trimmed, so this names our plugin and must fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 32: a CRLF after the opener is trimmed like an LF'
+
+# The same CRLF boundary on a CONTINUATION line, not the array's first line.
+# The two are stripped by different rules -- the opening line is consumed by the
+# key rule, every later line by the array rule -- so a fixture that only ever puts
+# the CR on the first line leaves the second rule untested.
+printf 'version = 3\ndisabled_plugins = [\r\n"""io.containerd.image-verifier.v1.\\\r\nbindir"""]\r\n\n[plugins]\n  [plugins.%s]\n    bin_dir = %s\n' "'io.containerd.image-verifier.v1.bindir'" "'/opt/containerd/image-verifier/bin'" >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml"
+grep -q "$(printf '\\\r$')" "${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" ||
+  fail 'case 32: the continuation-line fixture lost its CRLF -- the case would pass vacuously'
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 32: a CRLF continuation on a later array line must fail the node too'
+fi
+require_text "${output}" 'disabled_plugins' 'case 32: CRLF is stripped on every array line, not just the first'
+
+# CONTROL -- a CR that is NOT at a line boundary is ordinary content, so this
+# names a different plugin and must not disable ours.
+printf 'version = 3\ndisabled_plugins = ["""io.containerd.image-verifier.v1.\\rbindir"""]\n\n[plugins]\n  [plugins.%s]\n    bin_dir = %s\n' \
+  "'io.containerd.image-verifier.v1.bindir'" "'/opt/containerd/image-verifier/bin'" \
+  >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml"
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 32 control: an escaped \r inside the value is content, so that is a different plugin id and must not disable ours'
+require_text "${output}" 'OK   disabled' 'case 32 control: only a CR at a physical line boundary is a line ending'
+
+reset_node_sequence
+
+# ===========================================================================
+# 33. THE CONVERGENCE OVERRIDE IS A DECIMAL INTEGER. (#3320 review)
+#     The value passes the digit-only filter, then reaches bash arithmetic,
+#     which applies base-prefix rules to a leading zero. Measured in bash:
+#     `[[ 08 -ge 1 ]]` errors with "value too great for base", and 010 is
+#     EIGHT. So a documented, digit-only override is either rejected outright
+#     or silently runs a different number of convergence attempts than asked.
+# ===========================================================================
+write_node zeropad
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/zeropad/files/_etc_cri_conf.d_cri.toml"
+write_dir zeropad /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+
+output="$(run_script TALOS_NODES=zeropad IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=08 2>&1)" ||
+  fail 'case 33: a zero-padded attempt count is a positive integer and must be accepted'
+require_text "${output}" 'OK   zeropad' 'case 33: 08 is read as decimal 8'
+
+# CONTROL -- the guard still rejects a non-integer. Without this, the fix could
+# be satisfied by dropping the validation altogether.
+if output="$(run_script TALOS_NODES=zeropad IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=2x 2>&1)"; then
+  fail 'case 33 control: a non-integer attempt count must still be rejected'
+fi
+require_text "${output}" 'must be a positive integer' 'case 33 control: the digit filter still applies'
+
+# CONTROL -- zero is still not a positive integer, however it is padded.
+if output="$(run_script TALOS_NODES=zeropad IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=00 2>&1)"; then
+  fail 'case 33 control: a padded zero is still not at least 1'
+fi
+require_text "${output}" 'at least 1' 'case 33 control: 00 is decimal zero, still rejected'
+
+reset_node_sequence
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1819,4 +1819,73 @@ require_text "${output}" 'at least 1' 'case 33 control: 00 is decimal zero, stil
 
 reset_node_sequence
 
+
+# ===========================================================================
+# 34. THE CLOSING-RUN RULE IS NEEDED IN THE ARRAY SCANNER TOO. (#3320 review)
+#     Case 29 fixed the run in the ENTRY comparison. The scanner that decides
+#     where the array ENDS closes on the first three quotes as well, so it reads
+#     the fourth as a new opener and swallows whatever follows as string content.
+#
+#     TOML lets a sub-table be written without its implicit parent, so the very
+#     next line can be the verifier's own table. Swallowed, its populated bin_dir
+#     is never seen and a HEALTHY node fails the gate. The case 29 fixtures all
+#     carry an explicit [plugins] header, which absorbs the mis-parse and hides
+#     this -- so this case deliberately omits it.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["""io.containerd.snapshotter.v1.blockfile""""]
+
+[plugins.'io.containerd.image-verifier.v1.bindir']
+  bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 34: a four-quote close must not swallow the verifier table that follows it'
+require_text "${output}" 'OK   disabled' 'case 34: the array scanner consumes the whole closing quote run'
+
+reset_node_sequence
+
+# ===========================================================================
+# 35. A `[` INSIDE A TOP-LEVEL MULTILINE STRING IS NOT A TABLE HEADER. (#3320 review)
+#     The header rule fires on any line starting with `[` and clears root scope
+#     permanently. A physical line of an earlier top-level multiline string that
+#     begins with `[` therefore ends root scope, and the REAL disabled_plugins
+#     below it is never examined -- disabled stays 0, the verifier table still
+#     supplies a populated bin_dir, and the script reports OK while containerd
+#     has the plugin switched off. That is the FAIL-OPEN direction.
+# ===========================================================================
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+note = """
+[this is string content, not a table header]
+"""
+disabled_plugins = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 35: a bracketed line inside a multiline string must not end root scope and hide the real disabled_plugins'
+fi
+require_text "${output}" 'disabled_plugins' 'case 35: the real root key is still read after a bracketed string line'
+
+# CONTROL -- a REAL table header must still end root scope, or the fix would
+# re-alias a non-root disabled_plugins onto the root one (the hole case 24 closed).
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+
+[some.other.table]
+disabled_plugins = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 35 control: a non-root disabled_plugins must not be treated as the root one'
+require_text "${output}" 'OK   disabled' 'case 35 control: a real table header still ends root scope'
+
+reset_node_sequence
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1937,6 +1937,70 @@ if output="$(run_script TALOS_NODES=asciiesc 2>&1)"; then
 fi
 require_text "${output}" 'disabled_plugins' 'case 36 control: the genuinely disabled verifier is still detected'
 
+# ===========================================================================
+# Case 37 — a discovered node the autoscaler REMOVES mid-pass is an ordinary
+# node-set change, not an infrastructure failure. (#3320 review)
+#
+# `path_probe` fails for a node that has left, and that reachability failure used
+# to exit 2 immediately, so the post-pass inventory read never got the chance to
+# notice the node-set change and retry. The independently-concurrent
+# validate-image-verifier-liveness.yaml workflow therefore failed during an
+# ordinary scale-down or replacement, despite the convergence loop existing.
+# ===========================================================================
+install_sequenced_kubectl
+reset_node_sequence
+
+write_node departing
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/departing/files/_etc_cri_conf.d_cri.toml"
+# It answers the config read and then stops answering, which is exactly how a node
+# being drained behaves: the pass gets past the config and only then finds it gone.
+printf 'DEPARTED\n' >"${fixtures}/departing/lsfail_all"
+
+# Call 1 sees both; every later read sees only the survivor, so the node really has
+# left rather than merely gone quiet.
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-2 uid-2 departing)" \
+  >"${fixtures}/nodes.1.json"
+for call in 2 3 4; do
+  printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.${call}.json"
+done
+
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 0 ]] ||
+  fail "case 37: a node that left mid-pass must converge and report, got exit ${status} — ${output}"
+require_text "${output}" 'The node set changed while it was being checked' 'case 37: says it re-ran'
+require_text "${output}" 'All 1 node(s)' 'case 37: the verdict counts the fleet that actually exists'
+refute_text "${output}" 'cannot reach node departing' 'case 37: blamed infrastructure for an ordinary scale-down'
+
+# ===========================================================================
+# Case 37b CONTROL — a node that is unreachable but STILL IN THE FLEET must
+# still fail as infrastructure. (#3320 review)
+#
+# Without this, case 37 would be satisfied by any change that turns every
+# unreachable node into a retry — downgrading a real fault into a silent re-run
+# and eventually into a verdict for a fleet that was never checked, which is the
+# fail-open this whole script exists to detect.
+# ===========================================================================
+install_sequenced_kubectl
+reset_node_sequence
+
+write_node stuck
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/stuck/files/_etc_cri_conf.d_cri.toml"
+printf 'STUCK\n' >"${fixtures}/stuck/lsfail_all"
+
+# The fleet never changes: `stuck` is still registered, it just stopped answering.
+for call in 1 2 3 4; do
+  printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-3 uid-3 stuck)" \
+    >"${fixtures}/nodes.${call}.json"
+done
+
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 37b: an unreachable node still in the fleet must exit 2 (infrastructure), got ${status} — ${output}"
+require_text "${output}" 'cannot reach node stuck' 'case 37b: names the unreachable node'
+refute_text "${output}" 'can enforce image verification.' 'case 37b: reported a verdict it could not reach'
+
 reset_node_sequence
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -112,6 +112,15 @@ while [[ "$#" -gt 0 ]]; do
         printf 'rpc error: code = Unavailable desc = connection error\n' >&2
         exit 1
       fi
+      # The node stops answering the REACHABILITY probe specifically, while its file
+      # probes still resolve normally. That ordering is what reaches the departure
+      # check on the path_probe arms: those arms need a probe that returned a verdict
+      # (absent, or a non-lstat error) followed by a node that is no longer there --
+      # which `lsfail_all` cannot produce, because it fails the file probe too.
+      if [[ "${path}" == '/' && -f "${FIXTURES}/${node}/lsfail_root" ]]; then
+        printf 'error connecting to %s\n' "${node}" >&2
+        exit 1
+      fi
       # `ls /` is the reachability probe: the node answered, so it succeeds.
       [[ "${path}" == '/' ]] && exit 0
       if [[ -f "${listing}" ]]; then
@@ -2000,6 +2009,90 @@ output="$(run_script 2>&1)" || status=$?
   fail "case 37b: an unreachable node still in the fleet must exit 2 (infrastructure), got ${status} — ${output}"
 require_text "${output}" 'cannot reach node stuck' 'case 37b: names the unreachable node'
 refute_text "${output}" 'can enforce image verification.' 'case 37b: reported a verdict it could not reach'
+
+# ===========================================================================
+# Case 37c/d/e — EVERY departure path is guarded independently. (#3320 review)
+#
+# Case 37 reaches only the `directory_exists` failure. The departure handling also
+# sits on the `path_probe` absent arm, the `path_probe` error arm, and the
+# executable count — and with one shared case a later change could drop
+# `node_departed` from any of the three and still pass 37 and 37b. Each path gets
+# its own fixture, so each is a regression case on its own.
+#
+# `lsfail_root` rather than `lsfail_all` on the two path_probe arms: those arms are
+# only reached when the file probe RETURNED something, so the node has to answer the
+# probe and then stop answering the reachability check.
+# ===========================================================================
+
+# 37c — the `absent` arm: the node has no such config, then it is gone.
+install_sequenced_kubectl
+reset_node_sequence
+write_node gone-absent
+printf 'GONE\n' >"${fixtures}/gone-absent/lsfail_root"
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-4 uid-4 gone-absent)" \
+  >"${fixtures}/nodes.1.json"
+for call in 2 3 4; do
+  printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.${call}.json"
+done
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 0 ]] ||
+  fail "case 37c: a node that left on the path_probe ABSENT arm must converge, got exit ${status} — ${output}"
+require_text "${output}" 'All 1 node(s)' 'case 37c: reports the settled fleet'
+
+# 37d — the `error` arm: the probe fails for a reason other than absence, then gone.
+install_sequenced_kubectl
+reset_node_sequence
+write_node gone-error
+printf 'GONE\n' >"${fixtures}/gone-error/lsfail_root"
+printf 'RPC\n' >"${fixtures}/gone-error/lserror_etc_cri_conf.d_cri.toml"
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-5 uid-5 gone-error)" \
+  >"${fixtures}/nodes.1.json"
+for call in 2 3 4; do
+  printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.${call}.json"
+done
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 0 ]] ||
+  fail "case 37d: a node that left on the path_probe ERROR arm must converge, got exit ${status} — ${output}"
+require_text "${output}" 'All 1 node(s)' 'case 37d: reports the settled fleet'
+
+# 37e — the executable count: bin_dir exists, the long listing fails, then gone.
+install_sequenced_kubectl
+reset_node_sequence
+write_node gone-count
+verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/gone-count/files/_etc_cri_conf.d_cri.toml"
+write_dir gone-count /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+EOF
+# `lsfail` fails only the LONG form, so directory_exists passes and the count fails.
+printf 'GONE\n' >"${fixtures}/gone-count/lsfail"
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-6 uid-6 gone-count)" \
+  >"${fixtures}/nodes.1.json"
+for call in 2 3 4; do
+  printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.${call}.json"
+done
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 0 ]] ||
+  fail "case 37e: a node that left on the executable COUNT must converge, got exit ${status} — ${output}"
+require_text "${output}" 'All 1 node(s)' 'case 37e: reports the settled fleet'
+
+# CONTROLS — each of the three paths must STILL fail infra when the node is present.
+# Without these, 37c/d/e would be satisfied by turning every fault into a retry.
+install_sequenced_kubectl
+reset_node_sequence
+for call in 1 2 3 4; do
+  printf '{"items":[%s,%s,%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" \
+    "$(node_json prod-worker-4 uid-4 gone-absent)" "$(node_json prod-worker-5 uid-5 gone-error)" \
+    "$(node_json prod-worker-6 uid-6 gone-count)" >"${fixtures}/nodes.${call}.json"
+done
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 37f: unreachable nodes still in the fleet must exit 2, got ${status} — ${output}"
+refute_text "${output}" 'can enforce image verification.' 'case 37f: reported a verdict it could not reach'
 
 reset_node_sequence
 

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1019,6 +1019,25 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a different plugin whose name contains ours must not read as disabled'
 require_text "${output}" 'OK   disabled' 'case 24: entries are matched exactly, not by substring'
 
+# A quoted key that merely NORMALISES to ours is a DIFFERENT key. TOML treats a
+# bare and a quoted key as the same only when they spell the same characters, so
+# 'disabled_ plugins' -- with an interior space -- is a distinct setting that
+# containerd never reads. Deleting whitespace and quotes before comparing aliased
+# it onto ours and failed a node whose verifier is enabled: a false FAIL, the same
+# direction as the substring guard above and the worst one for a check whose only
+# output is "enforcement is off".
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+'disabled_ plugins' = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a quoted lookalike key must not be aliased onto the root key'
+require_text "${output}" 'OK   disabled' 'case 24: interior characters inside a quoted key are preserved'
+
 # Our identifier appearing only in a trailing TOML COMMENT is not an entry.
 cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
 version = 3

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -2079,20 +2079,38 @@ output="$(run_script 2>&1)" || status=$?
   fail "case 37e: a node that left on the executable COUNT must converge, got exit ${status} — ${output}"
 require_text "${output}" 'All 1 node(s)' 'case 37e: reports the settled fleet'
 
-# CONTROLS — each of the three paths must STILL fail infra when the node is present.
-# Without these, 37c/d/e would be satisfied by turning every fault into a retry.
-install_sequenced_kubectl
-reset_node_sequence
-for call in 1 2 3 4; do
-  printf '{"items":[%s,%s,%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" \
-    "$(node_json prod-worker-4 uid-4 gone-absent)" "$(node_json prod-worker-5 uid-5 gone-error)" \
-    "$(node_json prod-worker-6 uid-6 gone-count)" >"${fixtures}/nodes.${call}.json"
-done
-status=0
-output="$(run_script 2>&1)" || status=$?
-[[ "${status}" -eq 2 ]] ||
-  fail "case 37f: unreachable nodes still in the fleet must exit 2, got ${status} — ${output}"
-refute_text "${output}" 'can enforce image verification.' 'case 37f: reported a verdict it could not reach'
+# CONTROLS — each path must STILL fail infra when the node is PRESENT, and each needs
+# its OWN fleet. One fleet carrying all three problem nodes exits at the first of them,
+# so the error and count paths would never be asserted at all: a change turning either
+# into an unconditional retry would still pass. One unreachable node per control is what
+# makes each assertion reach the path it names.
+control_still_present() { # case-label, address, uid, expected-cause
+  install_sequenced_kubectl
+  reset_node_sequence
+  local call
+  for call in 1 2 3 4; do
+    printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json "prod-$2" "$3" "$2")" \
+      >"${fixtures}/nodes.${call}.json"
+  done
+  local status=0 output
+  output="$(run_script 2>&1)" || status=$?
+  [[ "${status}" -eq 2 ]] ||
+    fail "$1: an unreachable but PRESENT node must exit 2 (infrastructure), got ${status} — ${output}"
+  # The exit CODE alone proves nothing here. Making this path retry unconditionally also
+  # ends in exit 2 -- the retries exhaust the convergence bound and fail "never held
+  # still" -- so a control asserting only the status passes against the very mutation it
+  # exists to catch. Assert the CAUSE: this node was unreachable, not merely unsettled.
+  # The cause text differs per path -- the count path reports "could not list <dir> on
+  # <node>", the probe paths report "cannot reach node <node>" -- so each control names
+  # the message its own path emits rather than assuming one shape for all three.
+  require_text "${output}" "$4" "$1: failed for the wrong reason (expected: $4)"
+  refute_text "${output}" 'never held still' "$1: a present unreachable node was retried instead of failing infra"
+  refute_text "${output}" 'can enforce image verification.' "$1: reported a verdict it could not reach"
+}
+
+control_still_present 'case 37f (path_probe absent arm)' gone-absent uid-4 'cannot reach node gone-absent'
+control_still_present 'case 37g (path_probe error arm)'  gone-error  uid-5 'cannot reach node gone-error'
+control_still_present 'case 37h (executable count)'      gone-count  uid-6 'could not list /opt/containerd/image-verifier/bin on gone-count'
 
 reset_node_sequence
 

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1046,6 +1046,42 @@ if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
 fi
 require_text "${output}" 'disabled_plugins' 'case 24: double-quoted entries are read'
 
+# The root KEY may be quoted too. TOML treats a bare key and a quoted key as the
+# SAME key -- measured against pelletier/go-toml/v2, containerd's own parser
+# family: `disabled_plugins`, `"disabled_plugins"` and `'disabled_plugins'` all
+# unmarshal to one key. A bare-key-only match therefore never calls verdict() on
+# the quoted spellings, leaving disabled = 0 while containerd has the verifier
+# switched OFF -- a node reporting OK with no enforcement, the same fail-open
+# class as the quoted `]` and the substring match above.
+#
+# The table-header rule already strips quotes before comparing; the root key did
+# not, and that inconsistency is what this closes.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+"disabled_plugins" = ["io.containerd.image-verifier.v1.bindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a DOUBLE-QUOTED root disabled_plugins key must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: a double-quoted root key is read'
+
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+'disabled_plugins' = ["io.containerd.image-verifier.v1.bindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a SINGLE-QUOTED root disabled_plugins key must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: a single-quoted root key is read'
+
 # A LARGE config with the disabled key near the top. This is the SIGPIPE case:
 # an awk that printed its verdict and exited would close the pipe while
 # `talosctl read` was still writing, and under `set -o pipefail` that SIGPIPE is

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1169,6 +1169,101 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a multiline LITERAL entry with escape text must not be decoded onto our plugin id'
 require_text "${output}" 'OK   disabled' 'case 24: multiline literal entries keep escape text verbatim'
 
+# A MULTILINE string that genuinely SPANS PHYSICAL LINES. TOML trims a newline that
+# comes straight after the opening delimiter, so this names our plugin EXACTLY and
+# containerd has the verifier off -- measured with go-toml, which returns the bare id for
+# both the basic and the literal form.
+#
+# The walk restarted its quote state on every line, so the closing delimiter on the second
+# line read as a fresh OPENER; and the lines were joined with a SPACE, which turned the
+# newline TOML trims into a leading space. The entry compared as something that is not our
+# id and the node reported OK with no enforcement.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""
+io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a multiline BASIC entry spanning physical lines must be read as our plugin id'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: quote state is carried across array lines'
+
+# The LITERAL triple spans lines under the same rule.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['''
+io.containerd.image-verifier.v1.bindir''']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a multiline LITERAL entry spanning physical lines must be read as our plugin id'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: literal triples carry across lines too'
+
+# CONTROL: only the FIRST newline after the opener is trimmed. A second one is CONTENT, so
+# this entry is "\nio.containerd..." -- a DIFFERENT string that containerd never matches,
+# and the node must stay OK. Without this the fix could pass by stripping every leading
+# newline, which would alias a different plugin id onto ours.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""
+
+io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: only the first newline after a multiline opener is trimmed; a second is content'
+require_text "${output}" 'OK   disabled' 'case 24: a retained newline makes it a different plugin id'
+
+# A # inside a multiline string that SPANS lines. The comment stripper restarted its
+# quote state on every line, so on the second line the # read as a comment opener and
+# truncated the array there -- dropping our entry and reporting OK with the verifier off.
+# Carrying the string state across lines is what keeps the # as content. Measured with
+# go-toml: this list holds "a#b" AND our plugin id.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""
+a#b""", 'io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a # inside a SPANNING multiline string must not truncate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: comment state is carried across array lines'
+
+# A ] inside a multiline string that SPANS lines, in a MULTI-LINE array. The array-
+# terminator scan also restarted per line, so the ] on the second line ended the array
+# there -- and the entry on the THIRD line was never buffered at all. Our plugin is on
+# that third line, so the node reported OK with the verifier off. Measured with go-toml:
+# this list holds "a]b" AND our plugin id.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""
+a]b""",
+  'io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a ] inside a SPANNING multiline string must not terminate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: terminator state is carried across array lines'
+
 # A # inside a MULTILINE string is content, not a comment opener. ONE interior quote
 # is legal inside a multiline basic string and makes the quote count ODD, so a walk that
 # reads each quote singly ends up OUTSIDE the string at the #, truncates the array there,

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1594,7 +1594,6 @@ require_text "${output}" 'OK   disabled' 'case 28 control: continuation is decod
 
 reset_node_sequence
 
-
 # ===========================================================================
 # 29. A CLOSING RUN OF FOUR OR FIVE QUOTES. (#3320 review)
 #     TOML reads the FIRST quote of a four-quote run as content and the last

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -205,6 +205,11 @@ run_script() {
 # tree, and a test fixture is not a good reason to spend that).
 readonly canary='CANARY-registry-auth-value-must-never-be-printed'
 
+# A literal backslash, BUILT rather than typed, so no layer between this file and
+# the fixture can decode a TOML escape sequence on the way through.
+BS="$(awk 'BEGIN{printf "%c", 92}')"
+readonly BS
+
 verifier_config() {
   local bin_dir="$1"
   cat <<EOF
@@ -1098,6 +1103,107 @@ EOF
 output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a literal-quoted entry with escape text must not be decoded onto our plugin id'
 require_text "${output}" 'OK   disabled' 'case 24: literal entries keep escape text verbatim'
+
+# A MULTILINE BASIC entry ("""...""") is the same plugin id to containerd: go-toml
+# resolves the triple-quoted form to exactly the characters of our identifier, so
+# the verifier is OFF. Treating each quote as a single-char delimiter closed the
+# string on the SECOND quote of the opener and compared an EMPTY entry, so the node
+# reported OK with no enforcement -- the fail-open this script exists to prevent.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1.bindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a MULTILINE BASIC entry must be read as our plugin id'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: triple-quoted basic entries are parsed'
+
+# The MULTILINE LITERAL spelling ('''...''') resolves to the SAME characters --
+# measured with go-toml, which returns our identifier for the basic, the literal
+# and the plain forms alike. The reviewer named only the basic form; this half of
+# the hole is identical and fails open in exactly the same direction.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['''io.containerd.image-verifier.v1.bindir''']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a MULTILINE LITERAL entry must be read as our plugin id'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: triple-quoted literal entries are parsed'
+
+# A multiline BASIC entry interprets escapes exactly as the single-line form does,
+# so the escaped spelling is still our plugin id and must disable the node.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""io.containerd.image-verifier.v1${BS}u002ebindir"""]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: escapes inside a MULTILINE BASIC entry must be decoded'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: multiline basic escapes are decoded'
+
+# ...and the multiline LITERAL form interprets nothing, so the same text is a
+# DIFFERENT plugin id containerd never matches. Decoding it would alias a healthy
+# node onto ours and report a false FAIL.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['''io.containerd.image-verifier.v1${BS}u002ebindir''']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a multiline LITERAL entry with escape text must not be decoded onto our plugin id'
+require_text "${output}" 'OK   disabled' 'case 24: multiline literal entries keep escape text verbatim'
+
+# A # inside a MULTILINE string is content, not a comment opener. ONE interior quote
+# is legal inside a multiline basic string and makes the quote count ODD, so a walk that
+# reads each quote singly ends up OUTSIDE the string at the #, truncates the array there,
+# and drops our entry -- reporting OK while containerd has the verifier off.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["""a"b#c""", 'io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a # inside a MULTILINE string must not truncate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: # inside a triple-quoted string is content'
+
+# ...and a ] inside a MULTILINE string is not the array terminator. In a MULTI-LINE
+# array that early termination stops the buffer before the next line, so our entry on
+# it is never examined at all -- the same fail-open, reached through enumeration.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = [
+  """a"b]c""",
+  'io.containerd.image-verifier.v1.bindir',
+]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a ] inside a MULTILINE string must not terminate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: ] inside a triple-quoted string is content'
 
 # Our identifier appearing only in a trailing TOML COMMENT is not an entry.
 cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -943,6 +943,49 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a non-root disabled_plugins key must not be treated as the root one'
 require_text "${output}" 'OK   disabled' 'case 24: scoped to the root key'
 
+# A DIFFERENT plugin whose name merely CONTAINS ours must not disable us. This
+# is a false-FAIL guard: a substring test over the array text fails a node whose
+# verifier is perfectly enabled, which is the worst direction for a check whose
+# whole output is "enforcement is off".
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['example.io.containerd.image-verifier.v1.bindir-extra']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a different plugin whose name contains ours must not read as disabled'
+require_text "${output}" 'OK   disabled' 'case 24: entries are matched exactly, not by substring'
+
+# Our identifier appearing only in a trailing TOML COMMENT is not an entry.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['io.containerd.snapshotter.v1.blockfile'] # io.containerd.image-verifier.v1.bindir
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: our identifier in a comment must not read as disabled'
+require_text "${output}" 'OK   disabled' 'case 24: a trailing comment is not an array entry'
+
+# Double-quoted entries are TOML too, and must still be caught.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["io.containerd.image-verifier.v1.bindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a double-quoted disabled entry must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: double-quoted entries are read'
+
 # A LARGE config with the disabled key near the top. This is the SIGPIPE case:
 # an awk that printed its verdict and exited would close the pipe while
 # `talosctl read` was still writing, and under `set -o pipefail` that SIGPIPE is

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -926,6 +926,45 @@ if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
 fi
 require_text "${output}" 'disabled_plugins' 'case 24: multi-line array is read'
 
+# A COMMENT LINE inside the multi-line array. The lines are concatenated into one
+# buffer, so a comment that is not stripped swallows the entry on the next line:
+# that entry lands inside the comment text, fails the quote test, and is skipped.
+# The node then reads as ENABLED while containerd has the verifier DISABLED --
+# a false OK on the one check whose whole job is to catch exactly that.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = [
+  'io.containerd.snapshotter.v1.blockfile',
+  # image verification is off while we debug the registry
+  'io.containerd.image-verifier.v1.bindir',
+]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a comment line before the entry must not hide a disabled plugin'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: commented multi-line array is read'
+
+# The mirror image: a # INSIDE a quoted entry is content, not a comment, so
+# stripping must not truncate the entry and lose the plugin that follows it.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = [
+  'io.containerd.snapshotter.v1.blockfile#notacomment', 'io.containerd.image-verifier.v1.bindir',
+]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a # inside a quoted entry must not truncate the array'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: quoted # is content, not a comment'
+
 # A `disabled_plugins` key that belongs to some OTHER table is not the root key
 # and must not disable anything -- otherwise an unrelated setting could switch
 # this whole check off.

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -2109,8 +2109,8 @@ control_still_present() { # case-label, address, uid, expected-cause
 }
 
 control_still_present 'case 37f (path_probe absent arm)' gone-absent uid-4 'cannot reach node gone-absent'
-control_still_present 'case 37g (path_probe error arm)'  gone-error  uid-5 'cannot reach node gone-error'
-control_still_present 'case 37h (executable count)'      gone-count  uid-6 'could not list /opt/containerd/image-verifier/bin on gone-count'
+control_still_present 'case 37g (path_probe error arm)' gone-error uid-5 'cannot reach node gone-error'
+control_still_present 'case 37h (executable count)' gone-count uid-6 'could not list /opt/containerd/image-verifier/bin on gone-count'
 
 reset_node_sequence
 

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -136,12 +136,31 @@ exit 1
 FAKE
 chmod +x "${fake_bin}/talosctl"
 
+# Serves a SEQUENCE when one is staged: the Nth `kubectl get nodes` of a run is
+# answered from nodes.<N>.json when that file exists, and from nodes.json
+# otherwise. The script reads the inventory once before the checks and again
+# after them, so a per-call answer is what lets a test move the fleet in the
+# window between those two reads -- the autoscaler race the convergence loop
+# exists to close. Cases that stage no sequence are unaffected.
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
-cat "${FIXTURES}/nodes.json"
+call_count_file="${FIXTURES}/kubectl-call-count"
+call_number=$(( $(cat "${call_count_file}" 2>/dev/null || printf '0') + 1 ))
+printf '%s' "${call_number}" >"${call_count_file}"
+if [[ -f "${FIXTURES}/nodes.${call_number}.json" ]]; then
+  cat "${FIXTURES}/nodes.${call_number}.json"
+else
+  cat "${FIXTURES}/nodes.json"
+fi
 FAKE
 chmod +x "${fake_bin}/kubectl"
+
+# Clears both the counter and any staged sequence, so one case's fleet cannot
+# leak into the next.
+reset_node_sequence() {
+  rm -f "${fixtures}/kubectl-call-count" "${fixtures}"/nodes.[0-9].json
+}
 
 # A real `talosctl ls -l` header plus rows. Column 2 is MODE, last column is
 # NAME, and the LABEL column is EMPTY for some files on this cluster — which is
@@ -295,8 +314,8 @@ require_text "${output}" '2 of 3 node(s) cannot enforce' 'case 6: counts every f
 cat >"${fixtures}/nodes.json" <<'EOF'
 {
   "items": [
-    {"status": {"addresses": [{"type": "Hostname", "address": "prod-worker-1"}, {"type": "InternalIP", "address": "good"}]}},
-    {"status": {"addresses": [{"type": "InternalIP", "address": "empty"}]}}
+    {"metadata": {"name": "prod-worker-1", "uid": "uid-good"}, "status": {"addresses": [{"type": "Hostname", "address": "prod-worker-1"}, {"type": "InternalIP", "address": "good"}]}},
+    {"metadata": {"name": "prod-worker-2", "uid": "uid-empty"}, "status": {"addresses": [{"type": "InternalIP", "address": "empty"}]}}
   ]
 }
 EOF
@@ -615,7 +634,7 @@ refute_text "${output}" 'does not exist' 'case 19: blamed the cluster for a runn
 # caught it).
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
-printf '%s\n' '{"items":[{"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},{"status":{}}]}'
+printf '%s\n' '{"items":[{"metadata":{"name":"prod-worker-1","uid":"uid-good"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},{"metadata":{"name":"prod-worker-2","uid":"uid-2"},"status":{}}]}'
 exit 0
 FAKE
 chmod +x "${fake_bin}/kubectl"
@@ -644,8 +663,8 @@ refute_text "${output}" 'can enforce image verification.' 'case 18: reported a f
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-2"},{"type":"ExternalIP","address":"203.0.113.7"}]}}
+  {"metadata":{"name":"prod-worker-1","uid":"uid-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-2","uid":"uid-2"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-2"},{"type":"ExternalIP","address":"203.0.113.7"}]}}
 ]}'
 exit 0
 FAKE
@@ -666,7 +685,7 @@ refute_text "${output}" 'can enforce image verification.' \
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-1"},{"type":"InternalIP","address":"good"}]}}
+  {"metadata":{"name":"prod-worker-1","uid":"uid-1"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-1"},{"type":"InternalIP","address":"good"}]}}
 ]}'
 exit 0
 FAKE
@@ -775,8 +794,8 @@ run_script TALOS_NODES=probeerror >/dev/null 2>&1 ||
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-stale"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}}
+  {"metadata":{"name":"prod-worker-1","uid":"uid-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-stale","uid":"uid-stale"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}}
 ]}'
 exit 0
 FAKE
@@ -798,7 +817,7 @@ refute_text "${output}" 'can enforce image verification.' \
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-dual"},"status":{"addresses":[{"type":"InternalIP","address":"good"},{"type":"InternalIP","address":"empty"}]}}
+  {"metadata":{"name":"prod-worker-dual","uid":"uid-dual"},"status":{"addresses":[{"type":"InternalIP","address":"good"},{"type":"InternalIP","address":"empty"}]}}
 ]}'
 exit 0
 FAKE
@@ -814,8 +833,8 @@ require_text "${output}" 'prod-worker-dual' 'case 23: names the node carrying tw
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"onlysystem"}]}}
+  {"metadata":{"name":"prod-worker-1","uid":"uid-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
+  {"metadata":{"name":"prod-worker-2","uid":"uid-2"},"status":{"addresses":[{"type":"InternalIP","address":"onlysystem"}]}}
 ]}'
 exit 0
 FAKE
@@ -827,5 +846,191 @@ output="$(run_script 2>&1)" ||
   fail 'case 23: a fleet of distinct nodes with distinct InternalIPs must still be accepted'
 require_text "${output}" 'good' 'case 23: control reports the first discovered node'
 require_text "${output}" 'onlysystem' 'case 23: control reports the second discovered node'
+
+# ===========================================================================
+# Case 24 — the plugin is CONFIGURED and DISABLED. A bin_dir that is set,
+# present and full of executables proves nothing if containerd never loads the
+# plugin that runs them, so this node must FAIL exactly like one with no
+# verifier at all. Everything else about it is deliberately healthy, so a pass
+# here could only come from not looking at disabled_plugins.
+# ===========================================================================
+write_node disabled
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['io.containerd.image-verifier.v1.bindir']
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
+      password = '${canary}'
+      username = 'devantler'
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+write_dir disabled /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+disabled    -rwxr-xr-x   0     0     1024      2026-08-01T00:00:00Z                                                 .
+disabled    -rwxr-xr-x   0     0     1024      2026-08-01T00:00:00Z                                                 verifier
+EOF
+
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a disabled image-verifier plugin must fail the node'
+fi
+require_text "${output}" 'FAIL disabled' 'case 24: names the node that cannot enforce'
+require_text "${output}" 'disabled_plugins' 'case 24: says WHY, so the operator edits the right setting'
+refute_text "${output}" "${canary}" 'case 24: never prints registry credentials'
+
+# Control: the SAME node with the plugin left enabled passes. Without this, the
+# case above would also pass if the script had simply started failing this
+# fixture for some unrelated reason.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['io.containerd.snapshotter.v1.blockfile']
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
+      password = '${canary}'
+      username = 'devantler'
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24 control: an UNRELATED disabled plugin must not fail the node'
+require_text "${output}" 'OK   disabled' 'case 24 control: the node enforces'
+
+# A multi-line array is the shape containerd config actually uses once more than
+# one plugin is off; a single-line matcher would miss it and report the node OK.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = [
+  'io.containerd.snapshotter.v1.blockfile',
+  'io.containerd.image-verifier.v1.bindir',
+]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a disabled plugin listed in a MULTI-LINE array must still fail the node'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: multi-line array is read'
+
+# A `disabled_plugins` key that belongs to some OTHER table is not the root key
+# and must not disable anything -- otherwise an unrelated setting could switch
+# this whole check off.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+
+[plugins]
+  [plugins.'io.containerd.some.other.plugin']
+    disabled_plugins = ['io.containerd.image-verifier.v1.bindir']
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a non-root disabled_plugins key must not be treated as the root one'
+require_text "${output}" 'OK   disabled' 'case 24: scoped to the root key'
+
+# ===========================================================================
+# Case 25 — the node set changes WHILE the fleet is being checked. The
+# inventory is read before a serial pass, so an autoscaler that adds or
+# replaces a worker mid-run would otherwise leave that machine uninspected
+# while every node in the stale snapshot reported healthy.
+# ===========================================================================
+install_sequenced_kubectl() {
+  cat >"${fake_bin}/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+call_count_file="${FIXTURES}/kubectl-call-count"
+call_number=$(( $(cat "${call_count_file}" 2>/dev/null || printf '0') + 1 ))
+printf '%s' "${call_number}" >"${call_count_file}"
+if [[ -f "${FIXTURES}/nodes.${call_number}.json" ]]; then
+  cat "${FIXTURES}/nodes.${call_number}.json"
+else
+  cat "${FIXTURES}/nodes.json"
+fi
+FAKE
+  chmod +x "${fake_bin}/kubectl"
+}
+install_sequenced_kubectl
+
+node_json() { printf '{"metadata":{"name":"%s","uid":"%s"},"status":{"addresses":[{"type":"InternalIP","address":"%s"}]}}' "$1" "$2" "$3"; }
+
+# A worker joins between the pass and the re-read, then the fleet holds still:
+# the check re-runs over the new set and reports on what actually exists.
+reset_node_sequence
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.1.json"
+for call in 2 3; do
+  printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-2 uid-2 onlysystem)" \
+    >"${fixtures}/nodes.${call}.json"
+done
+output="$(run_script 2>&1)" ||
+  fail 'case 25: a settled inventory must be reported, not treated as a fault'
+require_text "${output}" 'The node set changed while it was being checked' 'case 25: says it re-ran'
+require_text "${output}" 'onlysystem' 'case 25: the node that joined mid-run IS inspected'
+require_text "${output}" 'All 2 node(s)' 'case 25: the verdict counts the fleet that actually exists'
+
+# The same race with the joiner NOT healthy: re-running has to reach a verdict
+# about it, not just re-count the fleet.
+reset_node_sequence
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.1.json"
+for call in 2 3; do
+  printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-2 uid-2 empty)" \
+    >"${fixtures}/nodes.${call}.json"
+done
+if output="$(run_script 2>&1)"; then
+  fail 'case 25: a node that joined mid-run and cannot enforce must fail the run'
+fi
+require_text "${output}" 'FAIL empty' 'case 25: the mid-run joiner is judged, not just counted'
+
+# An inventory that never settles is bounded rather than looping forever, and
+# fails closed instead of reporting on a fleet that never held still.
+reset_node_sequence
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.1.json"
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-2 uid-2 onlysystem)" >"${fixtures}/nodes.2.json"
+printf '{"items":[%s]}' "$(node_json prod-worker-2 uid-2 onlysystem)" >"${fixtures}/nodes.3.json"
+if output="$(run_script IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=2 2>&1)"; then
+  fail 'case 25: an inventory that never settles must not report a verdict'
+fi
+require_text "${output}" 'never held still' 'case 25: says the fleet would not settle'
+
+# ===========================================================================
+# Case 26 — an autoscaler replacement that REUSES the retired node's address.
+# Address alone cannot tell the two apart, so a machine that was never
+# inspected would be reported as one that passed. The UID is the discriminator.
+# ===========================================================================
+install_sequenced_kubectl
+reset_node_sequence
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-original good)" >"${fixtures}/nodes.1.json"
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-replacement good)" >"${fixtures}/nodes.2.json"
+if output="$(run_script IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=1 2>&1)"; then
+  fail 'case 26: a replacement reusing the address must not pass as the original'
+fi
+require_text "${output}" 'never held still' 'case 26: the replacement is detected as a change'
+
+# Control: the SAME node, same UID and address, across both reads settles at
+# once. Without it, case 26 would also pass if the script had simply started
+# rejecting every discovery run.
+reset_node_sequence
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-original good)" >"${fixtures}/nodes.1.json"
+printf '{"items":[%s]}' "$(node_json prod-worker-1 uid-original good)" >"${fixtures}/nodes.2.json"
+output="$(run_script IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=1 2>&1)" ||
+  fail 'case 26 control: an unchanged fleet must settle on the first attempt'
+require_text "${output}" 'All 1 node(s)' 'case 26 control: reports the unchanged fleet'
+
+# A node with no UID at all is refused rather than compared on address alone.
+reset_node_sequence
+printf '%s\n' '{"items":[{"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}}]}' >"${fixtures}/nodes.1.json"
+if output="$(run_script 2>&1)"; then
+  fail 'case 26: a node with no metadata.uid must not be accepted'
+fi
+require_text "${output}" 'no metadata.uid' 'case 26: names the missing identity'
+
+reset_node_sequence
 
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1887,4 +1887,56 @@ require_text "${output}" 'OK   disabled' 'case 35 control: a real table header s
 
 reset_node_sequence
 
+# ===========================================================================
+# case 36 -- A NON-ASCII \U ESCAPE MUST NOT ALIAS ONTO THE VERIFIER ID.
+#   `%c` is byte-oriented in several awks, so a code point above 255 is
+#   truncated modulo 256: U+10069 emits the single byte 0x69 (`i`), so the
+#   basic string below decoded to exactly `io.containerd.image-verifier.v1.bindir`.
+#   This node disables a DIFFERENT plugin and verifies images perfectly well,
+#   but the aliased decode reported it as having the verifier switched off --
+#   a healthy node failed on a config that never names the verifier.
+# ===========================================================================
+write_node escaped
+cat >"${fixtures}/escaped/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["\U00010069o.containerd.image-verifier.v1.bindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+write_dir escaped /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+output="$(run_script TALOS_NODES=escaped 2>&1)" ||
+  fail 'case 36: a non-ASCII \U escape must not alias onto the verifier ID and disable a healthy node'
+require_text "${output}" 'OK   escaped' 'case 36: the node that disables a different plugin still enforces'
+
+# CONTROL -- an ASCII \u escape that really does spell the verifier ID must STILL
+# be decoded and honoured. Without this the fix could be satisfied by decoding no
+# escapes at all, which would hide a genuinely disabled verifier -- the FAIL-OPEN
+# direction and far worse than the false alarm above.
+write_node asciiesc
+cat >"${fixtures}/asciiesc/files/_etc_cri_conf.d_cri.toml" <<'EOF'
+version = 3
+disabled_plugins = ["\u0069o.containerd.image-verifier.v1.bindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+write_dir asciiesc /opt/containerd/image-verifier/bin <<EOF
+${listing_header}
+10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
+10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+EOF
+if output="$(run_script TALOS_NODES=asciiesc 2>&1)"; then
+  fail 'case 36 control: an ASCII \u escape spelling the verifier ID must still be decoded and honoured'
+fi
+require_text "${output}" 'disabled_plugins' 'case 36 control: the genuinely disabled verifier is still detected'
+
+reset_node_sequence
+
 printf 'PASS: all cases\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -1069,6 +1069,36 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a literal-quoted key with escape text must not be decoded onto the root key'
 require_text "${output}" 'OK   disabled' 'case 24: literal strings keep escape text verbatim'
 
+# The SAME escape hole one level down: the ENTRY VALUES in the array. A basic-quoted
+# entry interprets escapes, so this names our plugin and containerd switches the verifier
+# off, while an un-decoded comparison misses it and the node reports OK -- a FAIL-OPEN.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ["io.containerd.image-verifier.v1\u002ebindir"]
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: an escaped basic-quoted ENTRY must be decoded before comparison'
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: TOML basic-string escapes are decoded in an array entry'
+
+# And the LITERAL spelling of the same entry is a DIFFERENT plugin id that containerd
+# never matches, so it must NOT disable us.
+cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
+version = 3
+disabled_plugins = ['io.containerd.image-verifier.v1\u002ebindir']
+
+[plugins]
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+EOF
+output="$(run_script TALOS_NODES=disabled 2>&1)" ||
+  fail 'case 24: a literal-quoted entry with escape text must not be decoded onto our plugin id'
+require_text "${output}" 'OK   disabled' 'case 24: literal entries keep escape text verbatim'
+
 # Our identifier appearing only in a trailing TOML COMMENT is not an entry.
 cat >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml" <<EOF
 version = 3

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -142,7 +142,11 @@ chmod +x "${fake_bin}/talosctl"
 # after them, so a per-call answer is what lets a test move the fleet in the
 # window between those two reads -- the autoscaler race the convergence loop
 # exists to close. Cases that stage no sequence are unaffected.
-cat >"${fake_bin}/kubectl" <<'FAKE'
+# Defined once and reused: later cases replace the fake with static variants, so
+# any case needing the sequenced behaviour back calls this rather than pasting a
+# second copy that could drift from this one.
+install_sequenced_kubectl() {
+  cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 call_count_file="${FIXTURES}/kubectl-call-count"
@@ -154,7 +158,10 @@ else
   cat "${FIXTURES}/nodes.json"
 fi
 FAKE
-chmod +x "${fake_bin}/kubectl"
+  chmod +x "${fake_bin}/kubectl"
+}
+
+install_sequenced_kubectl
 
 # Clears both the counter and any staged sequence, so one case's fleet cannot
 # leak into the next.
@@ -936,27 +943,42 @@ output="$(run_script TALOS_NODES=disabled 2>&1)" ||
   fail 'case 24: a non-root disabled_plugins key must not be treated as the root one'
 require_text "${output}" 'OK   disabled' 'case 24: scoped to the root key'
 
+# A LARGE config with the disabled key near the top. This is the SIGPIPE case:
+# an awk that printed its verdict and exited would close the pipe while
+# `talosctl read` was still writing, and under `set -o pipefail` that SIGPIPE is
+# indistinguishable from a genuine read failure -- so the node would be reported
+# as an INFRASTRUCTURE error (exit 2) rather than the FAIL it is. The verdict has
+# to survive reading the whole file.
+{
+  printf 'version = 3\n'
+  printf "disabled_plugins = ['io.containerd.image-verifier.v1.bindir']\n"
+  printf '\n[plugins]\n'
+  printf "  [plugins.'io.containerd.image-verifier.v1.bindir']\n"
+  printf "    bin_dir = '/opt/containerd/image-verifier/bin'\n"
+  # Filler well past a pipe buffer, so the producer is still writing when a
+  # short-circuiting reader would have quit.
+  awk 'BEGIN { for (i = 0; i < 20000; i++) print "# padding line to outrun the pipe buffer" }'
+} >"${fixtures}/disabled/files/_etc_cri_conf.d_cri.toml"
+
+if output="$(run_script TALOS_NODES=disabled 2>&1)"; then
+  fail 'case 24: a disabled plugin in a LARGE config must still fail the node'
+else
+  status=$?
+fi
+require_text "${output}" 'disabled_plugins' 'case 24: large config still reports the disabled plugin'
+if [ "${status}" -ne 1 ]; then
+  printf 'FAIL: case 24: a disabled plugin in a large config must exit 1 (verdict), got %s — a SIGPIPE from an early awk exit is being reported as an infrastructure error\n%s\n' \
+    "${status}" "${output}" >&2
+  exit 1
+fi
+refute_text "${output}" 'talosctl read failed' 'case 24: not misreported as a read failure'
+
 # ===========================================================================
 # Case 25 — the node set changes WHILE the fleet is being checked. The
 # inventory is read before a serial pass, so an autoscaler that adds or
 # replaces a worker mid-run would otherwise leave that machine uninspected
 # while every node in the stale snapshot reported healthy.
 # ===========================================================================
-install_sequenced_kubectl() {
-  cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-set -euo pipefail
-call_count_file="${FIXTURES}/kubectl-call-count"
-call_number=$(( $(cat "${call_count_file}" 2>/dev/null || printf '0') + 1 ))
-printf '%s' "${call_number}" >"${call_count_file}"
-if [[ -f "${FIXTURES}/nodes.${call_number}.json" ]]; then
-  cat "${FIXTURES}/nodes.${call_number}.json"
-else
-  cat "${FIXTURES}/nodes.json"
-fi
-FAKE
-  chmod +x "${fake_bin}/kubectl"
-}
 install_sequenced_kubectl
 
 node_json() { printf '{"metadata":{"name":"%s","uid":"%s"},"status":{"addresses":[{"type":"InternalIP","address":"%s"}]}}' "$1" "$2" "$3"; }
@@ -998,6 +1020,20 @@ if output="$(run_script IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=2 2>&1)"; then
   fail 'case 25: an inventory that never settles must not report a verdict'
 fi
 require_text "${output}" 'never held still' 'case 25: says the fleet would not settle'
+
+# The SAME fleet returned in a DIFFERENT order across the two reads must settle,
+# not re-run. `kubectl get nodes` guarantees no ordering, so comparing the
+# discovery stream as a string would call a re-ordered but identical fleet
+# "changed" and could burn the attempt bound into an exit 2 for a cluster that
+# never moved. Attempts are pinned at 1 so any re-run at all is a failure.
+install_sequenced_kubectl
+reset_node_sequence
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-1 uid-1 good)" "$(node_json prod-worker-2 uid-2 onlysystem)" >"${fixtures}/nodes.1.json"
+printf '{"items":[%s,%s]}' "$(node_json prod-worker-2 uid-2 onlysystem)" "$(node_json prod-worker-1 uid-1 good)" >"${fixtures}/nodes.2.json"
+output="$(run_script IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS=1 2>&1)" ||
+  fail 'case 25: a re-ordered but identical fleet must settle, not be treated as a change'
+require_text "${output}" 'All 2 node(s)' 'case 25: the re-ordered fleet is reported normally'
+refute_text "${output}" 'The node set changed' 'case 25: re-ordering is not a change'
 
 # ===========================================================================
 # Case 26 — an autoscaler replacement that REUSES the retired node's address.

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -248,6 +248,16 @@ config_facts_in() {
   "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
     BEGIN {
       SQ = sprintf("%c", 39); DQ = sprintf("%c", 34)
+      # A PHYSICAL LINE BOUNDARY inside the array, kept distinct from a space that
+      # is genuinely part of a value. TOML forbids a raw control character inside a
+      # string, so this byte cannot occur in content that containerd would accept.
+      #
+      # A real newline cannot be used: this awk (BWK, macOS) splits on a newline in
+      # split() whatever separator is given, and gawk/mawk in CI differ again. A
+      # SPACE was used before and lost the distinction the TOML rules turn on --
+      # """ id""" is a different plugin from """<newline>id""", and only the second
+      # has its leading character trimmed.
+      NLM = sprintf("%c", 1)
       toplevel = 1; in_array = 0; buf = ""; disabled = 0
       want = 0; found = 0; bin_dir = ""
     }
@@ -361,14 +371,62 @@ config_facts_in() {
     # No apostrophes in these comments: the whole program is a single-quoted
     # shell string, so one would end it. And close_at, not close, because awk
     # already has a close() builtin.
-    function verdict(text,   body, count, i, entry, quote, close_at, j, c) {
+    # Splits the array body at the commas that are actually SEPARATORS. A comma
+    # inside a string is content: go-toml resolves
+    #   [ LITERAL-QUOTED other, "io.containerd.image-verifier.v1.bindir" ]
+    # to ONE string naming a different plugin, so our verifier stays ENABLED --
+    # but splitting the raw text at every comma invented a second entry equal to
+    # our id and reported a healthy node as disabled.
+    function split_entries(body,   n, i, c, q, qlen, out, run) {
+      n = length(body); i = 1; out = 0; q = ""; qlen = 0
+      entries[1] = ""; out = 1
+      while (i <= n) {
+        c = substr(body, i, 1)
+        if (q == "") {
+          if (c == "," ) { out++; entries[out] = ""; i++; continue }
+          if (c == SQ || c == DQ) {
+            q = c
+            qlen = (substr(body, i, 3) == c c c) ? 3 : 1
+            entries[out] = entries[out] substr(body, i, qlen)
+            i += qlen
+            continue
+          }
+          entries[out] = entries[out] c; i++
+          continue
+        }
+        # Inside a string. A basic string escapes its delimiter; a literal one
+        # cannot contain its own quote at all, so nothing escapes there.
+        if (c == "\\" && q == DQ) {
+          entries[out] = entries[out] substr(body, i, 2); i += 2; continue
+        }
+        if (qlen == 3) {
+          if (substr(body, i, 3) == q q q) {
+            # Consume the WHOLE run. TOML lets one or two quotes sit against the
+            # closing delimiter as content, and leaving them behind here would
+            # re-open a string and swallow the next real separator.
+            run = 0
+            while (substr(body, i + run, 1) == q) run++
+            entries[out] = entries[out] substr(body, i, run); i += run; q = ""; qlen = 0
+            continue
+          }
+        } else if (c == q) {
+          entries[out] = entries[out] c; i++; q = ""; qlen = 0
+          continue
+        }
+        entries[out] = entries[out] c; i++
+      }
+      return out
+    }
+    function verdict(text,   body, count, i, entry, quote, close_at, j, c, run) {
       body = text
       sub(/^[^[]*\[/, "", body)
       sub(/\][^]]*$/, "", body)
-      count = split(body, entries, ",")
+      count = split_entries(body)
       for (i = 1; i <= count; i++) {
         entry = entries[i]
-        gsub(/^[ \t]+/, "", entry); gsub(/[ \t]+$/, "", entry)
+        # A line boundary around an entry is layout, exactly like a space: an array
+        # written one entry per line arrives with a marker on each side.
+        gsub("^[ \t" NLM "]+", "", entry); gsub("[ \t" NLM "]+$", "", entry)
         # TOML string values are quoted; an unquoted token is not an entry.
         quote = substr(entry, 1, 1)
         if (quote != SQ && quote != DQ) continue
@@ -380,15 +438,16 @@ config_facts_in() {
           # entry, so containerd had the verifier off and the node still reported OK.
           entry = substr(entry, 4)
           # TOML TRIMS a newline that comes immediately after the opening delimiter, and
-          # ONLY that one; a second newline is content. The array lines arrive joined by a
-          # single space each, so that first newline is exactly one leading space here --
-          # drop one, never a run. Dropping the run would make
+          # ONLY that one; a second newline is content. Trim exactly one LINE BOUNDARY --
+          # never a space. A space written on the same line is content, so
+          # """ id""" is the plugin " id" and our verifier stays ENABLED; trimming it
+          # reported a healthy node as disabled. Dropping a RUN would be wrong the
+          # other way: the real value of
           #   disabled_plugins = ["""
           #
           #   io.containerd.image-verifier.v1.bindir"""]
-          # compare equal to our id, when its real value begins with a newline and names a
-          # different plugin entirely.
-          if (substr(entry, 1, 1) == " ") entry = substr(entry, 2)
+          # begins with a newline and names a different plugin entirely.
+          if (substr(entry, 1, 1) == NLM) entry = substr(entry, 2)
           close_at = 0
           j = 1
           while (j <= length(entry)) {
@@ -398,6 +457,13 @@ config_facts_in() {
             j++
           }
           if (close_at == 0) continue
+          # The delimiter is the LAST three quotes of the run, not the first three:
+          # TOML reads the leading one or two as content, so """id"""" is the plugin
+          # id" -- a DIFFERENT plugin, and our verifier stays enabled. Closing at the
+          # first three compared the bare id and failed a healthy node.
+          run = 0
+          while (substr(entry, close_at + run, 1) == quote) run++
+          if (run > 3) close_at = close_at + run - 3
           entry = substr(entry, 1, close_at - 1)
           # Basic strings interpret escapes; literal ones keep the text verbatim, so
           # decoding a literal would alias a DIFFERENT plugin id onto ours.
@@ -436,13 +502,15 @@ config_facts_in() {
     # value that happens to start with a bracket cannot be mistaken for a table.
     in_array {
       line = strip_comment($0)
-      # Joined with a SPACE, deliberately. A real newline CANNOT be used: this awk
-      # (BWK, macOS) splits on a newline in split() whatever separator is given --
-      # measured: split("x<NL>y,z", a, ",") returns THREE fields -- so an embedded
-      # newline would tear one entry into several, and would behave differently again
-      # under the gawk/mawk that runs in CI. TOML newline semantics are recovered in
-      # verdict() from the single joining space instead.
-      buf = buf " " line
+      # awk splits records on a newline ALONE, so under CRLF every line keeps a
+      # trailing CR. TOML removes a CRLF line ending exactly as it removes an LF
+      # (measured with go-toml, both at the opening delimiter and at a backslash
+      # continuation), so a surviving CR made the value compare unequal to our
+      # plugin id and the script printed disabled=0 -- a node reporting OK with the
+      # verifier switched off. Drop the line ending here and represent the boundary
+      # itself, once, below.
+      sub(/\r$/, "", line)
+      buf = buf NLM line
       if (closes_array(line)) { in_array = 0; verdict(buf) }
       next
     }
@@ -503,26 +571,32 @@ config_facts_in() {
     # a false alarm on the one signal meant to mean enforcement is off. Literal
     # strings never reach this function, which is what keeps the triple-literal form
     # a DIFFERENT plugin id, exactly as containerd reads it.
-    function decode_basic(s, multiline,   out, i, n, c, d, code) {
+    function decode_basic(s, multiline,   out, i, n, c, d, code, j) {
       n = length(s); out = ""; i = 1
       while (i <= n) {
         c = substr(s, i, 1)
         if (c != "\\") { out = out c; i++; continue }
         d = substr(s, i + 1, 1)
-        # A backslash immediately before a physical newline removes that newline AND
-        # every leading whitespace character of the next line. The array arrives with
-        # its physical lines joined by ONE space, so the newline is that space here:
-        # consume the backslash and the whole whitespace run that follows it.
+        # A backslash that is the last non-whitespace character on a line removes the
+        # line ending AND all whitespace up to the next non-whitespace character. So
+        # the run consumed here must CONTAIN a line boundary: a backslash-space with no
+        # boundary after it is not a continuation at all (it is invalid TOML, which
+        # containerd would refuse to load), and treating it as one would decode a
+        # malformed value onto our plugin id and fail a node whose verifier is ENABLED.
         #
-        # Without this the buffered value kept a literal backslash-space, compared
-        # unequal to our identifier, and the script printed disabled=0 -- reporting OK
-        # while containerd had the verifier switched off. Reached only when the
-        # backslash is genuinely unescaped: a preceding \\ is consumed as a pair by
-        # the branch below before this one is ever tested.
-        if (multiline && (d == " " || d == "\t")) {
-          i += 2
-          while (i <= n && (substr(s, i, 1) == " " || substr(s, i, 1) == "\t")) i++
-          continue
+        # Without the rule the buffered value kept a literal backslash, compared unequal
+        # to our identifier, and the script printed disabled=0 -- reporting OK while
+        # containerd had the verifier switched off. Reached only when the backslash is
+        # genuinely unescaped: a preceding \\ is consumed as a pair by the branch below
+        # before this one is ever tested.
+        if (multiline && (d == " " || d == "\t" || d == NLM)) {
+          j = i + 1
+          while (j <= n && (substr(s, j, 1) == " " || substr(s, j, 1) == "\t")) j++
+          if (substr(s, j, 1) == NLM) {
+            i = j
+            while (i <= n && (substr(s, i, 1) == " " || substr(s, i, 1) == "\t" || substr(s, i, 1) == NLM)) i++
+            continue
+          }
         }
         if (d == "n")       { out = out "\n"; i += 2 }
         else if (d == "t")  { out = out "\t"; i += 2 }
@@ -580,6 +654,7 @@ config_facts_in() {
         # Fresh state per array, so a malformed earlier one cannot leak an open string.
         reset_scan_state()
         buf = strip_comment(substr($0, KEYPOS))
+        sub(/\r$/, "", buf)
         if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
         next
       }
@@ -827,6 +902,13 @@ convergence_attempts="${IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS:-3}"
 case "${convergence_attempts}" in
   '' | *[!0-9]*) fail_infra "IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS must be a positive integer, got '${convergence_attempts}'" ;;
 esac
+# Digits alone are not enough. Bash arithmetic applies BASE-PREFIX rules to a
+# leading zero, so a documented, digit-only override is silently misread:
+# measured, `[[ 08 -ge 1 ]]` errors with "value too great for base" and rejects a
+# positive integer outright, while 010 evaluates to EIGHT and quietly runs a
+# different number of convergence attempts than the operator asked for. `10#`
+# pins base 10; the empty value that would make it a syntax error is already out.
+convergence_attempts="$((10#${convergence_attempts}))"
 [[ "${convergence_attempts}" -ge 1 ]] ||
   fail_infra 'IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS must be at least 1'
 

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -348,20 +348,51 @@ config_facts_in() {
       }
       next
     }
-    # TOML treats a bare key and a quoted key as the SAME key, so
-    # "disabled_plugins" and the bare form name one setting. A bare-key-only
-    # match never reaches verdict() on the quoted spellings, leaving disabled = 0
-    # while containerd has the verifier switched OFF -- a node reporting OK with
-    # no enforcement, the same fail-open class as the quoted ] above. So
-    # NORMALISE the key before comparing, exactly as the table header rule below
-    # already does, rather than enumerating spellings in the pattern.
-    toplevel && match($0, /^[ \t]*[^=]*=/) {
-      key = substr($0, RSTART, RLENGTH - 1)
-      gsub(/[ \t]/, "", key)
-      gsub(SQ, "", key)
-      gsub(DQ, "", key)
-      if (key == "disabled_plugins") {
-        buf = strip_comment(substr($0, RSTART + RLENGTH))
+    # TOML treats a bare key and a quoted key as the SAME key only when they spell
+    # the SAME characters, so disabled_plugins and its quoted forms name one
+    # setting. A bare-key-only match never reaches verdict() on the quoted
+    # spellings, leaving disabled = 0 while containerd has the verifier switched
+    # OFF -- a node reporting OK with no enforcement.
+    #
+    # NORMALISING by deleting whitespace and quotes went too far the other way: it
+    # ALIASED DISTINCT keys onto ours. A key spelled with an interior space inside
+    # quotes is a different setting that containerd never reads, and deleting that
+    # space failed a node whose verifier was enabled -- a false alarm on the one
+    # signal meant to mean enforcement is off. So parse exactly ONE key and strip
+    # only its outer delimiters, preserving every character between them.
+    #
+    # Returns "" when the line is not a simple assignment -- including a DOTTED
+    # key, which names a setting inside a table rather than the root one. Sets
+    # KEYPOS to the index just past the =, so the caller never has to search for
+    # it and cannot be misled by an = inside the key text.
+    function root_key(s,   i, n, c, q, out) {
+      KEYPOS = 0
+      n = length(s)
+      i = 1
+      while (i <= n && (substr(s, i, 1) == " " || substr(s, i, 1) == "\t")) i++
+      c = substr(s, i, 1)
+      if (c == SQ || c == DQ) {
+        q = c; i++; out = ""
+        while (i <= n && substr(s, i, 1) != q) { out = out substr(s, i, 1); i++ }
+        if (i > n) return ""
+        i++
+      } else {
+        out = ""
+        while (i <= n) {
+          c = substr(s, i, 1)
+          if (c !~ /[A-Za-z0-9_-]/) break
+          out = out c; i++
+        }
+        if (out == "") return ""
+      }
+      while (i <= n && (substr(s, i, 1) == " " || substr(s, i, 1) == "\t")) i++
+      if (substr(s, i, 1) != "=") return ""
+      KEYPOS = i + 1
+      return out
+    }
+    toplevel {
+      if (root_key($0) == "disabled_plugins") {
+        buf = strip_comment(substr($0, KEYPOS))
         if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
         next
       }

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -123,15 +123,20 @@ discover_nodes() {
     jq -r '
       [.items[] | {
         name: (.metadata.name // "<unnamed node>"),
+        uid: ((.metadata.uid // "") | tostring),
         ips: [(.status.addresses // [])[]
               | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
               | .address]
       }] as $nodes
       | ($nodes | map(select(.ips | length != 1))
           | map("\(.name) (has \(.ips | length) InternalIP addresses, expected 1)")),
+        ($nodes | map(select(.uid == "" ))
+          | map("\(.name) (has no metadata.uid)")),
         ($nodes | map(select(.ips | length == 1))
           | group_by(.ips[0]) | map(select(length > 1))
-          | map("\(map(.name) | join(" and ")) share InternalIP \(.[0].ips[0])"))
+          | map("\(map(.name) | join(" and ")) share InternalIP \(.[0].ips[0])")),
+        ($nodes | map(select(.uid != "")) | group_by(.uid) | map(select(length > 1))
+          | map("\(map(.name) | join(" and ")) share UID \(.[0].uid)"))
       | .[]
     ' 2>/dev/null)" ||
     fail_infra 'could not parse node addresses from kubectl output'
@@ -139,12 +144,19 @@ discover_nodes() {
     fail_infra "unusable node inventory — refusing to report a fleet that was only partly enumerated: $(printf '%s' "${bad_nodes}" | tr '\n' ';' | sed 's/;$//')"
   fi
 
+  # Emitted as UID and address together. An address alone cannot tell a node
+  # apart from its own replacement: the autoscaler can retire a machine and
+  # bring up a new one that reuses the address, and comparing addresses would
+  # call that pair identical -- so a machine that was never inspected would be
+  # reported as one that passed. The UID is what makes "the same node" mean the
+  # same node.
   printf '%s' "${json}" |
     jq -r '
       .items[]
+      | . as $node
       | (.status.addresses // [])[]
       | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
-      | .address
+      | "\(($node.metadata.uid // "") | tostring)\t\(.address)"
     ' 2>/dev/null ||
     fail_infra 'could not parse node addresses from kubectl output'
 }
@@ -234,6 +246,58 @@ extract_bin_dir_from() {
   '
 }
 
+# Reports 'disabled' when this config file switches the image-verifier plugin
+# OFF, and nothing otherwise.
+#
+# A bin_dir that is configured, exists and holds an executable proves nothing if
+# containerd never loads the plugin that runs it. `disabled_plugins` is the
+# cheap half of that question: it lives in the SAME file the bin_dir came from,
+# so reading it costs nothing extra and closes the case where the configuration
+# looks complete and no verifier handles a single pull -- the same silent
+# enforcement failure this script exists to detect, one layer up. (Whether a
+# plugin that is NOT disabled actually loaded and stayed healthy needs a live
+# plugin-status query or a behavioural probe; that is #3101's job.)
+#
+# Scoped to TOP-LEVEL keys. `disabled_plugins` is a root key in containerd's
+# config, and TOML puts root keys before the first table header -- so once a
+# '[' header is seen, any later match belongs to some other table and must not
+# count. An unscoped match would let an unrelated key disable the check.
+#
+# Only the marker is ever printed. The array is assembled in awk and searched
+# there; the config itself never reaches a variable or an error message, because
+# /etc/cri/conf.d/cri.toml carries registry credentials and this output goes to
+# CI logs. See the SECURITY note at the top.
+plugin_disabled_in() {
+  local node="$1" file="$2"
+  "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
+    BEGIN {
+      SQ = sprintf("%c", 39); DQ = sprintf("%c", 34)
+      toplevel = 1; in_array = 0; buf = ""
+    }
+    function verdict(text,   probe) {
+      probe = text
+      gsub(SQ, "", probe); gsub(DQ, "", probe); gsub(/[ \t]/, "", probe)
+      if (index(probe, "io.containerd.image-verifier.v1.bindir") > 0) {
+        print "disabled"
+        exit
+      }
+    }
+    # A continuation of the array is consumed before the header rule below, so a
+    # value that happens to start with a bracket cannot be mistaken for a table.
+    in_array {
+      buf = buf $0
+      if (index($0, "]") > 0) { in_array = 0; verdict(buf) }
+      next
+    }
+    /^[ \t]*\[/ { toplevel = 0 }
+    !toplevel { next }
+    match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
+      buf = substr($0, RSTART + RLENGTH)
+      if (index(buf, "]") > 0) { verdict(buf) } else { in_array = 1 }
+    }
+  '
+}
+
 # Counts executable entries, skipping the directory's own '.' entry. MODE is
 # always column 2; NAME is always last. The LABEL column is empty for some files
 # on this cluster, so positional parsing from the left past column 2 is unsafe.
@@ -296,12 +360,12 @@ else
   # and if those nodes happen to be healthy the script exits 0 having silently
   # dropped the rest of the fleet. jq emitting a valid address and then failing
   # on a malformed one is exactly that case.
-  discovered_nodes="$(discover_nodes)" ||
+  discovered_identities="$(discover_nodes)" ||
     fail_infra 'node discovery failed — refusing to report a fleet that was only partly enumerated'
-  while IFS= read -r discovered; do
+  while IFS=$'\t' read -r _discovered_uid discovered; do
     [[ -n "${discovered}" ]] || continue
     nodes+=("${discovered}")
-  done <<<"${discovered_nodes}"
+  done <<<"${discovered_identities}"
 fi
 
 [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
@@ -310,6 +374,20 @@ fi
 # can enforce, 1 when it cannot.
 check_config() {
   local node="$1" file="$2" bin_dir status=0 executables exec_status=0
+
+  # Asked FIRST: a disabled plugin makes the rest of this verdict irrelevant.
+  # bin_dir could be configured, present and full of executables and containerd
+  # would still run none of them, so reporting on the directory before checking
+  # whether the plugin is switched on would describe a path that is not taken.
+  local disabled disabled_status=0
+  disabled="$(plugin_disabled_in "${node}" "${file}")" || disabled_status=$?
+  [[ "${disabled_status}" -eq 0 ]] ||
+    fail_infra "could not read ${file} on ${node} (the file exists but talosctl read failed)"
+  if [[ "${disabled}" == 'disabled' ]]; then
+    printf 'FAIL %s [%s]: the io.containerd.image-verifier.v1.bindir plugin is in disabled_plugins — containerd loads no verifier, so it permits every pull whatever bin_dir says\n' \
+      "${node}" "${file}"
+    return 1
+  fi
 
   bin_dir="$(extract_bin_dir_from "${node}" "${file}")" || status=$?
   # The file's existence was proven before this call, so a read failure here is
@@ -353,49 +431,113 @@ check_config() {
   return 0
 }
 
-failures=0
-for node in "${nodes[@]}"; do
-  # Every containerd instance present on the node is evaluated INDEPENDENTLY.
-  # Accepting the first config that declares a bin_dir would let a wired-up CRI
-  # containerd mask an unprotected system containerd (or the reverse) — and the
-  # two pull different images: CRI pulls workload images, the system instance
-  # pulls Talos' own. A verifier on one leaves the other open, which is the
-  # whole point of checking both.
-  configs_present=0
-  node_failures=0
-  for config_file in "${config_files[@]}"; do
-    case "$(path_probe "${node}" "${config_file}")" in
-      present) ;;
-      absent)
-        # A confirmed not-found normally proves the node answered — but the same
-        # phrase can come from a client-side fault (a missing talosconfig, say),
-        # which would otherwise read as "this node does not ship that config".
-        # The reachability probe is what tells those two apart.
-        node_reachable "${node}" ||
-          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
-        continue
-        ;;
-      *)
-        # Both "the node is gone" and "the node answered but this one probe
-        # failed" arrive here, and they deserve different diagnoses: the first
-        # is a fleet-wide fault, the second is specific to one containerd.
-        # Neither is a verdict, so both stop the run either way.
-        node_reachable "${node}" ||
-          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
-        fail_infra "could not determine whether ${config_file} exists on ${node} (talosctl ls failed for a reason other than the file being absent) — refusing to report a node whose containerd was never inspected"
-        ;;
-    esac
-    configs_present=$((configs_present + 1))
-    check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
-  done
+# One full sweep of the fleet currently in `nodes`. Kept as a function so the
+# discovery path can run it again on a changed inventory; it is deliberately NOT
+# invoked in a command substitution, because `fail_infra` inside one would exit
+# only the subshell and let a fleet that was never checked report a verdict --
+# the same trap the discovery path documents above.
+run_check_pass() {
+  failures=0
+  for node in "${nodes[@]}"; do
+    # Every containerd instance present on the node is evaluated INDEPENDENTLY.
+    # Accepting the first config that declares a bin_dir would let a wired-up CRI
+    # containerd mask an unprotected system containerd (or the reverse) — and the
+    # two pull different images: CRI pulls workload images, the system instance
+    # pulls Talos' own. A verifier on one leaves the other open, which is the
+    # whole point of checking both.
+    configs_present=0
+    node_failures=0
+    for config_file in "${config_files[@]}"; do
+      case "$(path_probe "${node}" "${config_file}")" in
+        present) ;;
+        absent)
+          # A confirmed not-found normally proves the node answered — but the same
+          # phrase can come from a client-side fault (a missing talosconfig, say),
+          # which would otherwise read as "this node does not ship that config".
+          # The reachability probe is what tells those two apart.
+          node_reachable "${node}" ||
+            fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+          continue
+          ;;
+        *)
+          # Both "the node is gone" and "the node answered but this one probe
+          # failed" arrive here, and they deserve different diagnoses: the first
+          # is a fleet-wide fault, the second is specific to one containerd.
+          # Neither is a verdict, so both stop the run either way.
+          node_reachable "${node}" ||
+            fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+          fail_infra "could not determine whether ${config_file} exists on ${node} (talosctl ls failed for a reason other than the file being absent) — refusing to report a node whose containerd was never inspected"
+          ;;
+      esac
+      configs_present=$((configs_present + 1))
+      check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
+    done
 
-  # No containerd configuration at all is not a clean node — it means this check
+    # No containerd configuration at all is not a clean node — it means this check
   # looked at nothing and would otherwise pass the node by default.
-  [[ "${configs_present}" -gt 0 ]] ||
-    fail_infra "no containerd configuration found on ${node} (looked in ${config_files[*]})"
+    [[ "${configs_present}" -gt 0 ]] ||
+      fail_infra "no containerd configuration found on ${node} (looked in ${config_files[*]})"
 
-  [[ "${node_failures}" -eq 0 ]] || failures=$((failures + 1))
-done
+    [[ "${node_failures}" -eq 0 ]] || failures=$((failures + 1))
+  done
+}
+
+# Rebuilds `nodes` from a UID/address identity list.
+nodes_from_identities() {
+  nodes=()
+  while IFS=$'\t' read -r _uid identity_address; do
+    [[ -n "${identity_address}" ]] || continue
+    nodes+=("${identity_address}")
+  done <<<"$1"
+}
+
+# The inventory is a snapshot taken BEFORE a serial pass, and Cluster Autoscaler
+# can add or replace workers while that pass runs. A node that joins mid-run --
+# or a replacement reusing a retired address -- would then go completely
+# uninspected while every node in the stale snapshot reported healthy: a green
+# verdict for a fleet that was never fully enumerated, which is the same
+# fail-open shape this script exists to detect.
+#
+# So the discovery path re-reads the inventory AFTER the checks and only reports
+# when the fleet it just checked is still the fleet that exists. A change is
+# ordinary autoscaling rather than a fault, so it costs a re-run, not a failure;
+# only an inventory that will not settle within the bound is an error, which
+# keeps a continuously-scaling cluster from either flapping or looping forever.
+# `sync_talos_registry_auth` in scripts/refresh-flux-ghcr-auth.sh converges the
+# same way and for the same reason.
+#
+# An explicitly requested fleet is NOT re-read: the caller named those nodes, so
+# a cluster changing under them does not change what was asked for.
+convergence_attempts="${IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS:-3}"
+case "${convergence_attempts}" in
+  '' | *[!0-9]*) fail_infra "IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS must be a positive integer, got '${convergence_attempts}'" ;;
+esac
+[[ "${convergence_attempts}" -ge 1 ]] ||
+  fail_infra 'IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS must be at least 1'
+
+if [[ "${nodes_requested}" -eq 1 ]]; then
+  run_check_pass
+else
+  attempt=0
+  while :; do
+    attempt=$((attempt + 1))
+    run_check_pass
+
+    inventory_after="$(discover_nodes)" ||
+      fail_infra 'could not re-read the node inventory after the checks — refusing to report a fleet that may have changed underneath the pass'
+
+    [[ "${inventory_after}" != "${discovered_identities}" ]] || break
+
+    [[ "${attempt}" -lt "${convergence_attempts}" ]] ||
+      fail_infra "the node inventory changed during each of ${convergence_attempts} attempt(s) — refusing to report a fleet that never held still long enough to be checked"
+
+    printf '\nThe node set changed while it was being checked (a node joined, left, or was replaced). Re-running over the current fleet — attempt %s of %s.\n' \
+      "$((attempt + 1))" "${convergence_attempts}"
+    discovered_identities="${inventory_after}"
+    nodes_from_identities "${discovered_identities}"
+    [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check after the inventory changed'
+  done
+fi
 
 if [[ "${failures}" -gt 0 ]]; then
   printf '\n%s of %s node(s) cannot enforce image verification.\n' "${failures}" "${#nodes[@]}" >&2

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -282,11 +282,33 @@ plugin_disabled_in() {
     # read failure -- so a genuinely disabled node on a large config would be
     # reported as an infrastructure error instead of the FAIL it is. Consume to
     # EOF and print from END. (extract_bin_dir_from documents the same hazard.)
-    function verdict(text,   probe) {
-      probe = text
-      gsub(SQ, "", probe); gsub(DQ, "", probe); gsub(/[ \t]/, "", probe)
-      if (index(probe, "io.containerd.image-verifier.v1.bindir") > 0) {
-        disabled = 1
+    function verdict(text,   body, count, i, entry, quote, close_at) {
+      # Compare ENTRIES, never the raw array text. A substring test over the
+      # whole expression reports a node as disabled while the plugin is enabled:
+      # a DIFFERENT plugin whose name merely contains ours
+      # (example.io.containerd.image-verifier.v1.bindir-extra) matches, and so
+      # does our name sitting in a trailing TOML comment. Either way a healthy
+      # node fails -- a false alarm on the one signal that is meant to mean
+      # enforcement is off.
+      #
+      # No apostrophes in these comments: the whole program is a single-quoted
+      # shell string, so one would end it. And close_at, not close, because awk
+      # already has a close() builtin.
+      body = text
+      sub(/^[^[]*\[/, "", body)
+      sub(/\][^]]*$/, "", body)
+      count = split(body, entries, ",")
+      for (i = 1; i <= count; i++) {
+        entry = entries[i]
+        gsub(/^[ \t]+/, "", entry); gsub(/[ \t]+$/, "", entry)
+        # TOML string values are quoted; an unquoted token is not an entry.
+        quote = substr(entry, 1, 1)
+        if (quote != SQ && quote != DQ) continue
+        entry = substr(entry, 2)
+        close_at = index(entry, quote)
+        if (close_at == 0) continue
+        entry = substr(entry, 1, close_at - 1)
+        if (entry == "io.containerd.image-verifier.v1.bindir") disabled = 1
       }
     }
     END { if (disabled) print "disabled" }

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -474,7 +474,7 @@ run_check_pass() {
     done
 
     # No containerd configuration at all is not a clean node — it means this check
-  # looked at nothing and would otherwise pass the node by default.
+    # looked at nothing and would otherwise pass the node by default.
     [[ "${configs_present}" -gt 0 ]] ||
       fail_infra "no containerd configuration found on ${node} (looked in ${config_files[*]})"
 

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -348,10 +348,23 @@ config_facts_in() {
       }
       next
     }
-    toplevel && match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
-      buf = strip_comment(substr($0, RSTART + RLENGTH))
-      if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
-      next
+    # TOML treats a bare key and a quoted key as the SAME key, so
+    # "disabled_plugins" and the bare form name one setting. A bare-key-only
+    # match never reaches verdict() on the quoted spellings, leaving disabled = 0
+    # while containerd has the verifier switched OFF -- a node reporting OK with
+    # no enforcement, the same fail-open class as the quoted ] above. So
+    # NORMALISE the key before comparing, exactly as the table header rule below
+    # already does, rather than enumerating spellings in the pattern.
+    toplevel && match($0, /^[ \t]*[^=]*=/) {
+      key = substr($0, RSTART, RLENGTH - 1)
+      gsub(/[ \t]/, "", key)
+      gsub(SQ, "", key)
+      gsub(DQ, "", key)
+      if (key == "disabled_plugins") {
+        buf = strip_comment(substr($0, RSTART + RLENGTH))
+        if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
+        next
+      }
     }
     !found && want && match($0, /^[ \t]*bin_dir[ \t]*=/) {
       value = substr($0, RSTART + RLENGTH)

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -44,7 +44,9 @@ exists, and holds at least one executable.
 Nodes are discovered from the cluster when --nodes/TALOS_NODES is not given, so
 autoscaled nodes are covered without anyone maintaining a list.
 
-Environment overrides: TALOSCTL, KUBECTL, TALOS_NODES, CONTAINERD_CONFIG_FILES
+Environment overrides: TALOSCTL, KUBECTL, TALOS_NODES, CONTAINERD_CONFIG_FILES,
+IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS (default 3; how many times discovery re-reads
+a node inventory that changed while the fleet was being checked, before giving up)
 Exit: 0 every node can enforce; 1 at least one cannot; 2 usage/infrastructure error.
 USAGE
   exit 2
@@ -272,18 +274,25 @@ plugin_disabled_in() {
   "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
     BEGIN {
       SQ = sprintf("%c", 39); DQ = sprintf("%c", 34)
-      toplevel = 1; in_array = 0; buf = ""
+      toplevel = 1; in_array = 0; buf = ""; disabled = 0
     }
+    # Records the verdict rather than printing and exiting on it. Exiting here
+    # would close the pipe while `talosctl read` is still writing, and under
+    # `set -o pipefail` the resulting SIGPIPE is indistinguishable from a real
+    # read failure -- so a genuinely disabled node on a large config would be
+    # reported as an infrastructure error instead of the FAIL it is. Consume to
+    # EOF and print from END. (extract_bin_dir_from documents the same hazard.)
     function verdict(text,   probe) {
       probe = text
       gsub(SQ, "", probe); gsub(DQ, "", probe); gsub(/[ \t]/, "", probe)
       if (index(probe, "io.containerd.image-verifier.v1.bindir") > 0) {
-        print "disabled"
-        exit
+        disabled = 1
       }
     }
+    END { if (disabled) print "disabled" }
     # A continuation of the array is consumed before the header rule below, so a
     # value that happens to start with a bracket cannot be mistaken for a table.
+    disabled { next }
     in_array {
       buf = buf $0
       if (index($0, "]") > 0) { in_array = 0; verdict(buf) }
@@ -526,7 +535,12 @@ else
     inventory_after="$(discover_nodes)" ||
       fail_infra 'could not re-read the node inventory after the checks — refusing to report a fleet that may have changed underneath the pass'
 
-    [[ "${inventory_after}" != "${discovered_identities}" ]] || break
+    # Compare the identity SET, not the stream. `kubectl get nodes` gives no
+    # ordering guarantee, so a plain string compare would call a re-ordered but
+    # otherwise identical fleet "changed", re-run the whole pass, and can burn
+    # the attempt bound into an exit 2 for a cluster that never moved.
+    [[ "$(printf '%s\n' "${inventory_after}" | LC_ALL=C sort)" \
+      != "$(printf '%s\n' "${discovered_identities}" | LC_ALL=C sort)" ]] || break
 
     [[ "${attempt}" -lt "${convergence_attempts}" ]] ||
       fail_infra "the node inventory changed during each of ${convergence_attempts} attempt(s) — refusing to report a fleet that never held still long enough to be checked"

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -301,8 +301,13 @@ config_facts_in() {
     function reset_scan_state() {
       sc_instr = 0; sc_q = ""; sc_qlen = 1
       ca_instr = 0; ca_q = ""; ca_qlen = 1
+      # The ARRAY path owns the lines from here to the closing bracket and carries its
+      # own quote state, so the top-level tracker must let go. Its opener was counted
+      # on this same line one rule earlier; leaving it set would swallow every line
+      # after the array -- including the verifier table -- as string content.
+      ml_open = ""
     }
-    function strip_comment(line,   out, i, c, n) {
+    function strip_comment(line,   out, i, c, n, sc_run) {
       n = length(line); out = ""
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
@@ -311,7 +316,15 @@ config_facts_in() {
             # Multiline BASIC strings take escapes too, so an escaped quote does not
             # begin the closing triple.
             if (c == "\\" && sc_q == DQ) { out = out c; i++; out = out substr(line, i, 1); continue }
-            if (substr(line, i, 3) == sc_q sc_q sc_q) { out = out sc_q sc_q sc_q; i += 2; sc_instr = 0; continue }
+            # Consume the WHOLE run. TOML reads the leading one or two quotes of a
+            # four- or five-quote run as CONTENT and the last three as the delimiter, so
+            # stopping at the first three leaves a stray quote that re-opens a string --
+            # and everything after it, including a real table header, is read as content.
+            if (substr(line, i, 3) == sc_q sc_q sc_q) {
+              sc_run = 0
+              while (substr(line, i + sc_run, 1) == sc_q) sc_run++
+              out = out substr(line, i, sc_run); i += sc_run - 1; sc_instr = 0; continue
+            }
             out = out c
             continue
           }
@@ -337,14 +350,23 @@ config_facts_in() {
     # leaving disabled = 0 and a verdict of OK while containerd had the verifier
     # switched off. That is the fail-open this script exists to prevent, so the
     # terminator is found with the same quote-aware scan strip_comment uses.
-    function closes_array(line,   i, c, n) {
+    function closes_array(line,   i, c, n, ca_run) {
       n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
         if (ca_instr) {
           if (ca_qlen == 3) {
             if (c == "\\" && ca_q == DQ) { i++; continue }
-            if (substr(line, i, 3) == ca_q ca_q ca_q) { i += 2; ca_instr = 0 }
+            # Same whole-run rule as strip_comment above. Closing at the first three left
+            # the fourth quote re-opening a string, so the array never terminated and the
+            # verifier own table -- which TOML permits directly after, with no explicit
+            # [plugins] parent -- was swallowed as string content. Its populated bin_dir
+            # was then never seen and a HEALTHY node failed the gate.
+            if (substr(line, i, 3) == ca_q ca_q ca_q) {
+              ca_run = 0
+              while (substr(line, i + ca_run, 1) == ca_q) ca_run++
+              i += ca_run - 1; ca_instr = 0
+            }
             continue
           }
           if (c == "\\" && ca_q == DQ) { i++; continue }
@@ -513,6 +535,48 @@ config_facts_in() {
       buf = buf NLM line
       if (closes_array(line)) { in_array = 0; verdict(buf) }
       next
+    }
+    # A MULTILINE STRING SPANS PHYSICAL LINES, and its content is not TOML syntax.
+    # The header rule below fires on any line starting with [ and clears root scope
+    # PERMANENTLY, so a line of string content beginning with [ ended root scope and
+    # the real disabled_plugins underneath it was never examined -- disabled stayed 0
+    # while the verifier table still supplied a populated bin_dir, and the script
+    # reported OK with containerd having the plugin switched off. A fail-open.
+    #
+    # Runs after the array rule, so array continuation lines are consumed there and
+    # never reach this tracker; they carry their own state.
+    function ml_track(line,   i, n, c, run) {
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (ml_open != "") {
+          if (c == "\\" && ml_open == DQ) { i++; continue }
+          if (substr(line, i, 3) == ml_open ml_open ml_open) {
+            run = 0
+            while (substr(line, i + run, 1) == ml_open) run++
+            i += run - 1
+            ml_open = ""
+          }
+          continue
+        }
+        # Outside a string a # opens a comment, so nothing after it is syntax.
+        if (c == "#") return
+        if (c == SQ || c == DQ) {
+          if (substr(line, i, 3) == c c c) { ml_open = c; i += 2; continue }
+          # A SINGLE-line string cannot span lines, so it only has to be skipped
+          # over here -- leaving it open would swallow the rest of the file.
+          i++
+          while (i <= n) {
+            if (substr(line, i, 1) == "\\" && c == DQ) { i += 2; continue }
+            if (substr(line, i, 1) == c) break
+            i++
+          }
+        }
+      }
+    }
+    {
+      if (ml_open != "") { ml_track($0); next }
+      ml_track($0)
     }
     /^[ \t]*\[/ {
       toplevel = 0

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -203,6 +203,40 @@ node_reachable() {
   "${talosctl_bin}" -n "$1" ls / >/dev/null 2>&1
 }
 
+# Whether the address this pass is checking has LEFT the fleet. Cluster Autoscaler
+# removes a worker mid-pass during an ordinary scale-down or replacement, and that
+# node then answers nothing -- which is indistinguishable from an infrastructure
+# fault until the inventory is re-read. Only the discovery path may re-read: an
+# explicitly requested fleet is what the caller ASKED for, so a cluster changing
+# under it does not change the question, and a requested node that stops answering
+# stays a fault.
+#
+# Keyed on the ADDRESS, not the uid/address identity: a replacement reusing a
+# retired address leaves the address present, so this reports "still here" and the
+# run fails infra rather than retrying. That is the conservative direction -- it can
+# only WITHHOLD a retry, never grant one for a node that is genuinely down.
+#
+# A re-read that itself fails reports "still here" for the same reason: `discover_nodes`
+# runs `fail_infra` in this command substitution's subshell, so the failure surfaces
+# as a non-zero status here rather than exiting, and an unreadable inventory must not
+# be what excuses an unreachable node.
+node_departed() {
+  local address="$1" fresh
+  [[ "${nodes_requested}" -eq 0 ]] || return 1
+  fresh="$(discover_nodes)" || return 1
+  ! printf '%s\n' "${fresh}" | cut -f2 | grep -qxF -- "${address}"
+}
+
+# A reachability failure is a fault only if the node is still in the fleet. Returns
+# 3 -- distinct from both success and the fail_infra exit -- when the node departed,
+# so the discovery loop can treat it as the ordinary node-set change it is.
+require_reachable_or_departed() {
+  local node="$1"
+  node_reachable "${node}" && return 0
+  node_departed "${node}" && return 3
+  fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+}
+
 # Emits TWO facts about ONE config file, from ONE read:
 #
 #   disabled=0|1   whether that file switches the image-verifier plugin OFF
@@ -872,8 +906,12 @@ check_config() {
     # "The directory is not there" and "the node stopped answering" are the same
     # failed `ls` from here. Only the first is a verdict; reporting the second as
     # one would blame the cluster for a runner-side fault.
-    node_reachable "${node}" ||
+    node_reachable "${node}" || {
+      # A node the autoscaler removed mid-pass is not a fault. 3 travels out through
+      # `check_config`'s caller, which must not fold it into an ordinary FAIL verdict.
+      node_departed "${node}" && return 3
       fail_infra "cannot reach node ${node} while checking ${bin_dir} (talosctl ls / failed)"
+    }
     printf 'FAIL %s [%s]: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
       "${node}" "${file}" "${bin_dir}"
     return 1
@@ -883,8 +921,12 @@ check_config() {
   # substitution, so its status is carried out explicitly — the same subshell
   # trap that made partial node discovery pass silently.
   executables="$(count_executables "${node}" "${bin_dir}")" || exec_status=$?
-  [[ "${exec_status}" -eq 0 ]] ||
+  if [[ "${exec_status}" -ne 0 ]]; then
+    # Same class as the probe above: the directory was there a moment ago, so a
+    # failure here is either a real fault or a node that has since left the fleet.
+    node_departed "${node}" && return 3
     fail_infra "could not list ${bin_dir} on ${node} (the directory exists but talosctl ls failed)"
+  fi
 
   if [[ "${executables}" -eq 0 ]]; then
     printf 'FAIL %s [%s]: bin_dir %s holds no executable — containerd permits every pull\n' \
@@ -921,8 +963,7 @@ run_check_pass() {
           # phrase can come from a client-side fault (a missing talosconfig, say),
           # which would otherwise read as "this node does not ship that config".
           # The reachability probe is what tells those two apart.
-          node_reachable "${node}" ||
-            fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+          require_reachable_or_departed "${node}" || return 3
           continue
           ;;
         *)
@@ -930,13 +971,17 @@ run_check_pass() {
           # failed" arrive here, and they deserve different diagnoses: the first
           # is a fleet-wide fault, the second is specific to one containerd.
           # Neither is a verdict, so both stop the run either way.
-          node_reachable "${node}" ||
-            fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+          require_reachable_or_departed "${node}" || return 3
           fail_infra "could not determine whether ${config_file} exists on ${node} (talosctl ls failed for a reason other than the file being absent) — refusing to report a node whose containerd was never inspected"
           ;;
       esac
       configs_present=$((configs_present + 1))
-      check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
+      # 3 is the departure sentinel, never a verdict about this node: folding it into
+      # `node_failures` would report a node that LEFT as one that cannot enforce.
+      config_status=0
+      check_config "${node}" "${config_file}" || config_status=$?
+      [[ "${config_status}" -ne 3 ]] || return 3
+      [[ "${config_status}" -eq 0 ]] || node_failures=$((node_failures + 1))
     done
 
     # No containerd configuration at all is not a clean node — it means this check
@@ -989,12 +1034,26 @@ convergence_attempts="$((10#${convergence_attempts}))"
   fail_infra 'IMAGE_VERIFIER_CONVERGENCE_ATTEMPTS must be at least 1'
 
 if [[ "${nodes_requested}" -eq 1 ]]; then
-  run_check_pass
+  # No convergence here by design, and the departure sentinel cannot arise: `node_departed`
+  # refuses outright unless this is the discovery path. Handled explicitly anyway so that a
+  # 3 arriving by some future route exits as the fault it is rather than falling through as
+  # a pass -- `set -e` would exit 3 undiagnosed, which reads as neither.
+  pass_status=0
+  run_check_pass || pass_status=$?
+  [[ "${pass_status}" -eq 0 ]] ||
+    fail_infra 'the check pass over an explicitly requested fleet did not complete — refusing to report nodes that were not checked'
 else
   attempt=0
   while :; do
     attempt=$((attempt + 1))
-    run_check_pass
+    # 3 means a node this pass was checking LEFT the fleet mid-pass. That is the same
+    # ordinary node-set change the post-pass comparison below exists for, just observed
+    # earlier -- the pass cannot finish, so it costs a re-run under the SAME bound rather
+    # than the infrastructure failure an unreachable node would otherwise be. Without this
+    # the independently-concurrent liveness workflow fails during a normal scale-down.
+    pass_status=0
+    run_check_pass || pass_status=$?
+    [[ "${pass_status}" -eq 0 || "${pass_status}" -eq 3 ]] || exit "${pass_status}"
 
     inventory_after="$(discover_nodes)" ||
       fail_infra 'could not re-read the node inventory after the checks — refusing to report a fleet that may have changed underneath the pass'
@@ -1003,7 +1062,12 @@ else
     # ordering guarantee, so a plain string compare would call a re-ordered but
     # otherwise identical fleet "changed", re-run the whole pass, and can burn
     # the attempt bound into an exit 2 for a cluster that never moved.
-    [[ "$(printf '%s\n' "${inventory_after}" | LC_ALL=C sort)" != "$(printf '%s\n' "${discovered_identities}" | LC_ALL=C sort)" ]] || break
+    # Only a COMPLETED pass may end the loop. After a departure the fleet can already
+    # look identical again -- the node left before the pre-pass read is re-compared -- and
+    # breaking there would report a verdict for a pass that stopped halfway.
+    if [[ "${pass_status}" -eq 0 ]]; then
+      [[ "$(printf '%s\n' "${inventory_after}" | LC_ALL=C sort)" != "$(printf '%s\n' "${discovered_identities}" | LC_ALL=C sort)" ]] || break
+    fi
 
     [[ "${attempt}" -lt "${convergence_attempts}" ]] ||
       fail_infra "the node inventory changed during each of ${convergence_attempts} attempt(s) — refusing to report a fleet that never held still long enough to be checked"

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -446,7 +446,8 @@ check_config() {
     disabled=*$'\n'bin_dir=*) ;;
     *) fail_infra "could not parse ${file} on ${node} (the read completed but produced no verdict)" ;;
   esac
-  disabled="${facts%%$'\n'*}"; disabled="${disabled#disabled=}"
+  disabled="${facts%%$'\n'*}"
+  disabled="${disabled#disabled=}"
   bin_dir="${facts#*$'\n'bin_dir=}"
 
   # Asked FIRST: a disabled plugin makes the rest of this verdict irrelevant.

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -311,7 +311,7 @@ config_facts_in() {
     # No apostrophes in these comments: the whole program is a single-quoted
     # shell string, so one would end it. And close_at, not close, because awk
     # already has a close() builtin.
-    function verdict(text,   body, count, i, entry, quote, close_at) {
+    function verdict(text,   body, count, i, entry, quote, close_at, j, c) {
       body = text
       sub(/^[^[]*\[/, "", body)
       sub(/\][^]]*$/, "", body)
@@ -323,9 +323,29 @@ config_facts_in() {
         quote = substr(entry, 1, 1)
         if (quote != SQ && quote != DQ) continue
         entry = substr(entry, 2)
-        close_at = index(entry, quote)
-        if (close_at == 0) continue
-        entry = substr(entry, 1, close_at - 1)
+        if (quote == DQ) {
+          # A BASIC entry escapes its closing quote, so a plain index() stops early and
+          # compares a TRUNCATED value; and its escapes must be decoded before comparing,
+          # exactly as for the key above. Our plugin id written with an escape IS our
+          # plugin, and containerd switches the verifier off -- comparing the raw text
+          # missed it and the node reported OK with no enforcement.
+          close_at = 0
+          j = 1
+          while (j <= length(entry)) {
+            c = substr(entry, j, 1)
+            if (c == "\\") { j += 2; continue }
+            if (c == quote) { close_at = j; break }
+            j++
+          }
+          if (close_at == 0) continue
+          entry = decode_basic(substr(entry, 1, close_at - 1))
+        } else {
+          # LITERAL entries interpret nothing, so the same text here is a DIFFERENT
+          # plugin id containerd never matches. Decoding it would alias it onto ours.
+          close_at = index(entry, quote)
+          if (close_at == 0) continue
+          entry = substr(entry, 1, close_at - 1)
+        }
         if (entry == "io.containerd.image-verifier.v1.bindir") disabled = 1
       }
     }

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -401,7 +401,7 @@ config_facts_in() {
           entry = substr(entry, 1, close_at - 1)
           # Basic strings interpret escapes; literal ones keep the text verbatim, so
           # decoding a literal would alias a DIFFERENT plugin id onto ours.
-          if (quote == DQ) entry = decode_basic(entry)
+          if (quote == DQ) entry = decode_basic(entry, 1)
           if (entry == "io.containerd.image-verifier.v1.bindir") disabled = 1
           continue
         }
@@ -421,7 +421,7 @@ config_facts_in() {
             j++
           }
           if (close_at == 0) continue
-          entry = decode_basic(substr(entry, 1, close_at - 1))
+          entry = decode_basic(substr(entry, 1, close_at - 1), 0)
         } else {
           # LITERAL entries interpret nothing, so the same text here is a DIFFERENT
           # plugin id containerd never matches. Decoding it would alias it onto ours.
@@ -496,12 +496,34 @@ config_facts_in() {
       }
       return v
     }
-    function decode_basic(s,   out, i, n, c, d, code) {
+    # `multiline` is 1 only for a TRIPLE-quoted basic string. The line-continuation
+    # rule below exists only there: in a single-line basic string a backslash before
+    # whitespace is not valid TOML at all, so applying it everywhere would decode a
+    # malformed value into our plugin id and fail a node whose verifier is ENABLED --
+    # a false alarm on the one signal meant to mean enforcement is off. Literal
+    # strings never reach this function, which is what keeps the triple-literal form
+    # a DIFFERENT plugin id, exactly as containerd reads it.
+    function decode_basic(s, multiline,   out, i, n, c, d, code) {
       n = length(s); out = ""; i = 1
       while (i <= n) {
         c = substr(s, i, 1)
         if (c != "\\") { out = out c; i++; continue }
         d = substr(s, i + 1, 1)
+        # A backslash immediately before a physical newline removes that newline AND
+        # every leading whitespace character of the next line. The array arrives with
+        # its physical lines joined by ONE space, so the newline is that space here:
+        # consume the backslash and the whole whitespace run that follows it.
+        #
+        # Without this the buffered value kept a literal backslash-space, compared
+        # unequal to our identifier, and the script printed disabled=0 -- reporting OK
+        # while containerd had the verifier switched off. Reached only when the
+        # backslash is genuinely unescaped: a preceding \\ is consumed as a pair by
+        # the branch below before this one is ever tested.
+        if (multiline && (d == " " || d == "\t")) {
+          i += 2
+          while (i <= n && (substr(s, i, 1) == " " || substr(s, i, 1) == "\t")) i++
+          continue
+        }
         if (d == "n")       { out = out "\n"; i += 2 }
         else if (d == "t")  { out = out "\t"; i += 2 }
         else if (d == "r")  { out = out "\r"; i += 2 }
@@ -538,7 +560,7 @@ config_facts_in() {
         }
         if (i > n) return ""
         i++
-        if (q == DQ) out = decode_basic(out)
+        if (q == DQ) out = decode_basic(out, 0)
       } else {
         out = ""
         while (i <= n) {

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -274,32 +274,51 @@ config_facts_in() {
       if (substr(line, i, 3) == c c c) return 3
       return 1
     }
-    function strip_comment(line,   out, i, c, n, instr, q, qlen) {
-      n = length(line); out = ""; instr = 0; q = ""; qlen = 1
+    # QUOTE STATE IS CARRIED ACROSS PHYSICAL LINES, in globals rather than locals. A
+    # multiline string may legitimately span lines -- TOML trims a newline that comes
+    # straight after the opener, so
+    #
+    #   disabled_plugins = ["""
+    #   io.containerd.image-verifier.v1.bindir"""]
+    #
+    # names our plugin exactly. Restarting the walk on each line read the closing
+    # delimiter on the second line as a fresh OPENER, and the entry compared as
+    # something that is not our id -- reporting OK with the verifier off.
+    #
+    # Only a TRIPLE delimiter carries: a single-line string left unterminated at the
+    # end of a line is invalid TOML, and carrying it would swallow the rest of the
+    # array on a typo. So the state is dropped unless it is a multiline one.
+    function reset_scan_state() {
+      sc_instr = 0; sc_q = ""; sc_qlen = 1
+      ca_instr = 0; ca_q = ""; ca_qlen = 1
+    }
+    function strip_comment(line,   out, i, c, n) {
+      n = length(line); out = ""
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
-        if (instr) {
-          if (qlen == 3) {
+        if (sc_instr) {
+          if (sc_qlen == 3) {
             # Multiline BASIC strings take escapes too, so an escaped quote does not
             # begin the closing triple.
-            if (c == "\\" && q == DQ) { out = out c; i++; out = out substr(line, i, 1); continue }
-            if (substr(line, i, 3) == q q q) { out = out q q q; i += 2; instr = 0; continue }
+            if (c == "\\" && sc_q == DQ) { out = out c; i++; out = out substr(line, i, 1); continue }
+            if (substr(line, i, 3) == sc_q sc_q sc_q) { out = out sc_q sc_q sc_q; i += 2; sc_instr = 0; continue }
             out = out c
             continue
           }
           out = out c
           # Basic strings take backslash escapes; literal ones do not.
-          if (c == "\\" && q == DQ) { i++; out = out substr(line, i, 1); continue }
-          if (c == q) instr = 0
+          if (c == "\\" && sc_q == DQ) { i++; out = out substr(line, i, 1); continue }
+          if (c == sc_q) sc_instr = 0
           continue
         }
         if (c == "#") break
         if (c == SQ || c == DQ) {
-          instr = 1; q = c; qlen = delim_len(line, i, c)
-          if (qlen == 3) { out = out c c c; i += 2; continue }
+          sc_instr = 1; sc_q = c; sc_qlen = delim_len(line, i, c)
+          if (sc_qlen == 3) { out = out c c c; i += 2; continue }
         }
         out = out c
       }
+      if (sc_instr && sc_qlen != 3) sc_instr = 0
       return out
     }
     # A ] INSIDE a quoted TOML string is not the array terminator. index() cannot
@@ -308,27 +327,28 @@ config_facts_in() {
     # leaving disabled = 0 and a verdict of OK while containerd had the verifier
     # switched off. That is the fail-open this script exists to prevent, so the
     # terminator is found with the same quote-aware scan strip_comment uses.
-    function closes_array(line,   i, c, n, instr, q, qlen) {
-      n = length(line); instr = 0; q = ""; qlen = 1
+    function closes_array(line,   i, c, n) {
+      n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
-        if (instr) {
-          if (qlen == 3) {
-            if (c == "\\" && q == DQ) { i++; continue }
-            if (substr(line, i, 3) == q q q) { i += 2; instr = 0 }
+        if (ca_instr) {
+          if (ca_qlen == 3) {
+            if (c == "\\" && ca_q == DQ) { i++; continue }
+            if (substr(line, i, 3) == ca_q ca_q ca_q) { i += 2; ca_instr = 0 }
             continue
           }
-          if (c == "\\" && q == DQ) { i++; continue }
-          if (c == q) instr = 0
+          if (c == "\\" && ca_q == DQ) { i++; continue }
+          if (c == ca_q) ca_instr = 0
           continue
         }
         if (c == SQ || c == DQ) {
-          instr = 1; q = c; qlen = delim_len(line, i, c)
-          if (qlen == 3) i += 2
+          ca_instr = 1; ca_q = c; ca_qlen = delim_len(line, i, c)
+          if (ca_qlen == 3) i += 2
           continue
         }
         if (c == "]") return 1
       }
+      if (ca_instr && ca_qlen != 3) ca_instr = 0
       return 0
     }
     # Compare ENTRIES, never the raw array text. A substring test over the whole
@@ -359,6 +379,16 @@ config_facts_in() {
           # ONE quote closed the string on its second character and compared an EMPTY
           # entry, so containerd had the verifier off and the node still reported OK.
           entry = substr(entry, 4)
+          # TOML TRIMS a newline that comes immediately after the opening delimiter, and
+          # ONLY that one; a second newline is content. The array lines arrive joined by a
+          # single space each, so that first newline is exactly one leading space here --
+          # drop one, never a run. Dropping the run would make
+          #   disabled_plugins = ["""
+          #
+          #   io.containerd.image-verifier.v1.bindir"""]
+          # compare equal to our id, when its real value begins with a newline and names a
+          # different plugin entirely.
+          if (substr(entry, 1, 1) == " ") entry = substr(entry, 2)
           close_at = 0
           j = 1
           while (j <= length(entry)) {
@@ -406,6 +436,12 @@ config_facts_in() {
     # value that happens to start with a bracket cannot be mistaken for a table.
     in_array {
       line = strip_comment($0)
+      # Joined with a SPACE, deliberately. A real newline CANNOT be used: this awk
+      # (BWK, macOS) splits on a newline in split() whatever separator is given --
+      # measured: split("x<NL>y,z", a, ",") returns THREE fields -- so an embedded
+      # newline would tear one entry into several, and would behave differently again
+      # under the gawk/mawk that runs in CI. TOML newline semantics are recovered in
+      # verdict() from the single joining space instead.
       buf = buf " " line
       if (closes_array(line)) { in_array = 0; verdict(buf) }
       next
@@ -519,6 +555,8 @@ config_facts_in() {
     }
     toplevel {
       if (root_key($0) == "disabled_plugins") {
+        # Fresh state per array, so a malformed earlier one cannot leak an open string.
+        reset_scan_state()
         buf = strip_comment(substr($0, KEYPOS))
         if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
         next

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -282,6 +282,34 @@ plugin_disabled_in() {
     # read failure -- so a genuinely disabled node on a large config would be
     # reported as an infrastructure error instead of the FAIL it is. Consume to
     # EOF and print from END. (extract_bin_dir_from documents the same hazard.)
+    # Removes a TOML comment, respecting quoted strings: a # opens a comment only
+    # OUTSIDE a string. The lines of a multiline array are concatenated into one
+    # buffer below, so a comment left in place swallows what follows it -- the
+    # entry on the next line lands inside the comment text, fails the quote test
+    # in verdict(), and is skipped. The node then reads as ENABLED while
+    # containerd has the verifier DISABLED, which is the false OK this whole
+    # checker exists to prevent. A ] inside a comment would also end the array
+    # early, so stripping has to happen before that test too.
+    #
+    # One quote-aware walk answers both questions, rather than a growing list of
+    # comment spellings to special-case.
+    function strip_comment(line,   out, i, c, n, instr, q) {
+      n = length(line); out = ""; instr = 0; q = ""
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (instr) {
+          out = out c
+          # Basic strings take backslash escapes; literal ones do not.
+          if (c == "\\" && q == DQ) { i++; out = out substr(line, i, 1); continue }
+          if (c == q) instr = 0
+          continue
+        }
+        if (c == "#") break
+        if (c == SQ || c == DQ) { instr = 1; q = c }
+        out = out c
+      }
+      return out
+    }
     function verdict(text,   body, count, i, entry, quote, close_at) {
       # Compare ENTRIES, never the raw array text. A substring test over the
       # whole expression reports a node as disabled while the plugin is enabled:
@@ -316,14 +344,15 @@ plugin_disabled_in() {
     # value that happens to start with a bracket cannot be mistaken for a table.
     disabled { next }
     in_array {
-      buf = buf $0
-      if (index($0, "]") > 0) { in_array = 0; verdict(buf) }
+      line = strip_comment($0)
+      buf = buf " " line
+      if (index(line, "]") > 0) { in_array = 0; verdict(buf) }
       next
     }
     /^[ \t]*\[/ { toplevel = 0 }
     !toplevel { next }
     match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
-      buf = substr($0, RSTART + RLENGTH)
+      buf = strip_comment(substr($0, RSTART + RLENGTH))
       if (index(buf, "]") > 0) { verdict(buf) } else { in_array = 1 }
     }
   '

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -635,7 +635,7 @@ config_facts_in() {
     # a false alarm on the one signal meant to mean enforcement is off. Literal
     # strings never reach this function, which is what keeps the triple-literal form
     # a DIFFERENT plugin id, exactly as containerd reads it.
-    function decode_basic(s, multiline,   out, i, n, c, d, code, j) {
+    function decode_basic(s, multiline,   out, i, n, c, d, code, j, cp) {
       n = length(s); out = ""; i = 1
       while (i <= n) {
         c = substr(s, i, 1)
@@ -672,7 +672,19 @@ config_facts_in() {
         else if (d == "u" || d == "U") {
           code = (d == "u") ? substr(s, i + 2, 4) : substr(s, i + 2, 8)
           if (length(code) == ((d == "u") ? 4 : 8) && code ~ /^[0-9A-Fa-f]+$/) {
-            out = out sprintf("%c", hexval(code))
+            cp = hexval(code)
+            # `%c` IS BYTE-ORIENTED in several awks, so a code point above 255 is
+            # truncated modulo 256 and ALIASES onto an ASCII character. Measured on the
+            # awk shipped with this host: U+10069 emits the single byte 0x69, so a key
+            # written as a U+10069 escape followed by "o.containerd.image-verifier.v1.bindir"
+            # decoded to exactly the verifier ID, and a config that never names the
+            # verifier read as though it did. The same aliasing in the other direction
+            # reports a healthy node disabled. Every identifier this script compares
+            # against is pure ASCII, so a code point above 127 CANNOT be part of a
+            # matching key: emit it as a marker no ASCII key can contain, keeping the
+            # code point so two distinct characters never collapse into one.
+            if (cp <= 127) out = out sprintf("%c", cp)
+            else out = out sprintf("%c%X%c", 1, cp, 1)
             i += (d == "u") ? 6 : 10
           } else { out = out c; i++ }
         }

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -264,11 +264,29 @@ config_facts_in() {
     # comment spellings to special-case. A # INSIDE a quoted entry is content:
     # truncating there would drop every entry after it on the same line, which
     # is the same false OK pointing the other way.
-    function strip_comment(line,   out, i, c, n, instr, q) {
-      n = length(line); out = ""; instr = 0; q = ""
+    # A TOML MULTILINE string opens and closes with THREE quotes. Reading each quote
+    # as its own single-char delimiter toggles the string state on and straight back
+    # off across the opener, so the body is then scanned as if it were unquoted: a #
+    # inside it truncates the array and a ] inside it ends it, dropping every later
+    # entry -- ours among them -- and reporting OK while the verifier is off. Answers
+    # how many characters the delimiter at i occupies.
+    function delim_len(line, i, c) {
+      if (substr(line, i, 3) == c c c) return 3
+      return 1
+    }
+    function strip_comment(line,   out, i, c, n, instr, q, qlen) {
+      n = length(line); out = ""; instr = 0; q = ""; qlen = 1
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
         if (instr) {
+          if (qlen == 3) {
+            # Multiline BASIC strings take escapes too, so an escaped quote does not
+            # begin the closing triple.
+            if (c == "\\" && q == DQ) { out = out c; i++; out = out substr(line, i, 1); continue }
+            if (substr(line, i, 3) == q q q) { out = out q q q; i += 2; instr = 0; continue }
+            out = out c
+            continue
+          }
           out = out c
           # Basic strings take backslash escapes; literal ones do not.
           if (c == "\\" && q == DQ) { i++; out = out substr(line, i, 1); continue }
@@ -276,7 +294,10 @@ config_facts_in() {
           continue
         }
         if (c == "#") break
-        if (c == SQ || c == DQ) { instr = 1; q = c }
+        if (c == SQ || c == DQ) {
+          instr = 1; q = c; qlen = delim_len(line, i, c)
+          if (qlen == 3) { out = out c c c; i += 2; continue }
+        }
         out = out c
       }
       return out
@@ -287,16 +308,25 @@ config_facts_in() {
     # leaving disabled = 0 and a verdict of OK while containerd had the verifier
     # switched off. That is the fail-open this script exists to prevent, so the
     # terminator is found with the same quote-aware scan strip_comment uses.
-    function closes_array(line,   i, c, n, instr, q) {
-      n = length(line); instr = 0; q = ""
+    function closes_array(line,   i, c, n, instr, q, qlen) {
+      n = length(line); instr = 0; q = ""; qlen = 1
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
         if (instr) {
+          if (qlen == 3) {
+            if (c == "\\" && q == DQ) { i++; continue }
+            if (substr(line, i, 3) == q q q) { i += 2; instr = 0 }
+            continue
+          }
           if (c == "\\" && q == DQ) { i++; continue }
           if (c == q) instr = 0
           continue
         }
-        if (c == SQ || c == DQ) { instr = 1; q = c; continue }
+        if (c == SQ || c == DQ) {
+          instr = 1; q = c; qlen = delim_len(line, i, c)
+          if (qlen == 3) i += 2
+          continue
+        }
         if (c == "]") return 1
       }
       return 0
@@ -322,6 +352,29 @@ config_facts_in() {
         # TOML string values are quoted; an unquoted token is not an entry.
         quote = substr(entry, 1, 1)
         if (quote != SQ && quote != DQ) continue
+        if (substr(entry, 1, 3) == quote quote quote) {
+          # A MULTILINE entry resolves to exactly the characters of the single-line
+          # form -- measured against go-toml, which returns our identifier for
+          # """id""", the literal triple, and plain "id" alike. Reading the opener as
+          # ONE quote closed the string on its second character and compared an EMPTY
+          # entry, so containerd had the verifier off and the node still reported OK.
+          entry = substr(entry, 4)
+          close_at = 0
+          j = 1
+          while (j <= length(entry)) {
+            c = substr(entry, j, 1)
+            if (c == "\\" && quote == DQ) { j += 2; continue }
+            if (substr(entry, j, 3) == quote quote quote) { close_at = j; break }
+            j++
+          }
+          if (close_at == 0) continue
+          entry = substr(entry, 1, close_at - 1)
+          # Basic strings interpret escapes; literal ones keep the text verbatim, so
+          # decoding a literal would alias a DIFFERENT plugin id onto ours.
+          if (quote == DQ) entry = decode_basic(entry)
+          if (entry == "io.containerd.image-verifier.v1.bindir") disabled = 1
+          continue
+        }
         entry = substr(entry, 2)
         if (quote == DQ) {
           # A BASIC entry escapes its closing quote, so a plain index() stops early and

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -281,6 +281,26 @@ config_facts_in() {
       }
       return out
     }
+    # A ] INSIDE a quoted TOML string is not the array terminator. index() cannot
+    # tell the two apart, so an earlier entry carrying a literal bracket ended the
+    # array early and every later entry -- including ours -- was never examined,
+    # leaving disabled = 0 and a verdict of OK while containerd had the verifier
+    # switched off. That is the fail-open this script exists to prevent, so the
+    # terminator is found with the same quote-aware scan strip_comment uses.
+    function closes_array(line,   i, c, n, instr, q) {
+      n = length(line); instr = 0; q = ""
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (instr) {
+          if (c == "\\" && q == DQ) { i++; continue }
+          if (c == q) instr = 0
+          continue
+        }
+        if (c == SQ || c == DQ) { instr = 1; q = c; continue }
+        if (c == "]") return 1
+      }
+      return 0
+    }
     # Compare ENTRIES, never the raw array text. A substring test over the whole
     # expression reports a node as disabled while the plugin is enabled: a
     # DIFFERENT plugin whose name merely contains ours
@@ -314,7 +334,7 @@ config_facts_in() {
     in_array {
       line = strip_comment($0)
       buf = buf " " line
-      if (index(line, "]") > 0) { in_array = 0; verdict(buf) }
+      if (closes_array(line)) { in_array = 0; verdict(buf) }
       next
     }
     /^[ \t]*\[/ {
@@ -330,7 +350,7 @@ config_facts_in() {
     }
     toplevel && match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
       buf = strip_comment(substr($0, RSTART + RLENGTH))
-      if (index(buf, "]") > 0) { verdict(buf) } else { in_array = 1 }
+      if (closes_array(buf)) { verdict(buf) } else { in_array = 1 }
       next
     }
     !found && want && match($0, /^[ \t]*bin_dir[ \t]*=/) {

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -365,6 +365,52 @@ config_facts_in() {
     # key, which names a setting inside a table rather than the root one. Sets
     # KEYPOS to the index just past the =, so the caller never has to search for
     # it and cannot be misled by an = inside the key text.
+    # A TOML BASIC (double-quoted) string INTERPRETS escapes, so a key written as
+    # "disabled_plugins" IS disabled_plugins and containerd switches the verifier
+    # off. Comparing the raw text missed it and the node reported OK with no enforcement
+    # -- a FAIL-OPEN, the direction that matters for this check.
+    #
+    # LITERAL (single-quoted) strings interpret nothing: measured with go-toml, the same
+    # text in single quotes stays the DISTINCT key disabled_plugins. Decoding it too
+    # would alias a key containerd never reads back onto ours, which is the
+    # over-normalisation this parser was written to remove. So decoding is scoped to the
+    # double-quoted form only.
+    #
+    # The target is pure ASCII, so an escape decoding outside ASCII can never spell it;
+    # such a key simply does not match, which is the safe direction.
+    function hexval(h,   i, n, c, v, digits) {
+      digits = "0123456789abcdef"
+      v = 0; n = length(h)
+      for (i = 1; i <= n; i++) {
+        c = tolower(substr(h, i, 1))
+        v = v * 16 + (index(digits, c) - 1)
+      }
+      return v
+    }
+    function decode_basic(s,   out, i, n, c, d, code) {
+      n = length(s); out = ""; i = 1
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c != "\\") { out = out c; i++; continue }
+        d = substr(s, i + 1, 1)
+        if (d == "n")       { out = out "\n"; i += 2 }
+        else if (d == "t")  { out = out "\t"; i += 2 }
+        else if (d == "r")  { out = out "\r"; i += 2 }
+        else if (d == "f")  { out = out sprintf("%c", 12); i += 2 }
+        else if (d == "b")  { out = out sprintf("%c", 8); i += 2 }
+        else if (d == DQ)   { out = out DQ; i += 2 }
+        else if (d == "\\") { out = out "\\"; i += 2 }
+        else if (d == "u" || d == "U") {
+          code = (d == "u") ? substr(s, i + 2, 4) : substr(s, i + 2, 8)
+          if (length(code) == ((d == "u") ? 4 : 8) && code ~ /^[0-9A-Fa-f]+$/) {
+            out = out sprintf("%c", hexval(code))
+            i += (d == "u") ? 6 : 10
+          } else { out = out c; i++ }
+        }
+        else { out = out c; i++ }
+      }
+      return out
+    }
     function root_key(s,   i, n, c, q, out) {
       KEYPOS = 0
       n = length(s)
@@ -373,9 +419,17 @@ config_facts_in() {
       c = substr(s, i, 1)
       if (c == SQ || c == DQ) {
         q = c; i++; out = ""
-        while (i <= n && substr(s, i, 1) != q) { out = out substr(s, i, 1); i++ }
+        # In a BASIC string a backslash escapes the next character, so scanning to the
+        # next quote would stop early on an escaped one and read a truncated key.
+        while (i <= n) {
+          c = substr(s, i, 1)
+          if (c == q) break
+          if (q == DQ && c == "\\" && i < n) { out = out substr(s, i, 2); i += 2; continue }
+          out = out c; i++
+        }
         if (i > n) return ""
         i++
+        if (q == DQ) out = decode_basic(out)
       } else {
         out = ""
         while (i <= n) {

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -203,85 +203,54 @@ node_reachable() {
   "${talosctl_bin}" -n "$1" ls / >/dev/null 2>&1
 }
 
-# Emits the bin_dir declared by ONE config file's image-verifier plugin, or
-# nothing when that file declares none.
+# Emits TWO facts about ONE config file, from ONE read:
 #
-# Scoped to the `io.containerd.image-verifier.v1.bindir` table on purpose.
-# `bin_dir` is a generic key name, and an unscoped match accepts one from an
-# unrelated plugin's table — reporting a node as enforcing on the strength of a
-# setting containerd never consults for image verification.
+#   disabled=0|1   whether that file switches the image-verifier plugin OFF
+#   bin_dir=<path> the bin_dir its image-verifier table declares, empty if none
 #
-# The config is piped straight into awk and only the extracted value is ever
-# printed. `/etc/cri/conf.d/cri.toml` carries registry credentials and this
-# script's output goes to CI logs, so the file must never be captured — not into
-# a variable, not into a temp file, not into an error message. See the SECURITY
-# note at the top.
+# ONE read, deliberately. These were two functions doing a `talosctl read` each,
+# and the pair could straddle a config change: the on-demand fleet workflow uses
+# a different concurrency group from deployments, so it can overlap a Talos or
+# containerd update. The first read could then see the OLD enabled config while
+# the second saw the REPLACEMENT populated bin_dir -- and a replacement that
+# disables the plugin without removing its binaries would be reported OK from
+# two snapshots that never coexisted. The node UID does not change, so the
+# convergence loop never retries it. Two facts about one configuration have to
+# come from one view of that configuration.
+#
+# Scoping, both halves:
+#  * `bin_dir` is scoped to the `io.containerd.image-verifier.v1.bindir` table.
+#    It is a generic key name, and an unscoped match accepts one from an
+#    unrelated plugin's table -- reporting a node as enforcing on the strength
+#    of a setting containerd never consults for image verification.
+#  * `disabled_plugins` is scoped to TOP-LEVEL keys. It is a root key, and TOML
+#    puts root keys before the first table header, so once a `[` header is seen
+#    any later match belongs to some other table and must not count. An
+#    unscoped match would let an unrelated key disable the check.
+#
+# The two never contend: root keys precede the first header, table keys follow
+# it, so `toplevel` is still 1 for one and already 0 for the other.
+#
+# The config is piped straight into awk and only the two extracted values are
+# ever printed. `/etc/cri/conf.d/cri.toml` carries registry credentials and this
+# script's output goes to CI logs, so the file must never be captured -- not
+# into a variable, not into a temp file, not into an error message. See the
+# SECURITY note at the top. Merging the reads keeps that property: a single
+# `talosctl read` still goes straight into awk and never reaches the shell.
 #
 # awk rather than sed because the table scoping needs state across lines, and
 # because awk consumes all input: a `sed ... | head -n 1` pipeline closes the
 # pipe early, and under `pipefail` the resulting SIGPIPE is indistinguishable
-# from a genuine read failure.
-extract_bin_dir_from() {
-  local node="$1" file="$2"
-  "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
-    BEGIN { SQ = sprintf("%c", 39); DQ = sprintf("%c", 34); want = 0; found = 0 }
-    found { next }
-    /^[ \t]*\[/ {
-      header = $0
-      gsub(/[ \t]/, "", header)
-      gsub(SQ, "", header)
-      gsub(DQ, "", header)
-      want = (header == "[plugins.io.containerd.image-verifier.v1.bindir]")
-      next
-    }
-    want && match($0, /^[ \t]*bin_dir[ \t]*=/) {
-      value = substr($0, RSTART + RLENGTH)
-      sub(/^[ \t]*/, "", value)
-      quote = substr(value, 1, 1)
-      if (quote != SQ && quote != DQ) next
-      value = substr(value, 2)
-      end = index(value, quote)
-      if (end == 0) next
-      print substr(value, 1, end - 1)
-      found = 1
-    }
-  '
-}
-
-# Reports 'disabled' when this config file switches the image-verifier plugin
-# OFF, and nothing otherwise.
-#
-# A bin_dir that is configured, exists and holds an executable proves nothing if
-# containerd never loads the plugin that runs it. `disabled_plugins` is the
-# cheap half of that question: it lives in the SAME file the bin_dir came from,
-# so reading it costs nothing extra and closes the case where the configuration
-# looks complete and no verifier handles a single pull -- the same silent
-# enforcement failure this script exists to detect, one layer up. (Whether a
-# plugin that is NOT disabled actually loaded and stayed healthy needs a live
-# plugin-status query or a behavioural probe; that is #3101's job.)
-#
-# Scoped to TOP-LEVEL keys. `disabled_plugins` is a root key in containerd's
-# config, and TOML puts root keys before the first table header -- so once a
-# '[' header is seen, any later match belongs to some other table and must not
-# count. An unscoped match would let an unrelated key disable the check.
-#
-# Only the marker is ever printed. The array is assembled in awk and searched
-# there; the config itself never reaches a variable or an error message, because
-# /etc/cri/conf.d/cri.toml carries registry credentials and this output goes to
-# CI logs. See the SECURITY note at the top.
-plugin_disabled_in() {
+# from a genuine read failure. For the same reason the verdicts are recorded and
+# printed from END rather than printed and exited on.
+config_facts_in() {
   local node="$1" file="$2"
   "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
     BEGIN {
       SQ = sprintf("%c", 39); DQ = sprintf("%c", 34)
       toplevel = 1; in_array = 0; buf = ""; disabled = 0
+      want = 0; found = 0; bin_dir = ""
     }
-    # Records the verdict rather than printing and exiting on it. Exiting here
-    # would close the pipe while `talosctl read` is still writing, and under
-    # `set -o pipefail` the resulting SIGPIPE is indistinguishable from a real
-    # read failure -- so a genuinely disabled node on a large config would be
-    # reported as an infrastructure error instead of the FAIL it is. Consume to
-    # EOF and print from END. (extract_bin_dir_from documents the same hazard.)
     # Removes a TOML comment, respecting quoted strings: a # opens a comment only
     # OUTSIDE a string. The lines of a multiline array are concatenated into one
     # buffer below, so a comment left in place swallows what follows it -- the
@@ -292,7 +261,9 @@ plugin_disabled_in() {
     # early, so stripping has to happen before that test too.
     #
     # One quote-aware walk answers both questions, rather than a growing list of
-    # comment spellings to special-case.
+    # comment spellings to special-case. A # INSIDE a quoted entry is content:
+    # truncating there would drop every entry after it on the same line, which
+    # is the same false OK pointing the other way.
     function strip_comment(line,   out, i, c, n, instr, q) {
       n = length(line); out = ""; instr = 0; q = ""
       for (i = 1; i <= n; i++) {
@@ -310,18 +281,17 @@ plugin_disabled_in() {
       }
       return out
     }
+    # Compare ENTRIES, never the raw array text. A substring test over the whole
+    # expression reports a node as disabled while the plugin is enabled: a
+    # DIFFERENT plugin whose name merely contains ours
+    # (example.io.containerd.image-verifier.v1.bindir-extra) matches. Either way
+    # a healthy node fails -- a false alarm on the one signal that is meant to
+    # mean enforcement is off.
+    #
+    # No apostrophes in these comments: the whole program is a single-quoted
+    # shell string, so one would end it. And close_at, not close, because awk
+    # already has a close() builtin.
     function verdict(text,   body, count, i, entry, quote, close_at) {
-      # Compare ENTRIES, never the raw array text. A substring test over the
-      # whole expression reports a node as disabled while the plugin is enabled:
-      # a DIFFERENT plugin whose name merely contains ours
-      # (example.io.containerd.image-verifier.v1.bindir-extra) matches, and so
-      # does our name sitting in a trailing TOML comment. Either way a healthy
-      # node fails -- a false alarm on the one signal that is meant to mean
-      # enforcement is off.
-      #
-      # No apostrophes in these comments: the whole program is a single-quoted
-      # shell string, so one would end it. And close_at, not close, because awk
-      # already has a close() builtin.
       body = text
       sub(/^[^[]*\[/, "", body)
       sub(/\][^]]*$/, "", body)
@@ -339,21 +309,46 @@ plugin_disabled_in() {
         if (entry == "io.containerd.image-verifier.v1.bindir") disabled = 1
       }
     }
-    END { if (disabled) print "disabled" }
     # A continuation of the array is consumed before the header rule below, so a
     # value that happens to start with a bracket cannot be mistaken for a table.
-    disabled { next }
     in_array {
       line = strip_comment($0)
       buf = buf " " line
       if (index(line, "]") > 0) { in_array = 0; verdict(buf) }
       next
     }
-    /^[ \t]*\[/ { toplevel = 0 }
-    !toplevel { next }
-    match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
+    /^[ \t]*\[/ {
+      toplevel = 0
+      if (!found) {
+        header = $0
+        gsub(/[ \t]/, "", header)
+        gsub(SQ, "", header)
+        gsub(DQ, "", header)
+        want = (header == "[plugins.io.containerd.image-verifier.v1.bindir]")
+      }
+      next
+    }
+    toplevel && match($0, /^[ \t]*disabled_plugins[ \t]*=/) {
       buf = strip_comment(substr($0, RSTART + RLENGTH))
       if (index(buf, "]") > 0) { verdict(buf) } else { in_array = 1 }
+      next
+    }
+    !found && want && match($0, /^[ \t]*bin_dir[ \t]*=/) {
+      value = substr($0, RSTART + RLENGTH)
+      sub(/^[ \t]*/, "", value)
+      quote = substr(value, 1, 1)
+      if (quote != SQ && quote != DQ) next
+      value = substr(value, 2)
+      end = index(value, quote)
+      if (end == 0) next
+      bin_dir = substr(value, 1, end - 1)
+      found = 1
+    }
+    # bin_dir LAST, so a value carrying anything unexpected cannot be mistaken
+    # for the disabled marker.
+    END {
+      print "disabled=" (disabled ? 1 : 0)
+      print "bin_dir=" bin_dir
     }
   '
 }
@@ -435,26 +430,34 @@ fi
 check_config() {
   local node="$1" file="$2" bin_dir status=0 executables exec_status=0
 
-  # Asked FIRST: a disabled plugin makes the rest of this verdict irrelevant.
-  # bin_dir could be configured, present and full of executables and containerd
-  # would still run none of them, so reporting on the directory before checking
-  # whether the plugin is switched on would describe a path that is not taken.
-  local disabled disabled_status=0
-  disabled="$(plugin_disabled_in "${node}" "${file}")" || disabled_status=$?
-  [[ "${disabled_status}" -eq 0 ]] ||
-    fail_infra "could not read ${file} on ${node} (the file exists but talosctl read failed)"
-  if [[ "${disabled}" == 'disabled' ]]; then
-    printf 'FAIL %s [%s]: the io.containerd.image-verifier.v1.bindir plugin is in disabled_plugins — containerd loads no verifier, so it permits every pull whatever bin_dir says\n' \
-      "${node}" "${file}"
-    return 1
-  fi
-
-  bin_dir="$(extract_bin_dir_from "${node}" "${file}")" || status=$?
+  # ONE read for both facts. Reading twice let the two verdicts describe two
+  # different configurations -- see config_facts_in.
+  local facts disabled=0
+  facts="$(config_facts_in "${node}" "${file}")" || status=$?
   # The file's existence was proven before this call, so a read failure here is
   # an infrastructure fault, never a verdict. Reporting it as "cannot enforce"
   # would be a misdiagnosis; swallowing it would be a fail-open.
   [[ "${status}" -eq 0 ]] ||
     fail_infra "could not read ${file} on ${node} (the file exists but talosctl read failed)"
+
+  # A truncated read is not a verdict either. awk always prints both markers, so
+  # their absence means the pipeline did not complete.
+  case "${facts}" in
+    disabled=*$'\n'bin_dir=*) ;;
+    *) fail_infra "could not parse ${file} on ${node} (the read completed but produced no verdict)" ;;
+  esac
+  disabled="${facts%%$'\n'*}"; disabled="${disabled#disabled=}"
+  bin_dir="${facts#*$'\n'bin_dir=}"
+
+  # Asked FIRST: a disabled plugin makes the rest of this verdict irrelevant.
+  # bin_dir could be configured, present and full of executables and containerd
+  # would still run none of them, so reporting on the directory before checking
+  # whether the plugin is switched on would describe a path that is not taken.
+  if [[ "${disabled}" == '1' ]]; then
+    printf 'FAIL %s [%s]: the io.containerd.image-verifier.v1.bindir plugin is in disabled_plugins — containerd loads no verifier, so it permits every pull whatever bin_dir says\n' \
+      "${node}" "${file}"
+    return 1
+  fi
 
   if [[ -z "${bin_dir}" ]]; then
     printf 'FAIL %s [%s]: no bin_dir in the io.containerd.image-verifier.v1.bindir table — the plugin has no directory to run, so containerd permits every pull\n' \

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -539,8 +539,7 @@ else
     # ordering guarantee, so a plain string compare would call a re-ordered but
     # otherwise identical fleet "changed", re-run the whole pass, and can burn
     # the attempt bound into an exit 2 for a cluster that never moved.
-    [[ "$(printf '%s\n' "${inventory_after}" | LC_ALL=C sort)" \
-      != "$(printf '%s\n' "${discovered_identities}" | LC_ALL=C sort)" ]] || break
+    [[ "$(printf '%s\n' "${inventory_after}" | LC_ALL=C sort)" != "$(printf '%s\n' "${discovered_identities}" | LC_ALL=C sort)" ]] || break
 
     [[ "${attempt}" -lt "${convergence_attempts}" ]] ||
       fail_infra "the node inventory changed during each of ${convergence_attempts} attempt(s) — refusing to report a fleet that never held still long enough to be checked"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The check that tells us our clusters can actually enforce image verification could report `OK` for
things it had not checked. Three separate ways, each of which looks exactly like a healthy result:

- A node could have the verifier **switched off** — the plugin listed as disabled — while its
  directory of verifier binaries was configured, present and full. The check looked at the directory
  and never asked whether containerd loads the plugin that runs it.
- The list of nodes was read **once, before** a run that walks them one at a time. A worker the
  autoscaler adds partway through was never looked at, and the run still reported every node in the
  older list as healthy.
- Nodes were identified by **address alone**. When the autoscaler retires a machine and the
  replacement takes over its address, those read as the same node — so a machine nobody inspected was
  reported as one that passed.

All three are the same failure this check exists to catch: a green verdict over something that was
never verified.

### What

The node now fails if the verifier plugin is disabled, and says which setting to look at. Node
discovery re-reads the fleet after the checks and runs again if it changed, bounded so a cluster
that is continuously scaling neither flaps nor loops forever. Nodes are identified by their unique
ID together with their address, and a node without one is refused rather than guessed at.

Each of the three is covered by a test that fails when its fix is removed.

Fixes #3108
