### PR TITLE
fix(kubescape): prevent posture storage contention

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
@@ -64,11 +64,13 @@ spec:
         # ghcr.io (GitHub Container Registry) — blobs on the GitHub package CDN:
         - matchName: "ghcr.io"
         - matchName: "pkg-containers.githubusercontent.com"
-        # docker.io — registry v2 + token endpoints; blobs on the Cloudflare CDN:
+        # docker.io — registry v2 + token endpoints; blobs may redirect through
+        # either Cloudflare or CloudFront:
         - matchName: "index.docker.io"
         - matchName: "registry-1.docker.io"
         - matchName: "auth.docker.io"
         - matchName: "production.cloudflare.docker.com"
+        - matchName: "production.cloudfront.docker.com"
         # quay.io — registry + its documented blob CDN hosts:
         - matchName: "quay.io"
         - matchName: "cdn01.quay.io"

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -200,12 +200,23 @@ spec:
     # failure mode is a scan that aborts before persisting results. This value
     # fully replaces the chart default, so it must stay complete.
     kubescapeScheduler:
+      # Preserve the current posture window explicitly. Chart 1.40.3 hashes one
+      # shared cluster seed for both scheduler defaults, so posture and
+      # vulnerability scans otherwise render to the same instant and contend
+      # for the storage service's single-writer SQLite database.
+      scanSchedule: "12 9 * * *"
       requestBody:
         commands:
           - CommandName: "kubescapeScan"
             args:
               scanV1:
                 keepLocal: true
+    # Run vulnerability collection in a separate authored window. Keep at
+    # least the present eight-hour gap: both scans emit high-volume writes, and
+    # storage v0.0.297 drops a request when another writer holds SQLite beyond
+    # its busy timeout.
+    kubevulnScheduler:
+      scanSchedule: "12 1 * * *"
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.
     persistence:

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly root_dir
 readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
+readonly network_policy="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -12,6 +13,7 @@ fail() {
 }
 
 command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to inspect the Kubescape HelmRelease'
+command -v helm >/dev/null 2>&1 || fail 'helm is required to render the pinned Kubescape chart'
 
 scanner_tag="$(yq -er '.spec.values.kubescape.image.tag | select(tag == "!!str")' "${helm_release}")" ||
   fail 'the Kubescape scanner image tag is missing or is not a string'
@@ -77,5 +79,128 @@ continuous_namespace_count="$(yq -er '
 readonly continuous_namespace_count
 [[ "${continuous_namespace_count}" == "0" ]] ||
   fail 'continuous-scanning matchingRules.namespaces must stay empty in this self-hosted deployment'
