### PR TITLE
fix(kubescape): allow Kubernetes registry CDN

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
@@ -76,12 +76,12 @@ spec:
         - matchName: "cdn01.quay.io"
         - matchName: "cdn02.quay.io"
         - matchName: "cdn03.quay.io"
-        # registry.k8s.io — redirects blob pulls to its Google Artifact Registry
-        # backing store (*.pkg.dev) and, for EU clients, to its prod S3 mirror
-        # buckets — kubevuln logged i/o timeouts pulling e.g. vpa-recommender from
-        # prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com.
-        # The pattern is scoped to the registry's own prod buckets (not all of S3):
+        # registry.k8s.io — redirects blob pulls through its CDN, its Google
+        # Artifact Registry backing store (*.pkg.dev), or, for EU clients, its
+        # prod S3 mirror buckets. The S3 pattern is scoped to the registry's own
+        # prod buckets rather than all of S3:
         - matchName: "registry.k8s.io"
+        - matchName: "cdn.registry.k8s.io"
         - matchPattern: "*.pkg.dev"
         - matchPattern: "prod-registry-k8s-io-*.s3.dualstack.*.amazonaws.com"
         # reg.kyverno.io — Kyverno's image registry:

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -171,36 +171,43 @@ readonly rendered_vulnerability_schedule
 [[ "${rendered_posture_schedule}" != "${rendered_vulnerability_schedule}" ]] ||
   fail 'the rendered posture and vulnerability CronJobs must use separate windows'
 
-# Docker Hub currently redirects some blob downloads to CloudFront rather than
-# its older Cloudflare hostname. If the redirect host is blocked, kubevuln
-# retries timeouts for hours and keeps the SQLite storage backend contended
-# while posture results try to persist.
-docker_cloudfront_matches="$(yq -er '
-  [.spec.egress[].toFQDNs[]? |
-    select(.matchName == "production.cloudfront.docker.com")] |
-  length
-' "${network_policy}")" || fail 'could not inspect the Kubescape egress policy'
-readonly docker_cloudfront_matches
-[[ "${docker_cloudfront_matches}" == "1" ]] ||
-  fail 'Kubescape egress must allow the Docker Hub CloudFront blob redirect host exactly once'
+# Registry blob pulls can redirect from their API hosts to separate CDN hosts.
+# If a redirect host is blocked, kubevuln retries timeouts for hours and keeps
+# the SQLite storage backend contended while posture results try to persist.
+assert_https_fqdn() {
+  local fqdn="$1"
+  local description="$2"
+  local matches
+  local https_rules
 
-docker_cloudfront_https_rules="$(yq -er '
-  [.spec.egress[] |
-    select(
-      (.toFQDNs // []) |
-      map(.matchName) |
-      contains(["production.cloudfront.docker.com"])
-    ) |
-    select(
-      (.toPorts | length) == 1 and
-      (.toPorts[0].ports | length) == 1 and
-      .toPorts[0].ports[0].port == "443" and
-      .toPorts[0].ports[0].protocol == "TCP"
-    )] |
-  length
-' "${network_policy}")" || fail 'could not inspect the Kubescape CloudFront port restriction'
-readonly docker_cloudfront_https_rules
-[[ "${docker_cloudfront_https_rules}" == "1" ]] ||
-  fail 'Kubescape CloudFront egress must be restricted to TCP port 443'
+  matches="$(REQUIRED_FQDN="${fqdn}" yq -er '
+    [.spec.egress[].toFQDNs[]? |
+      select(.matchName == strenv(REQUIRED_FQDN))] |
+    length
+  ' "${network_policy}")" || fail "could not inspect ${description} in the Kubescape egress policy"
+  [[ "${matches}" == "1" ]] ||
+    fail "Kubescape egress must allow ${description} exactly once"
+
+  https_rules="$(REQUIRED_FQDN="${fqdn}" yq -er '
+    [.spec.egress[] |
+      select(
+        (.toFQDNs // []) |
+        map(.matchName) |
+        contains([strenv(REQUIRED_FQDN)])
+      ) |
+      select(
+        (.toPorts | length) == 1 and
+        (.toPorts[0].ports | length) == 1 and
+        .toPorts[0].ports[0].port == "443" and
+        .toPorts[0].ports[0].protocol == "TCP"
+      )] |
+    length
+  ' "${network_policy}")" || fail "could not inspect ${description} port restriction"
+  [[ "${https_rules}" == "1" ]] ||
+    fail "Kubescape ${description} egress must be restricted to TCP port 443"
+}
+
+assert_https_fqdn 'production.cloudfront.docker.com' 'Docker Hub CloudFront blob redirect host'
+assert_https_fqdn 'cdn.registry.k8s.io' 'Kubernetes registry CDN redirect host'
 
 printf 'Kubescape self-hosted scan persistence contract is valid (%s).\n' "${scanner_tag}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- fix the live remaining cause of #3275: a blocked registry redirect kept the vulnerability backlog writing through the posture persist window, where SQLite rejected the detailed posture result
- allow the Kubernetes registry's current blob CDN redirect through the existing HTTPS-only egress rule
- generalize the persistence regression to require every observed registry redirect host exactly once on TCP port 443
- retain an unchanged rendered authorization surface

## Verification

- RED: persistence guard rejected the missing Kubernetes registry CDN host
- GREEN: persistence guard passes against the exact pinned Kubescape chart
- ShellCheck passes
- Kubescape and production Kustomize roots render
- authorization suite passes 107/107
- authorization validator passes with the approved renderer

## Live acceptance

- deploy through the protected merge queue
- verify the vulnerability backlog drains without redirect timeouts
- run one controlled posture scan and require a newer detailed stored result with non-empty controls

Fixes #3275
