### PR TITLE
fix(security): converge on the live node set before reporting the fleet clean

### DIFF
--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -671,4 +671,32 @@ output="$(run_script TALOS_NODES=pinned 2>&1)" || fail 'case 21: a pinned fleet 
 require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 21: reports the pinned node'
 [[ ! -s "${fixtures}/kubectl-args" ]] ||
   fail 'case 21: a pinned run consulted kubectl — convergence must not apply to an explicitly named fleet'
+
+# ===========================================================================
+# Case 22 — RED: the fleet draining to EMPTY between readings must not be
+# reported as a clean fleet.
+#
+# The "no nodes to check" guard runs once, before the sweep. The convergence
+# pass re-reads the inventory afterwards, so a reading that comes back empty —
+# a wrong context, an API server returning nothing, a cluster genuinely torn
+# down — would otherwise settle (empty equals empty), sweep zero nodes, and
+# print "All 0 node(s) can enforce image verification". Exit 0 over a fleet
+# that does not exist is the most confident wrong answer this script can give.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.5.1
+cat >"${fixtures}/nodes.json.1" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.5.1"}]}}
+]}
+EOF
+cat >"${fixtures}/nodes.json.last" <<'EOF'
+{"items":[]}
+EOF
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 22: an empty inventory must be refused, not reported clean (expected exit 2, got ${status})"
+require_text "${output}" 'no nodes to check' 'case 22: must name the empty inventory as the reason it refuses'
+refute_text "${output}" 'All 0 node(s) can enforce' 'case 22: reported a green verdict for an empty fleet'
 printf 'all cases passed\n'

--- a/scripts/tests/test-validate-image-verifier-liveness.sh
+++ b/scripts/tests/test-validate-image-verifier-liveness.sh
@@ -117,13 +117,37 @@ exit 1
 FAKE
 chmod +x "${fake_bin}/talosctl"
 
+# ---------------------------------------------------------------------------
+# Fake kubectl: serves the node inventory, and can serve a DIFFERENT one per
+# call so a fleet that changes mid-run can be tested.
+#
+# `nodes.json.<n>` is served on the n-th call, `nodes.json.last` on any call
+# past the end of that sequence, and plain `nodes.json` when no sequence is
+# staged. A per-call inventory is the only way to exercise the convergence
+# pass: a single static fixture cannot distinguish a check that re-reads the
+# fleet from one that trusts its opening snapshot.
+# ---------------------------------------------------------------------------
 cat >"${fake_bin}/kubectl" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${FIXTURES}/kubectl-args"
-cat "${FIXTURES}/nodes.json"
+calls=$(( $(cat "${FIXTURES}/kubectl-calls" 2>/dev/null || printf '0') + 1 ))
+printf '%s' "${calls}" >"${FIXTURES}/kubectl-calls"
+if [[ -f "${FIXTURES}/nodes.json.${calls}" ]]; then
+  cat "${FIXTURES}/nodes.json.${calls}"
+elif [[ -f "${FIXTURES}/nodes.json.last" ]]; then
+  cat "${FIXTURES}/nodes.json.last"
+else
+  cat "${FIXTURES}/nodes.json"
+fi
 FAKE
 chmod +x "${fake_bin}/kubectl"
+
+# Every staged inventory and the call counter, cleared between cases so one
+# case's sequence cannot leak into the next and silently change what it tests.
+reset_inventory() {
+  rm -f "${fixtures}"/nodes.json.* "${fixtures}/kubectl-calls"
+}
 
 readonly rules_type='imageverificationrules.security.talos.dev'
 readonly roots_type='tuftrustedroots.security.talos.dev'
@@ -367,8 +391,8 @@ resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.securit
   write_roots 10.0.1.5
 cat >"${fixtures}/nodes.json" <<'EOF'
 {"items":[
- {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"Hostname","address":"worker-1"},{"type":"InternalIP","address":"10.0.1.4"}]}},
- {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"Hostname","address":"worker-2"},{"type":"InternalIP","address":"10.0.1.5"}]}}
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"Hostname","address":"worker-1"},{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"Hostname","address":"worker-2"},{"type":"InternalIP","address":"10.0.1.5"}]}}
 ]}
 EOF
 status=0
