### PR TITLE
fix(deploy): enable orphaned-fence recovery at every deploy call site

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -192,3 +192,9 @@ jobs:
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
           wg-server-private-key: ${{ secrets.WG_SERVER_PRIVATE_KEY }}
+          # Release a synchronization Lease that an already-dead deploy left
+          # held, so one crashed run cannot wedge every later deploy and its own
+          # heal. This relaxes no guard: the composite still refuses unless no
+          # other fence is held, the heartbeat has stopped, and the holder's run
+          # attempt is proven terminal via the API (#3343).
+          recover-orphaned-fence: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1343,6 +1343,12 @@ jobs:
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
           wg-server-private-key: ${{ secrets.WG_SERVER_PRIVATE_KEY }}
+          # Release a synchronization Lease that an already-dead deploy left
+          # held, so one crashed run cannot wedge every later deploy and its own
+          # heal. This relaxes no guard: the composite still refuses unless no
+          # other fence is held, the heartbeat has stopped, and the holder's run
+          # attempt is proven terminal via the API (#3343).
+          recover-orphaned-fence: "true"
 
   heal-prod-on-failure:
     name: 🩹 Heal Prod (restore main after unsuccessful merge-group deploy)
@@ -1409,6 +1415,12 @@ jobs:
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
           wg-server-private-key: ${{ secrets.WG_SERVER_PRIVATE_KEY }}
+          # Release a synchronization Lease that an already-dead deploy left
+          # held, so one crashed run cannot wedge every later deploy and its own
+          # heal. This relaxes no guard: the composite still refuses unless no
+          # other fence is held, the heartbeat has stopped, and the holder's run
+          # attempt is proven terminal via the API (#3343).
+          recover-orphaned-fence: "true"
 
   ci-required-checks:
     name: CI - Required Checks

--- a/scripts/validate-merge-group-heal/main.go
+++ b/scripts/validate-merge-group-heal/main.go
@@ -34,6 +34,9 @@ const expectedHealCondition = "always() && " +
 // step reachable, so it is pinned rather than left to a reviewer to notice.
 const recoveryOptIn = `          recover-orphaned-fence: "true"`
 
