### PR TITLE
fix(security): constrain GitHub team membership on member identity and role

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-github-team-management.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-github-team-management.yaml
@@ -137,6 +137,105 @@ spec:
                   - ""
                   - admins
                   - maintainers
+    # #3146: the reference rule above constrains WHICH team is written to and
+    # nothing constrains WHO is written into it. A TeamMembership naming `admins`
+    # with policy.resolve Always, no teamId and no selector satisfies every
+    # condition above while carrying any account at all, and the org-admin
+    # provider then adds that account to a CODEOWNERS team. The policy's own
+    # description promises this is prevented, which is worse than an
+    # acknowledged gap.
+    #
+    # The allow-list lives HERE rather than being derived from the github-config
+    # artifact's own team definitions. That artifact is the exact input this
+    # policy exists to constrain, so reading the permitted members out of it
+    # would let a compromised artifact supply both the membership and its own
+    # authorisation. Keeping the list in the reviewed manifest is also what the
+    # team allow-list above already does, and it makes adding a member a
+    # reviewed change to this file rather than something the delegation can do
+    # to itself. Measured live: the fleet is two TeamMemberships, both
+    # `devantler` (admins/maintainer and maintainers/maintainer), so this list
+    # admits the entire current fleet and denies every other identity.
+    - name: teammemberships-allow-listed-members
+      match:
+        any:
+          - resources:
+              kinds:
+                - team.github.m.upbound.io/*/TeamMembership
+              namespaces:
+                - github-config
+      validate:
+        message: GitHub TeamMembership resources may only add allow-listed org members; set spec.forProvider.username to an allow-listed login (currently devantler) and do not supply a different one under initProvider. Adding a member is a reviewed change to restrict-github-team-management.yaml.
+        deny:
+          conditions:
+            any:
+              # upjet merges initProvider into any UNSET forProvider field, so the
+              # account actually reconciled is forProvider's when set and
+              # initProvider's otherwise. Resolving the effective value across both
+              # is what stops an initProvider-only username skipping the rule, the
+              # same bypass the maintainers ceiling below had to widen for.
+              # GitHub logins are case-insensitive, so normalise before matching:
+              # without it an allow-listed account spelled with different case is
+              # refused, which is a false denial rather than a bypass but a real one.
+              - key: "{{ to_lower(request.object.spec.forProvider.username || request.object.spec.initProvider.username || '') }}"
+                operator: AnyNotIn
+                value:
+                  - devantler
+              # The initProvider value is constrained on its own as well, so an
+              # approved forProvider username cannot front a foreign account if
+              # the merge semantics ever widen. Same belt-and-braces the
+              # reference conditions above apply to initProvider.teamIdRef.
+              - key: "{{ to_lower(request.object.spec.initProvider.username || '') }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+                  - devantler
+    # An allow-list, not a deny-list on `maintainer`: the team role is an
+    # enumeration the provider passes straight through to GitHub, so a value
+    # outside the two documented roles must be refused rather than assumed
+    # harmless — the same reasoning the repository-permission list below gives
+    # for not simply denying `admin`. An empty value is the provider default
+    # (`member`).
+    #
+    # NOT a per-member role ceiling. #3146 asked for `maintainer` to be
+    # constrained separately from `member` so that permission to add a member
+    # does not imply permission to make one a maintainer. Measured live, that
+    # distinction has nothing to bind to: the allow-list is a single account and
+    # both of its memberships already hold `maintainer`, so any ceiling either
+    # denies the whole live fleet or is vacuous. The identity rule above
+    # subsumes the concern for now — a role cannot be escalated for an account
+    # that cannot be added — and a ceiling becomes expressible, and worth
+    # adding, as soon as the allow-list holds more than one member.
+    - name: teammemberships-known-roles
+      match:
+        any:
+          - resources:
+              kinds:
+                - team.github.m.upbound.io/*/TeamMembership
+              namespaces:
+                - github-config
+      validate:
+        message: GitHub TeamMembership resources may grant only the member or maintainer role, in forProvider and initProvider.
+        deny:
+          conditions:
+            any:
+              # Each condition owns one block. Unlike the identity rule above, this
+              # needs no merge fallback: the allow-list here includes the empty
+              # string, so an unset forProvider.role is admitted and the
+              # initProvider condition below is what constrains the value the
+              # merge would supply. Folding the fallback in would add a conjunct
+              # no fixture can isolate.
+              - key: "{{ to_lower(request.object.spec.forProvider.role || '') }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+                  - member
+                  - maintainer
+              - key: "{{ to_lower(request.object.spec.initProvider.role || '') }}"
+                operator: AnyNotIn
+                value:
+                  - ""
+                  - member
+                  - maintainer
     - name: teamrepositories-reference-allow-listed-teams
       match:
         any:

--- a/tests/restrict-github-team-management/kyverno-test.yaml
+++ b/tests/restrict-github-team-management/kyverno-test.yaml
@@ -86,3 +86,40 @@ results:
       - github-config/maintainers-repo
     kind: TeamRepository
     result: pass
