### PR TITLE
fix(deploy): accept validating-only image policy handoff

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -1588,12 +1588,14 @@ image_verification_webhook_set_matches() {
   local webhook_file="$1"
   local operation="$2"
   local exclusive="$3"
+  local required="$4"
 
   jq -e \
     --argjson timeout "${IMAGE_VERIFICATION_WEBHOOK_TIMEOUT_SECONDS}" \
     --arg expected_path "/ivpol/${operation}/${IMAGE_VERIFICATION_POLICY}" \
     --arg retired "${RETIRED_IMAGE_VERIFICATION_POLICY}" \
-    --argjson exclusive "${exclusive}" '
+    --argjson exclusive "${exclusive}" \
+    --argjson required "${required}" '
     [
       .items[]?.webhooks[]?
       | select(
@@ -1601,19 +1603,31 @@ image_verification_webhook_set_matches() {
           and (.clientConfig.service.namespace // "") == "kyverno"
         )
     ] as $webhooks
-    | any(
-        $webhooks[];
-        (.clientConfig.service.path // "") == $expected_path
-        and .failurePolicy == "Fail"
-        and .timeoutSeconds == $timeout
-      )
+    | (
+      if $required then
+        any(
+          $webhooks[];
+          (.clientConfig.service.path // "") == $expected_path
+          and .failurePolicy == "Fail"
+          and .timeoutSeconds == $timeout
+        )
+      else
+        all(
+          $webhooks[];
+          ((.clientConfig.service.path // "") | contains($expected_path)) | not
+        )
+      end
+    )
     and (
       if $exclusive then
         all(
           $webhooks[];
           (.clientConfig.service.path // "") as $path
-          | if (($path | contains($expected_path)) or ($path | contains($retired))) then
-              $path == $expected_path
+          | if ($path | contains($retired)) then
+              false
+            elif ($path | contains($expected_path)) then
+              $required
+              and $path == $expected_path
               and .failurePolicy == "Fail"
               and .timeoutSeconds == $timeout
             else
@@ -1627,17 +1641,31 @@ image_verification_webhook_set_matches() {
   ' "${webhook_file}" >/dev/null
 }
 
+image_verification_policy_needs_mutating_webhook() {
+  # Kyverno v1.19 moved signature and attestation verification entirely into
+  # validation. Its IVPOL mutating webhook now only pins digests, and the API
+  # defaults mutateDigest to true when the field is absent.
+  yq -e \
+    '.spec.validationConfigurations.mutateDigest != false' \
+    "${IMAGE_VERIFICATION_POLICY_FILE}" >/dev/null
+}
+
 wait_for_image_verification_webhooks() {
   local exclusive="$1"
-  local attempt
+  local attempt mutation_required=false
+
+  if image_verification_policy_needs_mutating_webhook; then
+    mutation_required=true
+  fi
 
   for ((attempt = 1; attempt <= SYNC_ATTEMPTS; attempt++)); do
     assert_sync_lease_held || return 1
     read_image_verification_webhooks || return 1
     if image_verification_webhook_set_matches \
-      "${image_verification_mutating_webhooks_file}" "mutate" "${exclusive}" &&
+      "${image_verification_mutating_webhooks_file}" "mutate" "${exclusive}" \
+      "${mutation_required}" &&
       image_verification_webhook_set_matches \
-        "${image_verification_validating_webhooks_file}" "validate" "${exclusive}"; then
+        "${image_verification_validating_webhooks_file}" "validate" "${exclusive}" true; then
       return 0
     fi
     if ((attempt < SYNC_ATTEMPTS)); then
@@ -1653,7 +1681,12 @@ stage_image_verification_webhook_budget() {
       and .kind == "ImageValidatingPolicy"
       and .metadata.name == "verify-app-images"
       and .spec.failurePolicy == "Fail"
-      and .spec.webhookConfiguration.timeoutSeconds == 30' \
+      and .spec.webhookConfiguration.timeoutSeconds == 30
+      and (
+        .spec.validationConfigurations.mutateDigest == null
+        or .spec.validationConfigurations.mutateDigest == true
+        or .spec.validationConfigurations.mutateDigest == false
+      )' \
     "${IMAGE_VERIFICATION_POLICY_FILE}" >/dev/null; then
     echo "::error::The candidate consolidated image-verification policy is malformed or not fail-closed; refusing runtime pull probes."
     return 1
@@ -1697,10 +1730,11 @@ stage_image_verification_webhook_budget() {
   fi
 
   # The existing app-only policy can already own a webhook path with the same
-  # policy name. Require Kyverno to expose the new independent 30-second
-  # fail-closed mutate and validate paths while the retired KSail verifier is
-  # still present. This closes the policy-cache handoff gap: deletion is not
-  # evidence that the replacement has become effective.
+  # policy name. Require Kyverno to expose the candidate's exact independent
+  # fail-closed shape while the retired KSail verifier is still present:
+  # validation always, plus mutation only when digest pinning is enabled. This
+  # closes the policy-cache handoff gap: deletion is not evidence that the
+  # replacement has become effective.
   if ! wait_for_image_verification_webhooks false; then
     echo "::error::The consolidated fail-closed image-verification admission webhooks did not become effective before retirement of the existing KSail verifier."
     return 1

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -803,7 +803,8 @@ func fakeKubectlGetImageVerificationWebhooks(operation string) int {
 			"timeoutSeconds": 10,
 		})
 	}
-	if consolidated {
+	mutationRequired := os.Getenv("FAKE_IMAGE_VERIFICATION_MUTATION_REQUIRED") == "true"
+	if consolidated && (operation != "mutate" || mutationRequired) {
 		webhooks = append(webhooks, map[string]any{
 			"name": operation + ".verify-app-images.ivpol.kyverno.svc-fail",
 			"clientConfig": map[string]any{

--- a/scripts/tests/refresh-flux-ghcr-auth/fixture_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fixture_test.go
@@ -262,6 +262,16 @@ func (f *fixture) runHelperWithClusterState(
 	overrides map[string]string,
 	preserveClusterState bool,
 ) commandResult {
+	return f.runHelperExecutable(config, helperArgs, overrides, preserveClusterState, helperPath)
+}
+
+func (f *fixture) runHelperExecutable(
+	config any,
+	helperArgs []string,
+	overrides map[string]string,
+	preserveClusterState bool,
+	executable string,
+) commandResult {
 	f.t.Helper()
 	mustWriteJSON(f.t, f.decryptedConfig, config)
 	f.clearRunStatePreservingCluster(true, preserveClusterState)
@@ -277,7 +287,57 @@ func (f *fixture) runHelperWithClusterState(
 	for key, value := range overrides {
 		env[key] = value
 	}
-	return runCaptured(f.t, rootPath, env, helperPath, helperArgs...)
+	return runCaptured(f.t, rootPath, env, executable, helperArgs...)
+}
+
+func (f *fixture) runHelperWithMutationEnabled(
+	config any,
+	helperArgs []string,
+	overrides map[string]string,
+) commandResult {
+	f.t.Helper()
+	policyPath := filepath.Join(f.workspace, "verify-app-images.yaml")
+	policy := mustReadFile(filepath.Join(
+		rootPath,
+		"k8s",
+		"bases",
+		"infrastructure",
+		"cluster-policies",
+		"best-practices",
+		"verify-app-images.yaml",
+	))
+	if strings.Count(policy, "    mutateDigest: false") != 1 {
+		f.t.Fatal("canonical policy does not contain exactly one disabled mutateDigest field")
+	}
+	policy = strings.Replace(policy, "    mutateDigest: false", "    mutateDigest: true", 1)
+	if err := os.WriteFile(policyPath, []byte(policy), 0o600); err != nil {
+		f.t.Fatalf("write mutation-enabled policy: %v", err)
+	}
+
+	helper := mustReadFile(helperPath)
+	original := `readonly IMAGE_VERIFICATION_POLICY_FILE="k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml"`
+	if strings.Count(helper, original) != 1 {
+		f.t.Fatal("helper does not contain exactly one canonical image-verification policy path")
+	}
+	replacement := fmt.Sprintf(`readonly IMAGE_VERIFICATION_POLICY_FILE=%q`, policyPath)
+	helper = strings.Replace(helper, original, replacement, 1)
+	testHelper, err := os.CreateTemp(filepath.Join(rootPath, "scripts"), ".refresh-flux-ghcr-auth-test-*")
+	if err != nil {
+		f.t.Fatalf("create test helper: %v", err)
+	}
+	testHelperPath := testHelper.Name()
+	f.t.Cleanup(func() { _ = os.Remove(testHelperPath) })
+	if _, err := testHelper.WriteString(helper); err != nil {
+		_ = testHelper.Close()
+		f.t.Fatalf("write test helper: %v", err)
+	}
+	if err := testHelper.Close(); err != nil {
+		f.t.Fatalf("close test helper: %v", err)
+	}
+	if err := os.Chmod(testHelperPath, 0o700); err != nil {
+		f.t.Fatalf("make test helper executable: %v", err)
+	}
+	return f.runHelperExecutable(config, helperArgs, overrides, false, testHelperPath)
 }
 
 func (f *fixture) runKSailPullWrapper(config any, command []string, overrides map[string]string) commandResult {

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -1389,6 +1389,87 @@ func TestRetiredImageVerificationPolicyDeleteFailureFailsClosed(t *testing.T) {
 	requireNoLine(t, operations, "root-patch")
 }
 
+func TestValidationOnlyImageVerificationWebhookConverges(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_LOG_RUNTIME_PROBE_SUCCESS": "true",
+	})
+	requireSuccessResult(t, result)
+	operations := readLines(f.operationLog)
+	consolidatedReady := lineIndex(t, operations, "ivpol-policy-consolidated-ready")
+	ksailDelete := lineIndex(t, operations, "ivpol-policy-delete:verify-ksail-images")
+	webhookReady := lineIndex(t, operations, "ivpol-policy-webhooks-ready")
+	firstRuntimeProbe := lineIndex(
+		t,
+		operations,
+		"runtime-probe-success:prod-control-plane-2:ghcr.io/devantler-tech/wedding-app:latest",
+	)
+	if consolidatedReady >= ksailDelete || ksailDelete >= webhookReady || webhookReady >= firstRuntimeProbe {
+		t.Fatalf(
+			"unsafe validating-only handoff ordering: consolidated ready=%d ksail delete=%d webhook ready=%d runtime probe=%d",
+			consolidatedReady,
+			ksailDelete,
+			webhookReady,
+			firstRuntimeProbe,
+		)
+	}
+}
+
+func TestNonMutatingImageVerificationPolicyRejectsUnexpectedMutatingWebhook(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_IMAGE_VERIFICATION_MUTATION_REQUIRED": "true",
+		"FLUX_GHCR_SYNC_ATTEMPTS":                   "3",
+		"FLUX_GHCR_SYNC_INTERVAL":                   "0",
+	})
+	requireFailureResult(t, result)
+	requireContains(
+		t,
+		result.stdout+result.stderr,
+		"image-verification admission webhooks did not become effective before retirement",
+	)
+	operations := readLines(f.operationLog)
+	requireNoLine(t, operations, "ivpol-policy-delete:verify-ksail-images")
+	requireNotContains(t, strings.Join(operations, "\n"), "runtime-probe-success:")
+	requireNotContains(t, strings.Join(operations, "\n"), "node-drain:")
+	requireNoLine(t, operations, "root-patch")
+}
+
+func TestMutationEnabledImageVerificationPolicyRequiresBothWebhooks(t *testing.T) {
+	t.Parallel()
+	t.Run("missing mutating webhook", func(t *testing.T) {
+		f := newFixture(t)
+		result := f.runHelperWithMutationEnabled(validConfig(), nil, map[string]string{
+			"FLUX_GHCR_SYNC_ATTEMPTS": "3",
+			"FLUX_GHCR_SYNC_INTERVAL": "0",
+		})
+		requireFailureResult(t, result)
+		requireContains(
+			t,
+			result.stdout+result.stderr,
+			"image-verification admission webhooks did not become effective before retirement",
+		)
+		operations := readLines(f.operationLog)
+		requireNoLine(t, operations, "ivpol-policy-delete:verify-ksail-images")
+		requireNotContains(t, strings.Join(operations, "\n"), "node-drain:")
+		requireNoLine(t, operations, "root-patch")
+	})
+
+	t.Run("both webhooks", func(t *testing.T) {
+		f := newFixture(t)
+		result := f.runHelperWithMutationEnabled(validConfig(), nil, map[string]string{
+			"FAKE_IMAGE_VERIFICATION_MUTATION_REQUIRED": "true",
+		})
+		requireSuccessResult(t, result)
+		operations := readLines(f.operationLog)
+		requireLine(t, operations, "ivpol-policy-consolidated-ready")
+		requireLine(t, operations, "ivpol-policy-delete:verify-ksail-images")
+		requireLine(t, operations, "root-patch")
+	})
+}
+
 func TestImageVerificationWebhookConvergenceFailureFailsClosed(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- derive the required IVPOL webhook set from the candidate policy's `mutateDigest` setting
- accept Kyverno 1.19's validating-only, fail-closed shape when digest mutation is disabled
- reject stray mutation paths for a non-mutating policy and continue requiring both paths when mutation is enabled

## Root cause

Production runs Kyverno v1.19.0. In that release, image signature and attestation verification moved exclusively to the validating handler; the mutating handler only pins digests, and the webhook controller omits policies with `mutateDigest: false` from the mutating set. The platform policy sets that field to false, but the GHCR bridge still required both webhook paths. It therefore waited for an impossible state and blocked every merge-group deploy even though the effective validating path was fail-closed with the declared 30-second budget.

## Validation

- RED: validating-only effective state failed with `image-verification admission webhooks did not become effective`
- GREEN: validating-only state completes the handoff before retired-policy deletion and before runtime probes
- negative: unexpected mutating path is rejected for the current non-mutating policy
- negative: mutation-enabled policy fails without the mutating path and succeeds only with both paths
- `go test -timeout=20m ./scripts/tests/refresh-flux-ghcr-auth`
- `bash scripts/tests/test-refresh-flux-ghcr-auth-safety.sh`
- `shellcheck -x` on the bridge and sourced helpers
- `actionlint .github/workflows/ci.yaml`

Fixes #3426

