### PR TITLE
fix(security): block workload access to instance metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,6 +241,7 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'scripts/tests/test-cilium-bandwidth-manager-component.sh'
+              - 'scripts/tests/test-cilium-metadata-egress-policy.sh'
               - 'scripts/tests/test-cilium-mutual-auth-policy.sh'
               - 'scripts/tests/test-cilium-mutual-auth-policy-regressions.sh'
               - 'scripts/tests/test-coroot-postgres-scrape-policy.sh'
@@ -791,6 +792,15 @@ jobs:
         run: |
           bash scripts/tests/test-cilium-mutual-auth-policy-regressions.sh
           bash scripts/tests/test-cilium-mutual-auth-policy.sh
+
+      - name: 🔐 Validate workload metadata egress isolation
+        if: needs.changes.outputs.k8s == 'true'
+        # Render both provider infrastructure entry points. The control must
+        # cover every workload in Hetzner/prod without selecting Talos hosts
+        # or leaking into the local Docker provider.
+        run: |
+          shellcheck scripts/tests/test-cilium-metadata-egress-policy.sh
+          bash scripts/tests/test-cilium-metadata-egress-policy.sh
 
       - name: 🐘 Validate Coroot Postgres scrape policy
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
+++ b/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
@@ -5,8 +5,14 @@ metadata:
 spec:
   # Cilium endpoint selectors match managed workload endpoints. Deliberately
   # omit nodeSelector so Talos and host bootstrap traffic remain outside this
-  # policy while every pod on Hetzner workers receives the deny.
-  endpointSelector: {}
+  # policy. Crossplane keeps the same deny in its existing namespaced egress
+  # policy so that policy remains its only static egress owner.
+  endpointSelector:
+    matchExpressions:
+      - key: k8s:io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - crossplane-system
   egressDeny:
     - toCIDR:
         - 169.254.169.254/32

--- a/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
+++ b/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: deny-workload-instance-metadata-egress
+spec:
+  # Cilium endpoint selectors match managed workload endpoints. Deliberately
+  # omit nodeSelector so Talos and host bootstrap traffic remain outside this
+  # policy while every pod on Hetzner workers receives the deny.
+  endpointSelector: {}
+  egressDeny:
+    - toCIDR:
+        - 169.254.169.254/32

--- a/k8s/providers/hetzner/infrastructure/cilium/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/cilium/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
@@ -9,6 +9,10 @@ spec:
   # kubelet pulls at node level) AND the provider pods Crossplane creates here
   # (provider-upjet-github talks to the GitHub API).
   endpointSelector: {}
+  egressDeny:
+    # Keep workload access to the Hetzner instance metadata service blocked.
+    - toCIDR:
+        - 169.254.169.254/32
   egress:
     # Kube API for watching/updating managed resources and leader election.
     - toEntities:

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -10,6 +10,10 @@ resources:
   # the operator to create the key before the HelmRelease becomes Ready.
   - ../../../bases/infrastructure/audit-log-forwarder/
   - cluster-issuers/
+  # Prod-only workload isolation for the Hetzner instance metadata service.
+  # A Cilium endpoint selector covers pods, not Talos hosts, so bootstrap keeps
+  # its required metadata path while workloads cannot reuse node join material.
+  - cilium/
   # Crossplane provider-upjet-github package + activation policy. Lives in this
   # `infrastructure` layer (not `infrastructure/controllers/`) because these are
   # pkg.crossplane.io CRs that need the Crossplane CRDs the core HelmRelease in

