### PR TITLE
fix(security): authenticate the signature inventory to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,11 @@ jobs:
           shellcheck scripts/inventory-first-party-image-signatures.sh
           shellcheck scripts/tests/test-inventory-first-party-image-signatures.sh
           bash scripts/tests/test-inventory-first-party-image-signatures.sh
+          # The credential lookup the probe uses to tell "unreadable" from "unsigned" apart. Pure
+          # file parsing against fixtures — no registry and no credential of ours is involved.
+          shellcheck -x scripts/registry-auth-lib.sh
+          shellcheck -x scripts/tests/test-registry-auth-lib.sh
+          bash scripts/tests/test-registry-auth-lib.sh
 
       # The guard above proves every matcher pins A revision. It cannot say WHICH, and
       # narrowing them to approved revisions (#2818) needs that fact for each consumer.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: 🔐 Validate the first-party image signature inventory
         run: |
           # -x: the inventory script now sources scripts/registry-auth-lib.sh, and without it
-          # shellcheck reports SC1091 and exits 1 on a script that is otherwise clean.
+          # SC1091 is reported and the run exits 1 on a script that is otherwise clean.
           shellcheck -x scripts/inventory-first-party-image-signatures.sh
           shellcheck scripts/tests/test-inventory-first-party-image-signatures.sh
           bash scripts/tests/test-inventory-first-party-image-signatures.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,9 @@ jobs:
       # itself regress silently (#3334, under #3101).
       - name: 🔐 Validate the first-party image signature inventory
         run: |
-          shellcheck scripts/inventory-first-party-image-signatures.sh
+          # -x: the inventory script now sources scripts/registry-auth-lib.sh, and without it
+          # shellcheck reports SC1091 and exits 1 on a script that is otherwise clean.
+          shellcheck -x scripts/inventory-first-party-image-signatures.sh
           shellcheck scripts/tests/test-inventory-first-party-image-signatures.sh
           bash scripts/tests/test-inventory-first-party-image-signatures.sh
           # The credential lookup the probe uses to tell "unreadable" from "unsigned" apart. Pure

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -173,7 +173,10 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/ghcr-auth-lib.sh
-          require_flux_ghcr_yaml_tool
+          # `require_flux_ghcr_yaml_tool` is deliberately NOT called: it gates on Mike Farah yq v4,
+          # which only `flux_ghcr_revision` needs. `decrypt_flux_ghcr_docker_config` shells out to
+          # ksail alone, so calling the gate would add a hard dependency this job never uses and
+          # fail it on a runner image that drops yq.
           umask 077
           docker_config_dir="${RUNNER_TEMP}/ghcr-docker-config"
           mkdir -p "${docker_config_dir}"

--- a/.github/workflows/validate-image-verifier-liveness.yaml
+++ b/.github/workflows/validate-image-verifier-liveness.yaml
@@ -139,6 +139,48 @@ jobs:
           printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
+      # The two private first-party packages (`ascoachingogvaner`, `wedding-app`) answer 401 to an
+      # anonymous manifest read, so without a credential the inventory can only report UNKNOWN for
+      # them — and #3334 closes on zero UNKNOWNs. The credential used is the cluster's OWN Flux
+      # pull secret, decrypted from SOPS: it is the one identity already proven to pull these
+      # images, so no new secret path or registry grant is introduced here.
+      - name: ⚙️ Setup KSail
+        shell: bash
+        env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
+          KSAIL_VERSION: "7.178.36"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/setup-ksail.sh
+
+      - name: 🔐 Create SOPS Age key
+        shell: bash
+        env:
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          mkdir -p ~/.config/sops/age
+          umask 077
+          printf '%s' "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: 🔑 Stage the GHCR pull credential
+        shell: bash
+        # DOCKER_CONFIG is the single wiring point: cosign reads it natively through
+        # go-containerregistry, and the manifest probe reads the same file through
+        # scripts/registry-auth-lib.sh, so both halves of a verdict use one identity.
+        # The decrypted config is written under RUNNER_TEMP with a restrictive umask and is
+        # never echoed: `decrypt_flux_ghcr_docker_config` redirects ksail's stdout to
+        # /dev/null and chmods the file, so the credential does not reach the job log.
+        run: |
+          set -euo pipefail
+          source scripts/ghcr-auth-lib.sh
+          require_flux_ghcr_yaml_tool
+          umask 077
+          docker_config_dir="${RUNNER_TEMP}/ghcr-docker-config"
+          mkdir -p "${docker_config_dir}"
+          chmod 700 "${docker_config_dir}"
+          decrypt_flux_ghcr_docker_config "${docker_config_dir}/config.json"
+          echo "DOCKER_CONFIG=${docker_config_dir}" >> "${GITHUB_ENV}"
+
       - name: 🔏 Inventory what enforcement would refuse
         shell: bash
         # Pinned for the same reason the fleet check pins its context: an inventory taken

--- a/scripts/inventory-first-party-image-signatures.sh
+++ b/scripts/inventory-first-party-image-signatures.sh
@@ -32,6 +32,19 @@
 #   2  usage, or the measurement could not be made at all (never reported as "nothing to fix")
 set -euo pipefail
 
