### PR TITLE
fix(deploy): report what the runtime pull probe actually observed

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -1379,12 +1379,36 @@ delete_runtime_pull_probe() {
 # the legacy outage state, machine config already held the new token while the
 # running runtime still presented a revoked predecessor. imagePullPolicy Always
 # forces a registry resolution even when the exact private image is cached.
+# Describe an observed probe Pod in bounded, non-sensitive terms. Kubelet and
+# registry messages can carry node detail and scoped token URLs, so this reports
+# only the enumerated state fields that make a failure diagnosable, never a raw
+# message. An unreadable document degrades to "unavailable" rather than failing
+# the caller: this is evidence for an error path that has already been decided.
+summarize_runtime_probe_state() {
+  jq -r '
+    (first(.status.containerStatuses[]? | select(.name == "pull-probe")) // null) as $cs
+    | [
+        "phase=" + (.status.phase // "unknown"),
+        "podReason=" + (.status.reason // "none"),
+        (if $cs == null then
+           "containerStatus=absent"
+         else
+           "containerStatus=present",
+           "waitingReason=" + ($cs.state.waiting.reason // "none"),
+           "terminatedReason=" + ($cs.state.terminated.reason // "none")
+         end)
+      ]
+    | join(" ")
+  ' "$1" 2>/dev/null || printf 'unavailable'
+}
+
 probe_node_runtime_pull() {
   local node_name="$1"
   local probe_image="$2"
   local probe_name
   local attempt create_attempt image_id waiting_reason auth_rejected
   local probe_created=0
+  local probe_phase probe_state_summary="unavailable"
 
   assert_sync_lease_held || return 1
   runtime_probe_sequence=$((runtime_probe_sequence + 1))
@@ -1501,6 +1525,8 @@ probe_node_runtime_pull() {
       echo "::error::Runtime probe on ${node_name} received an imagePullSecret, so it did not prove the running containerd credential; refusing the drain."
       return 1
     fi
+    probe_state_summary="$(summarize_runtime_probe_state \
+      "${runtime_probe_state_file}")"
     image_id="$(jq -r '
       first(.status.containerStatuses[]?
         | select(.name == "pull-probe")
@@ -1510,6 +1536,23 @@ probe_node_runtime_pull() {
     if [[ -n "${image_id}" ]]; then
       delete_runtime_pull_probe "${probe_name}" || return 1
       return 0
+    fi
+    # A terminal phase with no container status means the kubelet disposed of
+    # the Pod without ever starting the probe container (for example
+    # OutOfmemory/OutOfpods admission on the pinned node). The running
+    # containerd credential was never exercised, so this is a mechanism
+    # failure, not credential evidence. Polling it to the end of the budget
+    # would spend the whole window and then misreport it as an unproved
+    # runtime, which is exactly what made this undiagnosable in production.
+    probe_phase="$(jq -r '.status.phase // ""' \
+      "${runtime_probe_state_file}")"
+    if [[ "${probe_phase}" == "Failed" || "${probe_phase}" == "Succeeded" ]] &&
+      ! jq -e \
+        'any(.status.containerStatuses[]?; .name == "pull-probe")' \
+        "${runtime_probe_state_file}" >/dev/null; then
+      delete_runtime_pull_probe "${probe_name}" || true
+      echo "::error::The runtime pull probe on ${node_name} did not run (${probe_state_summary}); the running containerd credential was never exercised, so this is not credential evidence. Refusing the drain."
+      return 1
     fi
     waiting_reason="$(jq -r '
       first(.status.containerStatuses[]?
@@ -1545,7 +1588,7 @@ probe_node_runtime_pull() {
   done
 
   delete_runtime_pull_probe "${probe_name}" || true
-  echo "::error::Timed out proving the running containerd GHCR credential on ${node_name}; refusing to drain workloads onto an unproved runtime."
+  echo "::error::Timed out proving the running containerd GHCR credential on ${node_name} after $((SYNC_ATTEMPTS))x${SYNC_INTERVAL}s (last observed probe state: ${probe_state_summary}); refusing to drain workloads onto an unproved runtime."
   return 1
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -2026,6 +2026,23 @@ func fakeKubectlGetRuntimeProbe(args []string) int {
 	}
 	status := map[string]any{}
 	probeIP, _ := fakeNodeAddress(probeNode)
+	// A probe the kubelet never reported on: the Pod exists but carries no
+	// containerStatuses at all. This is what a still-Pending probe, or one the
+	// kubelet rejected outright (OutOfmemory/OutOfpods), actually looks like.
+	if wordListContains(os.Getenv("FAKE_RUNTIME_PROBE_STALLED_NODES"), probeNode) {
+		status["phase"] = defaultString(os.Getenv("FAKE_RUNTIME_PROBE_STALLED_PHASE"), "Pending")
+		if reason := os.Getenv("FAKE_RUNTIME_PROBE_STALLED_REASON"); reason != "" {
+			status["reason"] = reason
+		}
+		if message := os.Getenv("FAKE_RUNTIME_PROBE_STALLED_MESSAGE"); message != "" {
+			status["message"] = message
+		}
+		fmt.Println(encodeJSON(map[string]any{
+			"spec":   map[string]any{"imagePullSecrets": pullSecrets},
+			"status": status,
+		}))
+		return 0
+	}
 	if (wordListContains(os.Getenv("FAKE_RUNTIME_PULL_FAIL_NODES"), probeNode) &&
 		!markerExists("talos-reboot-"+probeIP)) ||
 		wordListContains(os.Getenv("FAKE_RUNTIME_PULL_FAIL_IMAGES"), probeImage) {

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -1717,3 +1717,49 @@ func TestNodeDiscoveryFailureAfterSafeFanoutKeepsRootUnchanged(t *testing.T) {
 		t.Error("failed discovery changed root auth")
 	}
 }
+
+// A probe the kubelet never reports on must not present as an unproved runtime
+// credential. The gate is fail-closed either way, but the emitted evidence has
+// to say what was actually observed, or the next occurrence costs another
+// production outage to diagnose (platform#3429).
+func TestRuntimeProbeTimeoutReportsObservedPodState(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_ALL_TALOS_NODES_STALE":       "true",
+		"FAKE_BOOTSTRAP_WORKER_NAME":       "prod-worker-2",
+		"FAKE_RUNTIME_PROBE_STALLED_NODES": "prod-worker-1 prod-worker-2 prod-control-plane-1 prod-control-plane-2 prod-control-plane-3",
+		"FAKE_EMPTY_WORKLOAD_NODES":        "prod-worker-2",
+	})
+	requireFailureResult(t, result)
+	output := result.stdout + result.stderr
+	requireContains(t, output, "Timed out proving the running containerd GHCR credential")
+	// The whole point: the operator can tell a stuck probe from a bad credential.
+	requireContains(t, output, "phase=Pending")
+	requireContains(t, output, "containerStatus=absent")
+}
+
+// A probe the kubelet actively rejected (OutOfmemory/OutOfpods) reaches a
+// terminal Failed phase. Polling it for the full budget and then blaming the
+// runtime credential is both slow and wrong, so it must fail fast and say so.
+func TestRuntimeProbeKubeletRejectionFailsFastAndDistinctly(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_ALL_TALOS_NODES_STALE":         "true",
+		"FAKE_BOOTSTRAP_WORKER_NAME":         "prod-worker-2",
+		"FAKE_RUNTIME_PROBE_STALLED_NODES":   "prod-worker-1 prod-worker-2 prod-control-plane-1 prod-control-plane-2 prod-control-plane-3",
+		"FAKE_RUNTIME_PROBE_STALLED_PHASE":   "Failed",
+		"FAKE_RUNTIME_PROBE_STALLED_REASON":  "OutOfmemory",
+		"FAKE_RUNTIME_PROBE_STALLED_MESSAGE": "Node didn't have enough resource: memory",
+		"FAKE_EMPTY_WORKLOAD_NODES":          "prod-worker-2",
+	})
+	requireFailureResult(t, result)
+	output := result.stdout + result.stderr
+	requireContains(t, output, "did not run")
+	requireContains(t, output, "podReason=OutOfmemory")
+	// Not a credential verdict: the runtime was never exercised.
+	requireNotContains(t, output, "Timed out proving the running containerd GHCR credential")
+	// Kubelet's raw message can carry node detail; it must not reach the log.
+	requireNotContains(t, output, "Node didn't have enough resource")
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Production deploys stopped today because a safety gate could not tell "this node's
registry credential is bad" apart from "my own check never finished". It reported the
first when the second had happened, and it reported it with no evidence attached — so
the only way to find out what had actually gone wrong was to reproduce the outage.

Every platform merge goes through that gate, so while it was stuck, nothing could ship.

### What this changes

The gate still refuses to proceed whenever it cannot prove a node is safe — that is the
whole point of it and it is unchanged. Two things are different:

- when the check runs out of time, the error now says what it actually saw, so the next
  occurrence is diagnosable from the log instead of from a second outage
- when the check was never able to start at all, it says so immediately and in different
  words, rather than waiting out the full window and then blaming the node's credential

Part of #3429
