### PR TITLE
fix(kubescape): deploy contended-write storage hotfix

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -217,6 +217,20 @@ spec:
     # its busy timeout.
     kubevulnScheduler:
       scanSchedule: "12 1 * * *"
+    storage:
+      image:
+        # Storage v0.0.297 uses SQLite's 10-second default busy timeout, so
+        # concurrent vulnerability/profile writes can make a completed posture
+        # scan lose its detailed result with `database is locked`. The upstream
+        # 60-second fix first ships in v0.0.306, but v0.0.303+ removes the
+        # ApplicationProfile and NetworkNeighborhood APIs that this deployment
+        # still serves with live data. This compatibility image is the exact
+        # v0.0.297 source plus that upstream-reviewed timeout change and its
+        # executable PRAGMA regression test; the main-only publisher attaches
+        # SBOM/provenance and signs the digest before this pin may advance.
+        repository: ghcr.io/devantler-tech/platform-kubescape-storage
+        tag: "v0.0.297-sqlite-busy-timeout.1-6cf966641304389dcc414630ff92ed5876e1d019@sha256:a5abb439496eb1ffdb7c388aa0e4a06f2be70cc2e31e7ab1597b5c5c2a016b52"
+        pullPolicy: IfNotPresent
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.
     persistence:

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -171,6 +171,27 @@ readonly rendered_vulnerability_schedule
 [[ "${rendered_posture_schedule}" != "${rendered_vulnerability_schedule}" ]] ||
   fail 'the rendered posture and vulnerability CronJobs must use separate windows'
 
+storage_repository="$(yq -er '
+  .spec.values.storage.image.repository |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the authored Kubescape storage image repository is missing'
+readonly storage_repository
+storage_tag="$(yq -er '
+  .spec.values.storage.image.tag |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the authored Kubescape storage image tag is missing'
+readonly storage_tag
+rendered_storage_image="$(yq ea -er '
+  select(.kind == "Deployment" and .metadata.name == "storage") |
+  .spec.template.spec.containers[] |
+  select(.name == "apiserver") |
+  .image |
+  select(tag == "!!str")
+' "${rendered_chart}")" || fail 'the rendered Kubescape storage image is missing'
+readonly rendered_storage_image
+[[ "${rendered_storage_image}" == "${storage_repository}:${storage_tag}" ]] ||
+  fail 'the rendered Kubescape storage Deployment does not use the signed compatibility digest'
+
 # Registry blob pulls can redirect from their API hosts to separate CDN hosts.
 # If a redirect host is blocked, kubevuln retries timeouts for hours and keeps
 # the SQLite storage backend contended while posture results try to persist.

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -9,6 +9,7 @@ readonly patch_file="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/
 readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
 readonly source_commit='b35788b68337134fc2514574cde1ba7f1225fd43'
 readonly image_repository='ghcr.io/devantler-tech/platform-kubescape-storage'
+readonly image_tag='v0.0.297-sqlite-busy-timeout.1-6cf966641304389dcc414630ff92ed5876e1d019@sha256:a5abb439496eb1ffdb7c388aa0e4a06f2be70cc2e31e7ab1597b5c5c2a016b52'
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -97,19 +98,20 @@ grep -qF 'conn.SetBusyTimeout(60 * time.Second)' "${patch_file}" ||
 grep -qF 'assert.Equal(t, int64(60000), busyTimeoutMilliseconds)' "${patch_file}" ||
   fail 'the compatibility patch must prove the effective SQLite timeout'
 
-# The publishing PR deliberately lands before the deployment pin so the image
-# can be built, signed, and resolved to an immutable digest. Once an override is
-# present, fail closed on anything other than that signed repository + digest.
-storage_repository="$(yq -r '.spec.values.storage.image.repository // ""' "${helm_release}")"
+storage_repository="$(yq -er '
+  .spec.values.storage.image.repository |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the deployed Kubescape storage image repository is missing'
 readonly storage_repository
