### PR TITLE
fix(security): deny Delete management policies on GitHub team resources

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-github-team-management.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-github-team-management.yaml
@@ -254,3 +254,71 @@ spec:
                   - triage
                   - push
                   - maintain
+    # The other rules constrain WHICH team a resource may touch; this one
+    # constrains what Crossplane is allowed to do to it. The github-config Role
+    # holds `delete` on these kinds and the tenant's Flux Kustomization runs with
+    # prune: true, so an artifact that grants Delete and a later artifact that
+    # simply drops the CR together delete the real GitHub team — with its
+    # membership and every CODEOWNERS assignment. That is the one path here that
+    # destroys org state rather than escalating access, and recovery is manual.
+    #
+    # 🔴 A Delete grant has THREE spellings on these CRDs, and only the first is
+    # obvious. Read from the live cluster on all three kinds (2026-08-25), the
+    # enum is Observe|Create|Update|Delete|LateInitialize|* and the field's
+    # default is ["*"]:
+    #   1. the literal `Delete`;
+    #   2. `*`, a legal member that expands to every action including Delete;
+    #   3. OMITTING the field, which takes that ["*"] default.
+    # So absence is the most permissive value available, not a safe one, and a
+    # rule written against the word `Delete` alone would leave the two quieter
+    # spellings wide open. Requiring an explicit Delete-free list is what makes
+    # this closed rather than merely stated.
+    #
+    # Costs nothing operationally: all 39 live resources in github-config set
+    # the field explicitly, 32 as [Observe, Create, Update, LateInitialize] and
+    # 7 as [Observe]. None omits it; none carries Delete or `*`. This is also
+    # exactly the "Never Delete" safety rail docs/github-management.md already
+    # documents — enforced at admission instead of relied on by convention.
+    - name: teams-forbid-delete-management-policy
+      match:
+        any:
+          - resources:
+              kinds:
+                - team.github.m.upbound.io/*/Team
+                - team.github.m.upbound.io/*/TeamMembership
+                - team.github.m.upbound.io/*/TeamRepository
+              namespaces:
+                - github-config
+      validate:
+        message: >-
+          GitHub team resources must set spec.managementPolicies to an explicit list that excludes
+          Delete and the "*" wildcard. Omitting the field takes the CRD default ["*"], which grants
+          Delete, so it is rejected too — use ["Observe"] while adopting, then ["Observe", "Create",
+          "Update", "LateInitialize"].
+        deny:
+          conditions:
+            any:
+              # ⚠️ Each spelling is matched with JMESPath contains() against a
+              # literal, NOT with AnyIn. Kyverno expands `*` inside an operator's
+              # value list as a WILDCARD rather than the literal character, so
+              # `AnyIn [Delete, "*"]` matches every policy set and denies the
+              # paved road too — measured here, by isolating that one list entry
+              # while changing nothing else: with it the four compliant fixtures
+              # failed, without it all eleven passed. contains() has no such
+              # second meaning, so each condition below says exactly what it reads.
+              #
+              # Spelling 1 — the literal verb.
+              - key: "{{ contains(request.object.spec.managementPolicies || `[]`, 'Delete') }}"
+                operator: Equals
+                value: true
+              # Spelling 2 — the `*` wildcard member, which expands to every
+              # action including Delete.
+              - key: "{{ contains(request.object.spec.managementPolicies || `[]`, '*') }}"
+                operator: Equals
+                value: true
+              # Spelling 3 — absent, which takes the CRD default ["*"]. An empty
+              # list is denied with it: it grants nothing, so it is never a
+              # legitimate intent, and allowing it would leave a second silent hole.
+              - key: "{{ length(request.object.spec.managementPolicies || `[]`) }}"
+                operator: Equals
+                value: 0

--- a/tests/restrict-github-team-management/management-policies/kyverno-test.yaml
+++ b/tests/restrict-github-team-management/management-policies/kyverno-test.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-github-team-management-management-policies
+policies:
+  - >-
+    ../../../k8s/bases/infrastructure/cluster-policies/best-practices/restrict-github-team-management.yaml
+resources:
+  - resources.yaml
+results:
+  # A Delete grant is denied however it is spelled: the literal verb, the "*"
+  # wildcard that expands to it, and the omission the CRD defaults to ["*"].
+  # The last two are the ones a rule written against the word alone would miss.
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/delete-policy-team
+      - github-config/wildcard-policy-team
+      - github-config/absent-policy-team
+      - github-config/empty-policy-team
+    kind: Team
+    result: fail
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/delete-policy-membership
+    kind: TeamMembership
+    result: fail
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/delete-policy-repo
+      - github-config/wildcard-policy-repo
+    kind: TeamRepository
+    result: fail
+  # The two sets production actually uses must keep passing, on every kind.
+  # admins/maintainers here are the paved road as prod spells it, so a rule that
+  # over-reached would fail these rather than only the escalations above.
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/admins
+      - github-config/maintainers
+    kind: Team
+    result: pass
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/compliant-membership
+    kind: TeamMembership
+    result: pass
+  - policy: restrict-github-team-management
+    rule: teams-forbid-delete-management-policy
+    resources:
+      - github-config/compliant-repo
+    kind: TeamRepository
+    result: pass

--- a/tests/restrict-github-team-management/management-policies/resources.yaml
+++ b/tests/restrict-github-team-management/management-policies/resources.yaml
@@ -1,0 +1,177 @@
+---
+# The paved road, as production actually spells it: every live resource sets
+# managementPolicies explicitly and omits Delete. Measured 2026-08-25 across all
+# 39 resources in github-config — 32 carry exactly this set and 7 carry
+# ["Observe"]; none omits the field, and none carries Delete or "*".
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: admins
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    name: admins
+    privacy: closed
+---
+# Observe-first adoption, the other set in live use. Read-only, so trivially
+# Delete-free.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: maintainers
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+  forProvider:
+    name: maintainers
+    privacy: closed
+---
+# The literal escalation: Delete spelled out. Deleting this CR — or a Flux prune
+# dropping it — would delete the real GitHub team, its membership and every
+# CODEOWNERS assignment with it.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: delete-policy-team
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - Delete
+  forProvider:
+    name: delete-policy-team
+    privacy: closed
+---
+# The SAME grant without the word. "*" is a legal enum member on these CRDs and
+# expands to every action including Delete, so a rule matching only the literal
+# "Delete" leaves this wide open.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: wildcard-policy-team
+  namespace: github-config
+spec:
+  managementPolicies:
+    - "*"
+  forProvider:
+    name: wildcard-policy-team
+    privacy: closed
+---
+# The same grant by saying NOTHING. The CRD default is ["*"] — read from the
+# live cluster on all three kinds, 2026-08-25 — so omitting the field is the
+# most permissive value available, not a safe one.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: absent-policy-team
+  namespace: github-config
+spec:
+  forProvider:
+    name: absent-policy-team
+    privacy: closed
+---
+# An empty list is not a Delete grant, but it is also not a coherent management
+# intent; Crossplane treats it as "manage nothing". Denied with the absent case
+# so the rule's requirement is simply "state a Delete-free intent".
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: Team
+metadata:
+  name: empty-policy-team
+  namespace: github-config
+spec:
+  managementPolicies: []
+  forProvider:
+    name: empty-policy-team
+    privacy: closed
+---
+# The escalation reaches TeamMembership too — deleting a membership CR would
+# remove the real person from the real team.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: delete-policy-membership
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - Delete
+  forProvider:
+    teamIdRef:
+      name: admins
+    username: devantler
+---
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: compliant-membership
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    teamIdRef:
+      name: admins
+    username: devantler
+---
+# And TeamRepository — deleting one of these revokes the team's access to the
+# repository, taking its CODEOWNERS assignments with it.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamRepository
+metadata:
+  name: delete-policy-repo
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - Delete
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: platform
+    permission: push
+---
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamRepository
+metadata:
+  name: wildcard-policy-repo
+  namespace: github-config
+spec:
+  managementPolicies:
+    - "*"
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: platform
+    permission: push
+---
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamRepository
+metadata:
+  name: compliant-repo
+  namespace: github-config
+spec:
+  managementPolicies:
+    - Observe
+    - Create
+    - Update
+    - LateInitialize
+  forProvider:
+    teamIdRef:
+      name: admins
+    repository: platform
+    permission: push


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The github-config tenant can manage three GitHub team resources, and nothing stopped an artifact
from granting Crossplane permission to **delete** them. Because the tenant's sync prunes what
disappears from Git, one artifact granting delete plus a later one dropping the resource would
delete the real GitHub team — taking its membership and every code-ownership assignment with it.
It is the only path in this delegation that destroys organisation state rather than escalating
access, and recovery is manual.

### What

Admission now requires each of the three team resources to state explicitly what Crossplane may do,
and to exclude deletion. Verified against production first: all 39 live resources already comply,
so nothing operational changes — this makes the existing "never delete" convention enforced rather
than relied upon.

One finding worth flagging for review: **deletion could be granted three different ways**, and only
one of them is the obvious one. Read live from the cluster, the field also accepts a wildcard that
covers deletion, and **leaving it out entirely defaults to that wildcard** — so saying nothing was
the most permissive option available, not a safe default. The issue's original criteria assumed the
absent case was safe; measurement said otherwise, so this rejects all three. That is a deliberate
departure from the acceptance criteria as written, and the reason is in the code comment.

Fixes #3147
