### PR TITLE
fix(cilium): stop the metadata deny revoking all workload egress

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
+++ b/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
@@ -15,6 +15,13 @@ spec:
         operator: NotIn
         values:
           - crossplane-system
+  # Cilium turns on default-deny for every direction a policy has rules in, so
+  # an egressDeny rule on its own would revoke all egress from the endpoints
+  # selected above unless some other policy allows it back. This policy is
+  # meant to subtract one destination, not to become every workload's egress
+  # allow-list, so keep default-deny off and let the deny stand on its own.
+  enableDefaultDeny:
+    egress: false
   egressDeny:
     - toCIDR:
         - 169.254.169.254/32

--- a/scripts/tests/test-cilium-metadata-egress-policy.sh
+++ b/scripts/tests/test-cilium-metadata-egress-policy.sh
@@ -97,6 +97,15 @@ yq -e '.spec.egressDeny[0].toCIDR[0] == "169.254.169.254/32"' \
   "${rendered_policy}" >/dev/null ||
   fail 'the deny rule must target only the instance metadata address'
 
+# A policy carrying only egressDeny rules puts every selected endpoint into
+# default-deny egress: the CRD defaults enableDefaultDeny to true for each
+# direction that has rules. This policy selects every namespace except
+# crossplane-system and carries no egress allow rules, so leaving the field
+# unset silently revokes egress from every workload that has no allow policy
+# of its own. Pin it off so the deny stays a deny.
+yq -e '.spec.enableDefaultDeny.egress == false' "${rendered_policy}" >/dev/null ||
+  fail 'the metadata deny must not put selected endpoints into default-deny egress'
+
 yq -e '(.spec.endpointSelector | keys | length) == 1 and
   (.spec.endpointSelector.matchLabels | keys | length) == 1 and
   .spec.endpointSelector.matchLabels."k8s-app" == "kube-dns" and


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Four `kube-system` components are crash-looping in production right now, and the cluster cannot scale out.

The clusterwide metadata-egress policy was meant to subtract a single destination — the cloud instance metadata address. But Cilium turns on default-deny for every direction a policy has rules in, and this policy has a deny rule and no allow rules. So instead of subtracting one destination from the endpoints it selects, it revoked *all* of their egress unless some other policy happened to grant it back.

The policy selects every namespace except `crossplane-system`. In `kube-system`, exactly one workload has an egress allow policy of its own — CoreDNS — and CoreDNS is the one that is healthy. `cluster-autoscaler` (single replica, so scaling is fully down), `snapshot-controller`, `tetragon-operator` and `hubble-relay` all fail with timeouts reaching the apiserver and DNS service addresses.

This also explains the incident earlier today: the same mechanism, not the CIDR in the deny rule, is why a policy naming one address could take cluster DNS down.

### What

Turns default-deny off for egress on that one policy, so it subtracts a destination rather than becoming every workload's egress allow-list. The metadata deny itself is untouched, so the hardening the policy exists for is fully preserved — this only stops it revoking traffic it was never meant to govern.

The existing test asserted the rendered policy's shape but had no way to notice this, which is how it shipped green. It now pins the setting, and fails without it.

Operationally this is permissive-only: it can restore egress that is currently denied and cannot remove any. The affected pods should recover on their next restart once this reconciles, with no manual step needed.
