### PR TITLE
fix(security): assert the image-verification mechanism Talos actually uses

### DIFF
--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -3,22 +3,22 @@ name: Validate Image Verifier Liveness
 # Assert that node-level image verification can enforce AT ALL.
 #
 # The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml
-# were correct, active, and evaluating NOTHING for weeks, because containerd's
-# image-verifier plugin had no bin_dir and no verifier binary — a state
-# containerd documents as permitting every pull (devantler-tech/platform#2856).
-# Nothing in CI could see it: the rules were present, the node config matched the
-# repository, and every check was green.
+# read as correct whether or not anything on the node evaluates them, and nothing
+# in CI can tell those two states apart: the rules are present, the node config
+# matches the repository, and every check is green either way
+# (devantler-tech/platform#2856).
 #
-# The fleet check is DORMANT: it runs only on demand (`workflow_dispatch`), and
-# #3101 turns on its daily cadence as part of installing the verifier.
+# The mechanism is Talos' own. `security.ImageVerificationConfigController`
+# materialises each rule into an `ImageVerificationRules.security.talos.dev`
+# resource, and `security.TUFTrustedRootController` maintains the Sigstore TUF
+# trust root keyless verification needs. The fleet check asserts both are live
+# on every node.
 #
-# The verifier is absent fleet-wide today, so the check reports RED on every
-# node. That verdict is correct and is tracked on #3101 — it is not news any
-# individual run needs to act on. Publishing it daily on `main` would spend the
-# repository's CI-red channel, which means "something broke, fix it now", on a
-# known open issue that the tracker already states. Landing the checker dormant
-# keeps the capability reviewable and runnable on demand without burning that
-# signal, and activation becomes one reversible line in #3101.
+# The fleet check is DORMANT: it runs only on demand (`workflow_dispatch`).
+# Turning on a daily cadence belongs to #3336, which first establishes that a
+# matched rule actually refuses an unsigned pull — running rules and trust
+# material are necessary for enforcement, not proof of it, because a cached
+# image is never re-pulled.
 #
 # The checker's OWN tests need no cluster and no secrets, so they gate every PR
 # that touches the checker. They live in ci.yaml's `validate` job, which

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -41,7 +41,7 @@ jobs:
     name: 🔏 Validate Image Verifier Liveness
     # Dormancy is now the TRIGGER SET, not a job condition: `workflow_dispatch`
     # is the only event, so there is no PR or schedule path to guard against.
-    # Adding the daily `schedule:` is what activation means (#3101).
+    # Adding the daily `schedule:` is what activation means (#3336).
     runs-on: ubuntu-latest
     # KUBE_CONFIG and TALOS_CONFIG are `prod` ENVIRONMENT secrets, not repository
     # secrets — every other consumer (ci.yaml's deploy jobs, cd.yaml, dr-rebuild)

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -415,7 +415,6 @@ output="$(run_script 2>&1)" || fail 'case 16: a fleet of distinct nodes with dis
 require_text "${output}" 'OK   10.0.1.4' 'case 16: control reports the first discovered node'
 require_text "${output}" 'OK   10.0.1.6' 'case 16: control reports the second discovered node'
 
-
 # ===========================================================================
 # Case 17 — SECURITY: the check must never read a node FILE. Until 2026-08-24
 # it parsed /etc/cri/conf.d/cri.toml, which carries registry credentials on

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -78,6 +78,14 @@ node=''
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -n) node="$2"; shift 2 ;;
+    read)
+      # The script must never read a node FILE: /etc/cri/conf.d/cri.toml carries
+      # registry credentials and this output goes to CI logs. A sentinel FILE is
+      # used rather than stderr because the script redirects stderr on its query
+      # path, so a stream-based marker could be swallowed silently.
+      touch "${FIXTURES}/NODE_FILE_WAS_READ"
+      exit 1
+      ;;
     get)
       type="$2"
       # An unreachable node fails everything.
@@ -407,4 +415,20 @@ output="$(run_script 2>&1)" || fail 'case 16: a fleet of distinct nodes with dis
 require_text "${output}" 'OK   10.0.1.4' 'case 16: control reports the first discovered node'
 require_text "${output}" 'OK   10.0.1.6' 'case 16: control reports the second discovered node'
 
+
+# ===========================================================================
+# Case 17 — SECURITY: the check must never read a node FILE. Until 2026-08-24
+# it parsed /etc/cri/conf.d/cri.toml, which carries registry credentials on
+# this cluster, and this script's output goes to CI logs. Removing that read
+# removed the exposure; this pins it so a future change cannot quietly restore
+# it. The fake records any `talosctl read` in a sentinel FILE, because the
+# script redirects stderr on its query path and a stream marker could be
+# swallowed.
+# ===========================================================================
+rm -f "${fixtures}/NODE_FILE_WAS_READ"
+healthy_node credsafe
+output="$(run_script TALOS_NODES=credsafe 2>&1)" || fail 'case 17: control — the healthy node must still pass'
+require_text "${output}" 'OK   credsafe' 'case 17: control — reports the healthy node'
+[[ ! -e "${fixtures}/NODE_FILE_WAS_READ" ]] ||
+  fail 'case 17: the check read a node file — registry credentials are reachable from a script whose output goes to CI logs'
 printf 'all cases passed\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -129,6 +129,9 @@ readonly rules_type='imageverificationrules.security.talos.dev'
 readonly roots_type='tuftrustedroots.security.talos.dev'
 readonly rules_owner='security.ImageVerificationConfigController'
 readonly roots_owner='security.TUFTrustedRootController'
+readonly ksail_pattern='ghcr.io/devantler-tech/ksail*'
+readonly provider_pattern='ghcr.io/devantler-tech/provider-upjet-*'
+readonly app_pattern='ghcr.io/devantler-tech/*'
 
 write_node() {
   mkdir -p "${fixtures}/$1/resources"
@@ -137,7 +140,11 @@ write_node() {
 # Emits one resource object in the shape `talosctl get -o json` produces: a
 # STREAM of objects, not an array.
 resource_obj() {
-  local id="$1" phase="$2" owner="$3" type="$4"
+  local id="$1" phase="$2" owner="$3" type="$4" image_pattern="${5:-}"
+  local spec='{}'
+  if [[ -n "${image_pattern}" ]]; then
+    spec="{\"imagePattern\":\"${image_pattern}\"}"
+  fi
   cat <<EOF
 {
     "metadata": {
@@ -149,7 +156,7 @@ resource_obj() {
         "version": 1
     },
     "node": "fixture",
-    "spec": {}
+    "spec": ${spec}
 }
 EOF
 }
@@ -162,14 +169,21 @@ write_roots() {
   cat >"${fixtures}/$1/resources/${roots_type}"
 }
 
+# The complete ordered rule set declared by the manifest.
+write_healthy_rules() {
+  local node="$1"
+  {
+    resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${ksail_pattern}"
+    resource_obj 0001 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${provider_pattern}"
+    resource_obj 0002 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${app_pattern}"
+  } | write_rules "${node}"
+}
+
 # The healthy shape, used as the control for every RED case below.
 healthy_node() {
   local node="$1"
   write_node "${node}"
-  {
-    resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
-    resource_obj 0001 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
-  } | write_rules "${node}"
+  write_healthy_rules "${node}"
   resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
     write_roots "${node}"
 }
@@ -186,8 +200,44 @@ run_script() {
 healthy_node good
 output="$(run_script TALOS_NODES=good 2>&1)" || fail "case 1: expected exit 0 for a node that can enforce"
 require_text "${output}" 'OK   good' 'case 1: reports the healthy node'
-require_text "${output}" '2 rule(s) in phase running' 'case 1: counts the running rules'
+require_text "${output}" '3 rule(s) in phase running' 'case 1: counts every declared running rule'
 require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 1: reports the summary'
+
+# ===========================================================================
+# Case 1a — RED: SOME declared rules materialised and are running, but the
+# catch-all rule is absent. A presence-only check reports this node healthy even
+# though images matched only by that rule are pulled without verification.
+# ===========================================================================
+write_node partialrules
+{
+  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${ksail_pattern}"
+  resource_obj 0001 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${provider_pattern}"
+} | write_rules partialrules
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots partialrules
+status=0
+output="$(run_script TALOS_NODES=partialrules 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 1a: a node missing one declared ImageVerificationRules resource MUST fail'
+require_text "${output}" 'FAIL partialrules' 'case 1a: names the partially materialised node'
+require_text "${output}" 'declared rule set' 'case 1a: names the incomplete policy'
+
+# ===========================================================================
+# Case 1b — RED: the right NUMBER of rules is running, but the last pattern is
+# stale. Counts alone cannot prove that the declared ordered policy materialised.
+# ===========================================================================
+write_node driftrules
+{
+  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${ksail_pattern}"
+  resource_obj 0001 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' "${provider_pattern}"
+  resource_obj 0002 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev' 'ghcr.io/devantler-tech/stale-*'
+} | write_rules driftrules
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots driftrules
+status=0
+output="$(run_script TALOS_NODES=driftrules 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 1b: a runtime rule pattern that differs from the declaration MUST fail'
+require_text "${output}" 'FAIL driftrules' 'case 1b: names the node with policy drift'
+require_text "${output}" 'declared rule set' 'case 1b: names the drifted policy'
 
 # ===========================================================================
 # Case 2 — RED: the node holds NO ImageVerificationRules at all. The declared
@@ -240,9 +290,7 @@ require_text "${output}" 'not being enforced' 'case 4: names the condition that 
 # DIFFERENT failure from a missing rule and must be reported as its own.
 # ===========================================================================
 write_node noroot
-{
-  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
-} | write_rules noroot
+write_healthy_rules noroot
 status=0
 output="$(run_script TALOS_NODES=noroot 2>&1)" || status=$?
 [[ "${status}" -eq 1 ]] || fail 'case 5: running rules with no trust root MUST fail'
@@ -253,9 +301,7 @@ require_text "${output}" 'no trust material' 'case 5: names the condition that f
 # Case 6 — RED: a trust root that exists but is not running.
 # ===========================================================================
 write_node staleroot
-{
-  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
-} | write_rules staleroot
+write_healthy_rules staleroot
 resource_obj trusted_root.json tearingDown "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
   write_roots staleroot
 status=0

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -3,17 +3,18 @@
 #
 # WHY THIS EXISTS. The script's whole job is to notice a condition that looks
 # identical to health from every other angle: ImageVerificationConfig rules
-# present and correct, node config matching the repository, CI green — and no
-# verifier binary, so containerd permits every pull (devantler-tech/platform#2856).
+# declared in the repository, rendered manifests matching, CI green — and
+# nothing on the node actually enforcing them (devantler-tech/platform#2856).
 # A regression here is silent by construction: the script would exit 0 and the
-# cluster would read as enforcing. So these cases pin the FAILING paths, not just
-# the happy one, and the #2856 state (bin_dir present, directory present, empty)
-# gets its own case because it is the one that actually happened.
+# cluster would read as enforcing. So these cases pin the FAILING paths, not
+# just the happy one.
 #
-# The credential case is not decoration. The script reads
-# /etc/cri/conf.d/cri.toml, which carries registry auth on this cluster, and its
-# output goes to CI logs. A refactor that echoes the file — or quotes it in an
-# error — would publish a token. That is pinned here so it fails loudly.
+# The cases below pin BOTH directions of every verdict. A checker that can only
+# fail is as useless as one that can only pass — and this script has been each
+# of those in turn: until 2026-08-24 it asserted a containerd `bin_dir` that
+# does not exist on this platform, so it reported a confident FAIL on nodes that
+# were verifying correctly (#3108). Every RED case here therefore has a GREEN
+# control that differs in exactly one fixture.
 #
 # talosctl and kubectl are faked from fixture directories; no cluster, no
 # secrets, no network. Bash 3.2 compatible so it runs on a maintainer's macOS
@@ -57,19 +58,18 @@ refute_text() {
 }
 
 # ---------------------------------------------------------------------------
-# Fake talosctl: serves `read <file>` and `ls [-l] <path>` from a fixture tree.
-# A path with no fixture behaves like the real thing — non-zero, nothing on
-# stdout — which is what makes the "directory does not exist" case real rather
-# than simulated by a special-case flag.
+# Fake talosctl: serves `get <type> -o json` from a fixture tree, and `ls /` as
+# the reachability probe.
 #
-# Two behaviours mirror the real tool because the script now depends on them:
-#   * `ls` reports EXISTENCE for files as well as directories (verified against
-#     prod: `talosctl ls /etc/cri/conf.d/cri.toml` succeeds), so it can probe a
-#     config file without reading — and therefore without touching the registry
-#     credentials that file carries.
-#   * a node with no fixture directory at all is UNREACHABLE: every subcommand
-#     fails, including `ls /`. That is what lets the unreachable case be tested
-#     for real instead of via a special-case flag.
+# Three behaviours mirror the real tool because the script depends on each:
+#   * a type with NO instances exits 0 and emits NOTHING — that is a verdict
+#     ("this node holds no rules"), not an error, and the script must tell it
+#     apart from a failed query;
+#   * a query that FAILS exits non-zero — an infrastructure fault, never a
+#     verdict;
+#   * a node with no fixture directory is UNREACHABLE: every subcommand fails,
+#     including `ls /`. That lets the unreachable case be tested for real
+#     instead of via a special-case flag.
 # ---------------------------------------------------------------------------
 cat >"${fake_bin}/talosctl" <<'FAKE'
 #!/usr/bin/env bash
@@ -78,54 +78,27 @@ node=''
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -n) node="$2"; shift 2 ;;
-    read)
-      path="$2"
-      file="${FIXTURES}/${node}/files/${path//\//_}"
-      [[ -f "${file}" ]] || exit 1
-      cat "${file}"
+    get)
+      type="$2"
+      # An unreachable node fails everything.
+      [[ -d "${FIXTURES}/${node}" ]] || { printf 'error connecting to %s\n' "${node}" >&2; exit 1; }
+      # A query that faults on a REACHABLE node.
+      if [[ -f "${FIXTURES}/${node}/queryfail_${type}" ]]; then
+        printf 'rpc error: code = Unavailable desc = connection error\n' >&2
+        exit 1
+      fi
+      resource="${FIXTURES}/${node}/resources/${type}"
+      # No instances of this type: exit 0, emit nothing.
+      [[ -f "${resource}" ]] || exit 0
+      cat "${resource}"
       exit 0
       ;;
     ls)
       shift
