### PR TITLE
fix(kubescape): enable storage image attestations

### DIFF
--- a/.github/workflows/publish-kubescape-storage-hotfix.yaml
+++ b/.github/workflows/publish-kubescape-storage-hotfix.yaml
@@ -122,6 +122,11 @@ jobs:
           git apply "${HOTFIX_PATCH}"
           git diff --check
 
+      - name: Set up Buildx container driver
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver: docker-container
+
       - name: Log in to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -45,6 +45,10 @@ grep -qF 'git apply --check' "${workflow}" ||
   fail 'the compatibility patch must be checked before application'
 grep -qF 'go test ./pkg/registry/file' "${workflow}" ||
   fail 'the patched upstream storage package must run its tests before publish'
+grep -qF 'uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0' "${workflow}" ||
+  fail 'the publish job must install the pinned Buildx container driver for attestations'
+grep -qF 'driver: docker-container' "${workflow}" ||
+  fail 'the publish job must select the attestation-capable Buildx container driver'
 # IMAGE/DIGEST must expand in the workflow, not here.
 # shellcheck disable=SC2016
 grep -qF 'cosign sign --yes "${IMAGE}@${DIGEST}"' "${workflow}" ||

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -45,10 +45,42 @@ grep -qF 'git apply --check' "${workflow}" ||
   fail 'the compatibility patch must be checked before application'
 grep -qF 'go test ./pkg/registry/file' "${workflow}" ||
   fail 'the patched upstream storage package must run its tests before publish'
-grep -qF 'uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0' "${workflow}" ||
-  fail 'the publish job must install the pinned Buildx container driver for attestations'
-grep -qF 'driver: docker-container' "${workflow}" ||
-  fail 'the publish job must select the attestation-capable Buildx container driver'
+readonly buildx_action='docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c'
+readonly build_action='docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a'
+buildx_count="$(BUILD_ACTION="${buildx_action}" yq -er '
+  [.jobs.publish.steps[] | select(.uses == strenv(BUILD_ACTION))] | length
+' "${workflow}")" || fail 'could not inspect the publish job Buildx setup'
+readonly buildx_count
+[[ "${buildx_count}" == '1' ]] ||
+  fail 'the publish job must contain exactly one pinned Buildx setup step'
+
+buildx_driver="$(BUILD_ACTION="${buildx_action}" yq -er '
+  .jobs.publish.steps[] |
+  select(.uses == strenv(BUILD_ACTION)) |
+  .with.driver
+' "${workflow}")" || fail 'the publish Buildx step has no explicit driver'
+readonly buildx_driver
+[[ "${buildx_driver}" == 'docker-container' ]] ||
+  fail 'the publish Buildx step must select the attestation-capable container driver'
+
+buildx_index="$(BUILD_ACTION="${buildx_action}" yq -er '
+  .jobs.publish.steps |
+  to_entries |
+  .[] |
+  select(.value.uses == strenv(BUILD_ACTION)) |
+  .key
+' "${workflow}")" || fail 'could not locate the publish Buildx setup step'
+readonly buildx_index
+image_build_index="$(BUILD_ACTION="${build_action}" yq -er '
+  .jobs.publish.steps |
+  to_entries |
+  .[] |
+  select(.value.uses == strenv(BUILD_ACTION)) |
+  .key
+' "${workflow}")" || fail 'could not locate the publish image-build step'
+readonly image_build_index
+((buildx_index < image_build_index)) ||
+  fail 'the Buildx container driver must be active before the attested image build'
 # IMAGE/DIGEST must expand in the workflow, not here.
 # shellcheck disable=SC2016
 grep -qF 'cosign sign --yes "${IMAGE}@${DIGEST}"' "${workflow}" ||


### PR DESCRIPTION
## Summary
- install the pinned Buildx container driver in the main-only publish job
- keep SBOM and maximum provenance enabled rather than weakening the supply-chain contract
- extend the executable workflow guard to require the attestation-capable driver

## Root cause
The first publication run failed closed before pushing an image because Docker Buildx used the runner default `docker` driver, which does not support attestations. The unprivileged PR build was green because it intentionally performs a local build without attestations. This change selects `docker-container` only where publishing requires it.

## Validation
- RED: compatibility contract rejected the missing Buildx setup
- GREEN: compatibility contract requires pinned setup-buildx and docker-container
- actionlint
- zizmor
- shellcheck
- git diff --check

Relates to #3275.

> 🤖 Generated by the Daily AI Engineer (Codex lane). Exact-head review will be requested after CI starts.