### PR TITLE
fix(deploy): release the sync lease on a same-holder race instead of wedging the queue

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -3887,7 +3887,7 @@ acquire_sync_lease() {
   done
 
   failure_detail="$(head -c 1000 "${sync_lease_result_file}" | tr '\r\n' '  ')"
-  failure_detail="${failure_detail//'%'/'%25'}"
+  failure_detail="${failure_detail//%/%25}"
   if [[ -n "${failure_detail}" ]]; then
     echo "::error::Could not atomically acquire the GHCR synchronization lease. Last API error: ${failure_detail}"
   else
@@ -4243,7 +4243,7 @@ release_sync_lease() {
   local lease_file="${work_dir}/sync-lease-release.json"
   local patch_file_local="${work_dir}/sync-lease-release-patch.json"
   local result_file="${work_dir}/sync-lease-release-result.txt"
-  local now attempt observed_holder release_failure=""
+  local now attempt observed_holder release_failure="" failure_detail=""
 
   if [[ -n "${sync_lease_heartbeat_pid}" ]]; then
     kill "${sync_lease_heartbeat_pid}" 2>/dev/null || true
@@ -4268,12 +4268,13 @@ release_sync_lease() {
   # read and the command they paste.)
   for ((attempt = 1; attempt <= SYNC_LEASE_RELEASE_ATTEMPTS; attempt++)); do
     # Retrying an API failure in the same millisecond re-asks a server that has
-    # not had time to recover, so all three attempts land inside one blip and the
-    # retry adds nothing. A short linear backoff makes the later attempts sample
-    # a genuinely different moment. Bounded at 1s + 2s: this runs in cleanup,
-    # where the lease is already released on the happy path.
+    # not had time to recover, so every attempt lands inside one blip and the
+    # retry adds nothing. A linear backoff makes the later attempts sample a
+    # genuinely different moment. It scales SYNC_INTERVAL rather than hard-coding
+    # seconds, so this stays the same tunable knob every other retry loop here
+    # uses -- which also keeps the suite fast, since the tests set it to 0.
     if ((attempt > 1)); then
-      sleep "$((attempt - 1))"
+      sleep "$(((attempt - 1) * SYNC_INTERVAL))"
     fi
     if ! kubectl \
       --context "${KUBE_CONTEXT}" \
@@ -4286,14 +4287,18 @@ release_sync_lease() {
       continue
     fi
 
-    # --ignore-not-found prints nothing when the Lease is gone. Nothing is held,
-    # so there is nothing left for this transaction to hand back.
+    # --ignore-not-found prints nothing when the Lease is gone. That is NOT a
+    # quiet success: acquire_sync_lease CREATES the Lease when it is absent, so
+    # a concurrent transaction that found it deleted has already acquired it
+    # without ever conflicting with us. That is the same thing the foreign-holder
+    # branch below exists to surface -- this run can no longer prove it held the
+    # lease while it was mutating -- so it is reported on the same terms. Nothing
+    # is left held, so failing here wedges nothing.
     if [[ ! -s "${lease_file}" ]]; then
-      sync_lease_holder=""
-      sync_lease_acquired=false
-      return 0
+      echo "::error::The GHCR synchronization lease no longer exists; this run cannot prove it held the lease while it was mutating."
+      return 1
     fi
-    observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || {
+    observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}" 2>"${result_file}")" || {
       release_failure="invalid-lease-state"
       continue
     }
@@ -4354,9 +4359,20 @@ release_sync_lease() {
   # other -- which STAGE gave up, and what the API actually said. The caller's
   # own message carries neither, so an operator clearing the lease by hand would
   # otherwise have nothing to go on.
-  echo "::error::Could not clear the GHCR synchronization lease after ${SYNC_LEASE_RELEASE_ATTEMPTS} attempts (${release_failure:-unknown})."
-  printf '::warning::sync-lease release: last kubectl error: %s\n' \
-    "$(tr '\n' ' ' <"${result_file}" 2>/dev/null)"
+  # Sanitise exactly as acquire_sync_lease already does for this same class of
+  # content: bound it, flatten CR *and* LF, and escape '%'. GitHub Actions
+  # decodes %25/%0A/%0D inside a workflow command, so unescaped captured output
+  # can inject an annotation of its own -- which is why that escaping exists
+  # there. Emitting it raw here would have dropped all three protections.
+  if [[ -s "${result_file}" ]]; then
+    failure_detail="$(head -c 1000 "${result_file}" | tr '\r\n' '  ')"
+    failure_detail="${failure_detail//%/%25}"
+  fi
+  if [[ -n "${failure_detail}" ]]; then
+    echo "::error::Could not clear the GHCR synchronization lease after ${SYNC_LEASE_RELEASE_ATTEMPTS} attempts (${release_failure}). Last error: ${failure_detail}"
+  else
+    echo "::error::Could not clear the GHCR synchronization lease after ${SYNC_LEASE_RELEASE_ATTEMPTS} attempts (${release_failure})."
+  fi
   report_sync_lease_state 'lease release failed'
   return 1
 }

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -4243,7 +4243,7 @@ release_sync_lease() {
   local lease_file="${work_dir}/sync-lease-release.json"
   local patch_file_local="${work_dir}/sync-lease-release-patch.json"
   local result_file="${work_dir}/sync-lease-release-result.txt"
-  local now attempt observed_holder release_failure="" failure_detail=""
+  local now attempt backoff observed_holder release_failure="" failure_detail=""
 
   if [[ -n "${sync_lease_heartbeat_pid}" ]]; then
     kill "${sync_lease_heartbeat_pid}" 2>/dev/null || true
@@ -4270,12 +4270,17 @@ release_sync_lease() {
     # Retrying an API failure in the same millisecond re-asks a server that has
     # not had time to recover, so every attempt lands inside one blip and the
     # retry adds nothing. A linear backoff makes the later attempts sample a
-    # genuinely different moment. It scales SYNC_INTERVAL rather than hard-coding
-    # seconds, so this stays the same tunable knob every other retry loop here
-    # uses -- which also keeps the suite fast, since the tests set it to 0.
-    if ((attempt > 1)); then
-      sleep "$(((attempt - 1) * SYNC_INTERVAL))"
-    fi
+    # genuinely different moment, scaling SYNC_INTERVAL so this stays the same
+    # tunable knob every other retry loop here uses -- which also keeps the suite
+    # fast, since the tests set it to 0.
+    #
+    # Repeated sleeps rather than arithmetic: SYNC_INTERVAL is validated as
+    # ^[0-9]+([.][0-9]+)?$, so a DECIMAL is a documented-valid setting, and bash
+    # $(( )) is integer-only -- multiplying it would abort the release with an
+    # arithmetic syntax error on a value the script explicitly accepts.
+    for ((backoff = 1; backoff < attempt; backoff++)); do
+      sleep "${SYNC_INTERVAL}"
+    done
     if ! kubectl \
       --context "${KUBE_CONTEXT}" \
       --namespace flux-system \

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -4243,7 +4243,7 @@ release_sync_lease() {
   local lease_file="${work_dir}/sync-lease-release.json"
   local patch_file_local="${work_dir}/sync-lease-release-patch.json"
   local result_file="${work_dir}/sync-lease-release-result.txt"
-  local now attempt observed_holder
+  local now attempt observed_holder release_failure=""
 
   if [[ -n "${sync_lease_heartbeat_pid}" ]]; then
     kill "${sync_lease_heartbeat_pid}" 2>/dev/null || true
@@ -4260,22 +4260,60 @@ release_sync_lease() {
   # same-holder write renew_sync_lease is already documented to expect. A
   # release that refuses leaves the lease held, so that conjunct converts a
   # harmless race into a wedge that blocks every later transaction until a
-  # human clears it. A lease held by anyone else still refuses, below.
+  # human clears it. A lease held by anyone ELSE still refuses, below.
+  #
+  # (fence_lease_release_patch keeps its resourceVersion conjunct deliberately:
+  # there the holder is terminal and nothing races the write, so pinning the
+  # version is what proves the Lease has not moved between the report a human
+  # read and the command they paste.)
   for ((attempt = 1; attempt <= SYNC_LEASE_RELEASE_ATTEMPTS; attempt++)); do
+    if ((attempt > 1)); then
+      sleep "${SYNC_INTERVAL}"
+    fi
     if ! kubectl \
       --context "${KUBE_CONTEXT}" \
       --namespace flux-system \
+      --request-timeout=30s \
       get lease "${SYNC_LEASE_NAME}" \
+      --ignore-not-found \
       -o json >"${lease_file}" 2>"${result_file}"; then
+      release_failure="api-unreachable"
       continue
     fi
-    observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || continue
+
+    # --ignore-not-found prints nothing when the Lease is gone. Nothing is held,
+    # so there is nothing left for this transaction to hand back.
+    if [[ ! -s "${lease_file}" ]]; then
+      sync_lease_holder=""
+      sync_lease_acquired=false
+      return 0
+    fi
+    observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || {
+      release_failure="invalid-lease-state"
+      continue
+    }
+
+    # An empty holder IS this function's goal state, so reaching it is success
+    # however it happened. The reachable case is a patch that the apiserver
+    # APPLIED and whose response was then lost: kubectl exits non-zero, and the
+    # retry finds the Lease already cleared. Treating that as a failure would
+    # fail a wholly successful deploy over a released lease -- the same wedge
+    # this retry exists to remove, in the likeliest instance of the very
+    # transient it targets.
+    if [[ -z "${observed_holder}" ]]; then
+      sync_lease_holder=""
+      sync_lease_acquired=false
+      return 0
+    fi
 
     # Losing the lease to another holder stays fatal: this transaction can no
     # longer prove it held the lease while it was mutating, which is exactly
     # the condition the exclusion guarantee exists to surface. Retrying cannot
-    # change a holder that already moved away, so refuse immediately.
+    # change a holder that already moved away, so refuse immediately -- and say
+    # so, because this is a concurrency breach and not a transient.
     if [[ "${observed_holder}" != "${sync_lease_holder}" ]]; then
+      echo "::error::The GHCR synchronization lease is held by another transaction; refusing to release a lease this run does not own."
+      report_sync_lease_state 'release found a foreign lease holder'
       return 1
     fi
 
@@ -4293,6 +4331,7 @@ release_sync_lease() {
     if kubectl \
       --context "${KUBE_CONTEXT}" \
       --namespace flux-system \
+      --request-timeout=30s \
       patch lease "${SYNC_LEASE_NAME}" \
       --type=json \
       --patch-file="${patch_file_local}" \
@@ -4301,11 +4340,14 @@ release_sync_lease() {
       sync_lease_acquired=false
       return 0
     fi
+    release_failure="patch-rejected"
   done
 
-  # Every attempt read a lease still held by this transaction and still failed
-  # to clear it. That is a genuine refusal: report it rather than pretending
-  # the lease was released.
+  # Every attempt saw a lease still held by this transaction and still failed to
+  # clear it. Name the last cause: an operator needs to tell a transient apart
+  # from a rejected write.
+  echo "::error::Could not clear the GHCR synchronization lease after ${SYNC_LEASE_RELEASE_ATTEMPTS} attempts (${release_failure:-unknown})."
+  report_sync_lease_state 'release exhausted its attempts'
   return 1
 }
 

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -134,6 +134,7 @@ readonly FLUX_CONTROLLER_ROLLOUT_TIMEOUT="2m"
 readonly SYNC_LEASE_NAME="ghcr-auth-refresh"
 readonly SYNC_LEASE_DURATION_SECONDS=120
 readonly SYNC_LEASE_HEARTBEAT_SECONDS="${FLUX_GHCR_SYNC_LEASE_HEARTBEAT_SECONDS:-30}"
+readonly SYNC_LEASE_RELEASE_ATTEMPTS=3
 readonly CORDON_OWNER_ANNOTATION="platform.devantler.tech/ghcr-auth-drain-owner"
 readonly CORDON_OWNER_JSON_PATH="/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner"
 readonly CORDON_RECOVERY_ANNOTATION="platform.devantler.tech/ghcr-auth-drain-recovery"
@@ -4242,7 +4243,7 @@ release_sync_lease() {
   local lease_file="${work_dir}/sync-lease-release.json"
   local patch_file_local="${work_dir}/sync-lease-release-patch.json"
   local result_file="${work_dir}/sync-lease-release-result.txt"
-  local resource_version now
+  local now attempt observed_holder
 
   if [[ -n "${sync_lease_heartbeat_pid}" ]]; then
     kill "${sync_lease_heartbeat_pid}" 2>/dev/null || true
@@ -4250,42 +4251,62 @@ release_sync_lease() {
     sync_lease_heartbeat_pid=""
   fi
   [[ "${sync_lease_acquired}" == "true" && -n "${sync_lease_holder}" ]] || return 0
-  if ! kubectl \
-    --context "${KUBE_CONTEXT}" \
-    --namespace flux-system \
-    get lease "${SYNC_LEASE_NAME}" \
-    -o json >"${lease_file}"; then
-    return 1
-  fi
-  resource_version="$(jq -er \
-    --arg holder "${sync_lease_holder}" '
-    select(.spec.holderIdentity == $holder)
-    | .metadata.resourceVersion
-  ' "${lease_file}")" || return 1
-  now="$(kubernetes_microtime_now)"
-  jq -n \
-    --arg resource_version "${resource_version}" \
-    --arg holder "${sync_lease_holder}" \
-    --arg now "${now}" '
-    [
-      {op: "test", path: "/metadata/resourceVersion", value: $resource_version},
-      {op: "test", path: "/spec/holderIdentity", value: $holder},
-      {op: "replace", path: "/spec/holderIdentity", value: ""},
-      {op: "replace", path: "/spec/leaseDurationSeconds", value: 1},
-      {op: "replace", path: "/spec/renewTime", value: $now}
-    ]
-  ' >"${patch_file_local}"
-  if ! kubectl \
-    --context "${KUBE_CONTEXT}" \
-    --namespace flux-system \
-    patch lease "${SYNC_LEASE_NAME}" \
-    --type=json \
-    --patch-file="${patch_file_local}" \
-    >"${result_file}" 2>&1; then
-    return 1
-  fi
-  sync_lease_holder=""
-  sync_lease_acquired=false
+
+  # Killing the heartbeat shell does not reap the kubectl child it may be
+  # blocked in, so that renewal can still land between the read and the patch
+  # below. The CAS therefore tests holderIdentity ONLY. That alone carries the
+  # safety property of a release -- the lease is still ours -- while a
+  # resourceVersion conjunct would additionally fail on exactly the benign
+  # same-holder write renew_sync_lease is already documented to expect. A
+  # release that refuses leaves the lease held, so that conjunct converts a
+  # harmless race into a wedge that blocks every later transaction until a
+  # human clears it. A lease held by anyone else still refuses, below.
+  for ((attempt = 1; attempt <= SYNC_LEASE_RELEASE_ATTEMPTS; attempt++)); do
+    if ! kubectl \
+      --context "${KUBE_CONTEXT}" \
+      --namespace flux-system \
+      get lease "${SYNC_LEASE_NAME}" \
+      -o json >"${lease_file}" 2>"${result_file}"; then
+      continue
+    fi
+    observed_holder="$(jq -er '.spec.holderIdentity // ""' "${lease_file}")" || continue
+
+    # Losing the lease to another holder stays fatal: this transaction can no
+    # longer prove it held the lease while it was mutating, which is exactly
+    # the condition the exclusion guarantee exists to surface. Retrying cannot
+    # change a holder that already moved away, so refuse immediately.
+    if [[ "${observed_holder}" != "${sync_lease_holder}" ]]; then
+      return 1
+    fi
+
+    now="$(kubernetes_microtime_now)"
+    jq -n \
+      --arg holder "${sync_lease_holder}" \
+      --arg now "${now}" '
+      [
+        {op: "test", path: "/spec/holderIdentity", value: $holder},
+        {op: "replace", path: "/spec/holderIdentity", value: ""},
+        {op: "replace", path: "/spec/leaseDurationSeconds", value: 1},
+        {op: "replace", path: "/spec/renewTime", value: $now}
+      ]
+    ' >"${patch_file_local}"
+    if kubectl \
+      --context "${KUBE_CONTEXT}" \
+      --namespace flux-system \
+      patch lease "${SYNC_LEASE_NAME}" \
+      --type=json \
+      --patch-file="${patch_file_local}" \
+      >"${result_file}" 2>&1; then
+      sync_lease_holder=""
+      sync_lease_acquired=false
+      return 0
+    fi
+  done
+
+  # Every attempt read a lease still held by this transaction and still failed
+  # to clear it. That is a genuine refusal: report it rather than pretending
+  # the lease was released.
+  return 1
 }
 
 # The live image-verification policies are owned by the infrastructure Flux

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -4262,6 +4262,14 @@ release_sync_lease() {
   # harmless race into a wedge that blocks every later transaction until a
   # human clears it. A lease held by anyone else still refuses, below.
   for ((attempt = 1; attempt <= SYNC_LEASE_RELEASE_ATTEMPTS; attempt++)); do
+    # Retrying an API failure in the same millisecond re-asks a server that has
+    # not had time to recover, so all three attempts land inside one blip and the
+    # retry adds nothing. A short linear backoff makes the later attempts sample
+    # a genuinely different moment. Bounded at 1s + 2s: this runs in cleanup,
+    # where the lease is already released on the happy path.
+    if ((attempt > 1)); then
+      sleep "$((attempt - 1))"
+    fi
     if ! kubectl \
       --context "${KUBE_CONTEXT}" \
       --namespace flux-system \
@@ -4305,7 +4313,13 @@ release_sync_lease() {
 
   # Every attempt read a lease still held by this transaction and still failed
   # to clear it. That is a genuine refusal: report it rather than pretending
-  # the lease was released.
+  # the lease was released. The caller's message says only THAT the release
+  # failed; this is the one lease-failure path that emitted no state, so the
+  # operator clearing the lease by hand had nothing to go on. The last attempt's
+  # kubectl error is the missing half.
+  printf '::warning::sync-lease release: last kubectl error: %s\n' \
+    "$(tr '\n' ' ' <"${result_file}" 2>/dev/null)"
+  report_sync_lease_state 'lease release failed'
   return 1
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1008,6 +1008,17 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 		!hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) {
 		return commandFailure(56, "synchronization lease CAS failed")
 	}
+
+	// The release is the ONE writer that must not pin resourceVersion: a benign
+	// same-holder heartbeat write would otherwise fail it and leave the Lease
+	// held. Every other writer still must pin it -- acquire and renew both rely
+	// on it to avoid a lost update on leaseTransitions -- so keep requiring it
+	// of them rather than dropping the check for everyone.
+	releasesTheLease := hasPatchPath(patch, "replace", "/spec/holderIdentity") &&
+		patchValueString(patch, "replace", "/spec/holderIdentity") == ""
+	if !releasesTheLease && !hasPatchPath(patch, "test", "/metadata/resourceVersion") {
+		return commandFailure(56, "synchronization lease CAS failed")
+	}
 	for _, path := range []string{"/spec/acquireTime", "/spec/renewTime"} {
 		if hasPatchPath(patch, "replace", path) {
 			if err := validateKubernetesMicroTimes(patchValueString(patch, "replace", path)); err != nil {
@@ -1033,6 +1044,17 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 		patchValueString(patch, "replace", "/spec/holderIdentity") == "" {
 		touchMarker("sync-lease-release-conflict")
 		return commandFailure(56, "simulated transient failure releasing the lease")
+	}
+	// The apiserver APPLIES the release and the response is then lost (connection
+	// reset after the write). kubectl exits non-zero, so the caller retries and
+	// finds the Lease already cleared -- which is its goal state, not a failure.
+	if os.Getenv("FAKE_SYNC_LEASE_RELEASE_RESPONSE_LOST") == "true" &&
+		!markerExists("sync-lease-release-response-lost") &&
+		releasesTheLease {
+		touchMarker("sync-lease-release-response-lost")
+		setMarkerContent("sync-lease-holder", "")
+		setMarkerContent("sync-lease-resource-version", incrementDecimal(currentResourceVersion))
+		return commandFailure(54, "connection reset after releasing the lease")
 	}
 	if holder := patchValueString(patch, "replace", "/spec/holderIdentity"); hasPatchPath(patch, "replace", "/spec/holderIdentity") {
 		setMarkerContent("sync-lease-holder", holder)

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -995,12 +995,11 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 		setMarkerContent("sync-lease-resource-version", currentResourceVersion)
 	}
 	// A real apiserver evaluates the `test` operations a patch actually carries,
-	// and nothing more. The holderIdentity test is what makes any write to this
-	// Lease safe, so a caller that omits it is rejected outright. The
-	// resourceVersion test is optional and is honoured exactly when the caller
-	// asks for it -- requiring it here would force every writer to carry a
-	// conjunct that fails on a benign same-holder write, which is a property of
-	// this fake rather than of Kubernetes.
+	// and nothing more -- so honour resourceVersion exactly when it is present.
+	// The holderIdentity test is what makes any write to this Lease safe, so a
+	// caller that omits it is rejected outright. Which writers must ALSO pin
+	// resourceVersion is a policy question, not an apiserver one, and it is
+	// asserted separately below.
 	if !hasPatchOperation(patch, "test", "/spec/holderIdentity", currentHolder) {
 		return commandFailure(56, "synchronization lease CAS failed")
 	}
@@ -1035,6 +1034,14 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 		touchMarker("sync-lease-renew-conflict")
 		return commandFailure(56, "simulated same-holder lease renewal race")
 	}
+	// Every release attempt fails, so the loop's exhaustion path -- its final
+	// diagnostics -- becomes reachable. The one-shot fixtures above cannot get
+	// there by construction.
+	if os.Getenv("FAKE_SYNC_LEASE_RELEASE_ALWAYS_FAILS") == "true" && releasesTheLease {
+		touchMarker("sync-lease-release-always-fails")
+		return commandFailure(56, "persistent failure releasing the lease")
+	}
+
 	// A release whose CAS passed can still fail on a transient API error. The
 	// Lease is untouched, so the retry that follows must be able to complete the
 	// release rather than leaving it held.

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -978,8 +978,34 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 	}
 	currentResourceVersion := defaultString(markerContent("sync-lease-resource-version"), "10")
 	currentHolder := markerContent("sync-lease-holder")
-	if !hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) ||
-		!hasPatchOperation(patch, "test", "/spec/holderIdentity", currentHolder) {
+
+	// release_sync_lease kills the heartbeat shell, but not a kubectl child that
+	// shell may be blocked in. That orphaned renewal lands after the release has
+	// read the Lease and before its patch is applied. Model the write itself --
+	// a same-holder renewal advancing resourceVersion -- and let the ordinary
+	// CAS comparison below decide the outcome, exactly as an apiserver would.
+	// This fires on the release patch only: it is the one that clears
+	// holderIdentity.
+	if os.Getenv("FAKE_SYNC_LEASE_ORPHANED_HEARTBEAT_WRITE_BEFORE_RELEASE") == "true" &&
+		!markerExists("sync-lease-orphaned-heartbeat-write") &&
+		hasPatchPath(patch, "replace", "/spec/holderIdentity") &&
+		patchValueString(patch, "replace", "/spec/holderIdentity") == "" {
+		touchMarker("sync-lease-orphaned-heartbeat-write")
+		currentResourceVersion = incrementDecimal(currentResourceVersion)
+		setMarkerContent("sync-lease-resource-version", currentResourceVersion)
+	}
+	// A real apiserver evaluates the `test` operations a patch actually carries,
+	// and nothing more. The holderIdentity test is what makes any write to this
+	// Lease safe, so a caller that omits it is rejected outright. The
+	// resourceVersion test is optional and is honoured exactly when the caller
+	// asks for it -- requiring it here would force every writer to carry a
+	// conjunct that fails on a benign same-holder write, which is a property of
+	// this fake rather than of Kubernetes.
+	if !hasPatchOperation(patch, "test", "/spec/holderIdentity", currentHolder) {
+		return commandFailure(56, "synchronization lease CAS failed")
+	}
+	if hasPatchPath(patch, "test", "/metadata/resourceVersion") &&
+		!hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) {
 		return commandFailure(56, "synchronization lease CAS failed")
 	}
 	for _, path := range []string{"/spec/acquireTime", "/spec/renewTime"} {
@@ -997,6 +1023,16 @@ func fakeKubectlPatchSyncLease(args []string, namespace, patchFile string) int {
 		setMarkerContent("sync-lease-resource-version", incrementDecimal(currentResourceVersion))
 		touchMarker("sync-lease-renew-conflict")
 		return commandFailure(56, "simulated same-holder lease renewal race")
+	}
+	// A release whose CAS passed can still fail on a transient API error. The
+	// Lease is untouched, so the retry that follows must be able to complete the
+	// release rather than leaving it held.
+	if os.Getenv("FAKE_SYNC_LEASE_RELEASE_CONFLICT_ONCE") == "true" &&
+		!markerExists("sync-lease-release-conflict") &&
+		hasPatchPath(patch, "replace", "/spec/holderIdentity") &&
+		patchValueString(patch, "replace", "/spec/holderIdentity") == "" {
+		touchMarker("sync-lease-release-conflict")
+		return commandFailure(56, "simulated transient failure releasing the lease")
 	}
 	if holder := patchValueString(patch, "replace", "/spec/holderIdentity"); hasPatchPath(patch, "replace", "/spec/holderIdentity") {
 		setMarkerContent("sync-lease-holder", holder)

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
@@ -184,6 +184,31 @@ func TestReleaseRefusesAndReportsALeaseHeldByAnotherTransaction(t *testing.T) {
 	)
 }
 
+// The exhaustion path emits the diagnostics an operator clearing the lease by
+// hand depends on, and until this test existed nothing could even reach it --
+// every other release fixture fails at most once. It asserts the failing STAGE
+// and the captured API error travel together: either alone leaves the operator
+// guessing which half of the release gave up.
+func TestExhaustedReleaseReportsBothTheStageAndTheAPIError(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_SYNC_LEASE_RELEASE_ALWAYS_FAILS": "true",
+	})
+	requireFailureResult(t, result)
+	if !pathExists(filepath.Join(f.syncStateDir, "sync-lease-release-always-fails")) {
+		t.Fatal("fixture did not exercise the exhausted release path")
+	}
+	output := result.stdout + result.stderr
+	requireContains(t, output, "Could not clear the GHCR synchronization lease after")
+	requireContains(t, output, "(patch-rejected)")
+	requireContains(t, output, "persistent failure releasing the lease")
+	// The Lease is still ours and still held: the run must not claim otherwise.
+	if holder := mustRead(filepath.Join(f.syncStateDir, "sync-lease-holder")); holder == "" {
+		t.Fatal("exhausted release reported failure but cleared the Lease anyway")
+	}
+}
+
 func TestCurrentLeaseHolderRetriesSecretCASConflicts(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
@@ -107,6 +107,65 @@ func TestSameHolderLeaseRenewalRaceDoesNotAbortTheTransaction(t *testing.T) {
 	requireLine(t, readLines(f.operationLog), "root-patch")
 }
 
+// A completely successful transaction must still leave the Lease released. The
+// two cases below are the reachable ways its release path can be interrupted:
+// a same-holder write landing inside its read/patch window, and a transient
+// failure of the patch itself. Neither is a safety event -- the lease is still
+// ours throughout -- but a release that gives up leaves it held, and a held
+// Lease fails every later transaction closed until a human clears it. So each
+// case asserts the side effect (the Lease is actually released), not merely
+// that the run reported success.
+func TestSuccessfulTransactionReleasesTheLeaseDespiteAReleaseRace(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		environment string
+		marker      string
+	}{
+		"orphaned heartbeat write inside the release window": {
+			environment: "FAKE_SYNC_LEASE_ORPHANED_HEARTBEAT_WRITE_BEFORE_RELEASE",
+			marker:      "sync-lease-orphaned-heartbeat-write",
+		},
+		"transient failure of the release patch": {
+			environment: "FAKE_SYNC_LEASE_RELEASE_CONFLICT_ONCE",
+			marker:      "sync-lease-release-conflict",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			f := newFixture(t)
+			result := f.runHelper(validConfig(), nil, map[string]string{
+				test.environment: "true",
+			})
+			requireSuccessResult(t, result)
+			if !pathExists(filepath.Join(f.syncStateDir, test.marker)) {
+				t.Fatal("fixture did not exercise the lease release race")
+			}
+			if holder := mustRead(filepath.Join(f.syncStateDir, "sync-lease-holder")); holder != "" {
+				t.Fatalf("lease left held by %q after a successful transaction", holder)
+			}
+		})
+	}
+}
+
+// The exclusion guarantee is unchanged: a Lease that moved to another holder is
+// a genuine refusal, because this transaction can no longer prove it held the
+// lease while it was mutating. The tolerance above must not paper over that, and
+// the release must never clear a Lease it does not own.
+func TestReleaseNeverClearsALeaseHeldByAnotherTransaction(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_TRANSIENT_DRAIN_API_FAIL_NODE":                    "prod-worker-1",
+		"FAKE_INTERRUPT_SYNC_LEASE_HEARTBEAT_DURING_DRAIN":      "true",
+		"FAKE_REPLACE_SYNC_LEASE_DURING_HEARTBEAT_INTERRUPTION": "true",
+		"FLUX_GHCR_SYNC_LEASE_HEARTBEAT_SECONDS":                "1",
+	})
+	requireFailureResult(t, result)
+	if holder := mustRead(filepath.Join(f.syncStateDir, "sync-lease-holder")); holder != "newer-transaction" {
+		t.Fatalf("release disturbed a Lease owned by another transaction: holder is %q", holder)
+	}
+}
+
 func TestCurrentLeaseHolderRetriesSecretCASConflicts(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_safety_test.go
@@ -129,6 +129,10 @@ func TestSuccessfulTransactionReleasesTheLeaseDespiteAReleaseRace(t *testing.T) 
 			environment: "FAKE_SYNC_LEASE_RELEASE_CONFLICT_ONCE",
 			marker:      "sync-lease-release-conflict",
 		},
+		"release applied but its response lost": {
+			environment: "FAKE_SYNC_LEASE_RELEASE_RESPONSE_LOST",
+			marker:      "sync-lease-release-response-lost",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -149,9 +153,13 @@ func TestSuccessfulTransactionReleasesTheLeaseDespiteAReleaseRace(t *testing.T) 
 
 // The exclusion guarantee is unchanged: a Lease that moved to another holder is
 // a genuine refusal, because this transaction can no longer prove it held the
-// lease while it was mutating. The tolerance above must not paper over that, and
-// the release must never clear a Lease it does not own.
-func TestReleaseNeverClearsALeaseHeldByAnotherTransaction(t *testing.T) {
+// lease while it was mutating. The tolerance above must not paper over that.
+//
+// Asserting only that the foreign holder survives would NOT cover the guard --
+// the server-side CAS alone keeps it intact, so the test passes with the guard
+// deleted. Assert the refusal is reported instead: that distinguishes "refused
+// on sight, as a concurrency breach" from "burned every attempt and gave up".
+func TestReleaseRefusesAndReportsALeaseHeldByAnotherTransaction(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
 	result := f.runHelper(validConfig(), nil, map[string]string{
@@ -164,6 +172,16 @@ func TestReleaseNeverClearsALeaseHeldByAnotherTransaction(t *testing.T) {
 	if holder := mustRead(filepath.Join(f.syncStateDir, "sync-lease-holder")); holder != "newer-transaction" {
 		t.Fatalf("release disturbed a Lease owned by another transaction: holder is %q", holder)
 	}
+	requireContains(
+		t,
+		result.stdout+result.stderr,
+		"refusing to release a lease this run does not own",
+	)
+	requireNotContains(
+		t,
+		result.stdout+result.stderr,
+		"Could not clear the GHCR synchronization lease after",
+	)
 }
 
 func TestCurrentLeaseHolderRetriesSecretCASConflicts(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A prod deploy that does all of its work correctly can still report failure on its way out, and leave
behind the lock it was holding. Every later deploy then fails closed on that lock, and the automatic
recovery path cannot help because it fails closed on it too — so clearing it needs a person.

That is not hypothetical: it happened today. The platform merge queue stopped accepting anything for
the rest of the afternoon, and PR #3320 was evicted for a reason that had nothing to do with its
content.

## What

The step that hands the lock back now tolerates the harmless timing race that was making it give up —
the same tolerance the renewal step has always had — and retries a release that fails for a passing
reason instead of abandoning it.

Exclusivity is unchanged and deliberately so: a lock genuinely held by someone else is still refused,
and the human-only recovery for a lock whose owner has died is untouched.

Part of #3071