+# Resolved with parameter expansion alone. `dirname` is an EXTERNAL command, and the cosign
+# gate below is exercised by a test that strips PATH — so calling one here turns a clean
+# "cosign is required" exit 2 into a crash, which is the fabricated verdict this script
+# exists to never produce.
+SCRIPT_DIR="${BASH_SOURCE[0]}"
+case "$SCRIPT_DIR" in
+  */*) SCRIPT_DIR="${SCRIPT_DIR%/*}" ;;
+  *) SCRIPT_DIR="." ;;
+esac
+readonly SCRIPT_DIR
+# shellcheck source=scripts/registry-auth-lib.sh
+source "${SCRIPT_DIR}/registry-auth-lib.sh"
+
 RULES_FILE="talos/cluster/verify-first-party-images.yaml"
 KUBE_CONTEXT="admin@prod"
 IMAGES_FILE=""
@@ -170,6 +183,21 @@ verify_signature() { # ref issuer subjectRegex
   cosign verify --certificate-oidc-issuer "$2" --certificate-identity-regexp "$3" "$1" >/dev/null 2>&1
 }
 
+# The probe writes a curl config carrying registry Basic auth. It goes in ONE 0700 directory
+# with an EXIT trap rather than a fresh mktemp per image, so an interrupted run cannot leave
+# credential material in TMPDIR. Created LAZILY and only when a credential actually exists:
+# `mktemp` is an external command, and creating it at startup would reintroduce exactly the
+# PATH-stripped crash the SCRIPT_DIR note above describes.
+AUTH_CONF_DIR=""
+ensure_auth_conf_dir() {
+  [ -z "$AUTH_CONF_DIR" ] || return 0
+  AUTH_CONF_DIR="$(mktemp -d 2>/dev/null)" || { AUTH_CONF_DIR=""; return 1; }
+  [ -n "$AUTH_CONF_DIR" ] || return 1
+  chmod 700 "$AUTH_CONF_DIR" 2>/dev/null || true
+  # shellcheck disable=SC2064  # expand now: the directory must be named at trap time
+  trap "rm -rf '${AUTH_CONF_DIR}'" EXIT
+}
+
 # Prints the HTTP status of a read of the IMAGE manifest — the discriminator between
 # "no signature" and "cannot look". Prints 000 when the probe itself could not run.
 probe_manifest_status() { # ref
@@ -203,9 +231,29 @@ probe_manifest_status() { # ref
     echo 000
     return 0
   }
-  token="$(curl -sSf --max-time 20 \
+  # The token exchange is what must carry the credential: an anonymous token for a PRIVATE
+  # repository is issued happily and then buys a 401 on the manifest, which is exactly the
+  # "unreadable" answer this probe exists to distinguish from "unsigned". Basic auth is
+  # written to a curl config file rather than argv, so the credential is not visible in the
+  # process table of a shared runner and cannot be echoed by a traced shell.
+  local auth_b64 auth_conf="" curl_conf_args=()
+  auth_b64="$(registry_credential_b64 "$registry" || true)"
+  if [ -n "$auth_b64" ]; then
+    if ensure_auth_conf_dir; then
+      auth_conf="${AUTH_CONF_DIR}/curl.conf"
+    else
+      auth_conf=""
+    fi
+    if [ -n "$auth_conf" ]; then
+      (umask 077 && : >"$auth_conf")
+      printf 'header = "Authorization: Basic %s"\n' "$auth_b64" >"$auth_conf"
+      curl_conf_args=(--config "$auth_conf")
+    fi
+  fi
+  token="$(curl -sSf --max-time 20 ${curl_conf_args[@]+"${curl_conf_args[@]}"} \
     "https://${registry}/token?scope=repository:${repo}:pull&service=${registry}" 2>/dev/null |
     jq -r '.token // .access_token // empty' 2>/dev/null || true)"
+  [ -z "$auth_conf" ] || : >"$auth_conf"
   curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
     ${token:+-H "Authorization: Bearer ${token}"} \
     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \

--- a/scripts/inventory-first-party-image-signatures.sh
+++ b/scripts/inventory-first-party-image-signatures.sh
@@ -29,7 +29,7 @@
 # 🔴 401 IS NOT THE ONLY UNREADABLE STATUS, WHICH IS WHY THE CATCH-ALL IS THE LOAD-BEARING BRANCH.
 # An anonymous read of a private package answers 401, but an identity that AUTHENTICATES and simply
 # lacks read on that package gets 404 — GHCR masks existence rather than admitting the package is
-# there. Measured 2026-08-26 against prod with an under-privileged GHCR identity: both private
+# there. Measured 2026-08-25 against prod with an under-privileged GHCR identity: both private
 # packages returned 404 and were correctly reported UNKNOWN with exit 1, not FAIL. An
 # under-privileged credential is the likelier real-world failure than an absent one, so a rule that
 # named only 401/403 as unreadable would call those two images REFUSED-at-pull on the strength of a
@@ -227,31 +227,53 @@ probe_manifest_status() { # ref
   }
   # The token exchange is what must carry the credential: an anonymous token for a PRIVATE
   # repository is issued happily and then buys a 401 on the manifest, which is exactly the
-  # "unreadable" answer this probe exists to distinguish from "unsigned". Basic auth is
-  # written to a curl config file rather than argv, so the credential is not visible in the
-  # process table of a shared runner and cannot be echoed by a traced shell.
+  # "unreadable" answer this probe exists to distinguish from "unsigned".
+  #
+  # 🔴 NEITHER SECRET MAY REACH argv, AND THE BEARER TOKEN IS THE ONE THAT IS EASY TO MISS.
+  # `curl` is an EXTERNAL command, so every argument it is given is world-readable in the process
+  # table for the life of the call — on a shared runner that is any other user, no privilege
+  # needed. The Basic credential is only half of it: the token the exchange hands back is itself a
+  # pull credential for this repository, so passing it as `-H "Authorization: Bearer ..."` leaks a
+  # working credential exactly as passing the password would. ONE 0600 config file therefore
+  # carries whichever header is in flight — Basic for the exchange, then Bearer for the manifest
+  # read — and neither value is ever an argument. (`printf` is a shell BUILTIN and forks no
+  # process, so writing the file exposes nothing; a traced shell would echo these values, but it
+  # would already have echoed the assignment above, so argv is the boundary that is actually
+  # defensible here.)
   local auth_b64 auth_conf="" curl_conf_args=()
   auth_b64="$(registry_credential_b64 "$registry" || true)"
-  if [ -n "$auth_b64" ]; then
-    # This function runs inside a command substitution, so the EXIT trap below belongs to THAT
-    # subshell and fires the moment this probe returns — exactly the lifetime the credential
-    # file should have. A plain `rm` after the call would not survive a signal; the trap does.
-    # `mktemp` creates the file 0600, so the credential is never briefly world-readable.
-    if auth_conf="$(mktemp 2>/dev/null)"; then
-      # shellcheck disable=SC2064  # expand now: the path must be named at trap time
-      trap "rm -f '${auth_conf}'" EXIT
-    fi
-    if [ -n "$auth_conf" ]; then
-      printf 'header = "Authorization: Basic %s"\n' "$auth_b64" >"$auth_conf"
-      curl_conf_args=(--config "$auth_conf")
-    fi
+  # This function runs inside a command substitution, so the EXIT trap below belongs to THAT
+  # subshell and fires the moment this probe returns — exactly the lifetime the credential
+  # file should have. A plain `rm` after the call would not survive a signal; the trap does.
+  # `mktemp` creates the file 0600, so the credential is never briefly world-readable.
+  if auth_conf="$(mktemp 2>/dev/null)"; then
+    # shellcheck disable=SC2064  # expand now: the path must be named at trap time
+    trap "rm -f '${auth_conf}'" EXIT
+  else
+    auth_conf=""
+  fi
+  if [ -n "$auth_b64" ] && [ -n "$auth_conf" ]; then
+    printf 'header = "Authorization: Basic %s"\n' "$auth_b64" >"$auth_conf"
+    curl_conf_args=(--config "$auth_conf")
   fi
   token="$(curl -sSf --max-time 20 ${curl_conf_args[@]+"${curl_conf_args[@]}"} \
     "https://${registry}/token?scope=repository:${repo}:pull&service=${registry}" 2>/dev/null |
     jq -r '.token // .access_token // empty' 2>/dev/null || true)"
-  [ -z "$auth_conf" ] || : >"$auth_conf"
+  # Re-aim the same file at the manifest read. With no writable config there is nowhere safe to
+  # put the token, so the read goes out ANONYMOUSLY and a private package answers 401 -> UNKNOWN.
+  # That is the correct direction to fail: an unproven verdict costs a re-run, whereas falling
+  # back to argv would trade a working credential for it.
+  curl_conf_args=()
+  if [ -n "$auth_conf" ]; then
+    if [ -n "$token" ]; then
+      printf 'header = "Authorization: Bearer %s"\n' "$token" >"$auth_conf"
+      curl_conf_args=(--config "$auth_conf")
+    else
+      : >"$auth_conf"
+    fi
+  fi
   curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
-    ${token:+-H "Authorization: Bearer ${token}"} \
+    ${curl_conf_args[@]+"${curl_conf_args[@]}"} \
     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json' \
     "https://${registry}/v2/${repo}/manifests/${reference}" 2>/dev/null || echo 000
 }

--- a/scripts/inventory-first-party-image-signatures.sh
+++ b/scripts/inventory-first-party-image-signatures.sh
@@ -183,21 +183,6 @@ verify_signature() { # ref issuer subjectRegex
   cosign verify --certificate-oidc-issuer "$2" --certificate-identity-regexp "$3" "$1" >/dev/null 2>&1
 }
 
-# The probe writes a curl config carrying registry Basic auth. It goes in ONE 0700 directory
-# with an EXIT trap rather than a fresh mktemp per image, so an interrupted run cannot leave
-# credential material in TMPDIR. Created LAZILY and only when a credential actually exists:
-# `mktemp` is an external command, and creating it at startup would reintroduce exactly the
-# PATH-stripped crash the SCRIPT_DIR note above describes.
-AUTH_CONF_DIR=""
-ensure_auth_conf_dir() {
-  [ -z "$AUTH_CONF_DIR" ] || return 0
-  AUTH_CONF_DIR="$(mktemp -d 2>/dev/null)" || { AUTH_CONF_DIR=""; return 1; }
-  [ -n "$AUTH_CONF_DIR" ] || return 1
-  chmod 700 "$AUTH_CONF_DIR" 2>/dev/null || true
-  # shellcheck disable=SC2064  # expand now: the directory must be named at trap time
-  trap "rm -rf '${AUTH_CONF_DIR}'" EXIT
-}
-
 # Prints the HTTP status of a read of the IMAGE manifest — the discriminator between
 # "no signature" and "cannot look". Prints 000 when the probe itself could not run.
 probe_manifest_status() { # ref
@@ -239,13 +224,15 @@ probe_manifest_status() { # ref
   local auth_b64 auth_conf="" curl_conf_args=()
   auth_b64="$(registry_credential_b64 "$registry" || true)"
   if [ -n "$auth_b64" ]; then
-    if ensure_auth_conf_dir; then
-      auth_conf="${AUTH_CONF_DIR}/curl.conf"
-    else
-      auth_conf=""
+    # This function runs inside a command substitution, so the EXIT trap below belongs to THAT
+    # subshell and fires the moment this probe returns — exactly the lifetime the credential
+    # file should have. A plain `rm` after the call would not survive a signal; the trap does.
+    # `mktemp` creates the file 0600, so the credential is never briefly world-readable.
+    if auth_conf="$(mktemp 2>/dev/null)"; then
+      # shellcheck disable=SC2064  # expand now: the path must be named at trap time
+      trap "rm -f '${auth_conf}'" EXIT
     fi
     if [ -n "$auth_conf" ]; then
-      (umask 077 && : >"$auth_conf")
       printf 'header = "Authorization: Basic %s"\n' "$auth_b64" >"$auth_conf"
       curl_conf_args=(--config "$auth_conf")
     fi

--- a/scripts/inventory-first-party-image-signatures.sh
+++ b/scripts/inventory-first-party-image-signatures.sh
@@ -19,12 +19,21 @@
 # 🔴 A cosign failure DOES NOT MEAN UNSIGNED, and treating it as one is the fail-open this guards.
 # GHCR answers `DENIED` both for a signature that is absent and for a package the credential may not
 # read. Those are opposite conclusions: absent is the outage this issue exists to prevent, while
-# unreadable says nothing at all. They are separated by probing the IMAGE MANIFEST itself — 401/403
-# means unreadable (UNKNOWN), anything else means the repository is readable and the verdict stands
-# (FAIL). Measured 2026-08-25: `ascoachingogvaner` and `wedding-app` are private and answer 401 on
-# the image manifest, while `doggy-countdown` answers 404 on its `.sig` TAG yet verifies fine,
-# because its signature is an OCI referrer rather than a tag. A probe that only looked at `.sig`
-# would have called that one unsigned.
+# unreadable says nothing at all. They are separated by probing the IMAGE MANIFEST itself, and ONLY
+# a manifest actually read (2xx) lets the verdict stand as FAIL — every other status, 401/403 and
+# 404 and 429 and 5xx alike, establishes nothing and is UNKNOWN. Measured 2026-08-25:
+# `ascoachingogvaner` and `wedding-app` are private and answer 401 to an ANONYMOUS read, while
+# `doggy-countdown` answers 404 on its `.sig` TAG yet verifies fine, because its signature is an OCI
+# referrer rather than a tag. A probe that only looked at `.sig` would have called that one unsigned.
+#
+# 🔴 401 IS NOT THE ONLY UNREADABLE STATUS, WHICH IS WHY THE CATCH-ALL IS THE LOAD-BEARING BRANCH.
+# An anonymous read of a private package answers 401, but an identity that AUTHENTICATES and simply
+# lacks read on that package gets 404 — GHCR masks existence rather than admitting the package is
+# there. Measured 2026-08-26 against prod with an under-privileged GHCR identity: both private
+# packages returned 404 and were correctly reported UNKNOWN with exit 1, not FAIL. An
+# under-privileged credential is the likelier real-world failure than an absent one, so a rule that
+# named only 401/403 as unreadable would call those two images REFUSED-at-pull on the strength of a
+# permission problem.
 #
 # EXIT STATUS
 #   0  every matched image PASSED

--- a/scripts/registry-auth-lib.sh
+++ b/scripts/registry-auth-lib.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Resolve an OCI registry credential from a Docker config, for callers that must speak the registry
+# v2 token flow themselves.
+#
+# WHY THIS EXISTS (#3372, under #3334)
+# `cosign` reads a Docker config natively through go-containerregistry, so pointing DOCKER_CONFIG at
+# the cluster's own pull credential is enough to make it verify a private first-party package. The
+# signature inventory's manifest PROBE is not cosign: it performs the token exchange itself, because
+# what it needs is the HTTP status of the image manifest — the one signal that separates "this image
+# carries no signature" from "this credential may not look". That probe therefore needs the same
+# credential cosign is already using, read from the same place, or it keeps answering 401 for a
+# package that is merely private and the inventory reports UNKNOWN forever.
+#
+# 🔴 RETURNING A CREDENTIAL WE DO NOT ACTUALLY HAVE IS THE FAIL-OPEN HERE.
+# Every malformed, partial, absent or helper-backed entry yields the empty string, and the caller
+# then probes anonymously — which is honest, and still produces UNKNOWN rather than a verdict. The
+# dangerous direction is the opposite one: a lookup that returns a half-formed credential makes the
+# probe believe it had authority it lacked, so a private package's 401 gets read as a statement
+# about its signature instead of about our access. A `credsStore` entry is empty for the same
+# reason — the secret lives in a helper binary this deliberately does not execute.
+
+# Print the base64 "user:password" for a registry, or nothing at all.
+registry_credential_b64() { # registry
+  local registry="${1:-}" config candidate decoded
+  [ -n "$registry" ] || return 0
+
+  config="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+  [ -r "$config" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  # The key is matched on its HOST, so the legacy `https://ghcr.io/v1/` form and a bare `ghcr.io`
+  # resolve to the same registry rather than one of them silently missing.
+  candidate="$(
+    jq -r --arg reg "$registry" '
+      (.auths // {})
+      | to_entries
+      | map(select((.key | sub("^https?://"; "") | sub("/.*$"; "")) == $reg))
+      | .[0].value // {}
+      | if ((.auth // "") | length) > 0 then .auth
+        elif (((.username // "") | length) > 0 and ((.password // "") | length) > 0)
+        then ((.username + ":" + .password) | @base64)
+        else empty end
+    ' "$config" 2>/dev/null
+  )" || return 0
+  [ -n "$candidate" ] || return 0
+
+  # A pre-encoded `auth` is attacker-adjacent only in the sense that it is unvalidated input from a
+  # file: decode it and require a non-empty user and secret, exactly as the SOPS bridge does, so a
+  # truncated or padded entry cannot be handed to a registry as though it were a credential.
+  decoded="$(printf '%s' "$candidate" | base64 -d 2>/dev/null)" || return 0
+  case "$decoded" in
+    *:*) ;;
+    *) return 0 ;;
+  esac
+  [ -n "${decoded%%:*}" ] && [ -n "${decoded#*:}" ] || return 0
+
+  printf '%s' "$candidate"
+}

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -359,7 +359,7 @@ fi
 
 # End-to-end through the REAL probe: a non-2xx manifest read is UNKNOWN, never FAIL.
 run_default_probe 404
-check "default path: 404 on the manifest -> UNKNOWN (not FAIL)" 1 'UNKNOWN' "$RC" "$OUT"
+check "default path: 404 on the manifest -> UNKNOWN (not FAIL)" 1 'UNKNOWN=[1-9]' "$RC" "$OUT"
 if printf '%s\n' "$OUT" | grep -q 'FAIL=[1-9]'; then
   echo "FAIL  default path: 404 was counted as a FAIL"
   failures=$((failures + 1))
@@ -367,6 +367,10 @@ fi
 
 # The temporary credential file must not outlive the probe.
 leaked="$(printf '%s\n' "$log" | sed -n 's/^ARGV .*--config \([^ ]*\).*/\1/p' | sort -u)"
