### PR TITLE
fix(security): hold the heartbeat URL in a Secret, not the CronJob spec

### DIFF
--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -168,9 +168,11 @@ Recommended monitor: [healthchecks.io](https://healthchecks.io) (free,
 open-source, native Slack integration). Create a check with a ~5 min period and
 ~10 min grace, connect it to Slack, and put its ping URL in
 `alertmanager_heartbeat_url` (below — the variable name is retained from the old
-stack for compatibility). The URL is injected by Flux substitution; unset, it
-defaults to an invalid URL, so local/CI simply never heartbeat — harmless
-(`|| true` keeps the Job from flapping).
+stack for compatibility). Flux substitutes the URL into the
+`cluster-heartbeat-url` Secret, which the Job mounts read-only, so it is not
+readable from the CronJob spec. Unset, it defaults to an invalid URL, so
+local/CI simply never heartbeat — harmless (`|| true` keeps the Job from
+flapping).
 
 ## Off-cluster backup
 
@@ -189,7 +191,7 @@ present in the per-cluster `secret.enc.yaml` (under
 - `alertmanager_webhook_url` — Slack incoming-webhook, reused by Coroot's
   webhook integration (prod-only).
 - `alertmanager_heartbeat_url` — external heartbeat monitor, reused by the
-  `cluster-heartbeat` CronJob.
+  `cluster-heartbeat` CronJob via the `cluster-heartbeat-url` Secret it mounts.
 
 | Env   | `alertmanager_webhook_url`        | `alertmanager_heartbeat_url`     |
 | ----- | --------------------------------- | -------------------------------- |

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
@@ -23,11 +23,11 @@
 # CiliumNetworkPolicy's world:443 + DNS egress; it does not depend on
 # Coroot itself.
 #
-# The URL is injected by Flux substitution from the per-cluster SOPS
-# secret; unset (local/CI) it defaults to an invalid URL so the ping
-# reaches nowhere. `|| true` keeps the Job from flapping into a failed
-# state when the monitor is unset/unreachable — the alarm signal is the
-# *absence* of pings, observed externally, never the Job's exit code.
+# The URL is injected by Flux substitution into a SECRET
+# (secret-cluster-heartbeat.yaml), which this Job mounts read-only -- not into
+# this spec. Substituting it here would persist a live third-party credential
+# in an object that any holder of the built-in `view` ClusterRole can read.
+# Unset (local/CI) it defaults to an invalid URL so the ping reaches nowhere.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -62,6 +62,14 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
+            # fsGroup is what makes the mounted URL readable at all. Secret volume
+            # files are owned by root:root unless fsGroup is set, so a non-root
+            # container reading a mode-0440 file gets EACCES and the heartbeat stops
+            # -- which an external dead-man monitor reports as the CLUSTER being
+            # down. Setting fsGroup makes kubelet chown the volume to root:65532,
+            # which the group-readable mode then opens to this container and nothing
+            # else.
+            fsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -70,11 +78,40 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - >-
-                  curl -sf --max-time 10
-                  --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused
-                  "${alertmanager_heartbeat_url:=https://example.invalid/no-heartbeat-configured}"
-                  || true
+                - |
+                  set -eu
+
+                  # Read from the mounted Secret rather than a substituted spec
+                  # value: anything that can `get cronjob` in this namespace could
+                  # otherwise read the live monitor URL straight off the object
+                  # (the built-in `view` ClusterRole grants batch, and is bound to
+                  # the OIDC identity). Secrets are deliberately not granted there.
+                  HEARTBEAT_URL=$(cat /etc/cluster-heartbeat/url)
+
+                  # The value becomes a curl CONFIG directive below, where a
+                  # newline starts a SECOND directive -- so an LF in the Secret
+                  # would let the config say `output = ...` or anything else curl
+                  # accepts. A valid URL cannot contain a control character, so
+                  # rejecting them costs nothing and turns a malformed Secret into
+                  # a loud failure instead of a silently reconfigured request.
+                  if [ "$(printf '%s' "$HEARTBEAT_URL" | tr -d '[:cntrl:]')" != "$HEARTBEAT_URL" ]; then
+                    echo "ERROR: heartbeat URL contains control characters" >&2
+                    exit 1
+                  fi
+
+                  # Passed via --config on stdin, not as an argv element, so the
+                  # URL never appears in /proc/<pid>/cmdline. Matches
+                  # cron-job-cnpg-degraded-alert.yaml.
+                  #
+                  # `|| true` is retained deliberately: the alarm signal is the
+                  # ABSENCE of pings observed externally, never this Job's exit
+                  # code, so an unreachable monitor must not flap the Job into a
+                  # failed state. It does not mask the guard above, which exits
+                  # before curl runs.
+                  printf 'url = %s\n' "$HEARTBEAT_URL" |
+                    curl -sf --max-time 10 \
+                      --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
+                      --config - || true
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -85,6 +122,10 @@ spec:
                 capabilities:
                   drop:
                     - ALL
+              volumeMounts:
+                - name: heartbeat-url
+                  mountPath: /etc/cluster-heartbeat
+                  readOnly: true
               resources:
                 requests:
                   cpu: 5m
@@ -94,3 +135,21 @@ spec:
                   # the short-lived curl never throttles.
                   cpu: 50m
                   memory: 32Mi
+          volumes:
+            # 288 is 0440: readable by root and by the pod's fsGroup (65532, set
+            # above), rather than by anything else that lands in this pod. It must
+            # carry the GROUP bit: kubelet owns secret-volume files root:fsGroup,
+            # never uid:fsGroup, so an owner-only 0400 is unreadable by the
+            # container's own non-root user. The Secret is the one
+            # secret-cluster-heartbeat.yaml creates from the per-cluster Flux
+            # substitution.
+            #
+            # Written in DECIMAL deliberately, matching cron-job-cnpg-degraded-alert.yaml:
+            # an unquoted `0440` is read as octal 288 by Kubernetes' own parser
+            # (sigs.k8s.io/yaml, which is YAML 1.1) and as decimal 440 -- mode 0670 --
+            # by every YAML 1.2 reader, yq and kyaml included. The two disagree
+            # silently and nothing validates the difference.
+            - name: heartbeat-url
+              secret:
+                secretName: cluster-heartbeat-url
+                defaultMode: 288

--- a/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
@@ -13,6 +13,9 @@ resources:
   - http-route.yaml
   - cilium-network-policy.yaml
   - cron-job.yaml
+  # Heartbeat monitor URL, held in a Secret rather than substituted into the
+  # CronJob spec above (see that file and secret-cluster-heartbeat.yaml):
+  - secret-cluster-heartbeat.yaml
   # Degraded-CNPG-cluster alert (one resource per file, per the naming convention):
   - service-account-cnpg-degraded-alert.yaml
   - secret-cnpg-degraded-alert.yaml

--- a/k8s/bases/infrastructure/controllers/coroot/secret-cluster-heartbeat.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/secret-cluster-heartbeat.yaml
@@ -1,0 +1,23 @@
+# External dead-man's-switch URL for the cluster-heartbeat CronJob
+# (${alertmanager_heartbeat_url}, e.g. healthchecks.io — injected by Flux from
+# the per-cluster SOPS bootstrap Secret), so there is no new secret to provision.
+#
+# The URL lives in a Secret rather than substituted into the CronJob spec,
+# matching secret-cnpg-degraded-alert.yaml and secret-posture-staleness-alert.yaml
+# in this same directory. A substituted spec value is readable straight off the
+# object by anyone who can `get cronjob` in this namespace — and the built-in
+# `view` ClusterRole grants read on `batch` and is bound to the OIDC identity in
+# cluster-role-bindings/oidc-view.yaml, so a read-only identity could recover a
+# live third-party credential. Secrets are deliberately not granted there.
+#
+# The inline default keeps `ksail workload validate` (which has no SOPS access)
+# building and leaves local/CI inert.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-heartbeat-url
+  namespace: observability
+type: Opaque
+stringData:
+  url: ${alertmanager_heartbeat_url:=https://example.invalid/no-heartbeat-configured}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The cluster's dead-man's-switch URL — a live third-party monitor credential — was readable by anyone with read-only access to the cluster. Flux substituted it directly into the heartbeat CronJob's container arguments, and the built-in `view` role that read-only OIDC identities carry grants read on CronJobs. Its confidentiality depended on nobody looking.

### What

The URL now lives in a Secret that the job mounts read-only, instead of being written into the job's own spec. Read-only identities are deliberately not granted Secrets, so the credential stops being visible to them. This follows the pattern the two neighbouring alert jobs in the same namespace already use.

The heartbeat itself is unchanged in behaviour — it still pings on the same schedule, and still never reports a failure of its own, because the alarm is the *absence* of pings seen from outside.

No fingerprint re-approval is needed: the `🔐 Validate EKS Authorization` check **passed** at this head. The issue predicted it would move; that prediction was wrong, and the reason is recorded in a comment below.

Fixes #3159
