### PR TITLE
fix(kubescape): publish storage lock compatibility image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,8 @@ jobs:
               - 'scripts/tests/test-validate-image-verifier-liveness.sh'
               - 'scripts/generate-kubescape-exceptions/**'
               - 'scripts/tests/test-kubescape-self-hosted-scan-persistence.sh'
+              - 'scripts/tests/test-kubescape-storage-hotfix.sh'
+              - '.github/workflows/publish-kubescape-storage-hotfix.yaml'
               - 'scripts/kubescape-backlog-bridge/**'
               # The updater and its annotation helper are one fail-closed
               # contract for the vendored CDI/KubeVirt manifests.
@@ -1051,6 +1053,16 @@ jobs:
         run: |
           shellcheck scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
           bash scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+
+      - name: 💾 Validate Kubescape storage compatibility image
+        if: needs.changes.outputs.k8s == 'true'
+        # Storage v0.0.303+ removes APIs this deployment still serves, while
+        # v0.0.297 drops contended SQLite writes after its default timeout.
+        # Keep the narrow compatibility build and its immutable deployment pin
+        # executable and reviewable until an upstream compatible release exists.
+        run: |
+          shellcheck scripts/tests/test-kubescape-storage-hotfix.sh
+          bash scripts/tests/test-kubescape-storage-hotfix.sh
 
       - name: 📤 Save kubeconform schema cache
         # Runs even if the validate step above failed (see the restore step's

--- a/.github/workflows/publish-kubescape-storage-hotfix.yaml
+++ b/.github/workflows/publish-kubescape-storage-hotfix.yaml
@@ -1,0 +1,164 @@
+name: Publish Kubescape Storage Hotfix
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/publish-kubescape-storage-hotfix.yaml
+      - k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch
+      - scripts/tests/test-kubescape-storage-hotfix.sh
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/publish-kubescape-storage-hotfix.yaml
+      - k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch
+      - scripts/tests/test-kubescape-storage-hotfix.sh
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  KUBESCAPE_STORAGE_SOURCE_COMMIT: b35788b68337134fc2514574cde1ba7f1225fd43
+  IMAGE: ghcr.io/devantler-tech/platform-kubescape-storage
+  IMAGE_TAG: v0.0.297-sqlite-busy-timeout.1-${{ github.sha }}
+  PATCH_PATH: k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch
+
+jobs:
+  verify:
+    name: Verify pinned source and patch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check out platform contract
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check out exact Kubescape storage source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: kubescape/storage
+          ref: ${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}
+          path: upstream
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: upstream/go.mod
+          cache: false
+
+      - name: Apply and test compatibility patch
+        working-directory: upstream
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}
+          HOTFIX_PATCH: ${{ github.workspace }}/${{ env.PATCH_PATH }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_COMMIT}"
+          git apply --check "${HOTFIX_PATCH}"
+          git apply "${HOTFIX_PATCH}"
+          git diff --check
+          go test ./pkg/registry/file
+
+      - name: Build compatibility image without publishing
+        working-directory: upstream
+        env:
+          VERSION: ${{ env.IMAGE_TAG }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --file build/Dockerfile \
+            --build-arg "image_version=${VERSION}" \
+            .
+
+  publish:
+    name: Publish and sign immutable image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check out platform contract
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check out exact Kubescape storage source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: kubescape/storage
+          ref: ${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}
+          path: upstream
+          persist-credentials: false
+
+      - name: Reapply reviewed patch to exact source
+        working-directory: upstream
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}
+          HOTFIX_PATCH: ${{ github.workspace }}/${{ env.PATCH_PATH }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_COMMIT}"
+          git apply --check "${HOTFIX_PATCH}"
+          git apply "${HOTFIX_PATCH}"
+          git diff --check
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push compatibility image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./upstream
+          file: ./upstream/build/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          build-args: image_version=${{ env.IMAGE_TAG }}
+          provenance: mode=max
+          sbom: true
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.IMAGE_TAG }}
+            io.devantler.kubescape-storage.upstream-revision=${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}
+
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign and verify published digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          test -n "${DIGEST}"
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+          cosign verify \
+            --certificate-identity "https://github.com/devantler-tech/platform/.github/workflows/publish-kubescape-storage-hotfix.yaml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE}@${DIGEST}"
+          printf 'Published signed image: %s@%s\n' "${IMAGE}" "${DIGEST}"