-      long=0
-      [[ "${1:-}" == '-l' ]] && { long=1; shift; } || true
       path="${1:-/}"
-      # An unreachable node fails everything, exactly as the real client does
-      # when it cannot talk to the API.
       [[ -d "${FIXTURES}/${node}" ]] || { printf 'error connecting to %s\n' "${node}" >&2; exit 1; }
-      listing="${FIXTURES}/${node}/dirs/${path//\//_}"
-      content="${FIXTURES}/${node}/files/${path//\//_}"
-      # The node drops out mid-check: its config files still probe and read, but
-      # every OTHER `ls` now fails — including the `/` reachability probe. That
-      # ordering is the point: the check gets past the config and only then finds
-      # the node gone, which is the path a start-of-run probe cannot cover.
-      if [[ -f "${FIXTURES}/${node}/lsfail_all" && ! -f "${content}" ]]; then
-        printf 'error connecting to %s\n' "${node}" >&2
-        exit 1
-      fi
-      # A path that fails for a reason OTHER than being absent: the real client
-      # emits an RPC error here, not an lstat one. Kept distinct from the
-      # no-fixture case below so a transient fault can be told apart from a
-      # config the node genuinely does not ship.
-      if [[ -f "${FIXTURES}/${node}/lserror${path//\//_}" ]]; then
-        printf 'rpc error: code = Unavailable desc = connection error\n' >&2
-        exit 1
-      fi
-      # `ls /` is the reachability probe: the node answered, so it succeeds.
+      [[ -f "${FIXTURES}/${node}/unreachable" ]] && { printf 'error connecting to %s\n' "${node}" >&2; exit 1; }
       [[ "${path}" == '/' ]] && exit 0
-      if [[ -f "${listing}" ]]; then
-        # A node that answers the short-form existence probe and then fails the
-        # long-form listing: the directory was there, the node stopped talking.
-        if [[ "${long}" -eq 1 && -f "${FIXTURES}/${node}/lsfail" ]]; then
-          printf 'error connecting to %s\n' "${node}" >&2
-          exit 1
-        fi
-        [[ "${long}" -eq 1 ]] && cat "${listing}"
-        exit 0
-      fi
-      # A regular file exists but has no directory listing — `ls` on it succeeds
-      # and never emits its CONTENTS.
-      [[ -f "${content}" ]] && exit 0
       printf 'lstat %s: no such file or directory\n' "${path}" >&2
       exit 1
       ;;
@@ -139,29 +112,58 @@ chmod +x "${fake_bin}/talosctl"
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >>"${FIXTURES}/kubectl-args"
 cat "${FIXTURES}/nodes.json"
 FAKE
 chmod +x "${fake_bin}/kubectl"
 
