### PR TITLE
fix(observability): restore Crossplane condition metrics

### DIFF
--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kube-state-metrics
-          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1@sha256:85108987d044b18a098126732f98602df408888c0f7d456241f5abefb9744bc1
           imagePullPolicy: IfNotPresent
           args:
             - --custom-resource-state-config-file=/etc/kube-state-metrics/custom-resource-state.yaml

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -597,10 +597,15 @@ require_line \
   "${deployment}" \
   'serviceAccountName: crossplane-sync-exporter' \
   'the exporter must use its dedicated service account'
-require_text \
+# kube-state-metrics <=2.18 can drop every custom-resource family when several
+# GVKs intentionally share this metric's HELP header (upstream #2453 / #2866).
+# v2.19.1 is the first stable release carrying the index-preserving header fix;
+# pin its multi-architecture manifest exactly so the silent-series regression
+# cannot return through a tag move or a downgrade.
+require_line \
   "${deployment}" \
-  'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:' \
-  'the kube-state-metrics image must be immutable'
+  'image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1@sha256:85108987d044b18a098126732f98602df408888c0f7d456241f5abefb9744bc1' \
+  'the custom-resource exporter must use the first stable kube-state-metrics release with duplicate-header alignment fixed'
 require_text \
   "${deployment}" \
   'ghcr.io/coroot/prometheus:2.55.1-ubi9-0@sha256:' \


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production evaluation after #3318 proved that kube-state-metrics v2.17.0 still serves HTTP 200 with an empty metrics body even though all 16 managed GVK stores register and list successfully. The alerter now executes, but correctly reports `scrape healthy but no condition series`.

This matches kubernetes/kube-state-metrics#2453 and its fix kubernetes/kube-state-metrics#2866: duplicate HELP headers were removed without preserving metric-family indexes, so repeated custom-resource families could disappear. The fix first shipped in stable v2.19.1.

## What changed

- upgrade only the dedicated Crossplane exporter from kube-state-metrics v2.17.0 to v2.19.1
- pin the official multi-architecture manifest digest
- turn the version floor and digest into an exact contract assertion so the silent regression cannot return through a downgrade or tag move

## Verification

- RED: focused exporter contract rejected the v2.17.0 deployment
- GREEN: `bash scripts/tests/test-crossplane-sync-exporter.sh`
- `ksail workload validate`
- `ksail --config ksail.prod.yaml workload validate`
- `kubectl kustomize k8s/clusters/local/`
- `kubectl kustomize k8s/clusters/prod/`
- `bash -n scripts/tests/test-crossplane-sync-exporter.sh`
- `shellcheck scripts/tests/test-crossplane-sync-exporter.sh`

The current production failure was reproduced directly at the exporter loopback endpoint and through the scheduled alerter. The merge-group deployment is the first safe runtime evaluation of the new image; #3052 stays open until production serves non-empty `crossplane_managed_resource_condition` series and a post-deploy alerter Job reports the exporter healthy.

Part of #3052.