### PR TITLE
fix(security): guard the unifi source's commit pin against silent regression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,9 @@ jobs:
               # Both halves, for the same reason as the guard above.
               - 'scripts/guard-limitrange-premise.sh'
               - 'scripts/tests/test-guard-limitrange-premise.sh'
+              # Both halves, for the same reason as the guard above.
+              - 'scripts/guard-gitrepository-commit-pin.sh'
+              - 'scripts/tests/test-guard-gitrepository-commit-pin.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -863,6 +866,21 @@ jobs:
         run: |
           bash scripts/guard-checkov-skip-reasons.sh k8s
           bash scripts/tests/test-guard-checkov-skip-reasons.sh
+
+      - name: 📌 Validate every GitRepository is pinned to a commit
+        if: needs.changes.outputs.k8s == 'true'
+        # A GitRepository naming a mutable ref reconciles whatever the branch tip is,
+        # so the trust boundary becomes the source repository's own enforcement.
+        # #2707 closed that on the unifi source by pinning the full commit, which fixes
+        # the content cryptographically and makes moving it a reviewed Platform change.
+        # That mitigation lived in one YAML file with nothing asserting it, so reverting
+        # it — deliberately or as collateral — would silently restore the exposure with
+        # nothing in CI noticing (#3124). This runs the guard over the tree and pins its
+        # verdict in all three directions, including the anti-vacuity case: finding NO
+        # GitRepository at all is cannot-check, never a clean pass.
+        run: |
+          bash scripts/guard-gitrepository-commit-pin.sh k8s
+          bash scripts/tests/test-guard-gitrepository-commit-pin.sh
 
       - name: 📐 Validate LimitRange-premised suppressions actually have a LimitRange
         if: needs.changes.outputs.k8s == 'true'

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -27,6 +27,19 @@
 # therefore reports a Kustomization as an unpinned GitRepository — a false
 # refusal on a file that is correct. Only a top-level `.kind` decides.
 #
+# 🔴 AND `.kind` ALONE DOES NOT IDENTIFY A RESOURCE — `.apiVersion` IS HALF OF IT.
+#
+# `GitRepository` is not a reserved word. An unrelated CRD may declare that kind,
+# and such a resource has no `spec.ref.commit` and is not subject to this policy,
+# so counting it fails CI on a correct file. Only the Flux Source Controller group
+# `source.toolkit.fluxcd.io/*` is in scope.
+#
+# ⚠️ Narrowing the selector is itself a fail-open risk, which is why the group
+# decision is NOT made in the yq predicate: a document whose apiVersion is missing
+# or empty would then simply fail to match and disappear from the guard without a
+# word — deleting one line would hide an unpinned source. An apiVersion this guard
+# cannot decide is exit 2, exactly like YAML it cannot parse.
+#
 # ⚠️ ANTI-VACUITY: finding NO GitRepository at all is exit 2, not exit 0.
 # A selector that matched nothing is indistinguishable from a healthy tree, which
 # is the failure mode this guard exists to prevent one level down. "Nothing to
@@ -90,14 +103,59 @@ while IFS= read -r file; do
   # exits 2 on this repository's own manifests -- 1 of its 725 files is exactly that shape.
   # Two stages rather than one `and`, so the second never sees a non-mapping.
   # A genuinely unparseable file still fails, and is still cannot-check.
-  if ! rows="$(yq eval-all \
-    'select(tag == "!!map") | select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
+  #
+  # 🔴 `yq eval`, NEVER `yq eval-all`. `eval-all` merges every document in the file into ONE
+  # stream, so `@tsv` renders them as a SINGLE tab-joined line rather than one line per
+  # document. `read` then assigns document 1's namespace and name and absorbs everything
+  # else into `commit`, which can never match 40-hex — so a file holding TWO correctly
+  # pinned GitRepositories was refused as a violation, reported `1 of 1` instead of `2`, and
+  # printed the next document's fields inside the offending commit value. Multi-document
+  # files are the norm in Kubernetes manifests and no fixture used one, so every existing
+  # multi-document assertion passed by putting each document in its own file. `eval`
+  # evaluates each document independently and emits one row per document.
+  #
+  # 🔴 NO EMITTED FIELD BEFORE THE LAST MAY BE EMPTY. Tab is IFS *whitespace*, so `read`
+  # strips a leading empty field and collapses runs of tabs — every later field then shifts
+  # left, `name` lands empty, and the `-n "$name"` guard below skips the document silently.
+  # A GitRepository with no apiVersion would therefore vanish from the guard, which is the
+  # fail-open this apiVersion check exists to close. `// "x"` alone is NOT enough: yq's
+  # alternative operator fires on null but NOT on an empty string, so `apiVersion: ""`
+  # still emits an empty field. `(X // "" | select(. != "")) // "<sentinel>"` catches both.
+  # Only the trailing `commit` may be empty, because a stripped trailing field still reads
+  # back as the empty string.
+  if ! rows="$(yq eval \
+    'select(tag == "!!map") | select(.kind == "GitRepository") | [((.apiVersion // "" | select(. != "")) // "<absent>"), ((.metadata.namespace // "" | select(. != "")) // "-"), ((.metadata.name // "" | select(. != "")) // "-"), (.spec.ref.commit // "")] | @tsv' \
     "$file" 2>/dev/null)"; then
     die "could not parse '$file' — refusing to report a tree it could not read"
   fi
 
-  while IFS=$'\t' read -r ns name commit; do
+  while IFS=$'\t' read -r api ns name commit; do
     [ -n "${name:-}" ] || continue