-# A real `talosctl ls -l` header plus rows. Column 2 is MODE, last column is
-# NAME, and the LABEL column is EMPTY for some files on this cluster — which is
-# why the script must not parse positionally from the left past column 2. One
-# fixture below reproduces that empty-label row on purpose.
-listing_header='NODE       MODE         UID   GID   SIZE(B)   LASTMOD           LABEL                                      NAME'
+readonly rules_type='imageverificationrules.security.talos.dev'
+readonly roots_type='tuftrustedroots.security.talos.dev'
+readonly rules_owner='security.ImageVerificationConfigController'
+readonly roots_owner='security.TUFTrustedRootController'
 
 write_node() {
+  mkdir -p "${fixtures}/$1/resources"
+}
+
+# Emits one resource object in the shape `talosctl get -o json` produces: a
+# STREAM of objects, not an array.
+resource_obj() {
+  local id="$1" phase="$2" owner="$3" type="$4"
+  cat <<EOF
+{
+    "metadata": {
+        "id": "${id}",
+        "namespace": "security",
+        "owner": "${owner}",
+        "phase": "${phase}",
+        "type": "${type}",
+        "version": 1
+    },
+    "node": "fixture",
+    "spec": {}
+}
+EOF
+}
+
+write_rules() {
+  cat >"${fixtures}/$1/resources/${rules_type}"
+}
+
+write_roots() {
+  cat >"${fixtures}/$1/resources/${roots_type}"
+}
+
+# The healthy shape, used as the control for every RED case below.
+healthy_node() {
   local node="$1"
-  mkdir -p "${fixtures}/${node}/files" "${fixtures}/${node}/dirs"
-}
-
-write_config() {
-  local node="$1" path="$2"
-  cat >"${fixtures}/${node}/files/${path//\//_}"
-}
-
-write_dir() {
-  local node="$1" path="$2"
-  cat >"${fixtures}/${node}/dirs/${path//\//_}"
+  write_node "${node}"
+  {
+    resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
+    resource_obj 0001 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
+  } | write_rules "${node}"
+  resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+    write_roots "${node}"
 }
 
 run_script() {
@@ -170,662 +172,239 @@ run_script() {
     "$@" bash "${script}"
 }
 
-# --- The credential value that must never appear in output. -----------------
-# Deliberately NOT shaped like a real token. The property under test is "no
-# config content reaches stdout", which any distinctive sentinel proves — while
-# a realistic `ghp_`-shaped literal is itself a finding for the secret scanners
-# this repository gates on (betterleaks/secretlint/trufflehog report 0 on this
-# tree, and a test fixture is not a good reason to spend that).
-readonly canary='CANARY-registry-auth-value-must-never-be-printed'
-
-verifier_config() {
-  local bin_dir="$1"
-  cat <<EOF
-version = 3
-
-[plugins]
-  [plugins.'io.containerd.cri.v1.images']
-    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
-      password = '${canary}'
-      username = 'devantler'
-
-  [plugins.'io.containerd.image-verifier.v1.bindir']
-    bin_dir = '${bin_dir}'
-EOF
-}
-
-no_verifier_config() {
-  cat <<EOF
-version = 3
-
-[plugins]
-  [plugins.'io.containerd.cri.v1.images']
-    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
-      password = '${canary}'
-      username = 'devantler'
-EOF
-}
-
 # ===========================================================================
-# Case 1 — GREEN: bin_dir configured, exists, holds an executable.
+# Case 1 — GREEN: rules in phase running, trust root in phase running.
 # ===========================================================================
-write_node good
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/good/files/_etc_cri_conf.d_cri.toml"
-write_dir good /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
-EOF
-
+healthy_node good
 output="$(run_script TALOS_NODES=good 2>&1)" || fail "case 1: expected exit 0 for a node that can enforce"
 require_text "${output}" 'OK   good' 'case 1: reports the healthy node'
+require_text "${output}" '2 rule(s) in phase running' 'case 1: counts the running rules'
 require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 1: reports the summary'
 
 # ===========================================================================
-# Case 2 — RED, and this is the #2856 state: bin_dir configured, directory
-# present, NO executable in it. containerd permits every pull here.
+# Case 2 — RED: the node holds NO ImageVerificationRules at all. The declared
+# rules were never materialised, so nothing constrains a pull.
 # ===========================================================================
-write_node empty
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/empty/files/_etc_cri_conf.d_cri.toml"
-write_dir empty /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   drwxr-xr-x   0     0     3         Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
-EOF
-
-if output="$(run_script TALOS_NODES=empty 2>&1)"; then
-  fail "case 2: an empty bin_dir MUST fail — this is the exact state that let an unsigned image run (#2856)"
-fi
-require_text "${output}" 'FAIL empty' 'case 2: names the failing node'
-require_text "${output}" 'holds no executable' 'case 2: names the condition that failed'
+write_node norules
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots norules
+status=0
+output="$(run_script TALOS_NODES=norules 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 2: a node with no ImageVerificationRules MUST fail'
+require_text "${output}" 'FAIL norules' 'case 2: names the failing node'
+require_text "${output}" 'never materialised' 'case 2: names the condition that failed'
 
 # ===========================================================================
-# Case 3 — RED: no bin_dir configured at all in any config file. This is what
-# the cluster actually looked like when #2856 was found.
+# Case 3 — RED: rules exist as resources but none reached phase "running".
+# This is the case a presence-only check would pass.
 # ===========================================================================
-write_node unset
-no_verifier_config >"${fixtures}/unset/files/_etc_cri_conf.d_cri.toml"
-no_verifier_config >"${fixtures}/unset/files/_etc_containerd_config.toml"
-
-if output="$(run_script TALOS_NODES=unset 2>&1)"; then
-  fail 'case 3: a node with no bin_dir configured MUST fail'
-fi
-require_text "${output}" 'FAIL unset' 'case 3: names the failing node'
-require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 3: names the condition that failed'
-
-# ===========================================================================
-# Case 4 — RED: bin_dir configured but the directory does not exist.
-# ===========================================================================
-write_node missing
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/missing/files/_etc_cri_conf.d_cri.toml"
-
-if output="$(run_script TALOS_NODES=missing 2>&1)"; then
-  fail 'case 4: a configured-but-absent bin_dir MUST fail'
-fi
-require_text "${output}" 'does not exist' 'case 4: names the condition that failed'
-
-# ===========================================================================
-# Case 5 — SECURITY: cri.toml carries registry auth and this output goes to CI
-# logs. No path through the script may print it — including the failure paths,
-# which are the tempting place to dump "the config we read".
-# ===========================================================================
-for node in good empty unset missing; do
-  output="$(run_script TALOS_NODES="${node}" 2>&1 || true)"
-  refute_text "${output}" "${canary}" "case 5: leaked the registry credential from ${node}'s config into output"
-  refute_text "${output}" 'password' "case 5: echoed a config auth key from ${node}"
-done
-
-# ===========================================================================
-# Case 6 — a mixed fleet fails, and reports EVERY bad node rather than stopping
-# at the first. A partial rollout that left one node unverified is precisely the
-# case a first-failure exit would hide.
-# ===========================================================================
-if output="$(run_script TALOS_NODES=good,empty,unset 2>&1)"; then
-  fail 'case 6: a fleet containing an unenforcing node MUST fail'
-fi
-require_text "${output}" 'OK   good' 'case 6: still reports the healthy node'
-require_text "${output}" 'FAIL empty' 'case 6: reports the empty-bindir node'
-require_text "${output}" 'FAIL unset' 'case 6: reports the unconfigured node'
-require_text "${output}" '2 of 3 node(s) cannot enforce' 'case 6: counts every failure, not just the first'
-
-# ===========================================================================
-# Case 7 — node discovery. With no --nodes/TALOS_NODES the script reads the
-# cluster, so autoscaled nodes are covered without anyone maintaining a list.
-# The autoscaler node was central to #2856's evidence.
-# ===========================================================================
-cat >"${fixtures}/nodes.json" <<'EOF'
+write_node notrunning
 {
-  "items": [
-    {"status": {"addresses": [{"type": "Hostname", "address": "prod-worker-1"}, {"type": "InternalIP", "address": "good"}]}},
-    {"status": {"addresses": [{"type": "InternalIP", "address": "empty"}]}}
-  ]
-}
+  resource_obj 0000 tearingDown "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
+} | write_rules notrunning
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots notrunning
+status=0
+output="$(run_script TALOS_NODES=notrunning 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 3: rules present but not running MUST fail'
+require_text "${output}" 'FAIL notrunning' 'case 3: names the failing node'
+require_text "${output}" 'not being enforced' 'case 3: names the condition that failed'
+
+# ===========================================================================
+# Case 4 — RED: a rule in phase running but owned by something OTHER than the
+# ImageVerificationConfig controller. Without the owner check, any resource of
+# that type parked in the namespace would vouch for enforcement.
+# ===========================================================================
+write_node wrongowner
+resource_obj 0000 running some.other.Controller 'ImageVerificationRules.security.talos.dev' |
+  write_rules wrongowner
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots wrongowner
+status=0
+output="$(run_script TALOS_NODES=wrongowner 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 4: a rule owned by another controller MUST NOT satisfy the check'
+require_text "${output}" 'FAIL wrongowner' 'case 4: names the failing node'
+require_text "${output}" 'not being enforced' 'case 4: names the condition that failed'
+
+# ===========================================================================
+# Case 5 — RED: running rules but NO trust root. Keyless verification has
+# nothing to verify a signature against, so the rules decide nothing. This is a
+# DIFFERENT failure from a missing rule and must be reported as its own.
+# ===========================================================================
+write_node noroot
+{
+  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
+} | write_rules noroot
+status=0
+output="$(run_script TALOS_NODES=noroot 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 5: running rules with no trust root MUST fail'
+require_text "${output}" 'FAIL noroot' 'case 5: names the failing node'
+require_text "${output}" 'no trust material' 'case 5: names the condition that failed'
+
+# ===========================================================================
+# Case 6 — RED: a trust root that exists but is not running.
+# ===========================================================================
+write_node staleroot
+{
+  resource_obj 0000 running "${rules_owner}" 'ImageVerificationRules.security.talos.dev'
+} | write_rules staleroot
+resource_obj trusted_root.json tearingDown "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots staleroot
+status=0
+output="$(run_script TALOS_NODES=staleroot 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 6: a non-running trust root MUST fail'
+require_text "${output}" 'FAIL staleroot' 'case 6: names the failing node'
+require_text "${output}" 'no usable trust material' 'case 6: names the condition that failed'
+
+# ===========================================================================
+# Case 7 — a mixed fleet fails and reports EVERY bad node, not just the first.
+# ===========================================================================
+status=0
+output="$(run_script TALOS_NODES=good,norules,noroot 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 7: a fleet containing an unenforcing node MUST fail'
+require_text "${output}" 'OK   good' 'case 7: still reports the healthy node'
+require_text "${output}" 'FAIL norules' 'case 7: reports the node with no rules'
+require_text "${output}" 'FAIL noroot' 'case 7: reports the node with no trust root'
+require_text "${output}" '2 of 3 node(s) cannot enforce' 'case 7: counts every failure, not just the first'
+
+# ===========================================================================
+# Case 8 — a query that FAULTS on a reachable node is an infrastructure error
+# (exit 2), never a verdict. Reporting it as "cannot enforce" would blame the
+# cluster for a runner-side fault; swallowing it would be a fail-open.
+# ===========================================================================
+healthy_node faulty
+touch "${fixtures}/faulty/queryfail_${rules_type}"
+status=0
+output="$(run_script TALOS_NODES=faulty 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] || fail 'case 8: a failed query MUST be an infrastructure error, not a verdict'
+require_text "${output}" 'could not read' 'case 8: names the query it could not run'
+refute_text "${output}" 'FAIL faulty' 'case 8: reported a verdict for a node it never inspected'
+rm -f "${fixtures}/faulty/queryfail_${rules_type}"
+output="$(run_script TALOS_NODES=faulty 2>&1)" || fail 'case 8: the same node must pass once the query fault is gone'
+require_text "${output}" 'OK   faulty' 'case 8: control — the node is otherwise healthy'
+
+# ===========================================================================
+# Case 9 — a trust-root query that faults is likewise an infrastructure error,
+# not a "no trust material" verdict.
+# ===========================================================================
+healthy_node rootfaulty
+touch "${fixtures}/rootfaulty/queryfail_${roots_type}"
+status=0
+output="$(run_script TALOS_NODES=rootfaulty 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] || fail 'case 9: a failed trust-root query MUST be an infrastructure error'
+refute_text "${output}" 'no trust material' 'case 9: misreported a query fault as a missing trust root'
+
+# ===========================================================================
+# Case 10 — an UNREACHABLE node aborts; it is never reported as checked.
+# ===========================================================================
+status=0
+output="$(run_script TALOS_NODES=ghost 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] || fail 'case 10: an unreachable node MUST abort, not yield a verdict'
+require_text "${output}" 'ghost' 'case 10: names the unreachable node'
+refute_text "${output}" 'OK   ghost' 'case 10: reported a verdict for a node it never checked'
+
+# ===========================================================================
+# Case 11 — node discovery. With no --nodes/TALOS_NODES the script reads the
+# fleet from kubectl and must use InternalIP, never Hostname.
+# ===========================================================================
+healthy_node 10.0.1.4
+write_node 10.0.1.5
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots 10.0.1.5
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"Hostname","address":"worker-1"},{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"Hostname","address":"worker-2"},{"type":"InternalIP","address":"10.0.1.5"}]}}
+]}
 EOF
-
-if output="$(run_script 2>&1)"; then
-  fail 'case 7: discovery must surface the unenforcing discovered node'
-fi
-require_text "${output}" 'OK   good' 'case 7: discovered the healthy node'
-require_text "${output}" 'FAIL empty' 'case 7: discovered the unenforcing node'
-refute_text "${output}" 'prod-worker-1' 'case 7: used InternalIP, not Hostname'
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] || fail 'case 11: discovery must surface the unenforcing discovered node'
+require_text "${output}" 'OK   10.0.1.4' 'case 11: discovered the healthy node'
+require_text "${output}" 'FAIL 10.0.1.5' 'case 11: discovered the unenforcing node'
+refute_text "${output}" 'worker-1' 'case 11: used InternalIP, not Hostname'
 
 # ===========================================================================
-# Case 8 — a verifier in ONE containerd must not vouch for the other.
-#
-# Both config files exist on every prod node (measured), and the two instances
-# pull different images: the CRI one pulls workload images, the system one pulls
-# Talos' own. So a node wired up on one side and bare on the other is HALF
-# unprotected — and an implementation that stops at the first config declaring a
-# bin_dir reports it as healthy. Both directions are pinned, because the
-# short-circuit only ever hides whichever file is read second.
+# Case 12 — KUBECTL_CONTEXT is forwarded to kubectl. The restored kubeconfig's
+# current-context is not guaranteed to be prod, so an unpinned context would
+# enumerate the wrong fleet and still exit 0.
 # ===========================================================================
