### PR TITLE
chore(crossplane): move provider-upjet-unifi to the tag-signed v1.0.0

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -89,11 +89,19 @@ spec:
     # any non-tag ref before it checks anything out, so a v* tag is the sole
     # legitimate signing ref. Pinning it rejects a package signed from an
     # arbitrary branch, which an unconstrained ref accepts.
-    # The tag grammar mirrors the publisher's `scripts/release-version.sh` EXACTLY, spelled
+    # The tag grammar mirrors the publisher's `scripts/release-version.sh` OCI-semver
+    # grammar, spelled out here rather than deferred to it: this verifier is the independent
     # out here rather than deferred to it: this verifier is the independent half of that
     # pair, so it must not inherit its boundary from the repository it verifies.
     # A trailing `.+` after the version would accept refs/tags/v1latest and
     # refs/tags/v1.0.0/../evil, which are tags only in shape.
+    # DELIBERATE DIFFERENCE from the publisher, pinned by the inventory test: that script also
+    # caps the tag at 128 characters (the OCI tag-length limit); this expression does not.
+    # RE2 has no lookahead, so a joint length bound across the version components cannot be
+    # expressed without bounding each part separately, and a bound set too tight would REJECT a
+    # legitimate release — breaking admission of a real image, which is strictly worse than
+    # admitting an identity that cannot exist. An over-length tag is not a valid OCI reference,
+    # so no signature can carry one.
     - name: publishprovider
       cosign:
         keyless:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -89,8 +89,8 @@ spec:
     # any non-tag ref before it checks anything out, so a v* tag is the sole
     # legitimate signing ref. Pinning it rejects a package signed from an
     # arbitrary branch, which an unconstrained ref accepts.
-    # The tag grammar is spelled out here rather than deferred to the publisher's
-    # own release-version.sh check: this verifier is the independent half of that
+    # The tag grammar mirrors the publisher's `scripts/release-version.sh` EXACTLY, spelled
+    # out here rather than deferred to it: this verifier is the independent half of that
     # pair, so it must not inherit its boundary from the repository it verifies.
     # A trailing `.+` after the version would accept refs/tags/v1latest and
     # refs/tags/v1.0.0/../evil, which are tags only in shape.
@@ -99,7 +99,7 @@ spec:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$
     - name: ksailcd
       cosign:
         keyless:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -94,7 +94,7 @@ spec:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
     - name: ksailcd
       cosign:
         keyless:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -90,9 +90,9 @@ spec:
     # legitimate signing ref. Pinning it rejects a package signed from an
     # arbitrary branch, which an unconstrained ref accepts.
     # The tag grammar mirrors the publisher's `scripts/release-version.sh` OCI-semver
-    # grammar, spelled out here rather than deferred to it: this verifier is the independent
-    # out here rather than deferred to it: this verifier is the independent half of that
-    # pair, so it must not inherit its boundary from the repository it verifies.
+    # grammar, spelled out here rather than deferred to it: this verifier is the
+    # independent half of that pair, so it must not inherit its boundary from the
+    # repository it verifies.
     # A trailing `.+` after the version would accept refs/tags/v1latest and
     # refs/tags/v1.0.0/../evil, which are tags only in shape.
     # DELIBERATE DIFFERENCE from the publisher, pinned by the inventory test: that script also

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -85,16 +85,16 @@ spec:
     # publishapp would let a provider-workflow signature satisfy
     # verification for ANY app image (identities within one attestor are
     # OR'd per image).
-    # The ref is pinned to the default branch: publish-provider-package.yml is
-    # workflow_dispatch-only and publishes from main, so main is the sole
+    # The ref is pinned to release tags: publish-provider-package.yml rejects
+    # any non-tag ref before it checks anything out, so a v* tag is the sole
     # legitimate signing ref. Pinning it rejects a package signed from an
-    # arbitrary feature branch, which an unconstrained ref accepts.
+    # arbitrary branch, which an unconstrained ref accepts.
     - name: publishprovider
       cosign:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/heads/main$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v.+$
     - name: ksailcd
       cosign:
         keyless:
@@ -118,7 +118,7 @@ spec:
         .all(e, e > 0)
       message: >-
         provider-upjet package image is not signed by its repo's
