### PR TITLE
fix(kubescape): persist detailed posture results

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -46,20 +46,12 @@ spec:
     clusterName: ${cluster_name}
     capabilities:
       configurationScan: enable
-      # Chart default (disable) — deliberately NOT enabled on this air-gapped
-      # install. With continuousScan enabled the operator's continuous-scanning
-      # service fires a `kubescapeScan` command per watched-resource event, and
-      # that request path never carries `scanV1.keepLocal` (upstream's offline
-      # fix, helm-charts#862, only patched the scheduler CronJob request body —
-      # see kubescapeScheduler.requestBody below). Offline, every such scan runs
-      # Submit-mode, dies at cloud account-ID generation ("chmod
-      # /home/nonroot/.kubescape: read-only file system"), persists NO
-      # workloadconfigurationscan CRs, and the ~1-per-36s retry flood keeps the
-      # scan queue permanently backlogged — starving the daily keepLocal
-      # scheduler scan that DOES work (observed live 2026-07-04, issue #2463).
-      # Posture freshness offline = the daily scheduler scan. Re-enable only if
-      # upstream propagates keepLocal into the continuous-scan command path.
-      continuousScan: disable
+      # Chart 1.40.3 derives clusterData.continuousPostureScan from this value,
+      # and Kubescape only stores detailed WorkloadConfigurationScan results
+      # when that runtime flag is true. Summaries are stored unconditionally,
+      # so disabling this produces deceptively fresh summaries while detailed
+      # posture silently ages (observed live 2026-08-28, issue #3275).
+      continuousScan: enable
       vulnerabilityScan: enable
       # kubevuln emits an OpenVEX document per scanned image (stored in-cluster
       # as OpenVulnerabilityExchangeContainer CRs), marking CVEs not_affected
@@ -131,6 +123,15 @@ spec:
       # storage component (storage:true, keepLocal:true). Vulnerability scanning
       # (kubevuln) is unaffected either way — it never gated on the cloud submit.
       kubescapeOffline: disable
+    # Enabling continuousScan also starts the operator's event-driven scan
+    # service. Keep its resource set explicitly empty: operator v0.2.159 turns
+    # this into an empty GVR watch pool, so scheduled keepLocal scans persist
+    # detailed posture without restoring the per-resource queue flood observed
+    # in issue #2463. Add a match only after that command path carries keepLocal.
+    continuousScanning:
+      matchingRules:
+        match: []
+        namespaces: []
     hostScanner:
       enabled: true
     nodeAgent:

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -47,4 +47,35 @@ readonly offline
 [[ "${offline}" == "disable" ]] ||
   fail 'Kubescape offline mode must stay disabled so the scanner can fetch policy artifacts'
 
+# The scanner's API-server persistence handler stores detailed
+# WorkloadConfigurationScan objects only when clusterData.continuousPostureScan
+# is true. Chart 1.40.3 derives that flag from this capability.
+continuous_scan="$(yq -er '.spec.values.capabilities.continuousScan' "${helm_release}")" ||
+  fail 'capabilities.continuousScan is missing'
+readonly continuous_scan
+[[ "${continuous_scan}" == "enable" ]] ||
+  fail 'continuousScan must be enabled so scheduled scans persist detailed posture results'
+
+# Enabling the capability also starts the operator's event-driven scanner. Keep
+# its resource set empty: the pinned operator turns an empty match list into an
+# empty watch pool, preserving scheduled persistence without scan-on-change
+# traffic that omits keepLocal.
+continuous_match_count="$(yq -er '
+  .spec.values.continuousScanning.matchingRules.match |
+  select(tag == "!!seq") |
+  length
+' "${helm_release}")" || fail 'continuous-scanning matchingRules.match must be an explicit list'
+readonly continuous_match_count
+[[ "${continuous_match_count}" == "0" ]] ||
+  fail 'continuous-scanning matchingRules.match must stay empty in this self-hosted deployment'
+
+continuous_namespace_count="$(yq -er '
+  .spec.values.continuousScanning.matchingRules.namespaces |
+  select(tag == "!!seq") |
+  length
+' "${helm_release}")" || fail 'continuous-scanning matchingRules.namespaces must be an explicit list'
+readonly continuous_namespace_count
+[[ "${continuous_namespace_count}" == "0" ]] ||
+  fail 'continuous-scanning matchingRules.namespaces must stay empty in this self-hosted deployment'
+
 printf 'Kubescape self-hosted scan persistence contract is valid (%s).\n' "${scanner_tag}"

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1329,7 +1329,20 @@ const (
 // or authorization value changes. The previous approved aggregate digest was:
 //
 //	54e239a1e85e29ed66523bd1d01bfb588678d88e5567d9522a013385ca1285f1
-const expectedRenderedSurfaceSHA = "820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669"
+//
+// Measured against main 606d60e8 for the Kubescape detailed-result storage
+// repair: the five production projections retain the same selected identities,
+// every pinned per-identity fingerprint still passes, and the same 35 known
+// Flux-substitution diagnostics remain. Rendering chart 1.40.3 on both sides
+// produces byte-identical Roles, ClusterRoles, RoleBindings,
+// ClusterRoleBindings, and ServiceAccounts. The aggregate moves only because
+// the Kubescape HelmRelease enables continuousPostureScan and supplies an empty
+// event-scanning match set; neither value names a subject, grant, security
+// context, or authorization resource. The previous approved aggregate digest
+// was:
+//
+//	820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669
+const expectedRenderedSurfaceSHA = "0490a49adb4aa2efac35428b70044db00542aca22747137377bfc1d8c99fed66"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## What changed

- enable Kubescape's `continuousPostureScan` storage path so scheduled scans persist detailed `WorkloadConfigurationScan` objects
- render an explicit empty continuous-scanning match set, preserving zero event-driven resource watches and avoiding the previous scan queue flood
- extend the self-hosted persistence guard and approve the authorization-surface digest with chart-rendered RBAC parity evidence

## Root cause

The scanner abort fixed by #3423 was one failure layer. Once v4.0.12 completed a recovery scan, detailed posture still remained at 1,542 objects from 2026-06-27 because chart 1.40.3 rendered `clusterData.continuousPostureScan: false`. Kubescape gates detailed-object writes on that flag but writes summaries unconditionally, which is why consumers saw fresh-looking summaries over stale detail.

## Safety

The pinned operator maps an empty matching-rule list to an empty GVR watch pool. Exact chart rendering confirms `continuousPostureScan: true`, `{"match":[],"namespaces":[]}`, and byte-identical Roles, ClusterRoles, bindings, and service accounts before and after this change.

## Verification

- RED: the exact v4.0.12 recovery scan reached terminal state after evaluating and saving results, but detailed storage remained `count=1542`, newest `2026-06-27T14:50:44Z`
- GREEN: `scripts/tests/test-kubescape-self-hosted-scan-persistence.sh`
- GREEN: ShellCheck for the persistence guard
- GREEN: local and production Kustomize overlays
- GREEN: exact chart render of the storage flag and empty matching rules
- GREEN: authorization validator with unchanged per-identity and chart-rendered RBAC surfaces

Production recovery will be verified from an exact post-deploy scan before this incident is considered resolved.

Fixes #3275