-write_node systembare
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/systembare/files/_etc_cri_conf.d_cri.toml"
-no_verifier_config >"${fixtures}/systembare/files/_etc_containerd_config.toml"
-write_dir systembare /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+rm -f "${fixtures}/kubectl-args"
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[{"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}]}
 EOF
-
-if output="$(run_script TALOS_NODES=systembare 2>&1)"; then
-  fail 'case 8: a bare SYSTEM containerd must fail even when the CRI one is wired up'
-fi
-require_text "${output}" '/etc/containerd/config.toml' 'case 8: names the unprotected containerd'
-require_text "${output}" 'OK   systembare [/etc/cri/conf.d/cri.toml]' 'case 8: still reports the wired-up one'
-
-write_node cribare
-no_verifier_config >"${fixtures}/cribare/files/_etc_cri_conf.d_cri.toml"
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/cribare/files/_etc_containerd_config.toml"
-write_dir cribare /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
-EOF
-
-if output="$(run_script TALOS_NODES=cribare 2>&1)"; then
-  fail 'case 8: a bare CRI containerd must fail even when the system one is wired up'
-fi
-require_text "${output}" '/etc/cri/conf.d/cri.toml' 'case 8: names the unprotected containerd'
-
-# ===========================================================================
-# Case 9 — a row whose LABEL column is empty must still be parsed. Real
-# `talosctl ls -l` output on this cluster omits the label for some files, which
-# breaks any parser that counts columns from the left past MODE.
-# ===========================================================================
-write_node nolabel
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/nolabel/files/_etc_cri_conf.d_cri.toml"
-write_dir nolabel /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug 11 19:39:51                                              cosign-verifier
-EOF
-
-output="$(run_script TALOS_NODES=nolabel 2>&1)" ||
-  fail 'case 9: an executable whose ls row has no SELinux label must still be counted'
-require_text "${output}" 'holds 1 executable' 'case 9: counted the unlabelled executable'
-
-# ===========================================================================
-# Case 10 — a NON-executable file in bin_dir does not satisfy the check.
-# containerd executes the binaries there; a stray README enforces nothing.
-# ===========================================================================
-write_node nonexec
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/nonexec/files/_etc_cri_conf.d_cri.toml"
-write_dir nonexec /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   -rw-r--r--   0     0     42        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   README
-EOF
-
-if output="$(run_script TALOS_NODES=nonexec 2>&1)"; then
-  fail 'case 10: a bin_dir holding only a non-executable file MUST fail'
-fi
-require_text "${output}" 'holds no executable' 'case 10: names the condition that failed'
-
-# ===========================================================================
-# Case 12 — a config file that does NOT exist must be skipped, not fatal.
-#
-# Every other fixture here has both config files present, which is also true of
-# today's nodes — so this path is reachable only on a node image where one is
-# absent, and it would then abort the whole run at an assignment under
-# `set -e` + `pipefail` rather than reporting anything. A checker that dies
-# silently on the drift it exists to watch is worse than no checker.
-# ===========================================================================
-write_node onlycri
-no_verifier_config >"${fixtures}/onlycri/files/_etc_cri_conf.d_cri.toml"
-# deliberately NO _etc_containerd_config.toml fixture
-
-if output="$(run_script TALOS_NODES=onlycri 2>&1)"; then
-  fail 'case 12: a node with no bin_dir anywhere must FAIL, not pass'
-fi
-require_text "${output}" 'FAIL onlycri' 'case 12: reported the node instead of aborting on the missing config file'
-require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 12: reached the real verdict'
-
-# The mirror image: a missing FIRST file must not stop the second from being
-# read, or a verifier declared only in the system config would be invisible.
-write_node onlysystem
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/onlysystem/files/_etc_containerd_config.toml"
-write_dir onlysystem /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
-EOF
-
-run_script TALOS_NODES=onlysystem >/dev/null 2>&1 ||
-  fail 'case 12: a missing first config file must not stop the second being read'
-
-# ===========================================================================
-# Case 11 — KUBECTL_CONTEXT is forwarded to kubectl. The restored kubeconfig's
-# current-context is not guaranteed to be prod, which is why the deploy
-# composite pins --context; a check that silently read the wrong cluster would
-# report a healthy fleet that is not the one being gated.
-# ===========================================================================
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >>"${FIXTURES}/kubectl-args"
-cat "${FIXTURES}/nodes.json"
-FAKE
-chmod +x "${fake_bin}/kubectl"
-
-: >"${fixtures}/kubectl-args"
 run_script KUBECTL_CONTEXT=admin@prod >/dev/null 2>&1 || true
-grep -Fq -- '--context admin@prod' "${fixtures}/kubectl-args" ||
-  fail 'case 11: KUBECTL_CONTEXT was not forwarded to kubectl'
-
-# ...and is omitted entirely when unset, rather than passed as an empty flag,
-# which kubectl rejects.
-: >"${fixtures}/kubectl-args"
+require_text "$(cat "${fixtures}/kubectl-args")" '--context admin@prod' 'case 12: KUBECTL_CONTEXT was not forwarded to kubectl'
+rm -f "${fixtures}/kubectl-args"
 run_script >/dev/null 2>&1 || true
-refute_text "$(cat "${fixtures}/kubectl-args")" '--context' 'case 11: passed an empty --context when KUBECTL_CONTEXT was unset'
-
-# ===========================================================================
-# Case 16 — a bin_dir holding ONLY a SUBDIRECTORY must FAIL. A directory's mode
-# string ('drwxr-xr-x') contains an 'x', so a check that counts any entry with
-# an 'x' reports this node as enforcing. containerd executes files in bin_dir
-# and does not descend, so such a node permits every pull — a fail-open in the
-# dangerous direction, and the exact class #2856 was.
-# ===========================================================================
-write_node dironly
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/dironly/files/_etc_cri_conf.d_cri.toml"
-write_dir dironly /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   .
-10.0.1.4   drwxr-xr-x   0     0     37        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   plugins
-EOF
-
-if output="$(run_script TALOS_NODES=dironly 2>&1)"; then
-  fail 'case 16: a bin_dir holding only a subdirectory MUST fail — directories are not verifier binaries'
-fi
-require_text "${output}" 'holds no executable' 'case 16: names the condition that failed'
-
-# ...while an executable SYMLINK in bin_dir still counts: a verifier installed
-# via a symlink into bin_dir is executed exactly like a regular file.
-write_node symlink
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/symlink/files/_etc_cri_conf.d_cri.toml"
-write_dir symlink /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.4   lrwxrwxrwx   0     0     31        Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
-EOF
-
-output="$(run_script TALOS_NODES=symlink 2>&1)" ||
-  fail 'case 16: an executable symlink in bin_dir must count as a verifier'
-require_text "${output}" 'holds 1 executable' 'case 16: counted the symlinked verifier'
+refute_text "$(cat "${fixtures}/kubectl-args")" '--context' 'case 12: passed an empty --context when KUBECTL_CONTEXT was unset'
 
 # ===========================================================================
 # Case 13 — an empty entry in the node list is a USAGE error (exit 2), not a
-# node to skip. Skipping it would check fewer nodes than asked for and still
-# exit 0: a clean report on a fleet the check never looked at.
+# silently shortened fleet. Checking FEWER nodes than were asked for and still
+# exiting 0 is a checker reporting a clean fleet it never looked at.
 # ===========================================================================
-# A trailing comma is the case a post-split scan structurally cannot catch:
-# `read -a` discards the trailing empty field, so 'good,' splits to exactly one
-# element and looks perfectly well-formed. Leading and doubled commas are here
-# for the same reason — the check is on the raw string, so all three share a
-# code path and all three are pinned.
-for malformed in 'good,,good' 'good,' ',good' 'good,,'; do
+for bad_list in ',good' 'good,' 'good,,good'; do
   status=0
-  output="$(run_script "TALOS_NODES=${malformed}" 2>&1)" || status=$?
-  [[ "${status}" -ne 0 ]] ||
-    fail "case 13: malformed node list '${malformed}' must not succeed"
-  [[ "${status}" -eq 2 ]] ||
-    fail "case 13: malformed node list '${malformed}' must exit 2 (usage), got ${status}"
-  require_text "${output}" 'empty entry' "case 13: names the malformed list for '${malformed}'"
-  refute_text "${output}" 'can enforce image verification.' \
-    "case 13: reported a verdict for the malformed list '${malformed}'"
+  output="$(run_script TALOS_NODES="${bad_list}" 2>&1)" || status=$?
+  [[ "${status}" -eq 2 ]] || fail "case 13: a malformed node list (${bad_list}) MUST be a usage error"
+  require_text "${output}" 'empty entry' "case 13: names the malformation in ${bad_list}"
 done
-
-# The well-formed list must still work — otherwise the guard above could be
-# rejecting everything and every assertion here would still pass.
-run_script TALOS_NODES=good,good >/dev/null 2>&1 ||
-  fail 'case 13: a well-formed comma-separated list must still be accepted'
+output="$(run_script TALOS_NODES='good,good' 2>&1)" || fail 'case 13: a well-formed comma-separated list must still be accepted'
 
 # ===========================================================================
-# Case 14 — a bin_dir belonging to a DIFFERENT plugin must not count.
-#
-# `bin_dir` is a generic TOML key. containerd consults only the one under
-# `io.containerd.image-verifier.v1.bindir` when verifying images, so a match
-# anywhere else reports a node as enforcing on the strength of a setting that
-# has nothing to do with verification — a fail-open produced by the parser
-# rather than by the cluster.
+# Case 14 — an explicitly EMPTY node list is a usage error, not a fallback to
+# cluster discovery: the option WAS supplied and named nothing, and discovery
+# would check a different fleet than the caller asked for.
 # ===========================================================================
-write_node otherplugin
-cat >"${fixtures}/otherplugin/files/_etc_cri_conf.d_cri.toml" <<EOF
-version = 3
-
-[plugins]
-  [plugins.'io.containerd.cri.v1.images']
-    [plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth]
-      password = '${canary}'
-      username = 'devantler'
-
-  [plugins.'io.containerd.nri.v1.nri']
-    bin_dir = '/opt/nri/bin'
-EOF
-# The unrelated plugin's directory is fully populated: if the check were to read
-# it, it would report a healthy node. Only the SCOPE keeps this failing.
-write_dir otherplugin /opt/nri/bin <<EOF
-${listing_header}
-10.0.1.4   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   nri-plugin
-EOF
-
-if output="$(run_script TALOS_NODES=otherplugin 2>&1)"; then
-  fail 'case 14: a bin_dir from an unrelated plugin table MUST NOT satisfy the check'
-fi
-require_text "${output}" 'no bin_dir in the io.containerd.image-verifier.v1.bindir table' 'case 14: reached the real verdict'
-refute_text "${output}" '/opt/nri/bin' 'case 14: read a bin_dir from the wrong table'
-
-# ===========================================================================
-# Case 15 — an UNREACHABLE node aborts; it is never reported as checked.
-#
-# The failure this guards is quiet: if a config file's absence is inferred from
-# a failed read, a node the runner cannot talk to looks identical to one that
-# simply does not ship that file. Every config would be "absent", the node would
-# be skipped, and the fleet summary would report a clean result for a node
-# nothing ever looked at.
-# ===========================================================================
-status=0
-output="$(run_script TALOS_NODES=unreachable 2>&1)" || status=$?
-if [[ "${status}" -ne 2 ]]; then
-  fail "case 15: an unreachable node must exit 2 (infrastructure), got ${status}"
-fi
-require_text "${output}" 'cannot reach node unreachable' 'case 15: names the unreachable node'
-refute_text "${output}" 'can enforce image verification.' 'case 15: reported a verdict for a node it never checked'
-
-# ===========================================================================
-# Case 17 — a node that stops answering AFTER its config was read is an
-# infrastructure error, not a verdict.
-#
-# `talosctl ls -l` on a bin_dir already proven to exist can still fail. awk over
-# empty input prints 0 quite happily, so discarding that status turns an
-# unreachable node into a confident "holds no executable" FAIL — the checker
-# blaming the cluster for a runner-side fault, at exit code 1 where a human
-# reads "the fleet is unprotected" rather than "the check did not run".
-# ===========================================================================
-write_node vanishing
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/vanishing/files/_etc_cri_conf.d_cri.toml"
-# `ls <dir>` succeeds (the existence probe) because a listing fixture exists,
-# but it is EMPTY, so `ls -l` on it produces no rows...
-write_dir vanishing /opt/containerd/image-verifier/bin </dev/null
-# ...and this makes the long-form listing fail outright, which is the real
-# shape: the directory was there a moment ago and the node is now unresponsive.
-printf 'FAIL_LS_LONG\n' >"${fixtures}/vanishing/lsfail"
-
-status=0
-output="$(run_script TALOS_NODES=vanishing 2>&1)" || status=$?
-if [[ "${status}" -eq 1 ]]; then
-  fail 'case 17: a failed listing on an existing bin_dir must not be reported as "holds no executable"'
-fi
-[[ "${status}" -eq 2 ]] ||
-  fail "case 17: a failed listing must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'could not list' 'case 17: names the listing failure'
-refute_text "${output}" 'can enforce image verification.' 'case 17: reported a verdict it could not reach'
-
-# ===========================================================================
-# Case 19 — a node that drops out between the config read and the bin_dir probe
-# is an infrastructure error, not "the directory does not exist".
-#
-# `directory_exists` sees the same failed `ls` either way. Reporting the
-# unreachable case as a verdict blames the cluster for a runner-side fault, and
-# a start-of-run reachability probe cannot cover it — the node was answering
-# when the run began.
-# ===========================================================================
-write_node dropout
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/dropout/files/_etc_cri_conf.d_cri.toml"
-printf 'DROPPED\n' >"${fixtures}/dropout/lsfail_all"
-
-status=0
-output="$(run_script TALOS_NODES=dropout 2>&1)" || status=$?
-if [[ "${status}" -eq 1 ]]; then
-  fail 'case 19: an unreachable node must not be reported as "bin_dir does not exist"'
-fi
-[[ "${status}" -eq 2 ]] ||
-  fail "case 19: a mid-check dropout must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'cannot reach node dropout' 'case 19: names the unreachable node'
-refute_text "${output}" 'does not exist' 'case 19: blamed the cluster for a runner-side fault'
-
-# ===========================================================================
-# Case 18 — PARTIAL node discovery must abort, never pass on the prefix.
-#
-# kubectl can return a valid node followed by one whose addresses are missing,
-# so jq emits an address and THEN fails. Run through a process substitution,
-# `fail_infra` exits only that subshell: the loop keeps the addresses already
-# emitted, and if those happen to be healthy the script exits 0 having silently
-# dropped the rest of the fleet. That is the fail-open this whole script exists
-# to detect, arriving through the enumeration rather than the verdict.
-# ===========================================================================
-# kubectl SUCCEEDS here — that is the whole point. The failure has to come from
-# jq, midway through valid output: the first node yields an address, the second
-# has no `status.addresses` at all, so jq errors on it AFTER writing "good" to
-# stdout. A fake that simply exits non-zero would abort discovery at the kubectl
-# step and never exercise the partial-output path (it did, and the ablation
-# caught it).
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[{"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},{"status":{}}]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
-
-status=0
-output="$(run_script 2>&1)" || status=$?
-if [[ "${status}" -eq 0 ]]; then
-  fail 'case 18: partial node discovery MUST NOT exit 0 — the rest of the fleet was never enumerated'
-fi
-[[ "${status}" -eq 2 ]] ||
-  fail "case 18: partial discovery must exit 2 (infrastructure), got ${status}"
-refute_text "${output}" 'can enforce image verification.' 'case 18: reported a fleet it only partly enumerated'
-
-# ===========================================================================
-# Case 22 — a discovered node with NO InternalIP must not be silently dropped.
-#
-# Distinct from case 18, and the distinction is the whole point: there the node
-# has no `status.addresses` at all, so jq ERRORS and discovery already fails
-# closed. Here the array is present and perfectly valid — it just holds only a
-# Hostname and an ExternalIP. jq's `select(.type == "InternalIP")` matches
-# nothing, emits nothing, and SUCCEEDS. The node vanishes from the fleet while
-# every other node reports OK, so the script prints a confident green verdict
-# for a fleet it never fully enumerated: the same fail-open shape the script
-# exists to detect, arriving through enumeration rather than the verdict.
-# ===========================================================================
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-2"},{"type":"ExternalIP","address":"203.0.113.7"}]}}
-]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
-
-status=0
-output="$(run_script 2>&1)" || status=$?
-[[ "${status}" -ne 0 ]] ||
-  fail 'case 22: a node with no InternalIP MUST NOT yield exit 0 — it was never checked'
-[[ "${status}" -eq 2 ]] ||
-  fail "case 22: a node with no InternalIP must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'prod-worker-2' 'case 22: names the node that has no InternalIP'
-refute_text "${output}" 'can enforce image verification.' \
-  'case 22: reported a verdict for a fleet that was only partly enumerated'
-
-# The healthy-fleet control: without it, a discover_nodes that rejected EVERY
-# node would pass every assertion above.
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"Hostname","address":"prod-worker-1"},{"type":"InternalIP","address":"good"}]}}
-]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
-run_script >/dev/null 2>&1 ||
-  fail 'case 22: a fleet whose nodes all have an InternalIP must still be accepted'
-
-# ===========================================================================
-# Case 20 — an explicitly EMPTY node list is a usage error, not a fallback.
-#
-# `--nodes "$TALOS_NODES"` with the variable unset expands to an empty string.
-# Treating that as "no list was given" silently switches to cluster discovery,
-# so the check reports a green verdict for a DIFFERENT fleet than the caller
-# asked for — and the explicit addresses are usually explicit precisely because
-# the current kube context is not the fleet in question.
-#
-# Discovery is wired to a healthy node here on purpose: if the fallback fires,
-# the script exits 0 and the assertion below is what catches it.
-# ===========================================================================
-run_script_with_args() {
-  env PATH="${fake_bin}:${PATH}" FIXTURES="${fixtures}" \
-    TALOSCTL="${fake_bin}/talosctl" KUBECTL="${fake_bin}/kubectl" \
-    bash "${script}" "$@"
-}
-
-status=0
-output="$(run_script_with_args --nodes '' 2>&1)" || status=$?
-[[ "${status}" -ne 0 ]] ||
-  fail 'case 20: --nodes "" must not silently fall back to cluster discovery'
-[[ "${status}" -eq 2 ]] ||
-  fail "case 20: --nodes '' must exit 2 (usage), got ${status}"
-refute_text "${output}" 'can enforce image verification.' \
-  'case 20: reported a verdict for a fleet the caller never asked for'
-
-# Same for the environment form, which is how CI passes the list.
 status=0
 output="$(run_script TALOS_NODES= 2>&1)" || status=$?