@@ -385,7 +409,7 @@ refute_text "${output}" 'worker-1' 'case 11: used InternalIP, not Hostname'
 # ===========================================================================
 rm -f "${fixtures}/kubectl-args"
 cat >"${fixtures}/nodes.json" <<'EOF'
-{"items":[{"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}]}
+{"items":[{"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}]}
 EOF
 run_script KUBECTL_CONTEXT=admin@prod >/dev/null 2>&1 || true
 require_text "$(cat "${fixtures}/kubectl-args")" '--context admin@prod' 'case 12: KUBECTL_CONTEXT was not forwarded to kubectl'
@@ -423,8 +447,8 @@ refute_text "${output}" 'OK   ' 'case 14: reported a verdict for a fleet the cal
 # ===========================================================================
 cat >"${fixtures}/nodes.json" <<'EOF'
 {"items":[
- {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
- {"metadata":{"name":"worker-9"},"status":{"addresses":[{"type":"Hostname","address":"worker-9"}]}}
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-9","uid":"uid-worker-9"},"status":{"addresses":[{"type":"Hostname","address":"worker-9"}]}}
 ]}
 EOF
 status=0
@@ -439,8 +463,8 @@ refute_text "${output}" 'All 1 node(s)' 'case 15: reported a verdict for a fleet
 # ===========================================================================
 cat >"${fixtures}/nodes.json" <<'EOF'
 {"items":[
- {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
- {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}
 ]}
 EOF
 status=0
@@ -452,8 +476,8 @@ require_text "${output}" 'worker-1 and worker-2' 'case 16: names the nodes shari
 # an unrelated reason.
 cat >"${fixtures}/nodes.json" <<'EOF'
 {"items":[
- {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
- {"metadata":{"name":"worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.6"}]}}
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.6"}]}}
 ]}
 EOF
 healthy_node 10.0.1.6
@@ -476,4 +500,175 @@ output="$(run_script TALOS_NODES=credsafe 2>&1)" || fail 'case 17: control — t
 require_text "${output}" 'OK   credsafe' 'case 17: control — reports the healthy node'
 [[ ! -e "${fixtures}/NODE_FILE_WAS_READ" ]] ||
   fail 'case 17: the check read a node file — registry credentials are reachable from a script whose output goes to CI logs'
+
+# ===========================================================================
+# Case 18 — RED: a node that JOINS while the serial pass is running must not be
+# skipped. The pass opens on a one-node fleet and a second, unenforcing worker
+# is present by the time it finishes.
+#
+# Reading the opening snapshot only, the script inspects 10.0.2.1, finds it
+# healthy and prints "All 1 node(s) can enforce image verification" — a green
+# verdict for a fleet that now contains a node it never looked at. That is the
+# same silence this whole script exists to break, one level up: not a node
+# lying about its state, but a node nobody asked.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.2.1
+write_node 10.0.2.2
+resource_obj trusted_root.json running "${roots_owner}" 'TUFTrustedRoots.security.talos.dev' |
+  write_roots 10.0.2.2
+cat >"${fixtures}/nodes.json.1" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.2.1"}]}}
+]}
+EOF
+cat >"${fixtures}/nodes.json.last" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.2.1"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.2.2"}]}}
+]}
+EOF
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 1 ]] ||
+  fail "case 18: a node that joined mid-pass was never inspected (expected exit 1, got ${status})"
+require_text "${output}" 'FAIL 10.0.2.2' 'case 18: the node that joined mid-pass must be checked, not skipped'
+refute_text "${output}" 'All 1 node(s) can enforce' 'case 18: reported a green verdict for a stale one-node snapshot'
+
+# ===========================================================================
+# Case 18a — GREEN control: the SAME two-node fleet, held still. Differs from
+# case 18 in exactly one fixture — the opening inventory already lists both
+# nodes — which proves case 18 is about the inventory changing and not merely
+# about 10.0.2.2 being unhealthy.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.2.3
+healthy_node 10.0.2.4
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.2.3"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.2.4"}]}}
+]}
+EOF
+output="$(run_script 2>&1)" || fail 'case 18a: control — a stable healthy fleet must pass'
+require_text "${output}" 'All 2 node(s) can enforce image verification.' 'case 18a: control — reports both nodes'
+
+# ===========================================================================
+# Case 19 — RED: an autoscaler replacement that REUSES the departed node's
+# InternalIP is a different node, and identity must say so.
+#
+# Every reading here lists exactly one node at 10.0.3.1; only the UID changes.
+# Compared on address alone the fleet looks perfectly stable, so the script
+# would converge immediately and report a node it never inspected as healthy.
+# Compared on UID the churn is visible, and the run refuses rather than
+# blessing one transient snapshot.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.3.1
+i=1
+while [[ "${i}" -le 8 ]]; do
+  cat >"${fixtures}/nodes.json.${i}" <<EOF
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-generation-${i}"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.3.1"}]}}
+]}
+EOF
+  i=$((i + 1))
+done
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] ||
+  fail "case 19: a replacement reusing an address was mistaken for the original (expected exit 2, got ${status})"
+require_text "${output}" 'will not hold still' 'case 19: must name the churning inventory as the reason it refuses'
+refute_text "${output}" 'All 1 node(s) can enforce' 'case 19: reported a green verdict across a node replacement'
+
+# ===========================================================================
+# Case 19a — GREEN control: the same single node at the same address, with a
+# STABLE UID. Differs from case 19 in exactly one fixture, so it proves the
+# refusal above is caused by the identity changing rather than by re-reading
+# the inventory at all — a check that refused every fleet would pass case 19
+# while being useless.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.3.2
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-stable"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.3.2"}]}}
+]}
+EOF
+output="$(run_script 2>&1)" || fail 'case 19a: control — a stable node must pass'
+require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 19a: control — reports the stable node'
+
+# ===========================================================================
+# Case 19b — a fleet that settles after ONE change is retried, not failed.
+# Ordinary autoscaling changes the fleet occasionally, and a check that turned
+# every such change into a hard failure would flap often enough to be ignored —
+# which is indistinguishable from not having the check.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.3.3
+healthy_node 10.0.3.4
+cat >"${fixtures}/nodes.json.1" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.3.3"}]}}
+]}
+EOF
+cat >"${fixtures}/nodes.json.last" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.3.3"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-worker-2"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.3.4"}]}}
+]}
+EOF
+output="$(run_script 2>&1)" || fail 'case 19b: a fleet that settles after one change must be retried, not failed'
+require_text "${output}" 'All 2 node(s) can enforce image verification.' 'case 19b: the settled fleet is what the verdict describes'
+require_text "${output}" 're-checking (attempt 2 of 3)' 'case 19b: must say it re-checked rather than silently changing its answer'
+
+# ===========================================================================
+# Case 20 — RED: a node with no metadata.uid is refused, not silently given an
+# empty identity. Two such nodes would compare equal to each other, collapsing
+# identity back to the address exactly where it matters most. The API server
+# always sets a UID, so its absence is a malformed inventory.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.4.1
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.4.1"}]}}
+]}
+EOF
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] || fail "case 20: a node with no UID must be refused (expected exit 2, got ${status})"
+require_text "${output}" 'has no metadata.uid' 'case 20: must name the node missing its UID'
+
+# ===========================================================================
+# Case 20a — RED: two nodes sharing one UID is the same collapse from the other
+# direction, and would make a replaced node compare equal to its predecessor.
+# ===========================================================================
+reset_inventory
+healthy_node 10.0.4.2
+healthy_node 10.0.4.3
+cat >"${fixtures}/nodes.json" <<'EOF'
+{"items":[
+ {"metadata":{"name":"worker-1","uid":"uid-duplicate"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.4.2"}]}},
+ {"metadata":{"name":"worker-2","uid":"uid-duplicate"},"status":{"addresses":[{"type":"InternalIP","address":"10.0.4.3"}]}}
+]}
+EOF
+status=0
+output="$(run_script 2>&1)" || status=$?
+[[ "${status}" -eq 2 ]] || fail "case 20a: two nodes sharing a UID must be refused (expected exit 2, got ${status})"
+require_text "${output}" 'share UID uid-duplicate' 'case 20a: must name the shared UID'
+
+# ===========================================================================
+# Case 21 — an explicitly pinned fleet is NOT converged on. --nodes is the
+# caller's claim about what to check, not a snapshot of a moving cluster, so
+# the convergence pass must not call kubectl at all — doing so would make a
+# pinned run depend on cluster access it deliberately does not need.
+# ===========================================================================
+reset_inventory
+rm -f "${fixtures}/kubectl-args"
+healthy_node pinned
+output="$(run_script TALOS_NODES=pinned 2>&1)" || fail 'case 21: a pinned fleet must still pass'
+require_text "${output}" 'All 1 node(s) can enforce image verification.' 'case 21: reports the pinned node'
+[[ ! -s "${fixtures}/kubectl-args" ]] ||
+  fail 'case 21: a pinned run consulted kubectl — convergence must not apply to an explicitly named fleet'
 printf 'all cases passed\n'

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -52,7 +52,14 @@ declared ImageVerificationRules pattern is materialised in order and in phase
 against.
 
 Nodes are discovered from the cluster when --nodes/TALOS_NODES is not given, so
-autoscaled nodes are covered without anyone maintaining a list.
+autoscaled nodes are covered without anyone maintaining a list. A discovered
+fleet is read again after the sweep and the verdict is only reported once two
+consecutive readings agree, because a serial sweep is not instantaneous and a
+node that joins or is replaced midway would otherwise go uninspected under a
+green summary. Nodes are identified by UID and address together, so a
+replacement reusing a departed node's address is not mistaken for it. An
+explicitly pinned fleet is the caller's claim about what to check and is not
+re-read.
 
 Environment overrides: TALOSCTL, KUBECTL, KUBECTL_CONTEXT, TALOS_NODES
 Exit: 0 every node can enforce; 1 at least one cannot; 2 usage/infrastructure error.
@@ -133,27 +140,36 @@ readonly declared_patterns_json
 # name and fail. Pin the context with KUBECTL_CONTEXT instead — the deploy
 # composite pins `--context admin@prod` for the same reason, because the
 # restored kubeconfig's current-context is not guaranteed to be prod.
-discover_nodes() {
+# Emits one `<uid>\t<InternalIP>` row per node, sorted, or fails closed.
+#
+# Identity is the UID *and* the address, never the address alone. Cluster
+# Autoscaler replaces a worker by deleting the Node object and creating a new
+# one, and the replacement can reuse the departed node's InternalIP. An
+# address-only identity reads that replacement as the original — so a node this
+# script never inspected is reported healthy under a familiar address. The UID
+# is the only field that distinguishes them, and the API server always sets it.
+discover_node_identities() {
   local json bad_nodes
   local -a context_args=()
   [[ -n "${KUBECTL_CONTEXT:-}" ]] && context_args=(--context "${KUBECTL_CONTEXT}")
   json="$("${kubectl_bin}" "${context_args[@]+"${context_args[@]}"}" get nodes -o json 2>/dev/null)" ||
     fail_infra 'could not list cluster nodes (kubectl get nodes failed)'
 
-  # Every node must map to EXACTLY ONE InternalIP, and those addresses must be
-  # unique across the fleet. Both halves are fail-opens the flattening hides:
+  # Every node must map to EXACTLY ONE InternalIP and carry a non-empty UID, and
+  # both must be unique across the fleet. Each is a fail-open the flattening
+  # hides:
   #
-  #   * a node whose addresses hold only a Hostname or an ExternalIP matches
-  #     nothing and the select SUCCEEDS, so that node silently leaves the fleet;
+  #   * a node with NO InternalIP — it vanishes from the list entirely;
+  #   * a node with SEVERAL — it is checked more than once under different
+  #     addresses while another is missed;
   #   * two nodes publishing the SAME InternalIP — a malformed or stale cloud
-  #     registration — emit that address twice, so both passes inspect the same
-  #     machine while the other node is never looked at.
+  #     inventory, where one silently masks the other;
+  #   * a node with NO UID, or two sharing one — identity collapses back to the
+  #     address, which is precisely the confusion this pass exists to refuse.
   #
   # Either way the remaining nodes report OK and the run prints a green verdict
-  # for a fleet it never fully enumerated: the same fail-open this script exists
-  # to detect, one layer earlier. `scripts/refresh-flux-ghcr-auth.sh`'s
-  # `validate_talos_node_inventory` refuses the same two shapes before it mutates
-  # anything, for the same reason.
+  # for a fleet it only partly enumerated. `validate_talos_node_inventory`
+  # refuses the same shapes before it mutates anything, for the same reason.
   #
   # Checked as its own pass so the offending nodes can be NAMED. Deriving it from
   # a jq error instead would either lose the names or push kubectl's output into
@@ -162,30 +178,40 @@ discover_nodes() {
     jq -r '
       [.items[] | {
         name: (.metadata.name // "<unnamed node>"),
+        uid: ((.metadata.uid // "") | tostring),
         ips: [(.status.addresses // [])[]
               | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
               | .address]
       }] as $nodes
       | ($nodes | map(select(.ips | length != 1))
           | map("\(.name) (has \(.ips | length) InternalIP addresses, expected 1)")),
+        ($nodes | map(select(.uid == ""))
+          | map("\(.name) (has no metadata.uid, so it cannot be told apart from a replacement reusing its address)")),
         ($nodes | map(select(.ips | length == 1))
           | group_by(.ips[0]) | map(select(length > 1))
-          | map("\(map(.name) | join(" and ")) share InternalIP \(.[0].ips[0])"))
+          | map("\(map(.name) | join(" and ")) share InternalIP \(.[0].ips[0])")),
+        ($nodes | map(select(.uid != ""))
+          | group_by(.uid) | map(select(length > 1))
+          | map("\(map(.name) | join(" and ")) share UID \(.[0].uid)"))
       | .[]
     ' 2>/dev/null)" ||
-    fail_infra 'could not parse node addresses from kubectl output'
+    fail_infra 'could not parse the node inventory from kubectl output'
   if [[ -n "${bad_nodes}" ]]; then
     fail_infra "unusable node inventory — refusing to report a fleet that was only partly enumerated: $(printf '%s' "${bad_nodes}" | tr '\n' ';' | sed 's/;$//')"
   fi
 
+  # Sorted so two readings of an unchanged fleet compare equal regardless of the
+  # order the API server happened to return them in.
   printf '%s' "${json}" |
     jq -r '
       .items[]
+      | ((.metadata.uid // "") | tostring) as $uid
       | (.status.addresses // [])[]
       | select(.type == "InternalIP" and ((.address // "") | tostring) != "")
-      | .address
-    ' 2>/dev/null ||
-    fail_infra 'could not parse node addresses from kubectl output'
+      | "\($uid)\t\(.address)"
+    ' 2>/dev/null |
+    LC_ALL=C sort ||
+    fail_infra 'could not parse the node inventory from kubectl output'
 }
 
 node_reachable() {
@@ -196,10 +222,33 @@ node_reachable() {
 # on bash 3.2 (macOS) as well as CI's bash 5. A check nobody can run locally is
 # a check nobody verifies before shipping.
 nodes=()
+inventory_signature=''
 if [[ "${nodes_requested}" -eq 1 && -z "${nodes_arg}" ]]; then
   printf 'ERROR: --nodes/TALOS_NODES was supplied but names no node — refusing to fall back to cluster discovery, which would check a different fleet than was asked for\n' >&2
   usage
 fi
+
+# Fills `nodes` and `inventory_signature` from the live cluster. Called once per
+# convergence attempt, so the fleet under test is re-read rather than inherited.
+load_discovered_nodes() {
+  local discovered_identities identity
+  # Discovery runs in a command substitution so its exit status reaches this
+  # shell. A process substitution would NOT: `fail_infra` inside it exits only
+  # that subshell, the loop keeps whatever partial output jq already emitted,
+  # and if those nodes happen to be healthy the script exits 0 having silently
+  # dropped the rest of the fleet. jq emitting a valid address and then failing
+  # on a malformed one is exactly that case.
+  discovered_identities="$(discover_node_identities)" ||
+    fail_infra 'node discovery failed — refusing to report a fleet that was only partly enumerated'
+  nodes=()
+  inventory_signature="${discovered_identities}"
+  while IFS= read -r identity; do
+    [[ -n "${identity}" ]] || continue
+    # `<uid>\t<address>` — the address is what talosctl is pointed at; the UID
+    # only ever participates in the identity comparison.
+    nodes+=("${identity#*$'\t'}")
+  done <<<"${discovered_identities}"
+}
 
 if [[ -n "${nodes_arg}" ]]; then
   # A malformed list ('a,,b', a leading or trailing comma, a shell variable that
@@ -217,18 +266,7 @@ if [[ -n "${nodes_arg}" ]]; then
   fi
   IFS=',' read -r -a nodes <<<"${nodes_arg}"
 else
-  # Discovery runs in a command substitution so its exit status reaches this
-  # shell. A process substitution would NOT: `fail_infra` inside it exits only
-  # that subshell, the loop keeps whatever partial output jq already emitted,
-  # and if those nodes happen to be healthy the script exits 0 having silently
-  # dropped the rest of the fleet. jq emitting a valid address and then failing
-  # on a malformed one is exactly that case.
-  discovered_nodes="$(discover_nodes)" ||
-    fail_infra 'node discovery failed — refusing to report a fleet that was only partly enumerated'
-  while IFS= read -r discovered; do
-    [[ -n "${discovered}" ]] || continue
-    nodes+=("${discovered}")
-  done <<<"${discovered_nodes}"
+  load_discovered_nodes
 fi
 
 [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
@@ -341,12 +379,63 @@ check_node() {
   return 0
 }
 
-failures=0
-for node in "${nodes[@]}"; do
-  check_node "${node}" || failures=$((failures + 1))
+# One serial sweep of the fleet. Verdict lines go to stdout so a caller can hold
+# them back until the inventory they describe is known to be current; returns 0
+# when every node enforces and 1 when any does not. `check_node`'s `fail_infra`
+# exits 2, and because this runs in a command substitution that status reaches
+# the caller instead of being swallowed.
+run_pass() {
+  local node failed=0
+  for node in "$@"; do
+    check_node "${node}" || failed=$((failed + 1))
+  done
+  [[ "${failed}" -eq 0 ]]
+}
+
+# How many times a changed inventory is re-checked before the run gives up.
+# Ordinary autoscaling changes the fleet occasionally, so a single change is a
+# retry rather than a failure; a fleet that changes on every attempt is churning
+# faster than this check can observe it, and reporting a verdict for one of
+# those transient snapshots would be exactly the stale-snapshot claim this pass
+# exists to refuse.
+readonly max_inventory_attempts=3
+
+pass_output=''
+pass_status=0
+attempt=1
+while :; do
+  pass_status=0
+  pass_output="$(run_pass "${nodes[@]}")" || pass_status=$?
+  # 2 is `fail_infra` from inside the pass: it has already explained itself on
+  # stderr, and it is not a verdict, so it is re-raised rather than retried.
+  [[ "${pass_status}" -le 1 ]] || exit "${pass_status}"
+
+  # An explicitly pinned fleet is the caller's claim about what to check, not a
+  # snapshot of a moving cluster, so there is nothing to converge on.
+  [[ -z "${nodes_arg}" ]] || break
+
+  # Re-read the inventory AFTER the pass. The snapshot the pass ran against was
+  # taken before it started, and a serial sweep of a real fleet is not
+  # instantaneous — a worker that joins, is replaced, or is removed midway is
+  # never inspected, yet the summary below would count only the nodes in the
+  # stale snapshot and call the fleet clean. Two consecutive identical readings
+  # are what make the verdict a statement about the fleet that exists now.
+  previous_signature="${inventory_signature}"
+  load_discovered_nodes
+  [[ "${inventory_signature}" != "${previous_signature}" ]] || break
+
+  attempt=$((attempt + 1))
+  if [[ "${attempt}" -gt "${max_inventory_attempts}" ]]; then
+    fail_infra "the node inventory changed on every one of ${max_inventory_attempts} attempts — refusing to report a fleet that will not hold still long enough to be checked"
+  fi
+  printf 'The node inventory changed while the fleet was being checked; re-checking (attempt %s of %s).\n' \
+    "${attempt}" "${max_inventory_attempts}" >&2
 done
 
-if [[ "${failures}" -gt 0 ]]; then
+printf '%s\n' "${pass_output}"
+
+if [[ "${pass_status}" -ne 0 ]]; then
+  failures="$(printf '%s\n' "${pass_output}" | grep -c '^FAIL ' || true)"
   printf '\n%s of %s node(s) cannot enforce image verification.\n' "${failures}" "${#nodes[@]}" >&2
   printf 'The ImageVerificationConfig rules in talos/cluster/verify-first-party-images.yaml are declared, but Talos is not enforcing them on those nodes.\n' >&2
   printf 'See devantler-tech/platform#2856 (finding) and #3336 (proving a refusal at pull).\n' >&2

--- a/scripts/validate-image-verifier-liveness.sh
+++ b/scripts/validate-image-verifier-liveness.sh
@@ -248,6 +248,13 @@ load_discovered_nodes() {
     # only ever participates in the identity comparison.
     nodes+=("${identity#*$'\t'}")
   done <<<"${discovered_identities}"
+
+  # An inventory that comes back EMPTY is an infrastructure fault, never the
+  # verdict "no node fails to enforce". Asserted on every reading rather than
+  # once before the sweep: the convergence pass re-reads, so a fleet that drains
+  # to nothing between readings would otherwise settle (empty equals empty),
+  # sweep no nodes at all, and report a clean fleet that does not exist.
+  [[ "${#nodes[@]}" -gt 0 ]] || fail_infra 'no nodes to check'
 }
 
 if [[ -n "${nodes_arg}" ]]; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The check that tells us whether the cluster is actually enforcing image
verification could report the whole fleet healthy while never having looked at
part of it. It listed the nodes once, then checked them one at a time; any node
that joined or was replaced while that was running was simply missed, and the
run still ended with "All N node(s) can enforce image verification". Because
nodes were recognised by IP address alone, an autoscaler replacing a worker at
the same address looked like the original node.

That matters more here than in an ordinary check: this is the signal we rely on
to know a supply-chain control is live, so a falsely green result is worse than
no result at all.

### Description

The check now confirms the fleet has stopped changing before it reports
anything, and tells nodes apart by identity rather than address. Normal
autoscaling just causes a re-check; a cluster changing too fast to observe is
reported as such instead of getting a green tick. Asking for specific nodes
explicitly is unchanged and still needs no cluster access.

No behaviour changes for a stable cluster, and there is no impact on anything
outside this check.

Fixes #3108
