### PR TITLE
fix(kubescape): restore self-hosted posture persistence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1042,6 +1042,14 @@ jobs:
           ksail workload validate
           ksail --config ksail.prod.yaml workload validate
 
+      - name: 🛡️ Validate Kubescape self-hosted scan persistence
+        # The in-cluster scanner has no SaaS backend. Versions before v4.0.12
+        # can override local-only intent and abort before persisting posture
+        # results, while the scheduler Job still reports success (#3275).
+        run: |
+          shellcheck scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+          bash scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+
       - name: 📤 Save kubeconform schema cache
         # Runs even if the validate step above failed (see the restore step's
         # note) so any schemas fetched before a rate-limit hit still persist for

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1043,6 +1043,7 @@ jobs:
           ksail --config ksail.prod.yaml workload validate
 
       - name: 🛡️ Validate Kubescape self-hosted scan persistence
+        if: needs.changes.outputs.k8s == 'true'
         # The in-cluster scanner has no SaaS backend. Versions before v4.0.12
         # can override local-only intent and abort before persisting posture
         # results, while the scheduler Job still reports success (#3275).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,7 @@ jobs:
               - 'scripts/validate-image-verifier-liveness.sh'
               - 'scripts/tests/test-validate-image-verifier-liveness.sh'
               - 'scripts/generate-kubescape-exceptions/**'
+              - 'scripts/tests/test-kubescape-self-hosted-scan-persistence.sh'
               - 'scripts/kubescape-backlog-bridge/**'
               # The updater and its annotation helper are one fail-closed
               # contract for the vendored CDI/KubeVirt manifests.

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -25,7 +25,7 @@
 # DELETE it (plus the manual step below, and the -format headlamp-configmap mode)
 # once the scanner is confirmed marking excepted controls in prod, OR once the
 # plugin is bumped to a release that reads the CRDs natively — whichever lands
-# first. As of 2026-07-28 neither holds: the deployed scanner is v4.0.10, which
+# first. As of 2026-08-28 neither holds: the deployed scanner is v4.0.12, which
 # should write status=passed/subStatus=w-exceptions into the stored
 # workloadconfigurationscansummaries, but a sweep of all ~2200 summaries found no
 # object carrying that subStatus (platform#2586, platform#2823).

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -179,9 +179,13 @@ spec:
         # which grant the scanner SA the `list` RBAC the getter needs (the chart never grants
         # it). The merged getter still swallows a missing-RBAC/CRD source, so this bump cannot
         # break scans on its own. Drop this override + the reader RBAC once the chart bumps
-        # the scanner to >= v4.0.10 AND grants it the securityexceptions RBAC. (Same
-        # component-image-ahead-of-chart pattern as the nodeAgent override above.)
-        tag: v4.0.10
+        # the scanner to >= v4.0.12 AND grants it the securityexceptions RBAC. v4.0.12
+        # also carries kubescape#2556: without a configured SaaS backend, older images
+        # can auto-enable submission and abort on account-ID chmod before the in-cluster
+        # receiver persists posture results. Keep the non-root security context; the
+        # scanner fix makes chmod best-effort and preserves explicit local-only intent.
+        # (Same component-image-ahead-of-chart pattern as the nodeAgent override above.)
+        tag: v4.0.12
     # Force the scheduled posture scan to run LOCAL-ONLY. REQUIRED — this is the
     # only thing keeping the scan off the cloud-submit path now that
     # capabilities.kubescapeOffline is disabled (see the note there). The chart

--- a/scripts/generate-kubescape-exceptions/headlamp-configmap.yaml.tmpl
+++ b/scripts/generate-kubescape-exceptions/headlamp-configmap.yaml.tmpl
@@ -25,7 +25,7 @@
 # DELETE it (plus the manual step below, and the -format headlamp-configmap mode)
 # once the scanner is confirmed marking excepted controls in prod, OR once the
 # plugin is bumped to a release that reads the CRDs natively — whichever lands