-[[ "${status}" -eq 2 ]] ||
-  fail "case 20: TALOS_NODES set-but-empty must exit 2 (usage), got ${status}"
-
-# Controls: an explicit non-empty list still works, and a genuinely UNSET
-# TALOS_NODES must still reach discovery — otherwise the guard above would be
-# rejecting the discovery path outright and case 7 would be the only thing
-# keeping it honest.
-run_script_with_args --nodes good >/dev/null 2>&1 ||
-  fail 'case 20: an explicit non-empty --nodes must still be accepted'
-run_script >/dev/null 2>&1 ||
-  fail 'case 20: an unset TALOS_NODES must still fall through to discovery'
+[[ "${status}" -eq 2 ]] || fail 'case 14: --nodes "" must not silently fall back to cluster discovery'
+refute_text "${output}" 'OK   ' 'case 14: reported a verdict for a fleet the caller never asked for'
 
 # ===========================================================================
-# Case 21 — a config probe that fails for a reason OTHER than "absent" is an
-# infrastructure error, never a config to skip.
-#
-# `talosctl ls <config>` failing is ambiguous: the file may not be there, or the
-# node may have hiccuped. Only the first is a verdict. Treating both as "this
-# node does not ship that config" means a transient fault silently removes one
-# containerd from the check — and if the OTHER containerd is wired up,
-# `configs_present` stays nonzero and the node passes while one of its two image
-# paths was never inspected.
-#
-# The system containerd here is deliberately HEALTHY: that is what makes the
-# skip invisible without this case.
+# Case 15 — PARTIAL node discovery must abort, never pass on the prefix. A node
+# with no InternalIP matches nothing and the jq select SUCCEEDS, so that node
+# silently leaves the fleet while the rest report OK.
 # ===========================================================================
-write_node probeerror
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/probeerror/files/_etc_containerd_config.toml"
-verifier_config /opt/containerd/image-verifier/bin >"${fixtures}/probeerror/files/_etc_cri_conf.d_cri.toml"
-write_dir probeerror /opt/containerd/image-verifier/bin <<EOF
-${listing_header}
-10.0.1.9   -rwxr-xr-x   0     0     8123456   Aug  4 14:58:45   system_u:object_r:containerd_plugin_t:s0   cosign-verifier
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-9"},"status":{"addresses":[{"type":"Hostname","address":"worker-9"}]}}
+]}
 EOF
-# The CRI config probe fails with an RPC error rather than an lstat one. The
-# node itself still answers `ls /`, so a reachability probe cannot catch this.
-printf 'PROBE_ERROR\n' >"${fixtures}/probeerror/lserror_etc_cri_conf.d_cri.toml"
-
-status=0
-output="$(run_script TALOS_NODES=probeerror 2>&1)" || status=$?
-[[ "${status}" -ne 0 ]] ||
-  fail 'case 21: a config probe error MUST NOT be skipped into a green verdict'
-[[ "${status}" -eq 2 ]] ||
-  fail "case 21: a config probe error must exit 2 (infrastructure), got ${status}"
-require_text "${output}" '/etc/cri/conf.d/cri.toml' 'case 21: names the config it could not probe'
-refute_text "${output}" 'can enforce image verification.' \
-  'case 21: reported a verdict for a node whose containerd was never inspected'
-refute_text "${output}" "${canary}" 'case 21: probe error must not carry config contents'
-
-# Control: with the probe error removed the same node passes, so the assertions
-# above are pinning the probe failure and not some unrelated defect in the
-# fixture.
-rm -f "${fixtures}/probeerror/lserror_etc_cri_conf.d_cri.toml"
-run_script TALOS_NODES=probeerror >/dev/null 2>&1 ||
-  fail 'case 21: the same node must pass once the probe error is gone'
-
-# ===========================================================================
-# Case 23 — two nodes publishing the SAME InternalIP must not pass.
-#
-# The flattening emits that address once per node, so both passes inspect the
-# SAME machine while the other node is never looked at — and since the machine
-# they both reach is healthy, the run reports a green fleet with a node it never
-# touched. Distinct from case 22: there the node contributes NO address, here it
-# contributes a duplicate one, so a "did every node yield an address?" check
-# passes and only a uniqueness check catches it.
-#
-# `scripts/refresh-flux-ghcr-auth.sh`'s `validate_talos_node_inventory` refuses
-# the same shape before it mutates anything; this mirrors that rule.
-# ===========================================================================
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-stale"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}}
-]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
-
 status=0
 output="$(run_script 2>&1)" || status=$?
-[[ "${status}" -ne 0 ]] ||
-  fail 'case 23: two nodes sharing one InternalIP MUST NOT yield exit 0 — one was never inspected'
-[[ "${status}" -eq 2 ]] ||
-  fail "case 23: a duplicate InternalIP must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'prod-worker-stale' 'case 23: names the nodes sharing an address'
-refute_text "${output}" 'can enforce image verification.' \
-  'case 23: reported a verdict for a fleet where one node was never inspected'
+[[ "${status}" -eq 2 ]] || fail 'case 15: a node with no InternalIP MUST NOT yield exit 0 — it was never checked'
+require_text "${output}" 'worker-9' 'case 15: names the node that has no InternalIP'
+refute_text "${output}" 'All 1 node(s)' 'case 15: reported a verdict for a fleet that was only partly enumerated'
 