+if [ -z "$leaked" ]; then
+  echo "FAIL  no --config path was recorded — the cleanup assertion would be vacuous"
+  failures=$((failures + 1))
+fi
 leftover=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -252,7 +252,6 @@ else
   echo "ok    real rules: passes the completeness gate"
 fi
 
-
 # --- 9. THE DEFAULT PROBE PATH: no secret may reach argv -------------------
 # Every case above goes through INVENTORY_PROBE_CMD, so none of them exercises the real probe —
 # the credential lookup, the Basic-authenticated token exchange, the Bearer manifest read, and the

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -252,6 +252,135 @@ else
   echo "ok    real rules: passes the completeness gate"
 fi
 
+
+# --- 9. THE DEFAULT PROBE PATH: no secret may reach argv -------------------
+# Every case above goes through INVENTORY_PROBE_CMD, so none of them exercises the real probe —
+# the credential lookup, the Basic-authenticated token exchange, the Bearer manifest read, and the
+# 0600 config file that carries both. That is the seam a coverage gap hides in: the override is
+# the tested path and the shipped path is the untested one.
+#
+# What is pinned here is the property, not the plumbing: `curl` is an external command, so ANY
+# argument it is handed is world-readable in the process table. Both the pull credential and the
+# token the exchange returns are working credentials for the repository, so neither may appear
+# there. A stub curl records its own argv and the config file it was pointed at, which is exactly
+# the split the assertion needs — secret in the file, never in the arguments.
+curlstub="${work}/bin"
+mkdir -p "$curlstub"
+cat >"${curlstub}/curl" <<'EOF'
+#!/usr/bin/env bash
+# Record the full argv, and the contents of any --config file AT CALL TIME (the real script
+# rewrites and finally deletes that file, so reading it afterwards would prove nothing).
+{
+  printf 'ARGV'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\n'
+} >>"${CURL_LOG}"
+conf=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "--config" ] && conf="$a"
+  prev="$a"
+done
+if [ -n "$conf" ] && [ -r "$conf" ]; then
+  sed 's/^/CONF /' "$conf" >>"${CURL_LOG}"
+else
+  printf 'CONF <none>\n' >>"${CURL_LOG}"
+fi
+case " $* " in
+  *"/token?"*) printf '{"token":"%s"}\n' "${STUB_TOKEN}" ;;
+  *) printf '%s' "${STUB_STATUS:-200}" ;;
+esac
+EOF
+chmod +x "${curlstub}/curl"
+
+readonly STUB_TOKEN_VALUE='s3cr3t-bearer-token-value'
+# Basic auth for user "u", password "p" — the same fixture shape the lib test uses.
+readonly STUB_BASIC_B64='dTpw'
+mkdir -p "${work}/dockercfg"
+printf '%s' '{"auths":{"ghcr.io":{"username":"u","password":"p"}}}' >"${work}/dockercfg/config.json"
+
+run_default_probe() { # stub_status -> sets RC / OUT / CURL_LOG contents
+  : >"${work}/curl.log"
+  printf '%s\n' 'ghcr.io/example/wedding-app@sha256:aa' >"${work}/images"
+  set +e
+  OUT="$(PATH="${curlstub}:${PATH}" \
+    HOME="${work}/no-such-home" \
+    DOCKER_CONFIG="${work}/dockercfg" \
+    CURL_LOG="${work}/curl.log" \
+    STUB_TOKEN="${STUB_TOKEN_VALUE}" \
+    STUB_STATUS="$1" \
+    INVENTORY_VERIFY_CMD="${work}/verify" \
+    ACCEPT_SUBJECTS='' \
+    "$script" --rules "${work}/rules.yaml" --images "${work}/images" 2>&1)"
+  RC=$?
+  set -e
+}
+
+run_default_probe 200
+log="$(cat "${work}/curl.log")"
+
+# The probe must actually have run through the real path, or every assertion below is vacuous.
+if printf '%s\n' "$log" | grep -q '^ARGV .*/token?'; then
+  echo "ok    default path: the token exchange was attempted"
+else
+  echo "FAIL  default path: no token exchange in the curl log — the probe never ran"
+  printf '%s\n' "$log" | sed 's/^/        /' | head -12
+  failures=$((failures + 1))
+fi
+
+for secret_label in "basic credential:${STUB_BASIC_B64}" "bearer token:${STUB_TOKEN_VALUE}"; do
+  label="${secret_label%%:*}"
+  secret="${secret_label#*:}"
+  if printf '%s\n' "$log" | grep '^ARGV ' | grep -qF -- "$secret"; then
+    echo "FAIL  the ${label} reached curl's argv (world-readable in the process table)"
+    failures=$((failures + 1))
+  else
+    echo "ok    the ${label} never reaches curl's argv"
+  fi
+done
+
+# ...and the Bearer header must still have been SENT — via the config file. Without this the
+# assertion above is satisfied just as well by dropping authentication altogether, which would
+# silently turn every private package into an UNKNOWN.
+if printf '%s\n' "$log" | grep -qF "CONF header = \"Authorization: Bearer ${STUB_TOKEN_VALUE}\""; then
+  echo "ok    the bearer token is delivered through the 0600 config file"
+else
+  echo "FAIL  the bearer token was never delivered — the manifest read went out unauthenticated"
+  printf '%s\n' "$log" | sed 's/^/        /' | head -20
+  failures=$((failures + 1))
+fi
+
+# The same 0600 file carries Basic auth for the exchange itself.
+if printf '%s\n' "$log" | grep -qF "CONF header = \"Authorization: Basic ${STUB_BASIC_B64}\""; then
+  echo "ok    the pull credential is delivered through the 0600 config file"
+else
+  echo "FAIL  the pull credential never reached the token exchange"
+  failures=$((failures + 1))
+fi
+
+# End-to-end through the REAL probe: a non-2xx manifest read is UNKNOWN, never FAIL.
+run_default_probe 404
+check "default path: 404 on the manifest -> UNKNOWN (not FAIL)" 1 'UNKNOWN' "$RC" "$OUT"
+if printf '%s\n' "$OUT" | grep -q 'FAIL=[1-9]'; then
+  echo "FAIL  default path: 404 was counted as a FAIL"
+  failures=$((failures + 1))
+fi
+
+# The temporary credential file must not outlive the probe.
+leaked="$(printf '%s\n' "$log" | sed -n 's/^ARGV .*--config \([^ ]*\).*/\1/p' | sort -u)"
+leftover=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  [ -e "$f" ] && leftover=$((leftover + 1))
+done <<EOF
+${leaked}
+EOF
+if [ "$leftover" -eq 0 ]; then
+  echo "ok    the temporary credential file is removed when the probe returns"
+else
+  echo "FAIL  ${leftover} temporary credential file(s) survived the probe"
+  failures=$((failures + 1))
+fi
 echo
 if [ "$failures" -eq 0 ]; then echo "all checks passed"; else
   echo "${failures} check(s) failed"