-# first. As of 2026-07-28 neither holds: the deployed scanner is v4.0.10, which
+# first. As of 2026-08-28 neither holds: the deployed scanner is v4.0.12, which
 # should write status=passed/subStatus=w-exceptions into the stored
 # workloadconfigurationscansummaries, but a sweep of all ~2200 summaries found no
 # object carrying that subStatus (platform#2586, platform#2823).

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to inspect the Kubescape HelmRelease'
+
+scanner_tag="$(yq -er '.spec.values.kubescape.image.tag | select(tag == "!!str")' "${helm_release}")" ||
+  fail 'the Kubescape scanner image tag is missing or is not a string'
+readonly scanner_tag
+
+scanner_version="${scanner_tag#v}"
+IFS=. read -r major minor patch extra <<<"${scanner_version}"
+readonly scanner_version major minor patch extra
+
+[[ -z "${extra}" && "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] ||
+  fail "Kubescape scanner tag ${scanner_tag} is not an exact vMAJOR.MINOR.PATCH release"
+
+# Kubescape <=4.0.11 can override an explicit local-only request, enter SaaS
+# submission with no backend configured, and abort on account-ID chmod before
+# its in-cluster report receiver persists WorkloadConfigurationScan objects.
+# Upstream kubescape#2556 fixes all three links and first ships in v4.0.12.
+if ((major < 4 || (major == 4 && minor == 0 && patch < 12))); then
+  fail "Kubescape scanner ${scanner_tag} predates v4.0.12 and can silently drop self-hosted posture results"
+fi
+
+keep_local="$(yq -er '
+  .spec.values.kubescapeScheduler.requestBody.commands[] |
+  select(.CommandName == "kubescapeScan") |
+  .args.scanV1.keepLocal
+' "${helm_release}")" || fail 'the scheduled Kubescape scan has no explicit keepLocal setting'
+readonly keep_local
+[[ "${keep_local}" == "true" ]] ||
+  fail 'the scheduled Kubescape scan must remain local-only in this self-hosted deployment'
+
+offline="$(yq -er '.spec.values.capabilities.kubescapeOffline' "${helm_release}")" ||
+  fail 'capabilities.kubescapeOffline is missing'
+readonly offline
+[[ "${offline}" == "disable" ]] ||
+  fail 'Kubescape offline mode must stay disabled so the scanner can fetch policy artifacts'
+
+printf 'Kubescape self-hosted scan persistence contract is valid (%s).\n' "${scanner_tag}"

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -17,12 +17,11 @@ scanner_tag="$(yq -er '.spec.values.kubescape.image.tag | select(tag == "!!str")
   fail 'the Kubescape scanner image tag is missing or is not a string'
 readonly scanner_tag
 
-scanner_version="${scanner_tag#v}"
-IFS=. read -r major minor patch extra <<<"${scanner_version}"
-readonly scanner_version major minor patch extra
-
-[[ -z "${extra}" && "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] ||
+[[ "${scanner_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] ||
   fail "Kubescape scanner tag ${scanner_tag} is not an exact vMAJOR.MINOR.PATCH release"
+readonly major="${BASH_REMATCH[1]}"
+readonly minor="${BASH_REMATCH[2]}"
+readonly patch="${BASH_REMATCH[3]}"
 
 # Kubescape <=4.0.11 can override an explicit local-only request, enter SaaS
 # submission with no backend configured, and abort on account-ID chmod before

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -17,7 +17,7 @@ scanner_tag="$(yq -er '.spec.values.kubescape.image.tag | select(tag == "!!str")
   fail 'the Kubescape scanner image tag is missing or is not a string'
 readonly scanner_tag
 
-[[ "${scanner_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] ||
+[[ "${scanner_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
   fail "Kubescape scanner tag ${scanner_tag} is not an exact vMAJOR.MINOR.PATCH release"
 readonly major="${BASH_REMATCH[1]}"
 readonly minor="${BASH_REMATCH[2]}"
@@ -34,7 +34,8 @@ fi
 keep_local="$(yq -er '
   .spec.values.kubescapeScheduler.requestBody.commands[] |
   select(.CommandName == "kubescapeScan") |
-  .args.scanV1.keepLocal
+  .args.scanV1.keepLocal |
+  select(tag == "!!bool")
 ' "${helm_release}")" || fail 'the scheduled Kubescape scan has no explicit keepLocal setting'
 readonly keep_local
 [[ "${keep_local}" == "true" ]] ||

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1315,7 +1315,21 @@ const (
 // previous approved aggregate digest was:
 //
 //	9309a857065fd3d675fd1a26414311d2c7a43717618c904a980c0fe8177839bd
-const expectedRenderedSurfaceSHA = "54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1"
+//
+// Measured against main 36eadf01 for the Kubescape self-hosted persistence
+// repair at 2a2dd717: the five production projections have identical
+// grant-bearing resources on both sides. Canonicalizing every Role,
+// ClusterRole, RoleBinding, ClusterRoleBinding, and ServiceAccount yields the
+// same digest, d328778e3d50a3c43346b6d012ab4c80b32a589e64ecaad74c63a68f078c3a53,
+// with stable counts: Role 11, ClusterRole 24, RoleBinding 15,
+// ClusterRoleBinding 12, and ServiceAccount 16. The validator reports no
+// missing, duplicate, or per-identity mismatches and the same 35 known Flux
+// substitution diagnostics. The aggregate changes only because the Kubescape
+// HelmRelease scanner image moves from v4.0.10 to v4.0.12; no security context
+// or authorization value changes. The previous approved aggregate digest was:
+//
+//	54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1
+const expectedRenderedSurfaceSHA = "820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The in-cluster posture scanner can compute a healthy compliance report while failing before its self-hosted result receiver persists the detailed findings. The scheduler only proves that it dispatched the scan, so the detail surface can remain stale without a failed Job.

## What

Upgrade the pinned Kubescape scanner to the first stable release containing the upstream no-backend submission fix. Keep the hardened non-root container and local-only scheduler contract intact, and add an executable CI guard that rejects scanner versions known to drop self-hosted results.

## Validation

The regression is RED on the previous scanner pin and GREEN on the fixed pin. Both local and production manifest overlays validate successfully, and the generated Headlamp artifact remains in sync.

Fixes #3275