-# A node carrying TWO InternalIPs is the same ambiguity from the other side:
-# which one talosctl would reach is unspecified, so it is refused rather than
-# guessed.
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-dual"},"status":{"addresses":[{"type":"InternalIP","address":"good"},{"type":"InternalIP","address":"empty"}]}}
-]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
+# ===========================================================================
+# Case 16 — two nodes publishing the SAME InternalIP must not pass: both passes
+# inspect the same machine while the other node is never looked at.
+# ===========================================================================
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}
+]}
+EOF
 status=0
 output="$(run_script 2>&1)" || status=$?
-[[ "${status}" -eq 2 ]] ||
-  fail "case 23: a node with two InternalIPs must exit 2 (infrastructure), got ${status}"
-require_text "${output}" 'prod-worker-dual' 'case 23: names the node carrying two addresses'
+[[ "${status}" -eq 2 ]] || fail 'case 16: two nodes sharing one InternalIP MUST NOT yield exit 0'
+require_text "${output}" 'worker-1 and worker-2' 'case 16: names the nodes sharing an address'
 
-# Control: distinct addresses across distinct nodes still pass, so the
-# uniqueness rule is not simply rejecting every multi-node fleet.
-cat >"${fake_bin}/kubectl" <<'FAKE'
-#!/usr/bin/env bash
-printf '%s\n' '{"items":[
-  {"metadata":{"name":"prod-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"good"}]}},
-  {"metadata":{"name":"prod-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"onlysystem"}]}}
-]}'
-exit 0
-FAKE
-chmod +x "${fake_bin}/kubectl"
-# Assert a verdict line for EACH address, not just exit 0: a regression that
-# silently drops one discovered node from the fleet still exits 0, so an
-# exit-status-only control would keep passing while enumeration shrank.
-output="$(run_script 2>&1)" ||
-  fail 'case 23: a fleet of distinct nodes with distinct InternalIPs must still be accepted'
-require_text "${output}" 'good' 'case 23: control reports the first discovered node'
-require_text "${output}" 'onlysystem' 'case 23: control reports the second discovered node'
+# Control: distinct addresses are still accepted, so case 16 is not passing for
+# an unrelated reason.
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.6"}]}}
+]}
+EOF
+healthy_node 10.0.1.6
+output="$(run_script 2>&1)" || fail 'case 16: a fleet of distinct nodes with distinct InternalIPs must still be accepted'
+require_text "${output}" 'OK   10.0.1.4' 'case 16: control reports the first discovered node'
+require_text "${output}" 'OK   10.0.1.6' 'case 16: control reports the second discovered node'
 
-printf 'PASS: all cases\n'
+printf 'all cases passed\n'

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -46,9 +46,10 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: validate-image-verifier-liveness.sh [--nodes <ip>[,<ip>...]]
 
-Asserts, for every node, that Talos' own image verification is live: at least one
-ImageVerificationRules resource in phase "running", and a TUFTrustedRoots trust
-root in phase "running" to verify against.
+Asserts, for every node, that Talos' own image verification is live: every
+declared ImageVerificationRules pattern is materialised in order and in phase
+"running", and a TUFTrustedRoots trust root is in phase "running" to verify
+against.
 
 Nodes are discovered from the cluster when --nodes/TALOS_NODES is not given, so
 autoscaled nodes are covered without anyone maintaining a list.
@@ -61,6 +62,9 @@ USAGE
 
 readonly talosctl_bin="${TALOSCTL:-talosctl}"
 readonly kubectl_bin="${KUBECTL:-kubectl}"
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly root_dir
+readonly policy_manifest="${root_dir}/talos/cluster/verify-first-party-images.yaml"
 
 nodes_arg="${TALOS_NODES:-}"
 
@@ -92,6 +96,37 @@ fail_infra() {
   printf 'ERROR: %s\n' "$1" >&2
   exit 2
 }
+
+# Read the ordered `rules[].image` policy without adding a yq dependency to the
+# production workflow. This manifest intentionally uses one plain or quoted
+# scalar per `- image:` row; if that shape disappears, an empty result fails
+# closed below instead of inventing an expected policy.
+declared_patterns_text="$(awk '
+  /^[[:space:]]*-[[:space:]]+image:[[:space:]]*/ {
+    line = $0
+    sub(/^[[:space:]]*-[[:space:]]+image:[[:space:]]*/, "", line)
+    sub(/[[:space:]]+#.*$/, "", line)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+    if ((substr(line, 1, 1) == "\"" && substr(line, length(line), 1) == "\"") ||
+        (substr(line, 1, 1) == sprintf("%c", 39) && substr(line, length(line), 1) == sprintf("%c", 39))) {
+      line = substr(line, 2, length(line) - 2)
+    }
+    if (line != "") print line
+  }
+' "${policy_manifest}")" || fail_infra "could not read declared image-verification rules from ${policy_manifest}"
+
+declared_rule_patterns=()
+while IFS= read -r pattern; do
+  [[ -n "${pattern}" ]] || continue
+  declared_rule_patterns+=("${pattern}")
+done <<<"${declared_patterns_text}"
+[[ "${#declared_rule_patterns[@]}" -gt 0 ]] ||
+  fail_infra "no image-verification rules found in ${policy_manifest}"
+readonly declared_rule_count="${#declared_rule_patterns[@]}"
+declared_patterns_json="$(printf '%s\n' "${declared_rule_patterns[@]}" |
+  jq -R -s -c 'split("\n") | map(select(length > 0))')" ||
+  fail_infra 'could not encode the declared image-verification rule set'
+readonly declared_patterns_json
 
 # KUBECTL must name a bare binary, never a command with flags: it is invoked
 # quoted, so "kubectl --context x" would be looked up as a single executable