--- a/scripts/tests/crossplane-egress-policy-rules.yaml
+++ b/scripts/tests/crossplane-egress-policy-rules.yaml
@@ -47,6 +47,9 @@ rules:
         },
         'spec': {
           'endpointSelector': {},
+          'egressDeny': [
+            {'toCIDR': ['169.254.169.254/32']}
+          ],
           'egress': [
             {'toEntities': ['kube-apiserver']},
             {

--- a/scripts/tests/test-cilium-metadata-egress-policy.sh
+++ b/scripts/tests/test-cilium-metadata-egress-policy.sh
@@ -12,53 +12,26 @@ fail() {
   exit 1
 }
 
-extract_policy() {
-  awk -v policy_name="${policy_name}" '
-    function reset_document() {
-      document = ""
-      is_clusterwide_policy = 0
-      is_target = 0
-    }
-
-    function finish_document() {
-      if (is_clusterwide_policy && is_target) {
-        count++
-        selected = document
-      }
-      reset_document()
-    }
-
-    BEGIN { reset_document() }
-    /^---[[:space:]]*$/ { finish_document(); next }
-    {
-      document = document $0 ORS
-      if ($0 ~ /^kind:[[:space:]]*CiliumClusterwideNetworkPolicy[[:space:]]*$/) {
-        is_clusterwide_policy = 1
-      }
-      if ($0 == "  name: " policy_name) {
-        is_target = 1
-      }
-    }
-    END {
-      finish_document()
-      if (count != 1) {
-        printf "expected exactly one rendered %s policy, found %d\n", policy_name, count > "/dev/stderr"
-        exit 1
-      }
-      printf "%s", selected
-    }
-  '
-}
-
 tmp_dir="$(mktemp -d)"
 readonly tmp_dir
 trap 'rm -rf "${tmp_dir}"' EXIT
+readonly prod_render="${tmp_dir}/prod.yaml"
 readonly rendered_policy="${tmp_dir}/policy.yaml"
 readonly local_render="${tmp_dir}/local.yaml"
 
-kubectl kustomize "${root_dir}/k8s/providers/hetzner/infrastructure" |
-  extract_policy >"${rendered_policy}" ||
-  fail 'the production build does not render exactly one metadata-egress deny policy'
+kubectl kustomize "${root_dir}/k8s/providers/hetzner/infrastructure" >"${prod_render}" ||
+  fail 'the production Hetzner infrastructure build did not render'
+policy_count="$(
+  yq ea \
+    "[select(.kind == \"CiliumClusterwideNetworkPolicy\" and .metadata.name == \"${policy_name}\")] | length" \
+    "${prod_render}"
+)" || fail 'the production policy count could not be read'
+[[ "${policy_count}" == 1 ]] ||
+  fail "the production build rendered ${policy_count} metadata-egress policies instead of one"
+yq ea \
+  "select(.kind == \"CiliumClusterwideNetworkPolicy\" and .metadata.name == \"${policy_name}\")" \
+  "${prod_render}" >"${rendered_policy}" ||
+  fail 'the production metadata-egress policy could not be extracted'
 
 kubectl kustomize "${root_dir}/k8s/providers/docker/infrastructure" >"${local_render}" ||
   fail 'the local Docker infrastructure build did not render'

--- a/scripts/tests/test-cilium-metadata-egress-policy.sh
+++ b/scripts/tests/test-cilium-metadata-egress-policy.sh
@@ -17,6 +17,8 @@ readonly tmp_dir
 trap 'rm -rf "${tmp_dir}"' EXIT
 readonly prod_render="${tmp_dir}/prod.yaml"
 readonly rendered_policy="${tmp_dir}/policy.yaml"
+readonly controllers_render="${tmp_dir}/controllers.yaml"
+readonly crossplane_policy="${tmp_dir}/crossplane-policy.yaml"
 readonly local_render="${tmp_dir}/local.yaml"
 
 kubectl kustomize "${root_dir}/k8s/providers/hetzner/infrastructure" >"${prod_render}" ||
@@ -33,6 +35,13 @@ yq ea \
   "${prod_render}" >"${rendered_policy}" ||
   fail 'the production metadata-egress policy could not be extracted'
 
+kubectl kustomize "${root_dir}/k8s/providers/hetzner/infrastructure/controllers/crossplane" >"${controllers_render}" ||
+  fail 'the production Crossplane controller build did not render'
+yq ea \
+  'select(.kind == "CiliumNetworkPolicy" and .metadata.namespace == "crossplane-system" and .metadata.name == "allow-crossplane")' \
+  "${controllers_render}" >"${crossplane_policy}" ||
+  fail 'the Crossplane egress policy could not be extracted'
+
 kubectl kustomize "${root_dir}/k8s/providers/docker/infrastructure" >"${local_render}" ||
   fail 'the local Docker infrastructure build did not render'
 if grep -Fq -- "name: ${policy_name}" "${local_render}"; then
@@ -45,9 +54,14 @@ fi
 yq -e '.apiVersion == "cilium.io/v2" and .kind == "CiliumClusterwideNetworkPolicy"' \
   "${rendered_policy}" >/dev/null ||
   fail 'the rendered control is not a CiliumClusterwideNetworkPolicy'
-yq -e '(.spec.endpointSelector | type) == "!!map" and (.spec.endpointSelector | length) == 0' \
+yq -e '(.spec.endpointSelector | keys | length) == 1 and
+  (.spec.endpointSelector.matchExpressions | length) == 1 and
+  .spec.endpointSelector.matchExpressions[0].key == "k8s:io.kubernetes.pod.namespace" and
+  .spec.endpointSelector.matchExpressions[0].operator == "NotIn" and
+  (.spec.endpointSelector.matchExpressions[0].values | length) == 1 and
+  .spec.endpointSelector.matchExpressions[0].values[0] == "crossplane-system"' \
   "${rendered_policy}" >/dev/null ||
-  fail 'the policy must select every workload endpoint'
+  fail 'the cluster-wide policy must exclude Crossplane from its workload selection'
 yq -e '.spec | has("nodeSelector") == false' "${rendered_policy}" >/dev/null ||
   fail 'the workload policy must not select Talos hosts'
 yq -e '.spec.egressDeny | length == 1' "${rendered_policy}" >/dev/null ||
@@ -61,5 +75,12 @@ yq -e '.spec.egressDeny[0].toCIDR | length == 1' "${rendered_policy}" >/dev/null
 yq -e '.spec.egressDeny[0].toCIDR[0] == "169.254.169.254/32"' \
   "${rendered_policy}" >/dev/null ||
   fail 'the deny rule must target only the instance metadata address'
+
+yq -e '(.spec.egressDeny | length) == 1 and
+  (.spec.egressDeny[0] | keys | length) == 1 and
+  (.spec.egressDeny[0].toCIDR | length) == 1 and
+  .spec.egressDeny[0].toCIDR[0] == "169.254.169.254/32"' \
+  "${crossplane_policy}" >/dev/null ||
+  fail 'the existing Crossplane policy must carry the same exact metadata deny'
 
 printf 'PASS: production denies workload metadata egress without selecting Talos hosts\n'

--- a/scripts/tests/test-cilium-metadata-egress-policy.sh
+++ b/scripts/tests/test-cilium-metadata-egress-policy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly policy_name="deny-workload-instance-metadata-egress"
+readonly deleted_policy="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/cilium/cilium-clusterwide-network-policy.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+extract_policy() {
+  awk -v policy_name="${policy_name}" '
+    function reset_document() {
+      document = ""
+      is_clusterwide_policy = 0
+      is_target = 0
+    }
+
+    function finish_document() {
+      if (is_clusterwide_policy && is_target) {
+        count++
+        selected = document
+      }
+      reset_document()
+    }
+
+    BEGIN { reset_document() }
+    /^---[[:space:]]*$/ { finish_document(); next }
+    {
+      document = document $0 ORS
+      if ($0 ~ /^kind:[[:space:]]*CiliumClusterwideNetworkPolicy[[:space:]]*$/) {
+        is_clusterwide_policy = 1
+      }
+      if ($0 == "  name: " policy_name) {
+        is_target = 1
+      }
+    }
+    END {
+      finish_document()
+      if (count != 1) {
+        printf "expected exactly one rendered %s policy, found %d\n", policy_name, count > "/dev/stderr"
+        exit 1
+      }
+      printf "%s", selected
+    }
+  '
+}
+
+tmp_dir="$(mktemp -d)"
+readonly tmp_dir
+trap 'rm -rf "${tmp_dir}"' EXIT
+readonly rendered_policy="${tmp_dir}/policy.yaml"
+readonly local_render="${tmp_dir}/local.yaml"
+
+kubectl kustomize "${root_dir}/k8s/providers/hetzner/infrastructure" |
+  extract_policy >"${rendered_policy}" ||
+  fail 'the production build does not render exactly one metadata-egress deny policy'
+
+kubectl kustomize "${root_dir}/k8s/providers/docker/infrastructure" >"${local_render}" ||
+  fail 'the local Docker infrastructure build did not render'
+if grep -Fq -- "name: ${policy_name}" "${local_render}"; then
+  fail 'the Hetzner metadata policy leaked into the local Docker build'
+fi
+
+[[ ! -e "${deleted_policy}" ]] ||
+  fail 'the deliberately deleted Cilium mutual-auth policy file was restored'
+
+yq -e '.apiVersion == "cilium.io/v2" and .kind == "CiliumClusterwideNetworkPolicy"' \
+  "${rendered_policy}" >/dev/null ||
+  fail 'the rendered control is not a CiliumClusterwideNetworkPolicy'
+yq -e '(.spec.endpointSelector | type) == "!!map" and (.spec.endpointSelector | length) == 0' \
+  "${rendered_policy}" >/dev/null ||
+  fail 'the policy must select every workload endpoint'
+yq -e '.spec | has("nodeSelector") == false' "${rendered_policy}" >/dev/null ||
+  fail 'the workload policy must not select Talos hosts'
+yq -e '.spec.egressDeny | length == 1' "${rendered_policy}" >/dev/null ||
+  fail 'the policy must have exactly one deny rule'
+yq -e '.spec.egressDeny[0] | (keys | length) == 1' "${rendered_policy}" >/dev/null ||
+  fail 'the deny rule must not carry additional destinations'
+yq -e '.spec.egressDeny[0] | has("toCIDR")' "${rendered_policy}" >/dev/null ||
+  fail 'the deny rule must use a CIDR destination'
+yq -e '.spec.egressDeny[0].toCIDR | length == 1' "${rendered_policy}" >/dev/null ||
+  fail 'the deny rule must contain exactly one CIDR'
+yq -e '.spec.egressDeny[0].toCIDR[0] == "169.254.169.254/32"' \
+  "${rendered_policy}" >/dev/null ||
+  fail 'the deny rule must target only the instance metadata address'
+
+printf 'PASS: production denies workload metadata egress without selecting Talos hosts\n'

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -1002,8 +1002,12 @@ assert_egress_shape() {
   local actual_rules
   local expected_rules
 
-  actual_rules="$(awk '/^  - / { print }' <<<"${candidate_policy}")"
-  expected_rules=$'  - toEntities:\n  - toFQDNs:\n  - toEndpoints:'
+  actual_rules="$(
+    yq e -N -r \
+      '.spec.egress[] | keys | map(select(. != "toPorts")) | .[]' \
+      - <<<"${candidate_policy}"
+  )" || fail 'Crossplane egress rule shapes could not be inspected'
+  expected_rules=$'toEntities\ntoFQDNs\ntoEndpoints'
   [ "${actual_rules}" = "${expected_rules}" ] ||
     fail 'Crossplane egress must contain only the reviewed Kubernetes API, HTTPS, and DNS rules'
 }

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -1015,7 +1015,7 @@ assert_egress_shape() {
 dns_egress_contract() {
   awk '
     /^  - toEndpoints:$/ { in_dns_egress = 1 }
-    in_dns_egress && /^  endpointSelector:/ { exit }
+    in_dns_egress && /^  [[:alnum:]_-]+:/ { exit }
     in_dns_egress { print }
   ' <<<"$1"
 }
@@ -1058,9 +1058,8 @@ if (assert_direct_https_contract "${wildcard_policy}") >/dev/null 2>&1; then
   fail 'the regression guard must reject wildcard Crossplane FQDN selectors'
 fi
 
-extra_fqdn_rule=$'  - toFQDNs:\n    - matchPattern: "*"\n    toPorts:\n    - ports:\n      - port: "443"\n        protocol: TCP\n  endpointSelector: {}'
-empty_selector='  endpointSelector: {}'
-extra_fqdn_policy="${policy/${empty_selector}/${extra_fqdn_rule}}"
+extra_fqdn_rule=$'  - toFQDNs:\n    - matchPattern: "*"\n    toPorts:\n    - ports:\n      - port: "443"\n        protocol: TCP\n  - toEndpoints:'
+extra_fqdn_policy="${policy/  - toEndpoints:/${extra_fqdn_rule}}"
 if (assert_egress_shape "${extra_fqdn_policy}") >/dev/null 2>&1; then
   fail 'the regression guard must reject additional Crossplane FQDN egress rules'
 fi

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -943,13 +943,19 @@ fi
 
 assert_no_unrestricted_egress() {
   local candidate_policy="$1"
+  local cidr_allow_count
 
   if grep -Eq "^[[:space:]]*-[[:space:]]+['\"]?(world|all)['\"]?([[:space:]]+#.*)?$" <<<"${candidate_policy}" ||
     grep -Eq "^[[:space:]]*-[[:space:]]+toEntities:[[:space:]]*(\\[[[:space:]]*['\"]?(world|all)['\"]?[[:space:]]*\\]|['\"]?(world|all)['\"]?)([[:space:]]+#.*)?$" <<<"${candidate_policy}"; then
     fail 'Crossplane must not receive unrestricted world or all-entity egress'
   fi
 
-  if grep -Eq '^[[:space:]]*-[[:space:]]+toCIDR(Set)?:' <<<"${candidate_policy}"; then
+  cidr_allow_count="$(
+    yq e -N -r \
+      '[.spec.egress[]? | select(has("toCIDR") or has("toCIDRSet"))] | length' \
+      - <<<"${candidate_policy}"
+  )" || fail 'Crossplane egress CIDR rules could not be inspected'
+  if [ "${cidr_allow_count}" -ne 0 ]; then
     fail 'Crossplane must not receive CIDR-based egress'
   fi
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Workloads can currently reach Hetzner instance metadata and potentially reuse cluster join material. The former draft fix targeted a policy that was deliberately deleted for separate security reasons, so reviving it would restore the wrong control.

## What

Add a provider-scoped workload deny for the metadata address while leaving Talos and host bootstrap outside the policy. A regression test keeps that boundary in the rendered configuration.

## Operational note

Static validation is green. Keep this PR draft until trusted runtime verification confirms both that workload access is denied in effect and that Talos bootstrap/autoscaling still succeeds.

Fixes #3153