+
+# The chart hashes one shared cluster seed for both default schedules, so its
+# nominally different posture/vulnerability defaults render to the same cron
+# instant. Both scans are high-volume writers to one SQLite-backed storage API;
+# keep their authored windows separated so detailed posture writes do not lose
+# the single-writer lock to vulnerability results. These value paths and their
+# CronJob mapping were verified against immutable chart 1.40.3; fail on a chart
+# bump so the new chart must be rendered and this contract deliberately renewed.
+chart_version="$(yq -er '
+  .spec.chart.spec.version |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the Kubescape chart version must be an exact string'
+readonly chart_version
+[[ "${chart_version}" == "1.40.3" ]] ||
+  fail 'the Kubescape chart changed; revalidate both rendered scheduler CronJobs before updating this guard'
+
+posture_schedule="$(yq -er '
+  .spec.values.kubescapeScheduler.scanSchedule |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the Kubescape posture schedule must be explicit'
+readonly posture_schedule
+[[ "${posture_schedule}" == "12 9 * * *" ]] ||
+  fail 'the Kubescape posture scan must stay in its authored daily window'
+
+vulnerability_schedule="$(yq -er '
+  .spec.values.kubevulnScheduler.scanSchedule |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the Kubescape vulnerability schedule must be explicit'
+readonly vulnerability_schedule
+[[ "${vulnerability_schedule}" == "12 1 * * *" ]] ||
+  fail 'the Kubescape vulnerability scan must stay separated from posture persistence'
+
+[[ "${posture_schedule}" != "${vulnerability_schedule}" ]] ||
+  fail 'posture and vulnerability scans must not contend for storage in the same window'
+
+# Exercise the immutable chart contract rather than trusting value-path names.
+# The K8s validation job already fetches Helm sources through KSail; this direct
+# render additionally proves that the reviewed chart maps each authored value to
+# the intended CronJob. Pin the archive bytes so a republished tag fails closed.
+readonly chart_repository='https://kubescape.github.io/helm-charts/'
+readonly chart_archive_sha256='2a0ffaa69068218f03a44139ac77c81905350208413c14ba697e9514f204af07'
+chart_dir="$(mktemp -d "${TMPDIR:-/tmp}/kubescape-chart.XXXXXX")" ||
+  fail 'could not create a temporary directory for the Kubescape chart'
+readonly chart_dir
+cleanup() {
+  rm -rf -- "${chart_dir}"
+}
+trap cleanup EXIT
+
+helm pull kubescape-operator \
+  --repo "${chart_repository}" \
+  --version "${chart_version}" \
+  --destination "${chart_dir}" >/dev/null || fail 'could not fetch the pinned Kubescape chart'
+readonly chart_archive="${chart_dir}/kubescape-operator-${chart_version}.tgz"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  chart_archive_actual_sha256="$(sha256sum "${chart_archive}" | cut -d ' ' -f 1)"
+else
+  chart_archive_actual_sha256="$(shasum -a 256 "${chart_archive}" | cut -d ' ' -f 1)"
+fi
+readonly chart_archive_actual_sha256
+[[ "${chart_archive_actual_sha256}" == "${chart_archive_sha256}" ]] ||
+  fail 'the pinned Kubescape chart archive checksum changed'
+
+readonly chart_values="${chart_dir}/values.yaml"
+readonly rendered_chart="${chart_dir}/rendered.yaml"
+yq '.spec.values' "${helm_release}" >"${chart_values}"
+helm template kubescape "${chart_archive}" \
+  --namespace kubescape \
+  --values "${chart_values}" >"${rendered_chart}" || fail 'the pinned Kubescape chart did not render'
+
+rendered_posture_schedule="$(yq ea -er '
+  select(.kind == "CronJob" and .metadata.name == "kubescape-scheduler") |
+  .spec.schedule |
+  select(tag == "!!str")
+' "${rendered_chart}")" || fail 'the rendered posture CronJob schedule is missing'
+readonly rendered_posture_schedule
+[[ "${rendered_posture_schedule}" == "${posture_schedule}" ]] ||
+  fail 'the rendered posture CronJob does not use the authored schedule'
+
+rendered_vulnerability_schedule="$(yq ea -er '
+  select(.kind == "CronJob" and .metadata.name == "kubevuln-scheduler") |
+  .spec.schedule |
+  select(tag == "!!str")
+' "${rendered_chart}")" || fail 'the rendered vulnerability CronJob schedule is missing'
+readonly rendered_vulnerability_schedule
+[[ "${rendered_vulnerability_schedule}" == "${vulnerability_schedule}" ]] ||
+  fail 'the rendered vulnerability CronJob does not use the authored schedule'
+
+[[ "${rendered_posture_schedule}" != "${rendered_vulnerability_schedule}" ]] ||
+  fail 'the rendered posture and vulnerability CronJobs must use separate windows'
+
+# Docker Hub currently redirects some blob downloads to CloudFront rather than
+# its older Cloudflare hostname. If the redirect host is blocked, kubevuln
+# retries timeouts for hours and keeps the SQLite storage backend contended
+# while posture results try to persist.
+docker_cloudfront_matches="$(yq -er '
+  [.spec.egress[].toFQDNs[]? |
+    select(.matchName == "production.cloudfront.docker.com")] |
+  length
+' "${network_policy}")" || fail 'could not inspect the Kubescape egress policy'
+readonly docker_cloudfront_matches
+[[ "${docker_cloudfront_matches}" == "1" ]] ||
+  fail 'Kubescape egress must allow the Docker Hub CloudFront blob redirect host exactly once'
+
+docker_cloudfront_https_rules="$(yq -er '
+  [.spec.egress[] |
+    select(
+      (.toFQDNs // []) |
+      map(.matchName) |
+      contains(["production.cloudfront.docker.com"])
+    ) |
+    select(
+      (.toPorts | length) == 1 and
+      (.toPorts[0].ports | length) == 1 and
+      .toPorts[0].ports[0].port == "443" and
+      .toPorts[0].ports[0].protocol == "TCP"
+    )] |
+  length
+' "${network_policy}")" || fail 'could not inspect the Kubescape CloudFront port restriction'
+readonly docker_cloudfront_https_rules
+[[ "${docker_cloudfront_https_rules}" == "1" ]] ||
+  fail 'Kubescape CloudFront egress must be restricted to TCP port 443'
 
 printf 'Kubescape self-hosted scan persistence contract is valid (%s).\n' "${scanner_tag}"

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1342,7 +1342,18 @@ const (
 // was:
 //
 //	820705ecf824f83fd8c693e46579dda594e51ce50a7044af5c340e8c3c013669
-const expectedRenderedSurfaceSHA = "0490a49adb4aa2efac35428b70044db00542aca22747137377bfc1d8c99fed66"
+//
+// Measured against main ed70dc25 for the Kubescape scan-window separation:
+// rendering chart 1.40.3 before and after the change produces byte-identical
+// Roles, ClusterRoles, RoleBindings, ClusterRoleBindings, and ServiceAccounts
+// (digest e75cc993ff03e6fb60365e1dff3beb4b084aeea046c10d488bbe0a32b6af411c;
+// counts 2, 5, 3, 6, and 5 respectively). The aggregate changes only because
+// the Kubescape HelmRelease now authors distinct posture and vulnerability
+// CronJob schedules; neither value names a subject, grant, security context,
+// or authorization resource. The previous approved aggregate digest was:
+//
+//	0490a49adb4aa2efac35428b70044db00542aca22747137377bfc1d8c99fed66
+const expectedRenderedSurfaceSHA = "026c985d74ec1230e7272488d2a55c028bb78916c4c8362f22c447c862111d78"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- separate daily posture and vulnerability scan windows
- allow Docker Hub's current blob redirect host so vulnerability retrieval cannot hold storage busy through repeated timeouts
- pin both conditions in the self-hosted persistence regression guard
- retain an unchanged rendered authorization surface

## Verification

- persistence regression guard passes against the exact pinned chart
- ShellCheck passes
- Kubescape and production Kustomize roots render
- exact chart render produces distinct CronJob schedules
- authorization suite passes 107/107
- authorization validator passes with the approved renderer
- rendered grant-bearing resources are byte-identical before and after

Fixes #3275