+
+    # A Kubernetes resource is identified by apiVersion AND kind, never by kind alone.
+    # `GitRepository` is not a reserved word: an unrelated CRD may use it, and such a
+    # resource has no `spec.ref.commit` and is not subject to this policy, so counting it
+    # would fail CI on a correct file.
+    #
+    # 🔴 BUT AN UNDECIDABLE apiVersion IS `cannot-check`, NEVER `not-Flux`. Filtering this
+    # inside the yq predicate is the obvious form and it is a fail-open: `null | test(...)`
+    # does not error, it simply does not match, so a document that DROPS its apiVersion line
+    # disappears from the guard silently — and in a mixed tree the anti-vacuity check below
+    # is satisfied by some other resource, so the guard reports "all commit-pinned" with an
+    # unpinned GitRepository beside it. That is the exact regression class this guard exists
+    # to prevent (#3124), reachable by deleting one line. So the group decision is made HERE,
+    # where "I cannot tell which API this is" gets its own exit-2 branch.
+    case "$api" in
+      source.toolkit.fluxcd.io/?*) ;;
+      '<absent>' | '')
+        die "'$file': GitRepository $ns/$name declares no apiVersion — cannot tell whether it is a Flux source, so this tree is unverified"
+        ;;
+      source.toolkit.fluxcd.io | source.toolkit.fluxcd.io/)
+        die "'$file': GitRepository $ns/$name has a malformed apiVersion '$api' (no version after the group) — refusing to guess whether it is a Flux source"
+        ;;
+      *) continue ;;
+    esac
+
     checked=$((checked + 1))
     if printf '%s' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
       continue

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -46,10 +46,22 @@ die() { printf 'guard-gitrepository-commit-pin: %s\n' "$*" >&2; exit 2; }
 root="$1"
 [ -d "$root" ] || die "root '$root' is not a directory"
 command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
-
-# Cheap prefilter: only files mentioning the kind can hold such a document. The
-# authoritative selection is the yq `.kind` test below.
-candidates="$(grep -rl --include='*.yaml' --include='*.yml' 'kind: GitRepository' "$root" 2>/dev/null)"
+# Cheap prefilter, matching the BARE kind name -- never "kind: GitRepository".
+#
+# 🔴 A PREFILTER THAT MISSES A FILE IS A FAIL-OPEN, NOT A MISSED WARNING.
+#
+# Any YAML rendering of this kind contains the bare substring, but the canonical
+# "kind: GitRepository" does not survive an extra space ("kind:   GitRepository")
+# or a quoted scalar. Matching that exact text skipped such a file entirely, and
+# in a MIXED tree the anti-vacuity check below was then satisfied by some OTHER,
+# well-formed resource -- so the guard reported "all commit-pinned", exit 0, with
+# an unpinned GitRepository sitting right beside it. That was measured on this
+# guard before the prefilter was widened, and it is the failure this whole file
+# exists to prevent, one level down.
+#
+# The authoritative selection remains the yq .kind test below. This line only
+# decides which files are OPENED, so it must over-match, never under-match.
+candidates="$(grep -rl --include='*.yaml' --include='*.yml' 'GitRepository' "$root" 2>/dev/null)"
 
 checked=0
 violations=0

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -64,7 +64,21 @@ command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
 #
 # The authoritative selection remains the yq .kind test below. This line only
 # decides which files are OPENED, so it must over-match, never under-match.
+#
+# 🔴 AND AN ERRORING PREFILTER IS THE SAME FAIL-OPEN BY ANOTHER ROUTE.
+#
+# `grep -r` exits 2 when it could not read something -- an unreadable directory,
+# a broken symlink loop, a vanished file -- and it still exits 0/1 for the parts
+# it DID read. With stderr discarded, a truncated candidate list is byte-for-byte
+# indistinguishable from a complete one. In a MIXED tree the anti-vacuity check
+# below is then satisfied by a file grep could read, so the guard prints
+# "all commit-pinned", exit 0, with an unpinned GitRepository sitting in the
+# directory it silently skipped. Exit 1 (genuinely no matches anywhere) is NOT an
+# error and is left to the anti-vacuity check, which is what that check is for.
 candidates="$(grep -rl --include='*.yaml' --include='*.yml' 'GitRepository' "$root" 2>/dev/null)"
+grep_status=$?
+[ "$grep_status" -le 1 ] ||
+  die "could not search '$root' (grep exit $grep_status) — refusing to report a tree it could not fully read"
 
 checked=0
 violations=0

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -40,7 +40,10 @@
 
 set -uo pipefail
 
-die() { printf 'guard-gitrepository-commit-pin: %s\n' "$*" >&2; exit 2; }
+die() {
+  printf 'guard-gitrepository-commit-pin: %s\n' "$*" >&2
+  exit 2
+}
 
 [ "$#" -eq 1 ] || die "usage: $0 <root-directory>"
 root="$1"
@@ -72,8 +75,8 @@ while IFS= read -r file; do
   [ -n "$file" ] || continue
 
   if ! rows="$(yq eval-all \
-      'select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
-      "$file" 2>/dev/null)"; then
+    'select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
+    "$file" 2>/dev/null)"; then
     die "could not parse '$file' — refusing to report a tree it could not read"
   fi
 
@@ -86,8 +89,8 @@ while IFS= read -r file; do
     violations=$((violations + 1))
     printf 'VIOLATION %s: GitRepository %s/%s is not pinned to a commit (spec.ref.commit=%s)\n' \
       "$file" "$ns" "$name" "${commit:-<absent>}" >&2