+// The shared composite both prod-deploy paths call.
+const deployCompositePath = "./.github/actions/deploy-prod"
+
 func validateWorkflowContract(workflow string) error {
 	healJob, ok := extractJob(workflow, "heal-prod-on-failure")
 	if !ok {
@@ -56,11 +59,6 @@ func validateWorkflowContract(workflow string) error {
 		{line: "      group: prod-deploy", description: "shared production lock"},
 		{line: "      cancel-in-progress: false", description: "non-preempting production lock"},
 		{line: "          ref: main", description: "current-main checkout"},
-		// Without this, a deploy that dies holding the GHCR synchronization Lease
-		// wedges the queue AND this heal job — the exact state the heal exists to
-		// clear (#3343). Opting in relaxes no guard: the composite still refuses to
-		// release unless the holder is provably terminal and its heartbeat stopped.
-		{line: recoveryOptIn, description: "orphaned-fence recovery"},
 	}
 	for _, requirement := range requirements {
 		if !containsExactLine(healJob, requirement.line) {
@@ -78,15 +76,27 @@ func validateWorkflowContract(workflow string) error {
 		)
 	}
 
-	// The heal job is the last line of defence; the deploy job reaching the same
-	// composite is what stops the wedge arising at all. Pin both, or a dead deploy
-	// still fails the NEXT deploy before any heal gets the chance to clear it.
-	deployJob, ok := extractJob(workflow, "deploy-prod")
-	if !ok {
-		return errors.New("missing deploy-prod job")
-	}
-	if !containsExactLine(deployJob, recoveryOptIn) {
-		return errors.New("deploy job is missing orphaned-fence recovery")
+	// Both jobs reach the same composite, and the opt-in is checked against the
+	// STEP rather than the job: a line accepted anywhere in the job would still
+	// pass after an edit moved it onto an unrelated step, leaving the composite
+	// on its default "false". The validator would then vouch for precisely the
+	// state it exists to catch. The heal job is the last line of defence; the
+	// deploy job reaching the composite is what stops the wedge arising at all.
+	for _, target := range []struct{ key, label string }{
+		{"deploy-prod", "deploy"},
+		{"heal-prod-on-failure", "heal"},
+	} {
+		job, ok := extractJob(workflow, target.key)
+		if !ok {
+			return fmt.Errorf("missing %s job", target.key)
+		}
+		step, ok := extractDeployStep(job)
+		if !ok {
+			return fmt.Errorf("%s job does not reach the shared deploy composite", target.label)
+		}
+		if !containsExactLine(step, recoveryOptIn) {
+			return fmt.Errorf("%s job is missing orphaned-fence recovery", target.label)
+		}
 	}
 
 	return nil
@@ -112,6 +122,50 @@ func extractJob(workflow string, jobKey string) (string, bool) {
 		if strings.HasPrefix(line, "  ") &&
 			!strings.HasPrefix(line, "   ") &&
 			strings.HasSuffix(line, ":") {
+			end = i
+			break
+		}
+	}
+
+	return strings.Join(lines[start:end], "\n"), true
+}
+
+// extractDeployStep returns the one step in a job that reaches the shared
+// deploy composite, so an input can be checked against THAT step rather than
+// against the whole job. It walks back from the `uses:` line to the list-item
+// start, because a step may declare `with:` before `uses:`.
+func extractDeployStep(job string) (string, bool) {
+	lines := strings.Split(job, "\n")
+	target := -1
+	for i, line := range lines {
+		// A step may write `- uses: …` on the list-item line itself or put `uses:`
+		// on its own line under `- name:`; both spellings are the same step.
+		if strings.TrimPrefix(strings.TrimSpace(line), "- ") == "uses: "+deployCompositePath {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		return "", false
+	}
+
+	start := 0
+	for i := target; i >= 0; i-- {
+		if strings.HasPrefix(strings.TrimLeft(lines[i], " "), "- ") {
+			start = i
+			break
+		}
+	}
+	indent := len(lines[start]) - len(strings.TrimLeft(lines[start], " "))
+
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		trimmed := strings.TrimLeft(lines[i], " ")
+		if trimmed == "" {
+			continue
+		}
+		lineIndent := len(lines[i]) - len(trimmed)
+		if lineIndent < indent || (lineIndent == indent && strings.HasPrefix(trimmed, "- ")) {
 			end = i
 			break
 		}

--- a/scripts/validate-merge-group-heal/main.go
+++ b/scripts/validate-merge-group-heal/main.go
@@ -2,15 +2,16 @@
 // workflow can still do its job.
 //
 // The heal job restores main after a merge-group deploy fails, and it needs
-// four things to be true to work at all: it must fire on a failed or cancelled
+// five things to be true to work at all: it must fire on a failed or cancelled
 // merge-group deploy that actually touched k8s and on nothing else; it must
 // hold the shared prod-deploy lock; that lock must not be preemptible, or the
-// heal is cancelled by the next deploy midway through; and it must check out
-// main, or it restores the wrong revision.
+// heal is cancelled by the next deploy midway through; it must check out
+// main, or it restores the wrong revision; and it must opt in to orphaned-fence
+// recovery, or it cannot clear the GHCR Lease a dead deploy left held.
 //
 // Each is one line of workflow YAML, and none of them fails loudly when it is
 // wrong — the damage shows up later, during an incident, when the heal either
-// does not run or restores the wrong thing. Pinning all four here turns that
+// does not run or restores the wrong thing. Pinning all five here turns that
 // into a CI failure on the pull request that breaks one.
 package main
 
@@ -28,8 +29,13 @@ const expectedHealCondition = "always() && " +
 	"(needs.deploy-prod.result == 'failure' || " +
 	"needs.deploy-prod.result == 'cancelled')"
 
+// The deploy-prod composite recovers an orphaned GHCR fence only when a call
+// site opts in — the input is default-off. This exact line is what makes that
+// step reachable, so it is pinned rather than left to a reviewer to notice.
+const recoveryOptIn = `          recover-orphaned-fence: "true"`
+
 func validateWorkflowContract(workflow string) error {
-	healJob, ok := extractHealJob(workflow)
+	healJob, ok := extractJob(workflow, "heal-prod-on-failure")
 	if !ok {
 		return errors.New("missing heal-prod-on-failure job")
 	}
@@ -50,6 +56,11 @@ func validateWorkflowContract(workflow string) error {
 		{line: "      group: prod-deploy", description: "shared production lock"},
 		{line: "      cancel-in-progress: false", description: "non-preempting production lock"},
 		{line: "          ref: main", description: "current-main checkout"},
+		// Without this, a deploy that dies holding the GHCR synchronization Lease
+		// wedges the queue AND this heal job — the exact state the heal exists to
+		// clear (#3343). Opting in relaxes no guard: the composite still refuses to
+		// release unless the holder is provably terminal and its heartbeat stopped.
+		{line: recoveryOptIn, description: "orphaned-fence recovery"},
 	}
 	for _, requirement := range requirements {
 		if !containsExactLine(healJob, requirement.line) {
@@ -67,14 +78,26 @@ func validateWorkflowContract(workflow string) error {
 		)
 	}
 
+	// The heal job is the last line of defence; the deploy job reaching the same
+	// composite is what stops the wedge arising at all. Pin both, or a dead deploy
+	// still fails the NEXT deploy before any heal gets the chance to clear it.
+	deployJob, ok := extractJob(workflow, "deploy-prod")
+	if !ok {
+		return errors.New("missing deploy-prod job")
+	}
+	if !containsExactLine(deployJob, recoveryOptIn) {
+		return errors.New("deploy job is missing orphaned-fence recovery")
+	}
+
 	return nil
 }
 
-func extractHealJob(workflow string) (string, bool) {
+func extractJob(workflow string, jobKey string) (string, bool) {
 	lines := strings.Split(workflow, "\n")
 	start := -1
+	header := "  " + jobKey + ":"
 	for i, line := range lines {
-		if line == "  heal-prod-on-failure:" {
+		if line == header {
 			start = i + 1
 			break
 		}

--- a/scripts/validate-merge-group-heal/main_test.go
+++ b/scripts/validate-merge-group-heal/main_test.go
@@ -16,6 +16,10 @@ jobs:
 
   deploy-prod:
     runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"
 
   heal-prod-on-failure:
     needs: [changes, deploy-prod, validate-publication-contract]
@@ -33,6 +37,9 @@ jobs:
       - uses: actions/checkout@example
         with:
           ref: main
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"
 
   required-checks:
     runs-on: ubuntu-latest
@@ -102,6 +109,35 @@ func TestValidateWorkflowContractRejectsBrokenHealContracts(t *testing.T) {
 			old:         "needs.deploy-prod.result == 'cancelled'",
 			replacement: "needs.deploy-prod.result == 'failure'",
 			wantError:   "must cover exactly failed and cancelled deploys while excluding success",
+		},
+		{
+			// The opt-in is what makes the composite's recovery step reachable at
+			// all, so dropping it silently restores the wedge this pin exists to
+			// prevent -- the heal cannot clear a Lease a dead deploy left held.
+			name: "heal job drops orphaned-fence recovery",
+			old: `          ref: main
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"`,
+			replacement: "          ref: main",
+			wantError:   "heal job is missing orphaned-fence recovery",
+		},
+		{
+			name: "deploy job drops orphaned-fence recovery",
+			old: `  deploy-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"`,
+			replacement: "  deploy-prod:\n    runs-on: ubuntu-latest",
+			wantError:   "deploy job is missing orphaned-fence recovery",
+		},
+		{
+			name:        "missing deploy job",
+			old:         "  deploy-prod:",
+			replacement: "  deploy-prod-disabled:",
+			wantError:   "missing deploy-prod job",
 		},
 	}
 

--- a/scripts/validate-merge-group-heal/main_test.go
+++ b/scripts/validate-merge-group-heal/main_test.go
@@ -119,8 +119,24 @@ func TestValidateWorkflowContractRejectsBrokenHealContracts(t *testing.T) {
       - uses: ./.github/actions/deploy-prod
         with:
           recover-orphaned-fence: "true"`,
-			replacement: "          ref: main",
-			wantError:   "heal job is missing orphaned-fence recovery",
+			replacement: `          ref: main
+      - uses: ./.github/actions/deploy-prod
+        with:
+          sops-age-key: placeholder`,
+			wantError: "heal job is missing orphaned-fence recovery",
+		},
+		{
+			// A job that no longer calls the composite at all is a different break
+			// from one that calls it without the opt-in, so they get separate cases.
+			name: "deploy job does not reach the deploy composite",
+			old: `  deploy-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"`,
+			replacement: "  deploy-prod:\n    runs-on: ubuntu-latest",
+			wantError:   "deploy job does not reach the shared deploy composite",
 		},
 		{
 			name: "deploy job drops orphaned-fence recovery",
@@ -130,14 +146,38 @@ func TestValidateWorkflowContractRejectsBrokenHealContracts(t *testing.T) {
       - uses: ./.github/actions/deploy-prod
         with:
           recover-orphaned-fence: "true"`,
-			replacement: "  deploy-prod:\n    runs-on: ubuntu-latest",
-			wantError:   "deploy job is missing orphaned-fence recovery",
+			replacement: `  deploy-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/deploy-prod
+        with:
+          sops-age-key: placeholder`,
+			wantError: "deploy job is missing orphaned-fence recovery",
 		},
 		{
 			name:        "missing deploy job",
 			old:         "  deploy-prod:",
 			replacement: "  deploy-prod-disabled:",
 			wantError:   "missing deploy-prod job",
+		},
+		{
+			// The opt-in must be bound to the step that reaches the composite.
+			// Relocating it to a neighbouring step leaves every line the validator
+			// used to look for present in the job, while the composite itself still
+			// runs on its default "false" -- the exact state this pin exists to catch.
+			name: "heal job relocates the opt-in off the deploy step",
+			old: `      - uses: actions/checkout@example
+        with:
+          ref: main
+      - uses: ./.github/actions/deploy-prod
+        with:
+          recover-orphaned-fence: "true"`,
+			replacement: `      - uses: actions/checkout@example
+        with:
+          ref: main
+          recover-orphaned-fence: "true"
+      - uses: ./.github/actions/deploy-prod`,
+			wantError: "heal job is missing orphaned-fence recovery",
 		},
 	}
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A prod deploy that dies while holding the GHCR synchronization Lease wedges the merge queue — and also wedges the heal job that exists to recover from exactly that. Clearing it needs a human with cluster write access.

The recovery for this was already built, and already permissioned: every call site grants `actions: read` specifically so the composite can prove the dead holder is dead. It was simply never switched on, so the recovery step logged `skipped` and could never run. That is what has left the queue wedged since 14:57Z today.

### What this changes

Turns the existing recovery on at all three deploy call sites, and pins it in the workflow contract validator so it cannot quietly revert.

No guard is relaxed. The composite still refuses to release unless no other fence is held, the heartbeat has stopped, and the holder's run attempt is proven terminal through the API — then releases via a compare-and-swap on that same observation. Anything unproven still refuses.

### Merge note — this PR clears the current wedge itself

`ci.yaml` and `cd.yaml` are both inside the `k8s` path filter, so this PR **does** run `deploy-prod` in the merge queue. The merge group builds the speculative merge commit, so that deploy runs *this* PR's workflow — with the flag on. It should therefore recover the orphaned Lease and deploy normally, rather than failing on it the way every deploy since 14:57Z has.

If the recovery declines for any reason, the deploy fails and this PR is evicted with nothing released — the same state as today, no worse.

Fixes #3343
Part of #3071