@@ -219,14 +254,19 @@ get_resource_json() {
   out="$("${talosctl_bin}" -n "${node}" get "${type}" -o json 2>/dev/null)" || status=$?
   [[ "${status}" -eq 0 ]] || return "${status}"
   # `jq -s` on empty input yields `[]`, which is the "none present" verdict.
-  printf '%s' "${out}" | jq -s -c '[.[] | {phase: (.metadata.phase // ""), owner: (.metadata.owner // "")}]' 2>/dev/null
+  printf '%s' "${out}" | jq -s -c '[.[] | {
+    id: (.metadata.id // ""),
+    phase: (.metadata.phase // ""),
+    owner: (.metadata.owner // ""),
+    imagePattern: (.spec.imagePattern // "")
+  }]' 2>/dev/null
 }
 
 # Verdict for ONE node. Returns 0 when that node's verification mechanism is
 # live, 1 when it is not.
 check_node() {
   local node="$1" rules trustroots status=0
-  local total_rules running_rules total_roots running_roots
+  local total_rules running_rules running_patterns total_roots running_roots
 
   rules="$(get_resource_json "${node}" "${rules_type}")" || status=$?
   if [[ "${status}" -ne 0 || -z "${rules}" ]]; then
@@ -250,6 +290,21 @@ check_node() {
   if [[ "${running_rules}" -eq 0 ]]; then
     printf 'FAIL %s: %s rule(s) present but none owned by %s in phase "running" — the rules exist as resources and are not being enforced\n' \
       "${node}" "${total_rules}" "${rules_owner}"
+    return 1
+  fi
+
+  # Talos assigns IDs 0000, 0001, ... in declaration order, and first match
+  # wins. Count and order are therefore both policy: one running rule is not a
+  # healthy substitute for three declared rules, and three stale patterns are
+  # not the declared policy merely because the totals happen to agree.
+  running_patterns="$(printf '%s' "${rules}" | jq -c --arg owner "${rules_owner}" \
+    '[sort_by(.id)[] | select(.phase == "running" and .owner == $owner) | .imagePattern]')" ||
+    fail_infra "could not compare materialised image-verification rules on ${node}"
+  if [[ "${total_rules}" -ne "${declared_rule_count}" ||
+    "${running_patterns}" != "${declared_patterns_json}" ]]; then
+    printf 'FAIL %s: materialised rules do not match the declared rule set — expected %s ordered running pattern(s) %s, found %s resource(s) with %s running pattern(s) %s\n' \
+      "${node}" "${declared_rule_count}" "${declared_patterns_json}" \
+      "${total_rules}" "${running_rules}" "${running_patterns}"
     return 1
   fi
 

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -1,36 +1,44 @@
 #!/usr/bin/env bash
 
-# Assert that the node image verifier can enforce AT ALL.
+# Assert that node-level image verification can enforce AT ALL.
 #
 # `talos/cluster/verify-first-party-images.yaml` declares ImageVerificationConfig
-# rules. Those rules are inert on their own: containerd does not verify images
-# itself, it delegates to the `io.containerd.image-verifier.v1.bindir` plugin,
-# which executes every binary in a configured `bin_dir`. containerd's documented
-# behaviour when that directory is unset, absent, or empty is to permit the pull:
+# rules. Talos v1.13 verifies images ITSELF: no external verifier binary is
+# involved, and containerd's `io.containerd.image-verifier.v1.bindir` plugin is
+# not the mechanism on this platform. Two node-local controllers own it:
 #
-#   "If bin_dir does not exist or contains no files, the image verifier does not
-#    block image pulls."
+#   * `security.ImageVerificationConfigController` materialises each declared
+#     rule into an `ImageVerificationRules.security.talos.dev` resource, and
+#   * `security.TUFTrustedRootController` maintains the Sigstore TUF trust root
+#     (`TUFTrustedRoots.security.talos.dev`) that keyless verification needs.
 #
-# So a cluster with perfect rules and no verifier binary reads EXACTLY like a
-# compliant one from every surface we routinely check — the rules are present,
-# the node config matches the repository, CI is green — while every image pulls
-# unverified. That is not hypothetical: it was the live state of this cluster,
-# found only by hand (devantler-tech/platform#2856).
-#
-# This check asserts the ENFORCEMENT PATH, not the configuration. Asserting that
-# the rules exist would NOT have caught #2856 — the rules were correct
-# throughout. It is deliberately the weaker of the two signals that issue asks
-# for; the strong one is a behavioural test that a known-unsigned image is
-# actually refused (#3101). This one's value is that it needs no node rollout
-# and fails loudly while the verifier is missing.
+# A rule that never reached `phase: running`, or a node with no trust root, is a
+# node where the declared rules decide nothing — while the repository, the
+# rendered manifests and CI all still read as compliant. That is the silent
+# enforcement gap this check exists to break (devantler-tech/platform#2856).
 #
 # It reads LIVE NODE STATE on purpose. A variant that read the repository would
 # re-create the exact blind spot it exists to close.
 #
-# SECURITY: the rendered `/etc/cri/conf.d/cri.toml` carries registry
-# credentials. Every read of it is piped straight into a key extractor; the
-# file's contents are never stored in a variable, echoed, or included in an
-# error message. Keep it that way — this script's output goes to CI logs.
+# WHAT THIS DOES NOT PROVE. That the controllers hold running rules and trust
+# material is necessary for enforcement, not sufficient: it does not establish
+# that a matched rule has ever produced a verification DECISION, because a
+# cached image is never re-pulled. That behavioural proof — a known-unsigned
+# image demonstrably refused at pull — is devantler-tech/platform#3336's job.
+# This check's value is that it needs no rollout and fails loudly when the
+# mechanism itself is not running.
+#
+# HISTORY, because it changes how a reader should read a green result: until
+# 2026-08-24 this script asserted a containerd `bin_dir`. No `bin_dir` is
+# configured anywhere on this cluster, so it reported a permanent, confident
+# FAIL on nodes that were verifying correctly (#3108). Trust its verdict only
+# from that date forward.
+#
+# SECURITY: this check reads Talos resources only. It deliberately does NOT read
+# `/etc/cri/conf.d/cri.toml`, which carries registry credentials on this
+# cluster — the previous bin_dir implementation had to, and this script's output
+# goes to CI logs. Keep it that way: no node file is read here, so no credential
+# can reach an error message.
 
 set -euo pipefail
 
@@ -38,13 +46,14 @@ usage() {
   cat >&2 <<'USAGE'
 Usage: validate-image-verifier-liveness.sh [--nodes <ip>[,<ip>...]]
 
-Asserts, for every node, that containerd's image-verifier bin_dir is configured,
-exists, and holds at least one executable.
+Asserts, for every node, that Talos' own image verification is live: at least one
+ImageVerificationRules resource in phase "running", and a TUFTrustedRoots trust
+root in phase "running" to verify against.
 
 Nodes are discovered from the cluster when --nodes/TALOS_NODES is not given, so
 autoscaled nodes are covered without anyone maintaining a list.
 
-Environment overrides: TALOSCTL, KUBECTL, TALOS_NODES, CONTAINERD_CONFIG_FILES
+Environment overrides: TALOSCTL, KUBECTL, KUBECTL_CONTEXT, TALOS_NODES
 Exit: 0 every node can enforce; 1 at least one cannot; 2 usage/infrastructure error.
 USAGE
   exit 2
@@ -78,11 +87,6 @@ while [[ "$#" -gt 0 ]]; do
     *) usage ;;
   esac
 done
-
-# Both containerd instances matter: the CRI one pulls workload images, the system
-# one pulls Talos' own. A verifier wired into only one leaves the other open.
-readonly default_config_files='/etc/cri/conf.d/cri.toml /etc/containerd/config.toml'
-read -r -a config_files <<<"${CONTAINERD_CONFIG_FILES:-${default_config_files}}"
 
 fail_infra() {
   printf 'ERROR: %s\n' "$1" >&2
@@ -149,120 +153,8 @@ discover_nodes() {
     fail_infra 'could not parse node addresses from kubectl output'
 }
 
-# `ls` reports a path's EXISTENCE without emitting its contents, so its exit
-# status is safe to branch on; `read` emits the whole config, so a failed read
-# must never be the thing that tells "absent" apart from "unreachable".
-#
-# That distinction is load-bearing. Inferring absence from a failed read means a
-# node the runner cannot reach — expired talosconfig, network partition, API
-# down — looks exactly like a node that simply does not ship that config file.
-# Such a node would be skipped silently, and if any OTHER containerd config
-# declared a verifier the fleet would pass while nothing had been checked: the
-# same fail-open shape this script exists to detect, reintroduced in the
-# detector.
-# Three-state probe: 'present', 'absent', or 'error'.
-#
-# A failed `ls` is ambiguous — the path may not be there, or the node may have
-# hiccuped — and only the first of those is a verdict. Collapsing both into
-# "this node does not ship that config" lets a transient fault silently drop one
-# containerd from the check; if the OTHER one is wired up, `configs_present`
-# stays nonzero and the node passes with half its image paths never inspected.
-#
-# Only a CONFIRMED not-found counts as absent, and the discriminator has to be
-# the stderr text because talosctl exits 1 for both. `ls` on a path emits only
-# that path's name and never file contents, so matching its stderr cannot expose
-# the registry credentials that `/etc/cri/conf.d/cri.toml` carries.
-path_probe() {
-  local node="$1" path="$2" err status=0
-  err="$("${talosctl_bin}" -n "${node}" ls "${path}" 2>&1 >/dev/null)" || status=$?
-  if [[ "${status}" -eq 0 ]]; then
-    printf 'present\n'
-    return 0
-  fi
-  case "${err}" in
-    *'no such file or directory'* | *'NotFound'* | *'not found'*) printf 'absent\n' ;;
-    *) printf 'error\n' ;;
-  esac
-}
-
 node_reachable() {
   "${talosctl_bin}" -n "$1" ls / >/dev/null 2>&1
-}
-
-# Emits the bin_dir declared by ONE config file's image-verifier plugin, or
-# nothing when that file declares none.
-#
-# Scoped to the `io.containerd.image-verifier.v1.bindir` table on purpose.
-# `bin_dir` is a generic key name, and an unscoped match accepts one from an
-# unrelated plugin's table — reporting a node as enforcing on the strength of a
-# setting containerd never consults for image verification.
-#
-# The config is piped straight into awk and only the extracted value is ever
-# printed. `/etc/cri/conf.d/cri.toml` carries registry credentials and this
-# script's output goes to CI logs, so the file must never be captured — not into
-# a variable, not into a temp file, not into an error message. See the SECURITY
-# note at the top.
-#
-# awk rather than sed because the table scoping needs state across lines, and
-# because awk consumes all input: a `sed ... | head -n 1` pipeline closes the
-# pipe early, and under `pipefail` the resulting SIGPIPE is indistinguishable
-# from a genuine read failure.
-extract_bin_dir_from() {
-  local node="$1" file="$2"
-  "${talosctl_bin}" -n "${node}" read "${file}" 2>/dev/null | awk '
-    BEGIN { SQ = sprintf("%c", 39); DQ = sprintf("%c", 34); want = 0; found = 0 }
-    found { next }
-    /^[ \t]*\[/ {
-      header = $0
-      gsub(/[ \t]/, "", header)
-      gsub(SQ, "", header)
-      gsub(DQ, "", header)
-      want = (header == "[plugins.io.containerd.image-verifier.v1.bindir]")
-      next
-    }
-    want && match($0, /^[ \t]*bin_dir[ \t]*=/) {
-      value = substr($0, RSTART + RLENGTH)
-      sub(/^[ \t]*/, "", value)
-      quote = substr(value, 1, 1)
-      if (quote != SQ && quote != DQ) next
-      value = substr(value, 2)
-      end = index(value, quote)
-      if (end == 0) next
-      print substr(value, 1, end - 1)
-      found = 1
-    }
-  '
-}
-
-# Counts executable entries, skipping the directory's own '.' entry. MODE is
-# always column 2; NAME is always last. The LABEL column is empty for some files
-# on this cluster, so positional parsing from the left past column 2 is unsafe.
-#
-# The MODE's first character is the entry TYPE, and it must be checked: a
-# directory's mode ('drwxr-xr-x') carries an 'x' too, so counting any entry with
-# an 'x' would let a bin_dir holding nothing but a subdirectory report as
-# enforcing. containerd executes FILES in bin_dir and does not descend into
-# subdirectories, so such a node permits every pull while this check calls it
-# healthy — the precise fail-open this script exists to detect. Regular files
-# ('-') and symlinks ('l') count; everything else does not.
-#
-# The listing's exit status is preserved, not discarded. The caller only reaches
-# this after the directory was proven to exist, so a failure here means the node
-# stopped answering mid-check — which must be an infrastructure error, never the
-# "holds no executable" verdict. `awk` on empty input prints 0 quite happily, so
-# swallowing the status turns an unreachable node into a confident FAIL line.
-count_executables() {
-  local node="$1" dir="$2" listing status=0
-  listing="$("${talosctl_bin}" -n "${node}" ls -l "${dir}" 2>/dev/null)" || status=$?
-  [[ "${status}" -eq 0 ]] ||
-    fail_infra "could not list ${dir} on ${node} (the directory exists but talosctl ls failed)"
-  printf '%s\n' "${listing}" |
-    awk 'NR > 1 && $NF != "." && substr($2, 1, 1) ~ /^[-l]$/ && $2 ~ /x/ { n++ } END { print n + 0 }'
-}
-
-directory_exists() {
-  local node="$1" dir="$2"
-  "${talosctl_bin}" -n "${node}" ls "${dir}" >/dev/null 2>&1
 }
 
 # Built with a read loop rather than `mapfile` so the script and its tests run
@@ -306,101 +198,103 @@ fi
 
 [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
 
-# Verdict for ONE containerd instance on one node. Returns 0 when that instance
-# can enforce, 1 when it cannot.
-check_config() {
-  local node="$1" file="$2" bin_dir status=0 executables exec_status=0
+readonly rules_type='imageverificationrules.security.talos.dev'
+readonly trustroot_type='tuftrustedroots.security.talos.dev'
+readonly rules_owner='security.ImageVerificationConfigController'
+readonly trustroot_owner='security.TUFTrustedRootController'
 
-  bin_dir="$(extract_bin_dir_from "${node}" "${file}")" || status=$?
-  # The file's existence was proven before this call, so a read failure here is
-  # an infrastructure fault, never a verdict. Reporting it as "cannot enforce"
-  # would be a misdiagnosis; swallowing it would be a fail-open.
-  [[ "${status}" -eq 0 ]] ||
-    fail_infra "could not read ${file} on ${node} (the file exists but talosctl read failed)"
+# Emits ONE resource type's rows on one node as a compact JSON array, or returns
+# non-zero. `talosctl get -o json` emits a STREAM of objects (not an array), and
+# emits nothing at all when the type has no instances, so `jq -s` is what turns
+# both shapes into something countable.
+#
+# An empty result and a failed query are NOT the same thing, and this returns
+# them differently on purpose: "the node holds no rules" is a verdict, "the
+# query failed" is an infrastructure fault. Collapsing them would let an
+# expired talosconfig or a partitioned node read as "verification is not
+# configured here" — a confident wrong answer, which is the failure mode this
+# script was rewritten to remove rather than reintroduce one level down.
+get_resource_json() {
+  local node="$1" type="$2" out status=0
+  out="$("${talosctl_bin}" -n "${node}" get "${type}" -o json 2>/dev/null)" || status=$?
+  [[ "${status}" -eq 0 ]] || return "${status}"
+  # `jq -s` on empty input yields `[]`, which is the "none present" verdict.
+  printf '%s' "${out}" | jq -s -c '[.[] | {id: (.metadata.id|tostring), phase: (.metadata.phase // ""), owner: (.metadata.owner // "")}]' 2>/dev/null
+}
 
-  if [[ -z "${bin_dir}" ]]; then
-    printf 'FAIL %s [%s]: no bin_dir in the io.containerd.image-verifier.v1.bindir table — the plugin has no directory to run, so containerd permits every pull\n' \
-      "${node}" "${file}"
-    return 1
-  fi
+# Verdict for ONE node. Returns 0 when that node's verification mechanism is
+# live, 1 when it is not.
+check_node() {
+  local node="$1" rules trustroots status=0
+  local total_rules running_rules total_roots running_roots
 
-  if ! directory_exists "${node}" "${bin_dir}"; then
-    # "The directory is not there" and "the node stopped answering" are the same
-    # failed `ls` from here. Only the first is a verdict; reporting the second as
-    # one would blame the cluster for a runner-side fault.
+  rules="$(get_resource_json "${node}" "${rules_type}")" || status=$?
+  if [[ "${status}" -ne 0 || -z "${rules}" ]]; then
+    # "The node is gone" and "the node answered but this query failed" deserve
+    # different diagnoses, and neither is a verdict.
     node_reachable "${node}" ||
-      fail_infra "cannot reach node ${node} while checking ${bin_dir} (talosctl ls / failed)"
-    printf 'FAIL %s [%s]: bin_dir %s is configured but does not exist — containerd permits every pull\n' \
-      "${node}" "${file}" "${bin_dir}"
+      fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+    fail_infra "could not read ${rules_type} on ${node} (the node is reachable but the query failed) — refusing to report a node whose verification state was never inspected"
+  fi
+
+  total_rules="$(printf '%s' "${rules}" | jq -r 'length')"
+  running_rules="$(printf '%s' "${rules}" | jq -r --arg owner "${rules_owner}" \
+    '[.[] | select(.phase == "running" and .owner == $owner)] | length')"
+
+  if [[ "${total_rules}" -eq 0 ]]; then
+    printf 'FAIL %s: no %s resources — the declared ImageVerificationConfig rules were never materialised on this node, so nothing constrains a pull\n' \
+      "${node}" "${rules_type}"
     return 1
   fi
 
-  # `fail_infra` inside count_executables would exit only the command
-  # substitution, so its status is carried out explicitly — the same subshell
-  # trap that made partial node discovery pass silently.
-  executables="$(count_executables "${node}" "${bin_dir}")" || exec_status=$?
-  [[ "${exec_status}" -eq 0 ]] ||
-    fail_infra "could not list ${bin_dir} on ${node} (the directory exists but talosctl ls failed)"
-
-  if [[ "${executables}" -eq 0 ]]; then
-    printf 'FAIL %s [%s]: bin_dir %s holds no executable — containerd permits every pull\n' \
-      "${node}" "${file}" "${bin_dir}"
+  if [[ "${running_rules}" -eq 0 ]]; then
+    printf 'FAIL %s: %s rule(s) present but none owned by %s in phase "running" — the rules exist as resources and are not being enforced\n' \
+      "${node}" "${total_rules}" "${rules_owner}"
     return 1
   fi
 
-  printf 'OK   %s [%s]: bin_dir %s holds %s executable(s)\n' \
-    "${node}" "${file}" "${bin_dir}" "${executables}"
+  status=0
+  trustroots="$(get_resource_json "${node}" "${trustroot_type}")" || status=$?
+  if [[ "${status}" -ne 0 || -z "${trustroots}" ]]; then
+    node_reachable "${node}" ||
+      fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
+    fail_infra "could not read ${trustroot_type} on ${node} (the node is reachable but the query failed) — refusing to report a node whose verification state was never inspected"
+  fi
+
+  total_roots="$(printf '%s' "${trustroots}" | jq -r 'length')"
+  running_roots="$(printf '%s' "${trustroots}" | jq -r --arg owner "${trustroot_owner}" \
+    '[.[] | select(.phase == "running" and .owner == $owner)] | length')"
+
+  # The trust root is checked SECOND and separately because its absence is a
+  # different failure from a missing rule: the rules can be perfectly live and
+  # still decide nothing if there is no Sigstore trust material to verify a
+  # keyless signature against.
+  if [[ "${total_roots}" -eq 0 ]]; then
+    printf 'FAIL %s: %s running rule(s) but no %s — keyless verification has no trust material, so a signature cannot be checked\n' \
+      "${node}" "${running_rules}" "${trustroot_type}"
+    return 1
+  fi
+
+  if [[ "${running_roots}" -eq 0 ]]; then
+    printf 'FAIL %s: trust root present but not owned by %s in phase "running" — keyless verification has no usable trust material\n' \
+      "${node}" "${trustroot_owner}"
+    return 1
+  fi
+
+  printf 'OK   %s: %s rule(s) in phase running, %s trust root(s) running\n' \
+    "${node}" "${running_rules}" "${running_roots}"
   return 0
 }
 
 failures=0
 for node in "${nodes[@]}"; do
-  # Every containerd instance present on the node is evaluated INDEPENDENTLY.
-  # Accepting the first config that declares a bin_dir would let a wired-up CRI
-  # containerd mask an unprotected system containerd (or the reverse) — and the
-  # two pull different images: CRI pulls workload images, the system instance
-  # pulls Talos' own. A verifier on one leaves the other open, which is the
-  # whole point of checking both.
-  configs_present=0
-  node_failures=0
-  for config_file in "${config_files[@]}"; do
-    case "$(path_probe "${node}" "${config_file}")" in
-      present) ;;
-      absent)
-        # A confirmed not-found normally proves the node answered — but the same
-        # phrase can come from a client-side fault (a missing talosconfig, say),
-        # which would otherwise read as "this node does not ship that config".
-        # The reachability probe is what tells those two apart.
-        node_reachable "${node}" ||
-          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
-        continue
-        ;;
-      *)
-        # Both "the node is gone" and "the node answered but this one probe
-        # failed" arrive here, and they deserve different diagnoses: the first
-        # is a fleet-wide fault, the second is specific to one containerd.
-        # Neither is a verdict, so both stop the run either way.
-        node_reachable "${node}" ||
-          fail_infra "cannot reach node ${node} (talosctl ls / failed) — refusing to report a fleet that was not checked"
-        fail_infra "could not determine whether ${config_file} exists on ${node} (talosctl ls failed for a reason other than the file being absent) — refusing to report a node whose containerd was never inspected"
-        ;;
-    esac
-    configs_present=$((configs_present + 1))
-    check_config "${node}" "${config_file}" || node_failures=$((node_failures + 1))
-  done
-
-  # No containerd configuration at all is not a clean node — it means this check
-  # looked at nothing and would otherwise pass the node by default.
-  [[ "${configs_present}" -gt 0 ]] ||
-    fail_infra "no containerd configuration found on ${node} (looked in ${config_files[*]})"
-
-  [[ "${node_failures}" -eq 0 ]] || failures=$((failures + 1))
+  check_node "${node}" || failures=$((failures + 1))
 done
 
 if [[ "${failures}" -gt 0 ]]; then
   printf '\n%s of %s node(s) cannot enforce image verification.\n' "${failures}" "${#nodes[@]}" >&2
-  printf 'The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml are not being evaluated on those nodes.\n' >&2
-  printf 'See devantler-tech/platform#2856 (finding) and #3101 (installing the verifier).\n' >&2
+  printf 'The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml are declared, but Talos is not enforcing them on those nodes.\n' >&2
+  printf 'See devantler-tech/platform#2856 (finding) and #3336 (proving a refusal at pull).\n' >&2
   exit 1
 fi
 

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -219,7 +219,7 @@ get_resource_json() {
   out="$("${talosctl_bin}" -n "${node}" get "${type}" -o json 2>/dev/null)" || status=$?
   [[ "${status}" -eq 0 ]] || return "${status}"
   # `jq -s` on empty input yields `[]`, which is the "none present" verdict.
-  printf '%s' "${out}" | jq -s -c '[.[] | {id: (.metadata.id|tostring), phase: (.metadata.phase // ""), owner: (.metadata.owner // "")}]' 2>/dev/null
+  printf '%s' "${out}" | jq -s -c '[.[] | {phase: (.metadata.phase // ""), owner: (.metadata.owner // "")}]' 2>/dev/null
 }
 
 # Verdict for ONE node. Returns 0 when that node's verification mechanism is

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -1,18 +1,22 @@
 # Container image signature verification (Talos 1.13+, ImageVerificationConfig).
 #
-# STATUS — THESE RULES ARE INERT ON THIS CLUSTER TODAY.
-# containerd does not verify images itself: it delegates to the
-# `io.containerd.image-verifier.v1.bindir` plugin, and permits every pull when
-# that plugin has no `bin_dir` or the directory holds no binary. No node
-# configures a `bin_dir` at all, so nothing below is evaluated and no pull is
-# gated by it. Installing and wiring the verifier is #3101; the finding is
-# #2856.
+# STATUS — Talos evaluates these rules on this cluster.
+# Talos v1.13 verifies images ITSELF. There is no external verifier binary, and
+# containerd's `io.containerd.image-verifier.v1.bindir` plugin is not the
+# mechanism here. `security.ImageVerificationConfigController` materialises each
+# rule below into an `ImageVerificationRules.security.talos.dev` resource on
+# every node, and `security.TUFTrustedRootController` maintains the Sigstore TUF
+# trust root that keyless verification needs.
+#
+# What is NOT established is that a matched rule has ever produced a
+# verification DECISION: every first-party image is already cached, so no
+# rule-matching pull occurs. Proving a refusal at pull is #3336. The original
+# finding is #2856.
 #
 # Check this, do not assume it. The repository cannot answer it — the rules read
-# as correct in exactly the state where they do nothing, which is why this went
-# unnoticed for weeks:
+# as correct whether or not anything evaluates them:
 #     scripts/validate-image-verifier-liveness.sh
-# Measured 2026-08-18: 7 of 7 nodes could not enforce.
+# Measured 2026-08-24: 7 of 7 nodes hold running rules and a running trust root.
 #
 # BEFORE ACTIVATING (#3101): an image that matches a rule but fails
 # verification is refused, so any first-party image that is running yet


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Our automated check for "is image signature verification actually switched on across the fleet?" was asking the wrong question, and answering it with confidence.

It checked for a helper program that this platform does not use — Talos does image verification itself. Because that helper is absent by design, the check reported failure on every node, always, and said so in plain words: *"1 of 1 node(s) cannot enforce image verification."* Anyone reading that would reasonably conclude the fleet has no signature enforcement at all.

It does. Measured against production today, all seven nodes hold live verification rules and current signing-trust material.

A check that is merely broken is noise. This one was worse: it pointed the wrong way, and it cited two open issues as corroboration, which is how the mistaken premise survived as long as it did.

### What this changes

- The check now asks whether the mechanism Talos actually uses is live on each node, and reports honestly. On production it went from a confident false alarm to a clean pass.
- The wording it prints — and the same claim repeated in the rules file and the workflow — is corrected, so an operator is no longer told enforcement is absent when it is present.
- The check no longer needs to read a node file that carries registry credentials, so a class of credential-leak risk leaves a script whose output lands in CI logs. Nothing about the everyday path got harder.

Fleet enforcement is unchanged — this is about the instrument, not the control it measures. The fleet check stays on-demand; switching it to a daily cadence belongs to #3336, which first has to prove an unsigned image is genuinely refused. Live rules and trust material are necessary for enforcement, not proof of it.

One paragraph in the rules file about which images might break on activation is deliberately left alone: that is #3334's question and rests on evidence I have not measured myself.

Part of #3108 — this delivers the mechanism correction. Two of that issue's criteria (a bounded node-inventory recheck, and node identity compared by UID) are independent of the mechanism, are not addressed here, and keep it open.