-  done <<< "$rows"
-done <<< "$candidates"
+  done <<<"$rows"
+done <<<"$candidates"
 
 if [ "$checked" -eq 0 ]; then
   die "no GitRepository document found under '$root' — selector matched nothing, so nothing was verified"

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Fail when a Flux `GitRepository` tracks a MUTABLE ref instead of a pinned commit.
+#
+# THE RULE THIS ENFORCES: every GitRepository document under the given root must
+# carry `spec.ref.commit` as a full 40-hex SHA.
+#
+# Why a pin rather than a signature. A GitRepository that names `branch: main`
+# reconciles whatever the branch tip is, so the trust boundary is entirely the
+# source repository's own enforcement. #2707 closed that on the `unifi` source by
+# pinning the full commit, and stated the reason in the manifest: a
+# source-repository compromise then cannot change resources already authorized
+# for patch/update without a separately reviewed Platform change. A 40-hex commit
+# fixes the CONTENT cryptographically — Flux fetches that object or fails — which
+# is strictly stronger than verifying who signed a tip that can still move.
+#
+# That mitigation lived in one YAML file with nothing asserting it. Reverting
+# `ref.commit` to `ref.branch` — deliberately, for auto-updates, or as collateral
+# in an unrelated refactor — would silently restore the original exposure and no
+# check in CI would notice (#3124). This guard removes that possibility rather
+# than documenting it.
+#
+# 🔴 SELECT ON THE DOCUMENT'S OWN `.kind`, NEVER ON THE TEXT.
+#
+# `kind: GitRepository` also appears inside a Kustomization's `spec.sourceRef`,
+# which is a REFERENCE to a source and carries no `ref` of its own. A text match
+# therefore reports a Kustomization as an unpinned GitRepository — a false
+# refusal on a file that is correct. Only a top-level `.kind` decides.
+#
+# ⚠️ ANTI-VACUITY: finding NO GitRepository at all is exit 2, not exit 0.
+# A selector that matched nothing is indistinguishable from a healthy tree, which
+# is the failure mode this guard exists to prevent one level down. "Nothing to
+# check" must never render as "checked and clean".
+#
+# Exit codes:
+#   0  every GitRepository found is pinned to a 40-hex commit
+#   1  at least one is not — the defect
+#   2  cannot check: bad usage, missing root, unparseable YAML, or no
+#      GitRepository document found anywhere under the root
+
+set -uo pipefail
+
+die() { printf 'guard-gitrepository-commit-pin: %s\n' "$*" >&2; exit 2; }
+
+[ "$#" -eq 1 ] || die "usage: $0 <root-directory>"
+root="$1"
+[ -d "$root" ] || die "root '$root' is not a directory"
+command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
+
+# Cheap prefilter: only files mentioning the kind can hold such a document. The
+# authoritative selection is the yq `.kind` test below.
+candidates="$(grep -rl --include='*.yaml' --include='*.yml' 'kind: GitRepository' "$root" 2>/dev/null)"
+
+checked=0
+violations=0
+
+# A here-string, not a pipe: a piped `while` runs in a subshell, so the counters
+# it increments would be discarded and the guard would report 0 violations.
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  if ! rows="$(yq eval-all \
+      'select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
+      "$file" 2>/dev/null)"; then
+    die "could not parse '$file' — refusing to report a tree it could not read"
+  fi
+
+  while IFS=$'\t' read -r ns name commit; do
+    [ -n "${name:-}" ] || continue
+    checked=$((checked + 1))
+    if printf '%s' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
+      continue
+    fi
+    violations=$((violations + 1))
+    printf 'VIOLATION %s: GitRepository %s/%s is not pinned to a commit (spec.ref.commit=%s)\n' \
+      "$file" "$ns" "$name" "${commit:-<absent>}" >&2
+  done <<< "$rows"
+done <<< "$candidates"
+
+if [ "$checked" -eq 0 ]; then
+  die "no GitRepository document found under '$root' — selector matched nothing, so nothing was verified"
+fi
+
+if [ "$violations" -gt 0 ]; then
+  cat >&2 <<'FIX'
+
+Every GitRepository must pin a full 40-hex commit:
+
+  spec:
+    ref:
+      commit: <40-hex sha>
+
+Replace the mutable ref with the commit you intend to deploy. Moving the pin is a
+reviewed Platform change, which is the control (#3124, #2707). If a mutable ref is
+genuinely required, this guard is the place to record that decision.
+FIX
+  printf 'guard-gitrepository-commit-pin: %d of %d GitRepository document(s) not commit-pinned\n' \
+    "$violations" "$checked" >&2
+  exit 1
+fi
+
+printf 'guard-gitrepository-commit-pin: OK — %d GitRepository document(s), all commit-pinned\n' "$checked"
+exit 0

--- a/scripts/guard-gitrepository-commit-pin.sh
+++ b/scripts/guard-gitrepository-commit-pin.sh
@@ -49,36 +49,31 @@ die() {
 root="$1"
 [ -d "$root" ] || die "root '$root' is not a directory"
 command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
-# Cheap prefilter, matching the BARE kind name -- never "kind: GitRepository".
+# 🔴 NO TEXT PREFILTER AT ALL. THE PARSER DECIDES WHICH FILES HOLD A GitRepository.
 #
-# 🔴 A PREFILTER THAT MISSES A FILE IS A FAIL-OPEN, NOT A MISSED WARNING.
+# Every text prefilter tried here has been a fail-open, because the question "does this file
+# contain a GitRepository?" is a question about PARSED YAML and a text match only approximates
+# it. Three approximations failed in turn:
 #
-# Any YAML rendering of this kind contains the bare substring, but the canonical
-# "kind: GitRepository" does not survive an extra space ("kind:   GitRepository")
-# or a quoted scalar. Matching that exact text skipped such a file entirely, and
-# in a MIXED tree the anti-vacuity check below was then satisfied by some OTHER,
-# well-formed resource -- so the guard reported "all commit-pinned", exit 0, with
-# an unpinned GitRepository sitting right beside it. That was measured on this
-# guard before the prefilter was widened, and it is the failure this whole file
-# exists to prevent, one level down.
+#   `kind: GitRepository`   missed `kind:   GitRepository` and quoted scalars.
+#   `GitRepository`         misses `kind: "GitRepository"` -- a legal escape that yq
+#                           parses as GitRepository and no raw-text search can see.
+#   any grep at all         reported a truncated list as a complete one when it hit an
+#                           unreadable path, since it still exits 0/1 for what it did read.
 #
-# The authoritative selection remains the yq .kind test below. This line only
-# decides which files are OPENED, so it must over-match, never under-match.
+# Each one is the same failure: in a MIXED tree the anti-vacuity check below is satisfied by
+# some OTHER well-formed resource, so the guard prints "all commit-pinned", exit 0, with an
+# unpinned GitRepository sitting beside it. Widening the pattern once more would only move the
+# boundary; enumerating every YAML file and letting `yq` apply `.kind` removes it. That costs
+# one `yq` invocation per file -- measured at ~6s over this repository's 725 manifests, which
+# is noise next to the job it runs in, and correctness here is not worth trading for it.
 #
-# 🔴 AND AN ERRORING PREFILTER IS THE SAME FAIL-OPEN BY ANOTHER ROUTE.
-#
-# `grep -r` exits 2 when it could not read something -- an unreadable directory,
-# a broken symlink loop, a vanished file -- and it still exits 0/1 for the parts
-# it DID read. With stderr discarded, a truncated candidate list is byte-for-byte
-# indistinguishable from a complete one. In a MIXED tree the anti-vacuity check
-# below is then satisfied by a file grep could read, so the guard prints
-# "all commit-pinned", exit 0, with an unpinned GitRepository sitting in the
-# directory it silently skipped. Exit 1 (genuinely no matches anywhere) is NOT an
-# error and is left to the anti-vacuity check, which is what that check is for.
-candidates="$(grep -rl --include='*.yaml' --include='*.yml' 'GitRepository' "$root" 2>/dev/null)"
-grep_status=$?
-[ "$grep_status" -le 1 ] ||
-  die "could not search '$root' (grep exit $grep_status) — refusing to report a tree it could not fully read"
+# `find` exits non-zero when it cannot traverse something, which is the same
+# "could not read the tree" case handled below, so that check is kept and now keys on find.
+candidates="$(find "$root" \( -name '*.yaml' -o -name '*.yml' \) -type f -print 2>/dev/null)"
+find_status=$?
+[ "$find_status" -eq 0 ] ||
+  die "could not enumerate '$root' (find exit $find_status) — refusing to report a tree it could not fully read"
 
 checked=0
 violations=0
@@ -88,8 +83,15 @@ violations=0
 while IFS= read -r file; do
   [ -n "$file" ] || continue
 
+  # `select(tag == "!!map")` FIRST, as its own stage. Now that every YAML file is parsed
+  # rather than only those matching a text pattern, sequence documents are routine here: a
+  # Kustomize JSON-patch file is a top-level ARRAY, and `.kind` against an array is a yq
+  # ERROR ("cannot index array with 'kind'"), not an empty result. Without this the guard
+  # exits 2 on this repository's own manifests -- 1 of its 725 files is exactly that shape.
+  # Two stages rather than one `and`, so the second never sees a non-mapping.
+  # A genuinely unparseable file still fails, and is still cannot-check.
   if ! rows="$(yq eval-all \
-    'select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
+    'select(tag == "!!map") | select(.kind == "GitRepository") | [(.metadata.namespace // "-"), (.metadata.name // "-"), (.spec.ref.commit // "")] | @tsv' \
     "$file" 2>/dev/null)"; then
     die "could not parse '$file' — refusing to report a tree it could not read"
   fi

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -56,7 +56,7 @@ assert_contains() { # <label> <needle>
   # that gives the upstream `printf` becomes the pipeline status under `pipefail`.
   # A needle matching EARLY would then read as a failed assertion while a needle
   # near the end passed — the harness silently inverting its own verdict.
-  if grep -qF -- "$2" <<< "$GUARD_OUT"; then
+  if grep -qF -- "$2" <<<"$GUARD_OUT"; then
     printf '  ok   %s\n' "$1"
   else
     printf '  FAIL %s: output did not contain %s\n' "$1" "$2"
@@ -73,7 +73,7 @@ mkcase() { # <name> -> echoes the root dir
 
 echo "== case: pinned commit is accepted =="
 root="$(mkcase pinned)"
-cat > "$root/gr.yaml" <<'YAML'
+cat >"$root/gr.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -90,7 +90,7 @@ assert_contains "reports the count it checked" "1 GitRepository document(s)"
 
 echo "== case: mutable branch ref is refused =="
 root="$(mkcase branchref)"
-cat > "$root/gr.yaml" <<'YAML'
+cat >"$root/gr.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -108,7 +108,7 @@ assert_contains "states the fix" "spec:"
 
 echo "== case: a short/malformed commit is refused =="
 root="$(mkcase shortsha)"
-cat > "$root/gr.yaml" <<'YAML'
+cat >"$root/gr.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -125,7 +125,7 @@ assert_contains "names the offending resource" "ns-short/case-short"
 
 echo "== anti-false-positive: a Kustomization sourceRef is NOT a GitRepository =="
 root="$(mkcase sourceref)"
-cat > "$root/ks.yaml" <<'YAML'
+cat >"$root/ks.yaml" <<'YAML'
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -136,7 +136,7 @@ spec:
     kind: GitRepository
     name: case-source
 YAML
-cat > "$root/gr.yaml" <<'YAML'
+cat >"$root/gr.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -158,7 +158,7 @@ echo "== regression: a non-canonically-spaced kind must NOT escape the prefilter
 # returned exit 0 -- reporting "all commit-pinned" with an unpinned GitRepository
 # right beside it. Both documents must be counted, and the odd one refused.
 root="$(mkcase mixedspacing)"
-cat > "$root/canonical.yaml" <<'YAML'
+cat >"$root/canonical.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -168,7 +168,7 @@ spec:
   ref:
     commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
 YAML
-cat > "$root/odd.yaml" <<'YAML'
+cat >"$root/odd.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind:   GitRepository
 metadata:
@@ -185,7 +185,7 @@ assert_contains "counted BOTH documents, not just the canonical one" "1 of 2 Git
 
 echo "== anti-vacuity: no GitRepository anywhere is CANNOT-CHECK, not clean =="
 root="$(mkcase empty)"
-cat > "$root/other.yaml" <<'YAML'
+cat >"$root/other.yaml" <<'YAML'
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -198,7 +198,7 @@ assert_contains "says the selector matched nothing" "matched nothing"
 
 echo "== cannot-check: unparseable YAML is never reported as clean =="
 root="$(mkcase broken)"
-cat > "$root/gr.yaml" <<'YAML'
+cat >"$root/gr.yaml" <<'YAML'
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Pins the GitRepository commit-pin guard's verdict in all THREE directions.
+#
+#   exit 0  every GitRepository document carries a 40-hex spec.ref.commit
+#   exit 1  at least one tracks a mutable ref, or a malformed commit
+#   exit 2  the guard could not check — bad usage, missing root, unparseable
+#           YAML, or NO GitRepository document found at all
+#
+# Two of these are anti-vacuity cases rather than behaviours. A tree with no
+# GitRepository must come back exit 2, NOT a clean exit 0: a selector that
+# matched nothing is indistinguishable from a healthy tree, and reporting it as
+# clean is the same class of failure the guard exists to prevent. And a
+# Kustomization referencing `kind: GitRepository` under `spec.sourceRef` must be
+# IGNORED — it carries no ref of its own, so counting it would be a false
+# refusal on a correct file.
+#
+# Every fixture carries its OWN namespace and name, so an assertion can only be
+# satisfied by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-gitrepository-commit-pin.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <root>
+  # Capture the status with `if` rather than toggling `set -e`: this file runs
+  # under `set -uo pipefail` with NO errexit, so `set -e` here would enable a
+  # mode the script never had.
+  if GUARD_OUT="$("$guard" "$1" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
+}
+
+assert_rc() { # <label> <expected-rc> <actual-rc>
+  assertions=$((assertions + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s (exit %s)\n' "$1" "$3"
+  else
+    printf '  FAIL %s: expected exit %s, got %s\n' "$1" "$2" "$3"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() { # <label> <needle>
+  assertions=$((assertions + 1))
+  # A here-string, NOT a pipe: `grep -q` exits on the first match, and the SIGPIPE
+  # that gives the upstream `printf` becomes the pipeline status under `pipefail`.
+  # A needle matching EARLY would then read as a failed assertion while a needle
+  # near the end passed — the harness silently inverting its own verdict.
+  if grep -qF -- "$2" <<< "$GUARD_OUT"; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: output did not contain %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+mkcase() { # <name> -> echoes the root dir
+  d="$scratch/$1"
+  mkdir -p "$d"
+  printf '%s' "$d"
+}
+
+echo "== case: pinned commit is accepted =="
+root="$(mkcase pinned)"
+cat > "$root/gr.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-pinned
+  namespace: ns-pinned
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+YAML
+run_guard "$root"
+assert_rc "pinned commit -> 0" 0 "$GUARD_RC"
+assert_contains "reports the count it checked" "1 GitRepository document(s)"
+
+echo "== case: mutable branch ref is refused =="
+root="$(mkcase branchref)"
+cat > "$root/gr.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-branch
+  namespace: ns-branch
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    branch: main
+YAML
+run_guard "$root"
+assert_rc "branch ref -> 1" 1 "$GUARD_RC"
+assert_contains "names the offending resource" "ns-branch/case-branch"
+assert_contains "states the fix" "spec:"
+
+echo "== case: a short/malformed commit is refused =="
+root="$(mkcase shortsha)"
+cat > "$root/gr.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-short
+  namespace: ns-short
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    commit: 7b17f7e3
+YAML
+run_guard "$root"
+assert_rc "abbreviated sha -> 1" 1 "$GUARD_RC"
+assert_contains "names the offending resource" "ns-short/case-short"
+
+echo "== anti-false-positive: a Kustomization sourceRef is NOT a GitRepository =="
+root="$(mkcase sourceref)"
+cat > "$root/ks.yaml" <<'YAML'
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: case-consumer
+  namespace: ns-sourceref
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: case-source
+YAML
+cat > "$root/gr.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-source
+  namespace: ns-sourceref
+spec:
+  url: https://github.com/devantler-tech/unifi
+  ref:
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+YAML
+run_guard "$root"
+assert_rc "sourceRef ignored, pinned source accepted -> 0" 0 "$GUARD_RC"
+assert_contains "counted exactly one document, not two" "1 GitRepository document(s)"
+
+echo "== anti-vacuity: no GitRepository anywhere is CANNOT-CHECK, not clean =="
+root="$(mkcase empty)"
+cat > "$root/other.yaml" <<'YAML'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case-unrelated
+  namespace: ns-empty
+YAML
+run_guard "$root"
+assert_rc "no GitRepository -> 2" 2 "$GUARD_RC"
+assert_contains "says the selector matched nothing" "matched nothing"
+
+echo "== cannot-check: unparseable YAML is never reported as clean =="
+root="$(mkcase broken)"
+cat > "$root/gr.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-broken
+  namespace: ns-broken
+spec:
+  ref:
+    commit: "unterminated
+   bad: [indent
+YAML
+run_guard "$root"
+assert_rc "unparseable YAML -> 2" 2 "$GUARD_RC"
+
+echo "== cannot-check: usage and missing root =="
+run_guard ""
+assert_rc "empty root -> 2" 2 "$GUARD_RC"
+if GUARD_OUT="$("$guard" 2>&1)"; then GUARD_RC=0; else GUARD_RC=$?; fi
+assert_rc "no argument -> 2" 2 "$GUARD_RC"
+if GUARD_OUT="$("$guard" "$scratch/does-not-exist" 2>&1)"; then GUARD_RC=0; else GUARD_RC=$?; fi
+assert_rc "nonexistent root -> 2" 2 "$GUARD_RC"
+
+echo
+if [ "$failures" -gt 0 ]; then
+  printf 'test-guard-gitrepository-commit-pin: %d of %d assertion(s) FAILED\n' "$failures" "$assertions" >&2
+  exit 1
+fi
+printf 'test-guard-gitrepository-commit-pin: all %d assertion(s) passed\n' "$assertions"

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -252,6 +252,68 @@ else
   assert_contains "says it could not search the tree" "refusing to report a tree it could not fully read"
 fi
 chmod 755 "$root/hidden"
+
+echo "== regression: an ESCAPED kind must NOT escape selection =="
+# `kind: "Git\u0052epository"` is legal YAML that parses as GitRepository, and NO raw-text
+# search can see it — the file does not contain the string "GitRepository" at all. A merely
+# QUOTED kind would not model this: `kind: "GitRepository"` still contains the substring, so a
+# grep prefilter matches it and the fixture would pass with the bug present. With a text prefilter this document was never opened, so in a mixed tree
+# the anti-vacuity check was satisfied by the pinned document beside it and the guard printed
+# "all commit-pinned", exit 0, with an unpinned escaped GitRepository present. This is why
+# selection is now the parser's job and there is no text prefilter at all.
+root="$(mkcase escaped)"
+cat >"$root/pinned.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-escaped-pinned
+  namespace: ns-escaped
+spec:
+  ref:
+    commit: cccccccccccccccccccccccccccccccccccccccc
+YAML
+cat >"$root/escaped.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: "Git\u0052epository"
+metadata:
+  name: case-escaped-unpinned
+  namespace: ns-escaped
+spec:
+  ref:
+    branch: main
+YAML
+run_guard "$root"
+assert_rc "escaped kind in a mixed tree -> 1" 1 "$GUARD_RC"
+assert_contains "names the escaped resource" "case-escaped-unpinned"
+assert_contains "counted BOTH documents, not just the literal one" "1 of 2"
+
+echo "== regression: a SEQUENCE document is not an error =="
+# Now that every YAML file is parsed rather than only text-matching ones, sequence documents
+# are routine: a Kustomize JSON-patch file is a top-level ARRAY, and `.kind` against an array
+# is a yq ERROR, not an empty result. Without the `tag == "!!map"` stage the guard exits 2 on
+# this repository's own manifests. A genuinely unparseable file must STILL be cannot-check,
+# which the case above this one pins.
+root="$(mkcase sequence)"
+cat >"$root/patch.yaml" <<'YAML'
+- op: add
+  path: /spec/listeners/-
+  value:
+    name: example
+    kind: GitRepository
+YAML
+cat >"$root/real.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-sequence
+  namespace: ns-sequence
+spec:
+  ref:
+    commit: dddddddddddddddddddddddddddddddddddddddd
+YAML
+run_guard "$root"
+assert_rc "a JSON-patch array alongside a pinned source -> 0" 0 "$GUARD_RC"
+assert_contains "counted only the real document" "1 GitRepository document(s)"
 echo "== cannot-check: usage and missing root =="
 run_guard ""
 assert_rc "empty root -> 2" 2 "$GUARD_RC"

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -151,6 +151,38 @@ run_guard "$root"
 assert_rc "sourceRef ignored, pinned source accepted -> 0" 0 "$GUARD_RC"
 assert_contains "counted exactly one document, not two" "1 GitRepository document(s)"
 
+echo "== regression: a non-canonically-spaced kind must NOT escape the prefilter =="
+# The prefilter used to match the literal "kind: GitRepository", which an extra
+# space defeats. Alone that produced a safe exit 2, but in a MIXED tree the
+# anti-vacuity check was satisfied by the well-formed resource and the guard
+# returned exit 0 -- reporting "all commit-pinned" with an unpinned GitRepository
+# right beside it. Both documents must be counted, and the odd one refused.
+root="$(mkcase mixedspacing)"
+cat > "$root/canonical.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-canonical
+  namespace: ns-mixed
+spec:
+  ref:
+    commit: 7b17f7e33ef507c24c395b884a433c62b92ace98
+YAML
+cat > "$root/odd.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind:   GitRepository
+metadata:
+  name: case-spaced
+  namespace: ns-mixed
+spec:
+  ref:
+    branch: main
+YAML
+run_guard "$root"
+assert_rc "mixed spacing, one unpinned -> 1" 1 "$GUARD_RC"
+assert_contains "names the oddly-spaced resource" "ns-mixed/case-spaced"
+assert_contains "counted BOTH documents, not just the canonical one" "1 of 2 GitRepository document(s)"
+
 echo "== anti-vacuity: no GitRepository anywhere is CANNOT-CHECK, not clean =="
 root="$(mkcase empty)"
 cat > "$root/other.yaml" <<'YAML'

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -314,6 +314,198 @@ YAML
 run_guard "$root"
 assert_rc "a JSON-patch array alongside a pinned source -> 0" 0 "$GUARD_RC"
 assert_contains "counted only the real document" "1 GitRepository document(s)"
+echo "== anti-false-positive: a FOREIGN CRD reusing kind GitRepository is not ours =="
+# A Kubernetes resource is identified by apiVersion AND kind. `GitRepository` is not a
+# reserved word, so an unrelated CRD may declare it; such a resource carries no
+# `spec.ref.commit` and is outside this policy. Selecting on kind alone failed CI on a
+# correct file. The Flux document beside it must still be counted, so the guard is proved
+# to be discriminating rather than simply ignoring the whole file.
+root="$(mkcase foreignkind)"
+cat >"$root/foreign.yaml" <<'YAML'
+apiVersion: example.dev/v1
+kind: GitRepository
+metadata:
+  name: case-foreign
+  namespace: ns-foreign
+spec:
+  endpoint: https://example.invalid
+YAML
+cat >"$root/flux.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-fluxsource
+  namespace: ns-foreign
+spec:
+  ref:
+    commit: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+YAML
+run_guard "$root"
+assert_rc "foreign kind ignored, Flux source accepted -> 0" 0 "$GUARD_RC"
+assert_contains "counted only the Flux document, not the foreign one" "1 GitRepository document(s)"
+
+echo "== anti-vacuity: a tree of ONLY foreign GitRepositories verified nothing =="
+# Narrowing the selector must not create a new silent pass: if every candidate was skipped
+# as foreign, nothing was checked, and that is cannot-check exactly as an empty tree is.
+root="$(mkcase foreignonly)"
+cat >"$root/foreign.yaml" <<'YAML'
+apiVersion: example.dev/v1
+kind: GitRepository
+metadata:
+  name: case-foreignonly
+  namespace: ns-foreignonly
+spec:
+  endpoint: https://example.invalid
+YAML
+run_guard "$root"
+assert_rc "only foreign GitRepositories -> 2" 2 "$GUARD_RC"
+assert_contains "says the selector matched nothing" "matched nothing"
+
+echo "== fail-open guard: a MISSING apiVersion is cannot-check, never not-Flux =="
+# Doing the group test inside the yq predicate is the obvious implementation and it is a
+# fail-open: `null | test(...)` does not error, it just fails to match, so deleting the
+# apiVersion line removes a GitRepository from the guard's view entirely. In a mixed tree
+# the anti-vacuity check is then satisfied by the pinned document beside it and the guard
+# reports success over an unpinned source. The unpinned document here is deliberately
+# paired with a healthy one so that a fail-open renders as exit 0, not exit 2.
+root="$(mkcase noapiversion)"
+cat >"$root/nover.yaml" <<'YAML'
+kind: GitRepository
+metadata:
+  name: case-noapiversion
+  namespace: ns-nover
+spec:
+  ref:
+    branch: main
+YAML
+cat >"$root/healthy.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-nover-healthy
+  namespace: ns-nover
+spec:
+  ref:
+    commit: ffffffffffffffffffffffffffffffffffffffff
+YAML
+run_guard "$root"
+assert_rc "GitRepository with no apiVersion -> 2" 2 "$GUARD_RC"
+assert_contains "names the undecidable resource" "ns-nover/case-noapiversion"
+
+echo "== fail-open guard: an EMPTY-STRING apiVersion is cannot-check too =="
+# Distinct from the missing-apiVersion case above, and it needs its own fixture: yq's `//`
+# alternative fires on null but NOT on an empty string, so `apiVersion: ""` slips past a
+# plain `// "<absent>"` and emits an EMPTY leading field. Tab is IFS whitespace, so `read`
+# then strips it, every field shifts left, `name` lands empty and the document is skipped
+# without a word. Paired with a healthy document so the fail-open renders as exit 0.
+root="$(mkcase emptyapiversion)"
+cat >"$root/emptyav.yaml" <<'YAML'
+apiVersion: ""
+kind: GitRepository
+metadata:
+  name: case-emptyapiversion
+  namespace: ns-emptyav
+spec:
+  ref:
+    branch: main
+YAML
+cat >"$root/healthy.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-emptyav-healthy
+  namespace: ns-emptyav
+spec:
+  ref:
+    commit: cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd
+YAML
+run_guard "$root"
+assert_rc "empty-string apiVersion -> 2" 2 "$GUARD_RC"
+assert_contains "names the empty-apiVersion resource" "ns-emptyav/case-emptyapiversion"
+
+echo "== fail-open guard: a Flux group with no version is cannot-check =="
+root="$(mkcase malformedapi)"
+cat >"$root/malformed.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io
+kind: GitRepository
+metadata:
+  name: case-malformedapi
+  namespace: ns-malformed
+spec:
+  ref:
+    branch: main
+YAML
+cat >"$root/healthy.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-malformed-healthy
+  namespace: ns-malformed
+spec:
+  ref:
+    commit: abababababababababababababababababababab
+YAML
+run_guard "$root"
+assert_rc "Flux group with no version -> 2" 2 "$GUARD_RC"
+assert_contains "names the malformed resource" "ns-malformed/case-malformedapi"
+
+echo "== regression: TWO GitRepository documents in ONE file are read separately =="
+# `yq eval-all` merges every document in a file into one stream, so `@tsv` emitted a single
+# tab-joined line and `read` absorbed document 2 into document 1's commit field. Two
+# correctly pinned sources in one file were therefore refused as a violation and counted
+# `1 of 1`. Multi-document files are the norm in Kubernetes manifests, and every earlier
+# multi-document assertion in this suite put each document in its own FILE, so nothing
+# covered this.
+root="$(mkcase multidocclean)"
+cat >"$root/both.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-multi-one
+  namespace: ns-multi
+spec:
+  ref:
+    commit: 1111111111111111111111111111111111111111
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-multi-two
+  namespace: ns-multi
+spec:
+  ref:
+    commit: 2222222222222222222222222222222222222222
+YAML
+run_guard "$root"
+assert_rc "two pinned documents in one file -> 0" 0 "$GUARD_RC"
+assert_contains "counted BOTH documents in the same file" "2 GitRepository document(s)"
+
+echo "== regression: an unpinned SECOND document in one file is still caught =="
+root="$(mkcase multidocdirty)"
+cat >"$root/both.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-multi-pinned
+  namespace: ns-multi2
+spec:
+  ref:
+    commit: 3333333333333333333333333333333333333333
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-multi-unpinned
+  namespace: ns-multi2
+spec:
+  ref:
+    branch: main
+YAML
+run_guard "$root"
+assert_rc "one unpinned document in a shared file -> 1" 1 "$GUARD_RC"
+assert_contains "names the SECOND document, not the first" "ns-multi2/case-multi-unpinned"
+assert_contains "counted both documents in the shared file" "1 of 2 GitRepository document(s)"
+
 echo "== cannot-check: usage and missing root =="
 run_guard ""
 assert_rc "empty root -> 2" 2 "$GUARD_RC"

--- a/scripts/tests/test-guard-gitrepository-commit-pin.sh
+++ b/scripts/tests/test-guard-gitrepository-commit-pin.sh
@@ -212,6 +212,46 @@ YAML
 run_guard "$root"
 assert_rc "unparseable YAML -> 2" 2 "$GUARD_RC"
 
+echo "== regression: a tree grep could not fully read is CANNOT-CHECK, not clean =="
+# `grep -r` exits 2 on an unreadable path while still reporting the parts it DID
+# read, and the guard discards its stderr. In a MIXED tree the anti-vacuity check
+# is then satisfied by the file grep COULD read, so the pre-fix guard printed
+# "all commit-pinned", exit 0, with an unpinned GitRepository in the directory it
+# silently skipped. This case pins that shut.
+root="$(mkcase unreadable)"
+mkdir -p "$root/readable" "$root/hidden"
+cat >"$root/readable/good.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-unreadable-good
+  namespace: ns-unreadable
+spec:
+  ref:
+    commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+YAML
+cat >"$root/hidden/bad.yaml" <<'YAML'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: case-unreadable-bad
+  namespace: ns-unreadable
+spec:
+  ref:
+    branch: main
+YAML
+chmod 000 "$root/hidden"
+# Running as root defeats the mode bits entirely, so the fixture would not model
+# the condition. Skipping loudly beats asserting against a fixture that did not
+# build — a control that cannot fire proves nothing.
+if cat "$root/hidden/bad.yaml" >/dev/null 2>&1; then
+  printf '  SKIP unreadable-path case: this user can read mode-000 dirs (root?)\n'
+else
+  run_guard "$root"
+  assert_rc "unreadable subtree -> 2" 2 "$GUARD_RC"
+  assert_contains "says it could not search the tree" "refusing to report a tree it could not fully read"
+fi
+chmod 755 "$root/hidden"
 echo "== cannot-check: usage and missing root =="
 run_guard ""
 assert_rc "empty root -> 2" 2 "$GUARD_RC"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The `unifi` GitRepository used to follow a moving branch, so Flux deployed whatever the branch tip
was and the only thing standing behind it was the source repository's own settings. That was closed
in #2707 by pinning the exact commit — a stronger control, because moving the pin now requires a
reviewed Platform change.

Nothing was protecting that decision. Reverting the pin to a branch — on purpose, or as a side
effect of unrelated work — would quietly bring the original exposure back, and no check would catch
it.

## What

Adds a CI guard that fails when any Flux source in this repository follows a moving branch instead
of a pinned commit, with a message naming the file and the fix. Proven in both directions, and it
refuses to report "clean" when it finds nothing to check.

No manifest or cluster behaviour changes — this is a static check only. The live `unifi`
Kustomization is unaffected and stays `Ready=True`.

Fixes #3124.