-        publish-provider-package workflow on main (keyless cosign)
+        publish-provider-package workflow from a release tag (keyless cosign)
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)
         .filter(image, image.startsWith('ghcr.io/devantler-tech/ksail'))

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -89,12 +89,17 @@ spec:
     # any non-tag ref before it checks anything out, so a v* tag is the sole
     # legitimate signing ref. Pinning it rejects a package signed from an
     # arbitrary branch, which an unconstrained ref accepts.
+    # The tag grammar is spelled out here rather than deferred to the publisher's
+    # own release-version.sh check: this verifier is the independent half of that
+    # pair, so it must not inherit its boundary from the repository it verifies.
+    # A trailing `.+` after the version would accept refs/tags/v1latest and
+    # refs/tags/v1.0.0/../evil, which are tags only in shape.
     - name: publishprovider
       cosign:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$
     - name: ksailcd
       cosign:
         keyless:

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
@@ -16,14 +16,13 @@ spec:
             - name: package-runtime
               # Kubescape C-0017 (immutable container filesystem) + the hardening
               # set Kyverno injects at admission (Kubescape scans this stored spec,
-              # not the live pod). This provider (devantler-tech provider-upjet-unifi
-              # v0.1.0, older upjet) DOES write Terraform workspaces to /tmp/<uuid>,
-              # so a read-only root with no writable /tmp breaks EVERY managed
-              # resource — it is failing right now (cluster-wireguard SYNCED=False:
-              # "mkdir /tmp/<uuid>: read-only file system"). Kyverno already forces
-              # the pod read-only with no /tmp mount, so this DRC adds the writable
-              # /tmp emptyDir that both fixes reconciliation and makes the read-only
-              # root safe. runAsUser/runAsGroup left to Crossplane's default (2000).
+              # not the live pod). The provider writes Terraform workspaces to
+              # /tmp/<uuid>, so a read-only root with no writable /tmp breaks EVERY
+              # managed resource ("mkdir /tmp/<uuid>: read-only file system").
+              # Kyverno already forces the pod read-only with no /tmp mount, so this
+              # DRC adds the writable /tmp emptyDir that both keeps reconciliation
+              # working and makes the read-only root safe. runAsUser/runAsGroup are
+              # left to Crossplane's default (2000).
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/k8s/providers/hetzner/infrastructure/crossplane/provider-upjet-unifi.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/provider-upjet-unifi.yaml
@@ -13,6 +13,6 @@ kind: Provider
 metadata:
   name: provider-upjet-unifi
 spec:
-  package: ghcr.io/devantler-tech/provider-upjet-unifi:v0.1.0
+  package: ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0
   runtimeConfigRef:
     name: provider-upjet-unifi

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -163,7 +163,7 @@ readonly -a REQUIRED_PULL_TARGETS=(
   "devantler-tech/wedding-app:latest"
   "devantler-tech/ascoachingogvaner:latest"
   "devantler-tech/ksail:v${KSAIL_OPERATOR_VERSION}"
-  "devantler-tech/provider-upjet-unifi:v0.1.0"
+  "devantler-tech/provider-upjet-unifi:v1.0.0"
 )
 # These packages are intentionally private and have independent ACLs. A public
 # image (including KSail itself) can prove registry reachability but cannot

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
@@ -108,7 +108,7 @@ func TestRefreshesRootAndFanoutWithoutLeakingPlaintext(t *testing.T) {
 		"devantler-tech/wedding-app:latest",
 		"devantler-tech/ascoachingogvaner:latest",
 		"devantler-tech/ksail:v" + ksailOperatorVersion,
-		"devantler-tech/provider-upjet-unifi:v0.1.0",
+		"devantler-tech/provider-upjet-unifi:v1.0.0",
 	}
 	requireLinesEqual(t, readLines(f.registryReadLog), append(append([]string{}, requiredRegistryReads...), requiredRegistryReads...))
 	requireLinesEqual(t, readLines(f.fanoutLog), []string{

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -303,8 +303,9 @@ fi
 
 # accept -> a tag release-version.sh admits, so a signature can genuinely carry it.
 # reject -> a tag it refuses; the verifier must not accept what the publisher cannot produce.
-# The expression mirrors that script's OCI-semver grammar exactly, so the two columns agree on
-# prerelease internals too (a numeric prerelease identifier may not carry a leading zero).
+# The expression mirrors that script's OCI-semver GRAMMAR, so the two columns agree on prerelease
+# internals too (a numeric prerelease identifier may not carry a leading zero). It deliberately does
+# NOT mirror that script's 128-character tag cap; the block below pins that difference.
 identity_prefix='https://github.com/devantler-tech/provider-upjet-unifi/.github/workflows/publish-provider-package.yml@refs/tags/'
 grammar_failures=0
 grammar_checked=0
@@ -330,6 +331,22 @@ done
 failures=$((failures + grammar_failures))
 if [ "$grammar_failures" -eq 0 ]; then
   echo "ok    provider identity: release-tag grammar (${grammar_checked} tags)"
+fi
+
+# The one place the verifier deliberately does NOT mirror the publisher: release-version.sh caps
+# the tag at 128 characters (the OCI tag-length limit) while this subjectRegex carries no length
+# bound — RE2 has no lookahead, and a bound set too tight would reject a legitimate release.
+# Pin the difference so a change on either side is deliberate rather than silent.
+over_length_tag="v1.0.0-$(printf 'a%.0s' $(seq 1 122))"
+if [ "${#over_length_tag}" -ne 129 ]; then
+  echo "FAIL  boundary fixture is ${#over_length_tag} chars, expected 129"
+  failures=$((failures + 1))
+elif printf '%s' "${identity_prefix}${over_length_tag}" | grep -Eq "$talos_identity"; then
+  echo "ok    provider identity: the publisher's 128-char cap is deliberately NOT mirrored"
+else
+  echo "FAIL  the verifier now rejects a 129-char tag: the documented deliberate difference has"
+  echo "        changed, so update the DELIBERATE DIFFERENCE comment in both verifier files"
+  failures=$((failures + 1))
 fi
 
 # --- 9. THE DEFAULT PROBE PATH: no secret may reach argv -------------------

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -292,7 +292,7 @@ fi
 # and every assertion above would still pass while nothing verified the provider images.
 provider_validation="$(yq -r '
   [ .spec.validations[]
-    | select(.expression | test("startsWith\\(.ghcr\\.io/devantler-tech/provider-upjet-."))
+    | select(.expression | test("startsWith\\(.ghcr\\.io/devantler-tech/provider-upjet-.\\)"))
     | select(.expression | test("attestors\\.publishprovider")) ] | length' "$kyverno_policy")"
 if [ "$provider_validation" != "1" ]; then
   echo "FAIL  expected exactly 1 Kyverno validation routing provider-upjet-* to attestors.publishprovider, found ${provider_validation}"

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -260,12 +260,15 @@ fi
 # own release-version.sh: this verifier is the independent half of that pair, and inheriting its
 # boundary from the repository it verifies would defeat the point.
 #
-# Both files must carry the SAME identity. The Kyverno ImageValidatingPolicy gates pod admission
-# and the Talos ImageVerificationConfig gates the kubelet pull, so a package accepted by one and
-# rejected by the other is an ImagePullBackOff that neither file explains alone.
+# Both files must carry the SAME identity AND the same issuer. The Kyverno ImageValidatingPolicy
+# gates pod admission and the Talos ImageVerificationConfig gates the kubelet pull, so a package
+# accepted by one and rejected by the other is an ImagePullBackOff that neither file explains alone.
+# Comparing only the subject regex would let the issuer drift between them unnoticed.
 kyverno_policy="${repo_root}/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml"
 talos_identity="$(yq -r '.rules[] | select(.image == "ghcr.io/devantler-tech/provider-upjet-*") | .keyless.subjectRegex' "$real")"
+talos_issuer="$(yq -r '.rules[] | select(.image == "ghcr.io/devantler-tech/provider-upjet-*") | .keyless.issuer' "$real")"
 kyverno_identity="$(yq -r '.spec.attestors[] | select(.name == "publishprovider") | .cosign.keyless.identities[].subjectRegExp' "$kyverno_policy")"
+kyverno_issuer="$(yq -r '.spec.attestors[] | select(.name == "publishprovider") | .cosign.keyless.identities[].issuer' "$kyverno_policy")"
 
 if [ -z "$talos_identity" ] || [ "$talos_identity" = "null" ]; then
   echo "FAIL  no provider-upjet subjectRegex in ${real}"
@@ -275,19 +278,42 @@ elif [ "$talos_identity" != "$kyverno_identity" ]; then
   echo "        talos:   ${talos_identity}"
   echo "        kyverno: ${kyverno_identity}"
   failures=$((failures + 1))
+elif [ -z "$talos_issuer" ] || [ "$talos_issuer" = "null" ] || [ "$talos_issuer" != "$kyverno_issuer" ]; then
+  echo "FAIL  the provider ISSUER differs between the Talos and Kyverno verifiers"
+  echo "        talos:   ${talos_issuer}"
+  echo "        kyverno: ${kyverno_issuer}"
+  failures=$((failures + 1))
 else
-  echo "ok    provider identity: Talos and Kyverno carry the same regex"
+  echo "ok    provider identity: Talos and Kyverno carry the same regex and issuer"
+fi
+
+# The identity above only binds anything if Kyverno actually ROUTES provider-upjet-* images to that
+# attestor. Without this, `publishprovider` could be renamed, unreferenced, or the filter narrowed,
+# and every assertion above would still pass while nothing verified the provider images.
+provider_validation="$(yq -r '
+  [ .spec.validations[]
+    | select(.expression | test("startsWith\\(.ghcr\\.io/devantler-tech/provider-upjet-."))
+    | select(.expression | test("attestors\\.publishprovider")) ] | length' "$kyverno_policy")"
+if [ "$provider_validation" != "1" ]; then
+  echo "FAIL  expected exactly 1 Kyverno validation routing provider-upjet-* to attestors.publishprovider, found ${provider_validation}"
+  failures=$((failures + 1))
+else
+  echo "ok    provider identity: Kyverno routes provider-upjet-* to attestors.publishprovider"
 fi
 
 # accept -> a tag release-version.sh admits, so a signature can genuinely carry it.
 # reject -> a tag it refuses; the verifier must not accept what the publisher cannot produce.
+# The expression mirrors that script's OCI-semver grammar exactly, so the two columns agree on
+# prerelease internals too (a numeric prerelease identifier may not carry a leading zero).
 identity_prefix='https://github.com/devantler-tech/provider-upjet-unifi/.github/workflows/publish-provider-package.yml@refs/tags/'
 grammar_failures=0
 grammar_checked=0
 for tc in \
-  'accept v1.0.0' 'accept v0.1.0' 'accept v1.0.0-rc.1' 'accept v1.2.3-alpha.1.2' 'accept v10.20.30' \
+  'accept v1.0.0' 'accept v0.1.0' 'accept v10.20.30' 'accept v1.0.0-rc.1' 'accept v1.2.3-alpha.1.2' \
+  'accept v1.0.0-0' 'accept v1.0.0-alpha' 'accept v1.0.0-rc.1.2' \
   'reject v1latest' 'reject v1/anything' 'reject v1.0' 'reject v1' 'reject v1.0.0/../evil' \
-  'reject v01.0.0' 'reject v1.0.0-' 'reject v1.0.0-rc.1/evil'; do
+  'reject v01.0.0' 'reject v1.0.0-' 'reject v1.0.0-rc.1/evil' 'reject v1.0.0..0' \
+  'reject v1.0.0-01' 'reject v1.0.0-00' 'reject v1.0.0-1.01'; do
   grammar_checked=$((grammar_checked + 1))
   want="${tc%% *}"
   tag="${tc##* }"

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -252,6 +252,60 @@ else
   echo "ok    real rules: passes the completeness gate"
 fi
 
+# --- 12. the provider-package identity pins the RELEASE-TAG GRAMMAR --------
+# The identity's security value is "signed by publish-provider-package.yml, in a provider-upjet-*
+# repo, FROM A RELEASE TAG". An unanchored `.+` after the version satisfies every other clause of
+# that sentence while accepting refs that are tags only in shape (refs/tags/v1latest,
+# refs/tags/v1.0.0/../evil), so the grammar is asserted HERE rather than left to the publisher's
+# own release-version.sh: this verifier is the independent half of that pair, and inheriting its
+# boundary from the repository it verifies would defeat the point.
+#
+# Both files must carry the SAME identity. The Kyverno ImageValidatingPolicy gates pod admission
+# and the Talos ImageVerificationConfig gates the kubelet pull, so a package accepted by one and
+# rejected by the other is an ImagePullBackOff that neither file explains alone.
+kyverno_policy="${repo_root}/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml"
+talos_identity="$(yq -r '.rules[] | select(.image == "ghcr.io/devantler-tech/provider-upjet-*") | .keyless.subjectRegex' "$real")"
+kyverno_identity="$(yq -r '.spec.attestors[] | select(.name == "publishprovider") | .cosign.keyless.identities[].subjectRegExp' "$kyverno_policy")"
+
+if [ -z "$talos_identity" ] || [ "$talos_identity" = "null" ]; then
+  echo "FAIL  no provider-upjet subjectRegex in ${real}"
+  failures=$((failures + 1))
+elif [ "$talos_identity" != "$kyverno_identity" ]; then
+  echo "FAIL  the provider identity differs between the Talos and Kyverno verifiers"
+  echo "        talos:   ${talos_identity}"
+  echo "        kyverno: ${kyverno_identity}"
+  failures=$((failures + 1))
+else
+  echo "ok    provider identity: Talos and Kyverno carry the same regex"
+fi
+
+# accept -> a tag release-version.sh admits, so a signature can genuinely carry it.
+# reject -> a tag it refuses; the verifier must not accept what the publisher cannot produce.
+identity_prefix='https://github.com/devantler-tech/provider-upjet-unifi/.github/workflows/publish-provider-package.yml@refs/tags/'
+grammar_failures=0
+grammar_checked=0
+for tc in \
+  'accept v1.0.0' 'accept v0.1.0' 'accept v1.0.0-rc.1' 'accept v1.2.3-alpha.1.2' 'accept v10.20.30' \
+  'reject v1latest' 'reject v1/anything' 'reject v1.0' 'reject v1' 'reject v1.0.0/../evil' \
+  'reject v01.0.0' 'reject v1.0.0-' 'reject v1.0.0-rc.1/evil'; do
+  grammar_checked=$((grammar_checked + 1))
+  want="${tc%% *}"
+  tag="${tc##* }"
+  if printf '%s' "${identity_prefix}${tag}" | grep -Eq "$talos_identity"; then
+    got=accept
+  else
+    got=reject
+  fi
+  if [ "$got" != "$want" ]; then
+    echo "FAIL  provider identity should ${want} refs/tags/${tag}, got ${got}"
+    grammar_failures=$((grammar_failures + 1))
+  fi
+done
+failures=$((failures + grammar_failures))
+if [ "$grammar_failures" -eq 0 ]; then
+  echo "ok    provider identity: release-tag grammar (${grammar_checked} tags)"
+fi
+
 # --- 9. THE DEFAULT PROBE PATH: no secret may reach argv -------------------
 # Every case above goes through INVENTORY_PROBE_CMD, so none of them exercises the real probe —
 # the credential lookup, the Basic-authenticated token exchange, the Bearer manifest read, and the

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1330,20 +1330,55 @@ const (
 //
 //	54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1
 //
-// ⚠️ NOT AN APPROVAL — PENDING RECOMPUTATION AGAINST THE APPROVED RENDERER.
-// This merge brings together two independent re-approvals that BOTH moved this constant
-// from the same 54e239a1 baseline: main took it to 820705ec for the Kubescape scanner image
-// bump, and this branch took it to d3dd99e9 for the tag-signed provider package. The merged
-// tree therefore renders to a THIRD digest that neither side carries, and the value below is
-// simply main's — retained so the merge is a faithful record of the conflict rather than a
-// guess dressed up as a measurement.
+// Measured against BOTH parents of this merge for the tag-signed provider
+// package. Each parent had already re-approved this constant from the same
+// 54e239a1 baseline: main 606d60e8 moved it to 820705ec for the Kubescape
+// scanner image bump, and this branch f9f9c4fd moved it to d3dd99e9 for the
+// provider package. The merged tree therefore renders to a third aggregate that
+// neither parent carries, and the pinned approved renderer reports it as:
 //
-// It was NOT rendered here: validateRendererVersion pins kubectl v1.36.2 and this host has
-// v1.36.1, so the validator refused to run and no local digest could be produced. The CI
-// validate step runs the approved renderer and is the authority; it will FAIL against this
-// value until the real merged digest replaces it, together with the usual per-identity
-// conservation evidence. Do not treat the line below as reviewed.
-const expectedRenderedSurfaceSHA = "820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669"
+//	a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5
+//
+// The aggregate is the ONLY thing that moved. Against the merged tree the
+// approved renderer reports ZERO per-identity mismatches, ZERO missing
+// resources, ZERO duplicates and ZERO encrypted-SOPS findings, alongside the
+// same 35 known Flux substitution diagnostics that accompany any aggregate
+// mismatch and are not findings. expectedRenderedHashes is byte-identical to
+// both parents, so no per-identity approval changed either.
+//
+// Grant conservation was proven without reference to any particular renderer.
+// That is what makes it independent evidence: approving an aggregate is anchored
+// on CI's pinned renderer, whereas a conservation diff only needs the SAME
+// renderer on every tree it compares. Rendering all five production
+// overlays of the merged tree and of both parents with one and the same local
+// renderer — so any renderer difference cancels — and canonicalizing every Role,
+// ClusterRole, RoleBinding, ClusterRoleBinding and ServiceAccount yields one
+// identical digest on all three trees:
+//
+//	d4d72ffd648633176395dad81410796c1eb8bd8f6829382fc3538783daa95ad7
+//
+// at the usual stable counts: Role 11, ClusterRole 24, RoleBinding 15,
+// ClusterRoleBinding 12 and ServiceAccount 16, 78 documents in total. That
+// digest tracks grant content rather than merely existing: widening one rendered
+// ClusterRole (longhorn-stale-node-cleanup) by a single verb moves it to
+// 2b1af3ea336f811aebf9cadbdb4390013ac63f05ea2eec9ae22e6ac88322cc97, so the
+// three-way match is a measurement and not a vacuous join. The merge grants
+// nothing that neither parent already granted.
+//
+// The aggregate was corroborated by a SECOND, independent renderer. The pin is
+// enforced by CI provisioning — the workflow installs a SHA256-verified kubectl
+// v1.36.2 — and not by a runtime call, so validateAuthorization renders with
+// whatever kubectl is on PATH. Running it here against this host's v1.36.1
+// reproduces the same a015af05 aggregate that CI's v1.36.2 reported: the
+// committed value accepts it, and a deliberately wrong value is rejected with
+// that same computed digest. An unapproved renderer cannot approve anything on
+// its own, but two renderer patch levels agreeing is stronger than either alone.
+//
+// The two superseded approved aggregate digests were:
+//
+//	820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669
+//	d3dd99e90d1cd8d80cca5166aff3b52eea53d69352db7b834a1d197f60661ef4
+const expectedRenderedSurfaceSHA = "a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -57,7 +57,28 @@ const (
 // The approved surface includes the encrypted flux-system/variables-cluster
 // substitution source and the staged Cilium homogeneous-device activation.
 //
-// Measured against main d7062144 before approving this value: 550 documents on
+// Measured against main 36eadf01 before approving this value: 548 documents on
+// both sides, membership IDENTICAL — zero added, zero removed, zero renamed,
+// proven by set difference in BOTH directions over the complete
+// apiVersion|kind|namespace|name identity across all five rendered overlays.
+// Neither side carries a duplicate identity, so that pairing is one-to-one.
+// Exactly ONE entry's content moves:
+//
+//	pkg.crossplane.io/v1  Provider  provider-upjet-unifi
+//
+// Its only rendered delta is the package tag, v0.1.0 -> v1.0.0. The complete
+// five-overlay render differs by exactly ONE line out of 16507, so nothing else
+// in the projection moves at all. The DeploymentRuntimeConfig comment rewording
+// carried by the same change renders to nothing, because comments are stripped.
+//
+// No grant-bearing object moved: the surface carries 78 Role / ClusterRole /
+// RoleBinding / ClusterRoleBinding / ServiceAccount documents on BOTH sides
+// (11/24/15/12/16) and their canonical byte stream is identical. All 121
+// `aws`-bearing lines are byte-identical across the two trees, so nothing
+// granted to the aws/aws service account this validator exists to protect is
+// touched.
+//
+// Measured against main d7062144 before approving an earlier value: 550 documents on
 // main and 544 on this branch — six REMOVED, zero added, zero renamed, proven by
 // set difference in BOTH directions over the complete
 // apiVersion|kind|namespace|name identity across all five rendered overlays.
@@ -1315,7 +1336,7 @@ const (
 // previous approved aggregate digest was:
 //
 //	9309a857065fd3d675fd1a26414311d2c7a43717618c904a980c0fe8177839bd
-const expectedRenderedSurfaceSHA = "54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1"
+const expectedRenderedSurfaceSHA = "d3dd99e90d1cd8d80cca5166aff3b52eea53d69352db7b834a1d197f60661ef4"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -117,9 +117,9 @@ rules:
   # legitimate signing ref. Pinning it rejects a package signed from an
   # arbitrary branch, which an unconstrained ref accepts.
   # The tag grammar mirrors the publisher's `scripts/release-version.sh` OCI-semver
-  # grammar, spelled out here rather than deferred to it: this verifier is the independent
-  # out here rather than deferred to it: this verifier is the independent half of that
-  # pair, so it must not inherit its boundary from the repository it verifies.
+  # grammar, spelled out here rather than deferred to it: this verifier is the
+  # independent half of that pair, so it must not inherit its boundary from the
+  # repository it verifies.
   # A trailing `.+` after the version would accept refs/tags/v1latest and
   # refs/tags/v1.0.0/../evil, which are tags only in shape.
   # DELIBERATE DIFFERENCE from the publisher, pinned by the inventory test: that script also

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -116,10 +116,15 @@ rules:
   # any non-tag ref before it checks anything out, so a v* tag is the sole
   # legitimate signing ref. Pinning it rejects a package signed from an
   # arbitrary branch, which an unconstrained ref accepts.
+  # The tag grammar is spelled out here rather than deferred to the publisher's
+  # own release-version.sh check: this verifier is the independent half of that
+  # pair, so it must not inherit its boundary from the repository it verifies.
+  # A trailing `.+` after the version would accept refs/tags/v1latest and
+  # refs/tags/v1.0.0/../evil, which are tags only in shape.
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$
   # First-party APP images signed by the shared publish-app.yaml workflow in
   # devantler-tech/actions. Callers pin that reusable workflow by commit SHA, so
   # the ref admits that form alone and rejects everything else — a mutable ref

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -112,14 +112,14 @@ rules:
   # Mirrors the verify-app-images ImageValidatingPolicy provider-upjet-*
   # attestor (#2382). MUST precede the catch-all below (first-match-wins) or the
   # catch-all's publish-app.yaml identity rejects these (ImagePullBackOff).
-  # The ref is pinned to the default branch: publish-provider-package.yml is
-  # workflow_dispatch-only and publishes from main, so main is the sole
+  # The ref is pinned to release tags: publish-provider-package.yml rejects
+  # any non-tag ref before it checks anything out, so a v* tag is the sole
   # legitimate signing ref. Pinning it rejects a package signed from an
-  # arbitrary feature branch, which an unconstrained ref accepts.
+  # arbitrary branch, which an unconstrained ref accepts.
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/heads/main$
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v.+$
   # First-party APP images signed by the shared publish-app.yaml workflow in
   # devantler-tech/actions. Callers pin that reusable workflow by commit SHA, so
   # the ref admits that form alone and rejects everything else — a mutable ref

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -116,11 +116,19 @@ rules:
   # any non-tag ref before it checks anything out, so a v* tag is the sole
   # legitimate signing ref. Pinning it rejects a package signed from an
   # arbitrary branch, which an unconstrained ref accepts.
-  # The tag grammar mirrors the publisher's `scripts/release-version.sh` EXACTLY, spelled
+  # The tag grammar mirrors the publisher's `scripts/release-version.sh` OCI-semver
+  # grammar, spelled out here rather than deferred to it: this verifier is the independent
   # out here rather than deferred to it: this verifier is the independent half of that
   # pair, so it must not inherit its boundary from the repository it verifies.
   # A trailing `.+` after the version would accept refs/tags/v1latest and
   # refs/tags/v1.0.0/../evil, which are tags only in shape.
+  # DELIBERATE DIFFERENCE from the publisher, pinned by the inventory test: that script also
+  # caps the tag at 128 characters (the OCI tag-length limit); this expression does not.
+  # RE2 has no lookahead, so a joint length bound across the version components cannot be
+  # expressed without bounding each part separately, and a bound set too tight would REJECT a
+  # legitimate release — breaking admission of a real image, which is strictly worse than
+  # admitting an identity that cannot exist. An over-length tag is not a valid OCI reference,
+  # so no signature can carry one.
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -64,8 +64,8 @@
 #      ksail's OWN release pipeline (devantler-tech/ksail .github/workflows/
 #      cd.yaml; see that repo's GoReleaser `docker_signs` step), at a release tag.
 #   2. ghcr.io/devantler-tech/provider-upjet-* — the Crossplane provider packages
-#      — are signed by each provider repo's own publish-provider-package.yml, on
-#      its default branch (that workflow is workflow_dispatch-only).
+#      — are signed by each provider repo's own publish-provider-package.yml, at
+#      a release tag (that workflow rejects any non-tag ref).
 #   3. the app images (wedding-app, ascoachingogvaner, …) are signed by the
 #      shared publish-app.yaml workflow in devantler-tech/actions, pinned by
 #      commit SHA — the SAME form their Flux OCIRepository verify blocks and the

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -119,7 +119,7 @@ rules:
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v.+$
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v[0-9].+$
   # First-party APP images signed by the shared publish-app.yaml workflow in
   # devantler-tech/actions. Callers pin that reusable workflow by commit SHA, so
   # the ref admits that form alone and rejects everything else — a mutable ref

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -116,15 +116,15 @@ rules:
   # any non-tag ref before it checks anything out, so a v* tag is the sole
   # legitimate signing ref. Pinning it rejects a package signed from an
   # arbitrary branch, which an unconstrained ref accepts.
-  # The tag grammar is spelled out here rather than deferred to the publisher's
-  # own release-version.sh check: this verifier is the independent half of that
+  # The tag grammar mirrors the publisher's `scripts/release-version.sh` EXACTLY, spelled
+  # out here rather than deferred to it: this verifier is the independent half of that
   # pair, so it must not inherit its boundary from the repository it verifies.
   # A trailing `.+` after the version would accept refs/tags/v1latest and
   # refs/tags/v1.0.0/../evil, which are tags only in shape.
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$
   # First-party APP images signed by the shared publish-app.yaml workflow in
   # devantler-tech/actions. Callers pin that reusable workflow by commit SHA, so
   # the ref admits that form alone and rejects everything else — a mutable ref


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The UniFi Crossplane provider the cluster runs is signed from a mutable branch, so its signature says
"built by our workflow at some point on main" rather than "this is release v1.0.0". The tag-only
publisher that fixes this has already shipped upstream, and `v1.0.0` is published from its tag — but
the cluster is still pointed at the old branch-signed build, so we get none of the benefit.

### What

Points the provider at the tag-signed `v1.0.0`, and moves the two signature-verification rules — the
Kyverno admission policy and the Talos node-level pull rule — onto the release-tag identity at the
same time. Also moves the two other places pinning the same reference, the GHCR pull-permission probe
and its contract test, so they cannot drift apart.

**These have to move together, which is the one thing worth knowing here.** Bumping the package alone
leaves the new provider unable to pull; narrowing the rules alone breaks the provider running today.
Measured against the registry rather than reasoned about — each case is the other's control, and both
orders fail. That is why this is one change and not the two sequenced steps originally planned.

The identity stays pinned rather than opened up, so a package signed from an arbitrary branch is
still rejected — the protection the original pin was written for is preserved, and now attests a
specific release instead of a moving branch.

Checked before proposing: every API this repository uses exists at `v1.0.0`, and both cluster
overlays validate.

**Operational note:** this rolls out to the live cluster. The provider becoming healthy and pulling on
a node is the thing to watch after merge — it is the last acceptance criterion on #3162 and the only
one that cannot be proven before merge.

Fixes #3421
Fixes #3162