+  # #3146: the member identity, independent of which team is referenced. Every
+  # fixture below is well-formed against the reference rule above, so a failure
+  # here can only come from the identity condition.
+  - policy: restrict-github-team-management
+    rule: teammemberships-allow-listed-members
+    resources:
+      - github-config/arbitrary-username
+      - github-config/initprovider-arbitrary-username
+      - github-config/initprovider-only-arbitrary-username
+    kind: TeamMembership
+    result: fail
+  - policy: restrict-github-team-management
+    rule: teammemberships-allow-listed-members
+    resources:
+      - github-config/admins-member
+      - github-config/allow-listed-maintainer
+      - github-config/mixed-case-username
+      - github-config/initprovider-only-allow-listed-username
+    kind: TeamMembership
+    result: pass
+  # #3146: the granted role is an enumeration, so unknown values are refused
+  # rather than assumed harmless — in forProvider and through the merge.
+  - policy: restrict-github-team-management
+    rule: teammemberships-known-roles
+    resources:
+      - github-config/unknown-role
+      - github-config/initprovider-unknown-role
+      - github-config/initprovider-unknown-role-behind-valid-forprovider
+    kind: TeamMembership
+    result: fail
+  - policy: restrict-github-team-management
+    rule: teammemberships-known-roles
+    resources:
+      - github-config/admins-member
+      - github-config/allow-listed-maintainer
+    kind: TeamMembership
+    result: pass

--- a/tests/restrict-github-team-management/resources.yaml
+++ b/tests/restrict-github-team-management/resources.yaml
@@ -297,3 +297,173 @@ spec:
       policy:
         resolve: Always
     permission: admin
+---
+# #3146: the member identity itself. Every condition on the reference rule above
+# passes here — allow-listed team, resolve Always, no teamId, no selector, empty
+# initProvider — and the org-admin provider still adds an arbitrary account to a
+# CODEOWNERS team. This fixture isolates the identity condition: it is a
+# well-formed membership in every other respect.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: arbitrary-username
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: attacker
+    role: member
+---
+# GitHub logins are case-insensitive, so this is the SAME account as the
+# allow-listed one and must be admitted. Without normalisation the allow-list
+# would refuse a legitimate identity — a false denial rather than a bypass, but
+# a real one, and the same reason the provider-identity rule above lowercases.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: mixed-case-username
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: DeVaNtLeR
+    role: member
+---
+# The initProvider merge, applied to the identity. forProvider is entirely
+# legitimate, so a rule keyed only on forProvider admits this while a foreign
+# account rides in underneath — the same shape as the foreign-team and
+# admin-grant bypasses already covered above.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: initprovider-arbitrary-username
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: devantler
+    role: member
+  initProvider:
+    username: attacker
+---
+# forProvider carries no username at all, so upjet merges initProvider's in and
+# that is the account actually reconciled. A rule reading forProvider alone sees
+# an empty string here, which is why the identity condition resolves the
+# effective value across both blocks.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: initprovider-only-arbitrary-username
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    role: member
+  initProvider:
+    username: attacker
+---
+# The paved road as it exists live: the allow-listed member holding maintainer.
+# Both live TeamMemberships have this exact shape, so the identity and role
+# rules must admit it or they deny the entire current fleet.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: allow-listed-maintainer
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: maintainers
+      policy:
+        resolve: Always
+    username: devantler
+    role: maintainer
+---
+# An allow-list, not a deny-list on `maintainer`: GitHub team roles are an
+# enumeration the provider passes through, so a value outside the two documented
+# roles must be refused rather than assumed harmless. Same rationale as the
+# repository-permission list above.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: unknown-role
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: devantler
+    role: owner
+---
+# The same unknown role supplied under initProvider, where the merge makes it
+# the effective role because forProvider sets none.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: initprovider-unknown-role
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: devantler
+  initProvider:
+    role: owner
+---
+# The initProvider-only authoring style with an ALLOW-LISTED account. This is the
+# control that isolates the merge resolution: the foreign-username fixture above
+# cannot do it, because with the fallback removed its effective value collapses to
+# the empty string, which the allow-list denies anyway — so it fails either way and
+# proves nothing about the merge. Here the effective value is the allow-listed
+# login only if initProvider is consulted; drop the fallback and this legitimate
+# membership is refused.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: initprovider-only-allow-listed-username
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    role: member
+  initProvider:
+    username: devantler
+---
+# forProvider carries a legitimate role, so the merge never reaches initProvider
+# and the effective role is `member`. The initProvider condition is the only one
+# that sees the unknown value here, which is what isolates it — the fixture above
+# is caught by both conditions and so isolates neither.
+apiVersion: team.github.m.upbound.io/v1beta1
+kind: TeamMembership
+metadata:
+  name: initprovider-unknown-role-behind-valid-forprovider
+  namespace: github-config
+spec:
+  forProvider:
+    teamIdRef:
+      name: admins
+      policy:
+        resolve: Always
+    username: devantler
+    role: member
+  initProvider:
+    role: owner


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The admission guard that is meant to stop a compromised or unintended github-config artifact from
adding people to our CODEOWNERS teams only checked **which team** was being written to — never
**who** was being added, or with what role. Its own description promises it prevents "adding
arbitrary users to arbitrary GitHub teams", so it read as a protection that was not actually there,
which is worse than an acknowledged gap.

### What changed

Team membership is now constrained on the member's identity and on the role granted, in both the
authored field block and the one that gets merged in underneath it. The current setup is unaffected —
both live memberships still pass, verified against the real cluster resources — and adding a member
becomes a reviewed change to this policy rather than something the delegated artifact can grant
itself.

One acceptance criterion on the issue was deliberately **not** implemented: a separate ceiling on the
maintainer role. With a single allow-listed member, who already holds maintainer on both teams, any
such ceiling either denies the entire live fleet or is vacuous — and it is redundant while a role
cannot be escalated for an account that cannot be added in the first place. The reasoning is recorded
beside the rule so it can be revisited the moment the allow-list holds more than one member.

Fixes #3146