-if [[ -n "${storage_repository}" ]]; then
-  [[ "${storage_repository}" == "${image_repository}" ]] ||
-    fail 'the deployed Kubescape storage image must use the reviewed compatibility repository'
-  storage_tag="$(yq -er '.spec.values.storage.image.tag | select(tag == "!!str")' "${helm_release}")" ||
-    fail 'the deployed Kubescape storage image tag is missing'
-  readonly storage_tag
-  [[ "${storage_tag}" =~ ^v0\.0\.297-sqlite-busy-timeout\.1@sha256:[0-9a-f]{64}$ ]] ||
-    fail 'the compatibility image must be pinned by immutable sha256 digest'
-fi
+[[ "${storage_repository}" == "${image_repository}" ]] ||
+  fail 'the deployed Kubescape storage image must use the reviewed compatibility repository'
+
+storage_tag="$(yq -er '
+  .spec.values.storage.image.tag |
+  select(tag == "!!str" and length > 0)
+' "${helm_release}")" || fail 'the deployed Kubescape storage image tag is missing'
+readonly storage_tag
+[[ "${storage_tag}" == "${image_tag}" ]] ||
+  fail 'the deployed compatibility image must match the signed immutable tag and digest'
 
 printf 'Kubescape storage compatibility-image contract is valid.\n'

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1383,7 +1383,19 @@ const (
 //
 //	a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5
 //	026c985d74ec1230e7272488d2a55c028bb78916c4c8362f22c447c862111d78
-const expectedRenderedSurfaceSHA = "a8f0075fcb41fb5b79c608ee9816bfe3c01062bf7c94696f3a044f2f55336a2a"
+//
+// Measured against main 1d7e98af for the Kubescape contended-write storage
+// repair: the five production projections retain the same selected identities,
+// every pinned per-identity fingerprint still passes, and the same 35 known
+// Flux substitution diagnostics remain. The authored delta is one image
+// override in the Kubescape HelmRelease, pinning the storage Deployment to the
+// signed digest built from storage v0.0.297 plus the upstream-reviewed
+// 60-second SQLite busy timeout. It adds no subject, grant, security context,
+// authorization resource, or rendered object. The previous approved aggregate
+// digest was:
+//
+//	a8f0075fcb41fb5b79c608ee9816bfe3c01062bf7c94696f3a044f2f55336a2a
+const expectedRenderedSurfaceSHA = "c6545d119e6811f72a00783fa66c478ce5e330411a69a87a181ef0111d67479e"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
## Incident

Kubescape posture scans reach terminal completion but lose detailed results when concurrent vulnerability/profile writes hold the shared SQLite database. Storage reports `database is locked`, so posture consumers continue reading stale results.

## Root fix

Storage v0.0.297 uses SQLite's 10-second default busy timeout. The upstream 60-second fix first ships in later storage releases that also remove live APIs this deployment still serves, so a direct upgrade is not compatibility-safe.

This PR pins the storage Deployment to the already-built, SBOM/provenance-attested, keylessly signed compatibility image. Its source is exactly storage v0.0.297 plus the upstream-reviewed 60-second timeout change and executable PRAGMA regression test:

`ghcr.io/devantler-tech/platform-kubescape-storage:v0.0.297-sqlite-busy-timeout.1-6cf966641304389dcc414630ff92ed5876e1d019@sha256:a5abb439496eb1ffdb7c388aa0e4a06f2be70cc2e31e7ab1597b5c5c2a016b52`

The dedicated Kyverno signer policy merged in #3438. The exact Talos repository matcher merged and deployed in #3439, and the protected live audit proves every node has all four ordered rules plus trust material before this image phase begins.

## Verification

- RED: live posture scan completed but detailed persistence failed with `sqlite: database is locked`
- RED: deployment contract failed while the signed compatibility image override was absent
- GREEN: exact repository, tag, and digest contract passes
- pinned-chart render uses the exact signed digest: PASS
- self-hosted scan persistence contract: PASS
- production Kustomize render: PASS
- ShellCheck and diff hygiene: PASS
- exact CI renderer authorization tests and full validator: PASS
- authorization aggregate recomputed from merged main; per-identity approvals unchanged

Current-head CI and substantive exact-head review are complete with no actionable issues. After protected deployment, acceptance requires a controlled posture scan whose detailed stored result advances without a persistence error.

Relates to #3275