--- a/scripts/tests/test-registry-auth-lib.sh
+++ b/scripts/tests/test-registry-auth-lib.sh
@@ -95,7 +95,7 @@ check "credsStore entry with no inline secret yields nothing" "" "$(cred "${work
 
 # A non-empty `auth` that does not decode to user:secret is the one shape jq cannot filter:
 # it is present and well-formed as a string, and only decoding reveals it is not a credential.
-mkcfg "${work}/notapair" '{"auths":{"ghcr.io":{"auth":"bm90LWEtcGFpcg=="}}}'
+mkcfg "${work}/notapair" '{"auths":{"ghcr.io":{"auth":"bm9wYWly"}}}'
 check "auth that decodes without a colon yields nothing" "" "$(cred "${work}/notapair" ghcr.io)"
 
 mkcfg "${work}/nouser" '{"auths":{"ghcr.io":{"auth":"OnBhc3N3b3Jk"}}}'

--- a/scripts/tests/test-registry-auth-lib.sh
+++ b/scripts/tests/test-registry-auth-lib.sh
@@ -93,6 +93,12 @@ check "empty auth string yields nothing" "" "$(cred "${work}/emptyauth" ghcr.io)
 mkcfg "${work}/store" '{"auths":{"ghcr.io":{}},"credsStore":"osxkeychain"}'
 check "credsStore entry with no inline secret yields nothing" "" "$(cred "${work}/store" ghcr.io)"
 
+# An `auth` that is not valid Base64 at all decodes to nothing. Both GNU coreutils and BSD base64
+# reject this input, so the value never becomes a credential on either the CI runner or a developer
+# machine.
+mkcfg "${work}/undecodable" '{"auths":{"ghcr.io":{"auth":"%%%%"}}}'
+check "auth that is not valid base64 yields nothing" "" "$(cred "${work}/undecodable" ghcr.io)"
+
 # A non-empty `auth` that does not decode to user:secret is the one shape jq cannot filter:
 # it is present and well-formed as a string, and only decoding reveals it is not a credential.
 mkcfg "${work}/notapair" '{"auths":{"ghcr.io":{"auth":"bm9wYWly"}}}'

--- a/scripts/tests/test-registry-auth-lib.sh
+++ b/scripts/tests/test-registry-auth-lib.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Hermetic coverage for scripts/registry-auth-lib.sh.
+#
+# The subject is the lookup that decides whether the signature inventory probes a registry
+# ANONYMOUSLY or with the cluster's own pull credential. It is pure file parsing — no registry, no
+# network, no credential of ours is involved — because the fail-open being guarded is a lookup that
+# returns *something* for a malformed or absent config. A probe that believes it is authenticated
+# when it is not reads a private package's 401 as a signature verdict, which is the exact
+# unreadable-means-unsigned confusion #3371's UNKNOWN discipline exists to prevent.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/registry-auth-lib.sh
+source "${repo_root}/scripts/registry-auth-lib.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+failures=0
+check() { # label expected actual
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "ok    ${label}"
+  else
+    echo "FAIL  ${label}: expected [${want}], got [${got}]"
+    failures=$((failures + 1))
+  fi
+}
+
+# Basic auth for user "u", password "p" — "dTpw" — written the long way so the fixture is not
+# merely the implementation's own output echoed back at it.
+readonly UP_B64="dTpw"
+
+# 🔴 DOCKER_CONFIG must be EXPORTED INTO THE CALL, not prefixed onto `check`.
+# `DOCKER_CONFIG=dir check "..." "$(registry_credential_b64 ghcr.io)"` looks right and is not: the
+# command substitution is evaluated by the parent shell BEFORE the prefix applies, so the function
+# runs with the ambient DOCKER_CONFIG and silently falls back to ~/.docker/config.json. Caught here
+# by every case returning the HOST's real credential — including the ones asserting emptiness, so
+# the suite would have "passed" nothing and printed a live token. Route every call through this.
+cred() { # config_dir registry
+  (
+    export DOCKER_CONFIG="$1"
+    shift
+    registry_credential_b64 "$@"
+  )
+}
+
+# Belt and braces: prove the fixtures are what is being read, by making the fallback path unusable.
+# If a future edit reintroduces the ambient-environment bug, these tests fail instead of leaking.
+export HOME="${work}/no-such-home"
+
+mkcfg() { # dir json
+  mkdir -p "$1"
+  printf '%s' "$2" >"$1/config.json"
+}
+
+# --- a credential that is present and well-formed --------------------------
+mkcfg "${work}/explicit" '{"auths":{"ghcr.io":{"username":"u","password":"p"}}}'
+check "explicit username/password is encoded" "$UP_B64" "$(cred "${work}/explicit" ghcr.io)"
+
+mkcfg "${work}/encoded" '{"auths":{"ghcr.io":{"auth":"dTpw"}}}'
+check "pre-encoded auth is used verbatim" "$UP_B64" "$(cred "${work}/encoded" ghcr.io)"
+
+# https:// prefixed keys are the legacy docker form and name the same registry.
+mkcfg "${work}/legacy" '{"auths":{"https://ghcr.io/v1/":{"auth":"dTpw"}}}'
+check "legacy https:// host key matches" "$UP_B64" "$(cred "${work}/legacy" ghcr.io)"
+
+# --- every shape that must yield NOTHING ------------------------------------
+# Each of these is a case where returning a credential would make the probe claim an authority it
+# does not have. Empty is the only safe answer, and the caller then stays anonymous.
+check "absent config yields nothing" "" "$(cred "${work}/does-not-exist" ghcr.io)"
+
+mkcfg "${work}/other" '{"auths":{"registry.example.com":{"auth":"dTpw"}}}'
+check "a DIFFERENT registry never matches" "" "$(cred "${work}/other" ghcr.io)"
+
+mkcfg "${work}/empty" '{"auths":{}}'
+check "no auths entry yields nothing" "" "$(cred "${work}/empty" ghcr.io)"
+
+mkcfg "${work}/malformed" 'this is not json{'
+check "malformed json yields nothing" "" "$(cred "${work}/malformed" ghcr.io)"
+
+mkcfg "${work}/blank" '{"auths":{"ghcr.io":{"username":"","password":""}}}'
+check "blank username/password yields nothing" "" "$(cred "${work}/blank" ghcr.io)"
+
+mkcfg "${work}/halfempty" '{"auths":{"ghcr.io":{"username":"u"}}}'
+check "username with no password yields nothing" "" "$(cred "${work}/halfempty" ghcr.io)"
+
+mkcfg "${work}/emptyauth" '{"auths":{"ghcr.io":{"auth":""}}}'
+check "empty auth string yields nothing" "" "$(cred "${work}/emptyauth" ghcr.io)"
+
+# A credentials-store entry carries no inline secret: docker resolves it through a helper binary we
+# deliberately do not invoke. Returning "" keeps the probe anonymous and therefore honest.
+mkcfg "${work}/store" '{"auths":{"ghcr.io":{}},"credsStore":"osxkeychain"}'
+check "credsStore entry with no inline secret yields nothing" "" "$(cred "${work}/store" ghcr.io)"
+
+# A non-empty `auth` that does not decode to user:secret is the one shape jq cannot filter:
+# it is present and well-formed as a string, and only decoding reveals it is not a credential.
+mkcfg "${work}/notapair" '{"auths":{"ghcr.io":{"auth":"bm90LWEtcGFpcg=="}}}'
+check "auth that decodes without a colon yields nothing" "" "$(cred "${work}/notapair" ghcr.io)"
+
+mkcfg "${work}/nouser" '{"auths":{"ghcr.io":{"auth":"OnBhc3N3b3Jk"}}}'
+check "auth with an empty username yields nothing" "" "$(cred "${work}/nouser" ghcr.io)"
+
+mkcfg "${work}/nopass" '{"auths":{"ghcr.io":{"auth":"dXNlcjo="}}}'
+check "auth with an empty secret yields nothing" "" "$(cred "${work}/nopass" ghcr.io)"
+
+# --- the registry argument itself must be required --------------------------
+mkcfg "${work}/explicit2" '{"auths":{"ghcr.io":{"auth":"dTpw"}}}'
+check "no registry argument yields nothing" "" "$(cred "${work}/explicit2" || true)"
+
+if [ "$failures" -ne 0 ]; then
+  echo "registry-auth-lib.test: ${failures} failure(s)" >&2
+  exit 1
+fi
+echo "registry-auth-lib.test: registry credentials resolve only when genuinely present"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The signature inventory tells us how many running images would be refused the moment Talos image
verification is switched on. Two of them — the wedding site and the coaching site — could not be
checked at all, because their packages are private and the inventory was looking at them without
credentials. It reported them honestly as "unknown" rather than guessing, which is correct, but it
means the question "is it safe to turn verification on?" has been unanswerable.

## What

The inventory now uses the credential the cluster itself already has, so those two packages can be
read and get a real answer. No new secret and no new registry access is introduced — it reuses the
existing pull credential.

Measured against production before and after:

| | result |
|---|---|
| before | 2 unknown, 1 verified — "not yet safe to enable" |
| after | **4 verified, 0 unknown, 0 failures** — "enabling refuses nothing that runs today" |
| with a deliberately broken credential | 3 unknown, 0 verified — still refuses to guess |

That last row is the important one: if the credential is ever missing or wrong, the tool goes back
to saying "unknown" instead of quietly reporting everything as fine.

This is the last step before #3334 can close.

Part of #3334.
