### PR TITLE
fix(security): stop exporting process arguments to the log store

### DIFF
--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -84,6 +84,28 @@ spec:
       # TracingPolicies will rely on.
       enableProcessCred: true
       enableProcessNs: true
+      # Command-line arguments are excluded from every exported event. The
+      # export sidecar's JSON reaches Coroot's log store, which has a broader
+      # access boundary and a longer retention window than the pod that ran the
+      # process, so an argument passed by any workload -- including workloads
+      # this repo does not own and cannot change -- is otherwise durably
+      # searchable there. Excluding the field at the exporter covers every
+      # current and future workload from one reviewed point, instead of relying
+      # on each call site to keep sensitive values out of argv.
+      #
+      # EXCLUDE-only is deliberate: Tetragon treats the presence of any INCLUDE
+      # filter as default-exclude for that event set, which would silently drop
+      # every field not listed. Field paths are relative to the event body, and
+      # `arguments` hangs off both `process` and `parent`.
+      #
+      # Trade-off: exported events no longer carry the flags a process ran with.
+      # Binary path, identity (pod / container / uid / capabilities), parentage
+      # and timing are all retained, so the process visibility the sidecar is
+      # deployed for is unchanged. Redaction filters were the alternative; they
+      # keep arguments but only for argument spellings someone has enumerated in
+      # advance, which leaves the unbounded residual this is meant to remove.
+      fieldFilters: |-
+        {"fields": "process.arguments,parent.arguments", "action": "EXCLUDE"}
       prometheus:
         enabled: true
         # The prometheus-operator ServiceMonitor CRD left with

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1296,7 +1296,26 @@ const (
 // ServiceAccount 16. The previous approved aggregate digest was:
 //
 //	3ef2555fe188f77b84a5927739842929f637688713fa6510bf2c682adce3643b
-const expectedRenderedSurfaceSHA = "9309a857065fd3d675fd1a26414311d2c7a43717618c904a980c0fe8177839bd"
+//
+// Measured against main 022dc5c4 for the Tetragon argument-export field filter:
+// the five production projections hold 541 documents on BOTH sides. Set
+// difference in BOTH directions over apiVersion|kind|namespace|name is empty,
+// so this adds, removes and renames nothing. Exactly ONE existing rendered
+// identity changes:
+//
+//	helm.toolkit.fluxcd.io/v2  HelmRelease  kube-system/tetragon
+//
+// Its only delta adds `tetragon.fieldFilters`, an exporter-side projection that
+// drops `process.arguments` and `parent.arguments` from emitted events. The
+// value grants nothing: it names neither a subject nor a resource, and it can
+// only remove fields from an exported event. Grant-bearing counts remain
+// byte-for-byte stable: Role 11, ClusterRole 24, RoleBinding 15,
+// ClusterRoleBinding 12, and ServiceAccount 16. All 541 identities were
+// compared pairwise, so the single-entry result is not a vacuous join. The
+// previous approved aggregate digest was:
+//
+//	9309a857065fd3d675fd1a26414311d2c7a43717618c904a980c0fe8177839bd
+const expectedRenderedSurfaceSHA = "54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Every process started anywhere in the cluster currently has its full command line copied into our searchable log store, which more people can read and which keeps data far longer than the pod that ran the process. So anything a workload passes as a command-line argument — including workloads we neither own nor can change — is durably searchable there, which breaks an assumption callers across the platform rely on.

### Changes

Arguments are now dropped at the exporter, closing the whole class in one reviewed place instead of chasing individual call sites forever. Process visibility is otherwise unchanged: exported events still identify the program, the pod and user that ran it, its privileges, and its parent process.

The trade-off is that exported events no longer show which flags a process ran with. Redaction was the alternative, but it only protects argument spellings someone has listed in advance — leaving exactly the open-ended gap this is meant to remove.

Fixes #3157