--- a/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch
+++ b/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch
@@ -1,0 +1,63 @@
+diff --git a/pkg/registry/file/sqlite.go b/pkg/registry/file/sqlite.go
+index 3d706533..c219537a 100644
+--- a/pkg/registry/file/sqlite.go
++++ b/pkg/registry/file/sqlite.go
+@@ -61,6 +61,14 @@ func NewPool(path string, size int) *sqlitemigration.Pool {
+ 		},
+ 		sqlitemigration.Options{
+ 			PoolSize: size,
++			// Under write bursts (per-container profile churn plus the
++			// RogueArtifact class) a writer can hold the lock beyond the
++			// driver's 10s default busy timeout on slow disks, surfacing raw
++			// "database is locked" to API clients. Wait instead of failing.
++			PrepareConn: func(conn *sqlite.Conn) error {
++				conn.SetBusyTimeout(60 * time.Second)
++				return nil
++			},
+ 		})
+ }
+ 
+diff --git a/pkg/registry/file/sqlite_test.go b/pkg/registry/file/sqlite_test.go
+index 9a1ba4ed..fb1e6a80 100644
+--- a/pkg/registry/file/sqlite_test.go
++++ b/pkg/registry/file/sqlite_test.go
+@@ -2,15 +2,39 @@ package file
+ 
+ import (
+ 	"context"
++	"path/filepath"
+ 	"testing"
+ 
+ 	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+ 	v1 "k8s.io/api/core/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"zombiezen.com/go/sqlite"
+ 	"zombiezen.com/go/sqlite/sqlitemigration"
++	"zombiezen.com/go/sqlite/sqlitex"
+ )
+ 
++func TestNewPoolSetsBusyTimeout(t *testing.T) {
++	pool := NewPool(filepath.Join(t.TempDir(), "busy-timeout.sq3"), 1)
++	require.NotNil(t, pool)
++	defer func() {
++		assert.NoError(t, pool.Close())
++	}()
++
++	conn, err := pool.Take(context.Background())
++	require.NoError(t, err)
++	defer pool.Put(conn)
++
++	var busyTimeoutMilliseconds int64
++	require.NoError(t, sqlitex.Execute(conn, "PRAGMA busy_timeout;", &sqlitex.ExecOptions{
++		ResultFunc: func(stmt *sqlite.Stmt) error {
++			busyTimeoutMilliseconds = stmt.ColumnInt64(0)
++			return nil
++		},
++	}))
++	assert.Equal(t, int64(60000), busyTimeoutMilliseconds)
++}
++
+ func TestMemoryConn(t *testing.T) {
+ 	pod := v1.Pod{
+ 		ObjectMeta: metav1.ObjectMeta{

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly workflow="${root_dir}/.github/workflows/publish-kubescape-storage-hotfix.yaml"
+readonly patch_file="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-busy-timeout.patch"
+readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
+readonly source_commit='b35788b68337134fc2514574cde1ba7f1225fd43'
+readonly image_repository='ghcr.io/devantler-tech/platform-kubescape-storage'
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail 'yq v4 is required'
+[[ -f "${workflow}" ]] || fail 'the Kubescape storage compatibility-image workflow is missing'
+[[ -f "${patch_file}" ]] || fail 'the Kubescape storage compatibility patch is missing'
+
+[[ "$(yq -er '.permissions | length' "${workflow}")" == '0' ]] ||
+  fail 'the hotfix workflow must deny permissions by default'
+[[ "$(yq -er '.jobs.publish.permissions.contents' "${workflow}")" == 'read' ]] ||
+  fail 'the publish job needs only read access to repository contents'
+[[ "$(yq -er '.jobs.publish.permissions.packages' "${workflow}")" == 'write' ]] ||
+  fail 'the publish job must scope package write permission to itself'
+[[ "$(yq -er '.jobs.publish.permissions."id-token"' "${workflow}")" == 'write' ]] ||
+  fail 'the publish job must scope OIDC signing permission to itself'
+
+[[ "$(yq -er '.env.KUBESCAPE_STORAGE_SOURCE_COMMIT' "${workflow}")" == "${source_commit}" ]] ||
+  fail 'the workflow must pin the reviewed v0.0.297 source commit'
+[[ "$(yq -er '.env.IMAGE' "${workflow}")" == "${image_repository}" ]] ||
+  fail 'the workflow image destination drifted'
+
+grep -qF 'repository: kubescape/storage' "${workflow}" ||
+  fail 'the workflow must check out the upstream storage source explicitly'
+# The literal GitHub expression is the contract.
+# shellcheck disable=SC2016
+grep -qF 'ref: ${{ env.KUBESCAPE_STORAGE_SOURCE_COMMIT }}' "${workflow}" ||
+  fail 'the upstream checkout must use the exact pinned commit'
+grep -qF 'persist-credentials: false' "${workflow}" ||
+  fail 'workflow checkouts must not persist credentials'
+grep -qF 'git apply --check' "${workflow}" ||
+  fail 'the compatibility patch must be checked before application'
+grep -qF 'go test ./pkg/registry/file' "${workflow}" ||
+  fail 'the patched upstream storage package must run its tests before publish'
+# IMAGE/DIGEST must expand in the workflow, not here.
+# shellcheck disable=SC2016
+grep -qF 'cosign sign --yes "${IMAGE}@${DIGEST}"' "${workflow}" ||
+  fail 'the published compatibility image must be keylessly signed by digest'
+
+[[ "$(grep -c '^diff --git ' "${patch_file}")" == '2' ]] ||
+  fail 'the compatibility patch must touch only implementation and regression-test files'
+grep -qF 'diff --git a/pkg/registry/file/sqlite.go b/pkg/registry/file/sqlite.go' "${patch_file}" ||
+  fail 'the compatibility patch does not modify SQLite pool setup'
+grep -qF 'diff --git a/pkg/registry/file/sqlite_test.go b/pkg/registry/file/sqlite_test.go' "${patch_file}" ||
+  fail 'the compatibility patch lacks an executable busy-timeout regression test'
+grep -qF 'conn.SetBusyTimeout(60 * time.Second)' "${patch_file}" ||
+  fail 'the compatibility patch must apply the upstream-reviewed 60-second timeout'
+grep -qF 'assert.Equal(t, int64(60000), busyTimeoutMilliseconds)' "${patch_file}" ||
+  fail 'the compatibility patch must prove the effective SQLite timeout'
+
+# The publishing PR deliberately lands before the deployment pin so the image
+# can be built, signed, and resolved to an immutable digest. Once an override is
+# present, fail closed on anything other than that signed repository + digest.
+storage_repository="$(yq -r '.spec.values.storage.image.repository // ""' "${helm_release}")"
+readonly storage_repository
+if [[ -n "${storage_repository}" ]]; then
+  [[ "${storage_repository}" == "${image_repository}" ]] ||
+    fail 'the deployed Kubescape storage image must use the reviewed compatibility repository'
+  storage_tag="$(yq -er '.spec.values.storage.image.tag | select(tag == "!!str")' "${helm_release}")" ||
+    fail 'the deployed Kubescape storage image tag is missing'
+  readonly storage_tag
+  [[ "${storage_tag}" =~ ^v0\.0\.297-sqlite-busy-timeout\.1@sha256:[0-9a-f]{64}$ ]] ||
+    fail 'the compatibility image must be pinned by immutable sha256 digest'
+fi
+
+printf 'Kubescape storage compatibility-image contract is valid.\n'


### PR DESCRIPTION
## Summary
- build Kubescape storage from the exact v0.0.297 source revision so the deployment keeps its still-consumed legacy APIs
- apply only the upstream-reviewed 60-second SQLite busy-timeout change, plus an executable PRAGMA regression test
- publish a per-commit GHCR image with SBOM/provenance and a keyless digest signature after main merges
- validate the source, patch, permissions, signing, and future immutable deployment pin in CI

## Incident evidence
Detailed posture persistence now reaches storage, but sustained vulnerability writes can hold SQLite beyond the default timeout. The storage API returns database-is-locked, while the scheduler still reaches a terminal success state and consumers keep reading stale posture. Schedule separation and registry egress repairs reduced the backlog but event-driven writers remain, so they cannot guarantee a quiet persistence window.

The upstream timeout fix is first released in v0.0.306. Storage v0.0.303+ removes APIs that this deployment still serves with live data, so a direct version bump is not compatible. This PR creates the narrow compatibility artifact first; a follow-up will pin its signed digest, deploy it, and require a fresh stored posture result before closing #3275.

## Validation
- RED: compatibility-image workflow missing
- GREEN: storage compatibility contract
- upstream Go package test against patched v0.0.297
- actionlint
- zizmor
- repository concurrency-queue validator
- git diff --check

> 🤖 Generated by the Daily AI Engineer (Codex lane). Exact-head review will be requested after CI starts.