### PR TITLE
feat(ci): guard against a render path acquiring a third network fetch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,6 +292,12 @@ jobs:
               # Both halves, for the same reason as the guard above.
               - 'scripts/guard-gitrepository-commit-pin.sh'
               - 'scripts/tests/test-guard-gitrepository-commit-pin.sh'
+              # Both halves, for the same reason as the guard above.
+              - 'scripts/guard-render-remote-resources.sh'
+              - 'scripts/tests/test-guard-render-remote-resources.sh'
+              # The reviewed disposition list the guard reads: editing a row
+              # changes what the guard permits, so it must re-run.
+              - 'scripts/render-remote-resource-exceptions.tsv'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -920,6 +926,25 @@ jobs:
         run: |
           bash scripts/guard-gitrepository-commit-pin.sh k8s
           bash scripts/tests/test-guard-gitrepository-commit-pin.sh
+
+      - name: 🌐 Validate no render path fetches over the network
+        if: needs.changes.outputs.k8s == 'true'
+        # Two entries in the prod controllers render fetch third-party manifests at
+        # render time, one of them from Cloudflare's `trunk` BRANCH. That makes the
+        # render irreproducible (the same commit can yield two different rendered
+        # surfaces), puts unreviewed third-party content into the prod authorization
+        # surface the EKS CI role validator exists to pin, and makes a required
+        # security gate hostage to a CDN — which is how it was found, when
+        # raw.githubusercontent.com returned 429 and took four authorization tests
+        # down on clean `main` (#3196).
+        #
+        # The two known entries carry rows in the reviewed exceptions list, so this
+        # runs green today and a THIRD one fails the build. A row must name a
+        # tracking issue, and a row whose URL is no longer referenced is itself a
+        # violation — so the list cannot quietly become the place remotes accumulate.
+        run: |
+          bash scripts/guard-render-remote-resources.sh k8s
+          bash scripts/tests/test-guard-render-remote-resources.sh
 
       - name: 📐 Validate LimitRange-premised suppressions actually have a LimitRange
         if: needs.changes.outputs.k8s == 'true'

--- a/scripts/guard-render-remote-resources.sh
+++ b/scripts/guard-render-remote-resources.sh
@@ -128,7 +128,7 @@ while IFS= read -r row || [ -n "$row" ]; do
   [ -n "$reason" ] ||
     die "$exceptions_file:$exception_lineno: '$url' carries no reason (column 3) — an exception without a stated reason is not reviewable"
   excepted_urls="$excepted_urls$url"$'\n'
-done < "$exceptions_file"
+done <"$exceptions_file"
 
 # ⚠️ AN EMPTY EXCEPTIONS FILE IS THE GOAL STATE, NOT A FAILURE.
 #
@@ -192,10 +192,10 @@ canonicalize() { # <dir> <entry>
 # tested against it.
 is_remote_form() { # <entry>
   case $1 in
-    *"://"*) return 0 ;;      # https://, http://, git::https://, ssh://
-    git@*) return 0 ;;        # scp-style SSH
-    git::*) return 0 ;;       # kustomize's explicit git prefix
-    gh:*) return 0 ;;         # kustomize's github shorthand
+    *"://"*) return 0 ;; # https://, http://, git::https://, ssh://
+    git@*) return 0 ;;   # scp-style SSH
+    git::*) return 0 ;;  # kustomize's explicit git prefix
+    gh:*) return 0 ;;    # kustomize's github shorthand
   esac
   # Schemeless host shorthand: `github.com/org/repo//path?ref=v1`. Requires a dot
   # in the first segment and a following slash, which no relative path in this tree

--- a/scripts/guard-render-remote-resources.sh
+++ b/scripts/guard-render-remote-resources.sh
@@ -106,9 +106,6 @@ root="$1"
 [ -d "$root" ] || die "root '$root' is not a directory"
 command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
 
-# `find` exits non-zero when it cannot traverse part of the tree. Reporting on a
-# partially-read tree is the same "could not read it" case as a parse failure, so it
-# is cannot-check rather than a verdict on what happened to be readable.
 exceptions_file="${RENDER_REMOTE_EXCEPTIONS:-$(dirname "$0")/render-remote-resource-exceptions.tsv}"
 [ -f "$exceptions_file" ] ||
   die "exceptions file '$exceptions_file' not found — refusing to run without the reviewed disposition list"
@@ -142,6 +139,18 @@ done < "$exceptions_file"
 # for was fixed. Anti-vacuity protects a SELECTOR that silently matched nothing; an
 # empty disposition list is a measured fact about the tree, and a good one.
 
+# 🔴 THE QUOTES AROUND "$1" ARE LOAD-BEARING, NOT STYLE.
+#
+# The value tested here comes from a kustomization, and it sits on the PATTERN side
+# of this `case`. Quoted, it is matched LITERALLY, which is what makes this safe.
+# Unquoted — the obvious "simplification" — a metacharacter in the entry becomes an
+# active glob, so `resources: [ "https://*" ]` would match the body of the first
+# excepted row, be counted as a tracked exception, and pass. That is a one-line
+# bypass of the entire guard, and it would also mark that row used, silencing the
+# stale-row check that would otherwise fire.
+#
+# Probed directly (2026-08-29): quoted → no match; the same expansion unquoted →
+# match. The test suite pins the behaviour so the quotes cannot be dropped silently.
 is_excepted() { # <url>
   case $'\n'"$excepted_urls" in *$'\n'"$1"$'\n'*) return 0 ;; esac
   return 1
@@ -149,6 +158,9 @@ is_excepted() { # <url>
 
 used_urls=""
 
+# `find` exits non-zero when it cannot traverse part of the tree. Reporting on a
+# partially-read tree is the same "could not read it" case as a parse failure, so it
+# is cannot-check rather than a verdict on what happened to be readable.
 candidates="$(find "$root" -name kustomization.yaml -type f -print 2>/dev/null)"
 find_status=$?
 [ "$find_status" -eq 0 ] ||

--- a/scripts/guard-render-remote-resources.sh
+++ b/scripts/guard-render-remote-resources.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+#
+# Fail when a kustomization under the given root pulls content over the NETWORK at
+# render time.
+#
+# THE RULE THIS ENFORCES: every `resources:` / `components:` / `bases:` entry must
+# resolve to a path inside this repository, and no `helmCharts:` entry may name a
+# remote `repo:`. A prod render must resolve entirely from reviewed, committed bytes.
+#
+# Why this matters (#3196). Two entries in the prod controllers render fetch
+# third-party manifests at render time, one of them from Cloudflare's `trunk`
+# BRANCH. Three consequences, none of which any existing check sees:
+#
+#   1. The render is not reproducible. `trunk` can move between two renders of the
+#      same commit, so one commit yields two different rendered surfaces with
+#      nothing in this repository having changed.
+#   2. Unreviewed third-party content reaches the prod AUTHORIZATION surface. The
+#      cert-approver bundle contributes ServiceAccount / ClusterRole /
+#      (Cluster)RoleBinding documents to the very surface the EKS CI role policy
+#      validator exists to pin. A `trunk` move lands with no PR and no digest.
+#   3. A required security gate becomes hostage to a third-party CDN. This was
+#      found because `raw.githubusercontent.com` returned HTTP 429 and the render
+#      aborted, taking four authorization tests down with it on clean `main`.
+#
+# The repository already has the mechanism for doing this properly:
+# `scripts/update-vendored-operators.sh` vendors pinned upstream bundles with
+# SHA-256 verification and CI re-validates the committed bytes. These entries are
+# the outliers, not a new problem. This guard stops a THIRD one appearing while
+# they are being vendored.
+#
+# 🔴 WHY THIS SCANS THE TREE RATHER THAN WALKING FROM THE RENDER ROOTS.
+#
+# The natural reading of "reachable from a prod render path" is a graph walk from
+# each render root. That form has a fail-open this one does not: the guard is only
+# as complete as its list of roots, so a render root added later — or renamed — is
+# simply not walked, and its remote entry is reported as clean. The failure is
+# silent and looks exactly like a healthy tree.
+#
+# Scanning every kustomization under the root is a strict SUPERSET of reachability,
+# so it cannot miss an offender for that reason. Its cost is the opposite error: it
+# would refuse a kustomization that is genuinely unreachable from any render and
+# deliberately remote. Measured over this repository (2026-08-29): 116
+# kustomizations under `k8s`, exactly 3 remote entries, all of them in the two
+# files #3196 names — so the superset costs nothing today. If a legitimately
+# unreachable remote ever appears, narrowing THIS guard is a reviewed change with
+# the reasoning recorded, which is the outcome we want; a missed root is not.
+#
+# 🔴 CLASSIFY LOCAL-FIRST, AND NEVER BY SCHEME ALONE.
+#
+# A `*://*` test is the obvious detector and it is a fail-open, because kustomize
+# accepts SCHEMELESS remote shorthand: `github.com/org/repo//path?ref=v1` is a
+# remote base and contains no `://` at all. So a scheme test reports it clean.
+#
+# But the repair cannot simply be "also match a bare hostname", because this is a
+# Kubernetes repository where DIRECTORIES ARE ROUTINELY NAMED LIKE HOSTS — an API
+# group such as `cert-manager.k8s.cloudflare.com` is a perfectly ordinary local
+# directory name, and a host-shaped pattern refuses it. That is a false refusal on
+# a correct file.
+#
+# Both are resolved by asking the FILESYSTEM first and the pattern second:
+#
+#   resolves to an existing path  -> LOCAL. Correct regardless of how it is spelled,
+#                                    so a host-named directory can never be refused.
+#   else, a recognised remote form -> REMOTE. The violation.
+#   else                           -> UNDECIDABLE, exit 2.
+#
+# ⚠️ ANTI-VACUITY, TWICE. Finding NO kustomization under the root is exit 2, and so
+# is examining ZERO entries. A selector that matched nothing is indistinguishable
+# from a clean tree, and reporting it as clean is the same class of failure this
+# guard exists to prevent one level down.
+#
+# ⚠️ AN UNDECIDABLE ENTRY IS cannot-check, NEVER clean. An entry that resolves to
+# nothing on disk and matches no remote form is one this guard cannot classify —
+# a dangling path, or a remote spelling not listed here. Skipping it is precisely
+# how a new remote spelling would enter unnoticed, so it stops the build and asks.
+#
+# 🔴 A REMOTE ENTRY IS ALLOWED ONLY BY A REVIEWED, ISSUE-REFERENCED EXCEPTION ROW.
+#
+# Wiring this guard while the two entries #3196 names are still remote would turn
+# `main` red, and the usual escape — ship the guard unwired until they are vendored
+# — is exactly the defect that keeps a working detector from ever running (#2757).
+# So the two known entries carry a row in
+# `scripts/render-remote-resource-exceptions.tsv`, and a THIRD one fails the build
+# today, which is child (1)'s whole point.
+#
+# A row is a tracked disposition, never an approval: it MUST name an issue, and a
+# row whose URL is no longer referenced is itself a VIOLATION. That is what stops
+# the exceptions list becoming the quiet place remote fetches accumulate — a
+# growing exception set is a smell, not progress.
+#
+# Exit codes:
+#   0  every entry resolves inside the repository
+#   1  at least one entry is remote and unexcepted, or an exception row is stale
+#   2  cannot check: bad usage, missing root, missing yq, unparseable YAML,
+#      an entry that cannot be classified, or an anti-vacuity failure
+
+set -uo pipefail
+
+die() {
+  printf 'guard-render-remote-resources: %s\n' "$*" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || die "usage: $0 <root-directory>"
+root="$1"
+[ -d "$root" ] || die "root '$root' is not a directory"
+command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
+
+# `find` exits non-zero when it cannot traverse part of the tree. Reporting on a
+# partially-read tree is the same "could not read it" case as a parse failure, so it
+# is cannot-check rather than a verdict on what happened to be readable.
+exceptions_file="${RENDER_REMOTE_EXCEPTIONS:-$(dirname "$0")/render-remote-resource-exceptions.tsv}"
+[ -f "$exceptions_file" ] ||
+  die "exceptions file '$exceptions_file' not found — refusing to run without the reviewed disposition list"
+
+# Parsed into two parallel newline-delimited lists. A malformed row is exit 2: a row
+# this guard cannot read is a disposition nobody can audit, and silently ignoring it
+# would let a remote entry pass on a row that says nothing.
+excepted_urls=""
+exception_lineno=0
+while IFS= read -r row || [ -n "$row" ]; do
+  exception_lineno=$((exception_lineno + 1))
+  case $row in '' | '#'*) continue ;; esac
+  url=$(printf '%s' "$row" | cut -f1)
+  issue=$(printf '%s' "$row" | cut -f2)
+  reason=$(printf '%s' "$row" | cut -f3)
+  [ -n "$url" ] ||
+    die "$exceptions_file:$exception_lineno: row has no URL"
+  printf '%s' "$issue" | grep -Eq '^#[0-9]+$' ||
+    die "$exceptions_file:$exception_lineno: '$url' names no tracking issue (column 2 must be #<number>, got '$issue') — an exception without an owner is not reviewable"
+  [ -n "$reason" ] ||
+    die "$exceptions_file:$exception_lineno: '$url' carries no reason (column 3) — an exception without a stated reason is not reviewable"
+  excepted_urls="$excepted_urls$url"$'\n'
+done < "$exceptions_file"
+
+# ⚠️ AN EMPTY EXCEPTIONS FILE IS THE GOAL STATE, NOT A FAILURE.
+#
+# The first draft of this guard died here on a file with no rows, by analogy with
+# the anti-vacuity checks above. That analogy is wrong and the check was a latent
+# outage: once #3196's children vendor the two entries, the correct file has zero
+# rows — so the guard would have failed CI at the exact moment the defect it exists
+# for was fixed. Anti-vacuity protects a SELECTOR that silently matched nothing; an
+# empty disposition list is a measured fact about the tree, and a good one.
+
+is_excepted() { # <url>
+  case $'\n'"$excepted_urls" in *$'\n'"$1"$'\n'*) return 0 ;; esac
+  return 1
+}
+
+used_urls=""
+
+candidates="$(find "$root" -name kustomization.yaml -type f -print 2>/dev/null)"
+find_status=$?
+[ "$find_status" -eq 0 ] ||
+  die "could not enumerate '$root' (find exit $find_status) — refusing to report a tree it could not fully read"
+
+# Collapse `.`/`..` textually rather than depending on realpath, so an entry that
+# names nothing still yields a stable path to test and report.
+canonicalize() { # <dir> <entry>
+  local base=$1 entry=$2 combined
+  case $entry in
+    /*) combined=$entry ;;
+    *) combined="$base/$entry" ;;
+  esac
+  printf '%s' "$combined" | awk -F/ -v abs="${combined:0:1}" '{
+    n = 0
+    for (i = 1; i <= NF; i++) {
+      if ($i == "" || $i == ".") continue
+      if ($i == "..") { if (n > 0) n--; continue }
+      parts[++n] = $i
+    }
+    out = ""
+    for (i = 1; i <= n; i++) out = out "/" parts[i]
+    if (abs == "/") print out; else print substr(out, 2)
+  }'
+}
+
+# The remote spellings kustomize accepts. Consulted ONLY after the filesystem has
+# said the entry does not resolve locally, so a host-named local directory is never
+# tested against it.
+is_remote_form() { # <entry>
+  case $1 in
+    *"://"*) return 0 ;;      # https://, http://, git::https://, ssh://
+    git@*) return 0 ;;        # scp-style SSH
+    git::*) return 0 ;;       # kustomize's explicit git prefix
+    gh:*) return 0 ;;         # kustomize's github shorthand
+  esac
+  # Schemeless host shorthand: `github.com/org/repo//path?ref=v1`. Requires a dot
+  # in the first segment and a following slash, which no relative path in this tree
+  # produces once the filesystem check above has already failed.
+  printf '%s' "$1" | grep -Eq '^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+/'
+}
+
+examined=0
+kustomizations=0
+violations=0
+excepted=0
+
+# A here-string, not a pipe: a piped `while` runs in a subshell, so every counter it
+# increments is discarded and the guard reports 0 violations over a dirty tree.
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  kustomizations=$((kustomizations + 1))
+  dir=$(dirname "$file")
+
+  # `bases:` is deprecated but still honoured by kustomize, so omitting it would
+  # leave a supported field through which a remote could enter unseen.
+  if ! entries="$(yq eval -r '(.resources // []) + (.components // []) + (.bases // []) | .[]' "$file" 2>/dev/null)"; then
+    die "could not parse '$file' — refusing to report a tree it could not read"
+  fi
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    examined=$((examined + 1))
+    target=$(canonicalize "$dir" "$entry")
+    # LOCAL FIRST. A path that exists is correct however it is spelled.
+    if [ -e "$target" ]; then
+      continue
+    fi
+    if is_remote_form "$entry"; then
+      if is_excepted "$entry"; then
+        used_urls="$used_urls$entry"$'\n'
+        excepted=$((excepted + 1))
+        continue
+      fi
+      violations=$((violations + 1))
+      printf 'VIOLATION %s: remote resource entry %s\n' "$file" "$entry" >&2
+      continue
+    fi
+    die "'$file': entry '$entry' resolves to nothing under this repository and matches no known remote form — cannot classify it, so this tree is unverified"
+  done <<<"$entries"
+
+  # A kustomize-native Helm fetch is the same render-time network dependency wearing
+  # a different field name, so closing `resources:` alone would leave the obvious
+  # bypass open.
+  if ! charts="$(yq eval -r '(.helmCharts // []) | .[] | (.repo // "")' "$file" 2>/dev/null)"; then
+    die "could not parse '$file' — refusing to report a tree it could not read"
+  fi
+  while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    examined=$((examined + 1))
+    if is_excepted "$repo"; then
+      used_urls="$used_urls$repo"$'\n'
+      excepted=$((excepted + 1))
+      continue
+    fi
+    violations=$((violations + 1))
+    printf 'VIOLATION %s: helmCharts entry fetches from remote repo %s\n' "$file" "$repo" >&2
+  done <<<"$charts"
+done <<<"$candidates"
+
+if [ "$kustomizations" -eq 0 ]; then
+  die "no kustomization.yaml found under '$root' — selector matched nothing, so nothing was verified"
+fi
+
+if [ "$examined" -eq 0 ]; then
+  die "found $kustomizations kustomization(s) under '$root' but not one resource entry — refusing to report a tree it did not actually read"
+fi
+
+# A row whose URL is no longer referenced has outlived its subject. Leaving it would
+# let the exception list drift into a standing permission for URLs nobody uses — and
+# on the day the same URL returns, it would be pre-approved with no review.
+while IFS= read -r url; do
+  [ -n "$url" ] || continue
+  case $'\n'"$used_urls" in
+    *$'\n'"$url"$'\n'*) ;;
+    *)
+      violations=$((violations + 1))
+      printf 'VIOLATION %s: exception row for %s is stale — no kustomization under %s references it any more; delete the row\n' \
+        "$exceptions_file" "$url" "$root" >&2
+      ;;
+  esac
+done <<<"$excepted_urls"
+
+if [ "$violations" -gt 0 ]; then
+  cat >&2 <<'FIX'
+
+A render must resolve entirely from bytes committed to this repository.
+
+Vendor the upstream content instead of fetching it, using the mechanism this
+repository already has:
+
+  scripts/update-vendored-operators.sh          # pin + SHA-256 verify + commit
+  scripts/update-vendored-operators.sh --validate-committed   # what CI re-checks
+
+Then replace the URL with the vendored path. If a remote is genuinely required,
+that is a reviewed decision and this guard is where it gets recorded (#3196).
+FIX
+  printf 'guard-render-remote-resources: %d remote entr(y/ies) across %d kustomization(s)\n' \
+    "$violations" "$kustomizations" >&2
+  exit 1
+fi
+
+printf 'guard-render-remote-resources: OK — %d entr(y/ies) across %d kustomization(s); %d in-repo, %d tracked exception(s)\n' \
+  "$examined" "$kustomizations" "$((examined - excepted))" "$excepted"
+exit 0

--- a/scripts/render-remote-resource-exceptions.tsv
+++ b/scripts/render-remote-resource-exceptions.tsv
@@ -1,0 +1,11 @@
+# Remote render entries that are KNOWN and TRACKED, not approved.
+#
+# Every row is a render-time network fetch that #3196 exists to remove. A row is a
+# temporary disposition with an owner, never a blessing: the fix is to vendor the
+# content (scripts/update-vendored-operators.sh) and DELETE the row. The guard
+# fails on a row whose URL is no longer referenced, so this list cannot rot.
+#
+# Columns, tab-separated:  <url>  <tracking-issue>  <reason>
+https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml	#3196	Cloudflare origin-ca-issuer CRD fetched from the moving `trunk` branch; vendoring is child (2) of #3196 and is the most urgent of the three.
+https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml	#3196	Second Cloudflare origin-ca-issuer CRD from the same moving `trunk` branch; vendored together with the row above.
+https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.11.0/deploy/ha-install.yaml	#3196	Pinned to tag v0.11.0 (no digest) and Renovate-managed; contributes ServiceAccount/ClusterRole/(Cluster)RoleBinding documents to the prod authorization surface. Vendoring is child (3) of #3196.

--- a/scripts/tests/test-guard-render-remote-resources.sh
+++ b/scripts/tests/test-guard-render-remote-resources.sh
@@ -95,7 +95,8 @@ mk() { # <name> -> echoes the root dir
 }
 
 printf '\n== exit 0: a clean tree ==\n'
-r=$(mk clean); mkdir -p "$r/base"
+r=$(mk clean)
+mkdir -p "$r/base"
 cat >"$r/base/cm.yaml" <<'Y'
 apiVersion: v1
 kind: ConfigMap
@@ -113,7 +114,8 @@ run_guard "$r"
 assert_rc "clean tree passes" 0 "$GUARD_RC"
 
 printf '\n== exit 0: a LOCAL directory named like a host is not a remote ==\n'
-r=$(mk hostnamed); mkdir -p "$r/cert-manager.k8s.cloudflare.com"
+r=$(mk hostnamed)
+mkdir -p "$r/cert-manager.k8s.cloudflare.com"
 cat >"$r/cert-manager.k8s.cloudflare.com/cm.yaml" <<'Y'
 apiVersion: v1
 kind: ConfigMap
@@ -170,7 +172,8 @@ assert_rc "remote under bases: is rejected" 1 "$GUARD_RC"
 assert_contains "names the bases url" "bases-field-marker"
 
 printf '\n== exit 1: a kustomize-native helm fetch ==\n'
-r=$(mk helmchart); mkdir -p "$r/local"
+r=$(mk helmchart)
+mkdir -p "$r/local"
 cat >"$r/local/cm.yaml" <<'Y'
 apiVersion: v1
 kind: ConfigMap
@@ -192,7 +195,8 @@ assert_rc "helmCharts remote repo is rejected" 1 "$GUARD_RC"
 assert_contains "names the helm repo" "helm-repo-marker"
 
 printf '\n== exit 1: an exception row that has gone stale ==\n'
-r=$(mk stale); mkdir -p "$r/base"
+r=$(mk stale)
+mkdir -p "$r/base"
 cat >"$r/base/cm.yaml" <<'Y'
 apiVersion: v1
 kind: ConfigMap
@@ -266,7 +270,8 @@ assert_rc "an unclassifiable entry is cannot-check" 2 "$GUARD_RC"
 assert_contains "says it cannot classify it" "cannot classify"
 
 printf '\n== exit 2: anti-vacuity — a tree with no kustomization at all ==\n'
-r=$(mk emptytree); mkdir -p "$r/sub"
+r=$(mk emptytree)
+mkdir -p "$r/sub"
 printf 'not a kustomization\n' >"$r/sub/readme.txt"
 run_guard "$r"
 assert_rc "no kustomization found is cannot-check, NOT a clean pass" 2 "$GUARD_RC"

--- a/scripts/tests/test-guard-render-remote-resources.sh
+++ b/scripts/tests/test-guard-render-remote-resources.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# Pins the render remote-resource guard's verdict in all THREE directions.
+#
+#   exit 0  every entry resolves in-repo, or carries a reviewed exception row
+#   exit 1  an unexcepted remote entry, or an exception row that has gone stale
+#   exit 2  the guard could not check — bad usage, missing root, unparseable YAML,
+#           an entry it cannot classify, a malformed exception row, or either
+#           anti-vacuity case
+#
+# The assertions that matter most are NOT the happy path. A guard that has only
+# seen passing input has proved nothing about what it rejects, and three of these
+# cases exist because the obvious implementation gets them wrong:
+#
+#   * SCHEMELESS REMOTE. `github.com/org/repo//path?ref=v1` is a kustomize remote
+#     base containing no `://`, so the natural scheme test reports it clean.
+#   * HOST-NAMED LOCAL DIRECTORY. This is a Kubernetes repository, so a directory
+#     named after an API group (`cert-manager.k8s.cloudflare.com`) is ordinary. A
+#     guard that repairs the case above by matching host-shaped strings then
+#     REFUSES a correct file.
+#   * STALE EXCEPTION ROW. An exception outliving its subject silently becomes a
+#     standing permission, pre-approving that URL on the day it returns.
+#
+# Every fixture carries its OWN distinctive resource name, so an assertion can only
+# be satisfied by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-render-remote-resources.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <root> [exceptions-file]
+  # `if` rather than toggling errexit: this file runs under `set -uo pipefail` with
+  # NO errexit, so `set -e` here would enable a mode the script never had.
+  if GUARD_OUT="$(RENDER_REMOTE_EXCEPTIONS="${2:-$scratch/empty-exceptions.tsv}" "$guard" "$1" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
+}
+
+assert_rc() { # <label> <expected-rc> <actual-rc>
+  assertions=$((assertions + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s (exit %s)\n' "$1" "$3"
+  else
+    printf '  FAIL %s: expected exit %s, got %s\n' "$1" "$2" "$3"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() { # <label> <needle>
+  assertions=$((assertions + 1))
+  # A here-string, NOT a pipe: `grep -q` exits on the first match, and the SIGPIPE
+  # the upstream `printf` then takes becomes the pipeline status under `pipefail`,
+  # so a needle matching EARLY would read as a failed assertion.
+  if grep -qF -- "$2" <<<"$GUARD_OUT"; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: output did not contain %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+# A fixture that did not actually get written passes a "the guard rejected it"
+# assertion for the wrong reason, so every fixture is verified to contain the line
+# that makes it the case it claims to be.
+fixture() { # <path> <marker>
+  assertions=$((assertions + 1))
+  if grep -qF -- "$2" "$1" 2>/dev/null; then
+    printf '  ok   fixture built: %s\n' "$(basename "$(dirname "$1")")"
+  else
+    printf '  FAIL fixture NOT built as intended: %s missing %s\n' "$1" "$2"
+    failures=$((failures + 1))
+  fi
+}
+
+# Deliberately EMPTY, and that is a case in its own right: once #3196's children
+# vendor the two live entries, the committed exceptions file has zero rows. An
+# earlier draft of the guard died on that, which would have failed CI at the exact
+# moment the defect was fixed. Every case below that expects a clean pass is also
+# an assertion that an empty disposition list is a legal, clean state.
+: >"$scratch/empty-exceptions.tsv"
+
+mk() { # <name> -> echoes the root dir
+  mkdir -p "$scratch/$1"
+  printf '%s' "$scratch/$1"
+}
+
+printf '\n== exit 0: a clean tree ==\n'
+r=$(mk clean); mkdir -p "$r/base"
+cat >"$r/base/cm.yaml" <<'Y'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clean-case-marker
+Y
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base/cm.yaml
+Y
+fixture "$r/kustomization.yaml" "base/cm.yaml"
+run_guard "$r"
+assert_rc "clean tree passes" 0 "$GUARD_RC"
+
+printf '\n== exit 0: a LOCAL directory named like a host is not a remote ==\n'
+r=$(mk hostnamed); mkdir -p "$r/cert-manager.k8s.cloudflare.com"
+cat >"$r/cert-manager.k8s.cloudflare.com/cm.yaml" <<'Y'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: host-named-dir-marker
+Y
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager.k8s.cloudflare.com/cm.yaml
+Y
+fixture "$r/kustomization.yaml" "cert-manager.k8s.cloudflare.com/cm.yaml"
+run_guard "$r"
+assert_rc "host-named local directory is NOT refused" 0 "$GUARD_RC"
+
+printf '\n== exit 1: an unexcepted https remote ==\n'
+r=$(mk httpsremote)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://example.invalid/https-remote-marker/install.yaml
+Y
+fixture "$r/kustomization.yaml" "https-remote-marker"
+run_guard "$r"
+assert_rc "unexcepted https remote is rejected" 1 "$GUARD_RC"
+assert_contains "names the offending url" "https-remote-marker"
+
+printf '\n== exit 1: a SCHEMELESS remote (no :// at all) ==\n'
+r=$(mk schemeless)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/org/schemeless-remote-marker//deploy?ref=v1.2.3
+Y
+fixture "$r/kustomization.yaml" "schemeless-remote-marker"
+run_guard "$r"
+assert_rc "schemeless remote shorthand is rejected" 1 "$GUARD_RC"
+assert_contains "names the schemeless url" "schemeless-remote-marker"
+
+printf '\n== exit 1: a remote hidden in the deprecated bases: field ==\n'
+r=$(mk basesfield)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - https://example.invalid/bases-field-marker/install.yaml
+Y
+fixture "$r/kustomization.yaml" "bases-field-marker"
+run_guard "$r"
+assert_rc "remote under bases: is rejected" 1 "$GUARD_RC"
+assert_contains "names the bases url" "bases-field-marker"
+
+printf '\n== exit 1: a kustomize-native helm fetch ==\n'
+r=$(mk helmchart); mkdir -p "$r/local"
+cat >"$r/local/cm.yaml" <<'Y'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helm-case-marker
+Y
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local/cm.yaml
+helmCharts:
+  - name: whatever
+    repo: https://example.invalid/helm-repo-marker
+Y
+fixture "$r/kustomization.yaml" "helm-repo-marker"
+run_guard "$r"
+assert_rc "helmCharts remote repo is rejected" 1 "$GUARD_RC"
+assert_contains "names the helm repo" "helm-repo-marker"
+
+printf '\n== exit 1: an exception row that has gone stale ==\n'
+r=$(mk stale); mkdir -p "$r/base"
+cat >"$r/base/cm.yaml" <<'Y'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stale-row-case-marker
+Y
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base/cm.yaml
+Y
+printf 'https://example.invalid/stale-exception-marker/x.yaml\t#3196\tno longer referenced\n' >"$scratch/stale.tsv"
+fixture "$scratch/stale.tsv" "stale-exception-marker"
+run_guard "$r" "$scratch/stale.tsv"
+assert_rc "stale exception row is rejected" 1 "$GUARD_RC"
+assert_contains "names the stale row" "stale-exception-marker"
+
+printf '\n== exit 0: a remote WITH a matching exception row ==\n'
+r=$(mk excepted)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://example.invalid/excepted-remote-marker/install.yaml
+Y
+printf 'https://example.invalid/excepted-remote-marker/install.yaml\t#3196\ttracked, pending vendoring\n' >"$scratch/ok.tsv"
+fixture "$scratch/ok.tsv" "excepted-remote-marker"
+run_guard "$r" "$scratch/ok.tsv"
+assert_rc "an excepted remote passes" 0 "$GUARD_RC"
+assert_contains "reports it as a tracked exception" "1 tracked exception"
+
+printf '\n== exit 2: an exception row naming no issue ==\n'
+printf 'https://example.invalid/no-issue-marker/x.yaml\t\tmissing the issue column\n' >"$scratch/noissue.tsv"
+fixture "$scratch/noissue.tsv" "no-issue-marker"
+run_guard "$(mk noissue_root)" "$scratch/noissue.tsv"
+assert_rc "exception row without a tracking issue is cannot-check" 2 "$GUARD_RC"
+assert_contains "says why the row is unreviewable" "names no tracking issue"
+
+printf '\n== exit 2: an entry that resolves to nothing and is not a known remote ==\n'
+r=$(mk dangling)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./dangling-entry-marker/does-not-exist.yaml
+Y
+fixture "$r/kustomization.yaml" "dangling-entry-marker"
+run_guard "$r"
+assert_rc "an unclassifiable entry is cannot-check" 2 "$GUARD_RC"
+assert_contains "says it cannot classify it" "cannot classify"
+
+printf '\n== exit 2: anti-vacuity — a tree with no kustomization at all ==\n'
+r=$(mk emptytree); mkdir -p "$r/sub"
+printf 'not a kustomization\n' >"$r/sub/readme.txt"
+run_guard "$r"
+assert_rc "no kustomization found is cannot-check, NOT a clean pass" 2 "$GUARD_RC"
+assert_contains "says the selector matched nothing" "selector matched nothing"
+
+printf '\n== exit 2: anti-vacuity — kustomizations exist but declare no entries ==\n'
+r=$(mk noentries)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+Y
+fixture "$r/kustomization.yaml" "kind: Kustomization"
+run_guard "$r"
+assert_rc "zero entries examined is cannot-check" 2 "$GUARD_RC"
+assert_contains "says it read no entry" "not one resource entry"
+
+printf '\n== exit 2: unparseable YAML ==\n'
+r=$(mk badyaml)
+printf 'resources:\n  - [unclosed\n' >"$r/kustomization.yaml"
+fixture "$r/kustomization.yaml" "unclosed"
+run_guard "$r"
+assert_rc "unparseable YAML is cannot-check" 2 "$GUARD_RC"
+assert_contains "says it could not parse" "could not parse"
+
+printf '\n== exit 2: usage and missing root ==\n'
+if GUARD_OUT="$("$guard" 2>&1)"; then GUARD_RC=0; else GUARD_RC=$?; fi
+assert_rc "no argument is cannot-check" 2 "$GUARD_RC"
+if GUARD_OUT="$("$guard" "$scratch/definitely-absent" 2>&1)"; then GUARD_RC=0; else GUARD_RC=$?; fi
+assert_rc "missing root is cannot-check" 2 "$GUARD_RC"
+
+printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
+[ "$failures" -eq 0 ] || exit 1
+printf 'test-guard-render-remote-resources: OK\n'

--- a/scripts/tests/test-guard-render-remote-resources.sh
+++ b/scripts/tests/test-guard-render-remote-resources.sh
@@ -225,6 +225,26 @@ run_guard "$r" "$scratch/ok.tsv"
 assert_rc "an excepted remote passes" 0 "$GUARD_RC"
 assert_contains "reports it as a tracked exception" "1 tracked exception"
 
+printf '\n== exit 1: a glob-shaped entry must NOT match an exception row ==\n'
+# Self-review of the first draft found this: the entry was interpolated into the
+# PATTERN side of a `case`, so `https://*` matched the body of the first excepted
+# row and passed as a "tracked exception". One line in a kustomization bypassed the
+# whole guard, and it also marked that row used, silencing the stale-row check.
+r=$(mk globinject)
+cat >"$r/kustomization.yaml" <<'Y'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://*
+Y
+printf 'https://example.invalid/glob-victim-marker/install.yaml\t#3196\ta row a glob must not match\n' >"$scratch/globvictim.tsv"
+fixture "$r/kustomization.yaml" "https://*"
+fixture "$scratch/globvictim.tsv" "glob-victim-marker"
+run_guard "$r" "$scratch/globvictim.tsv"
+assert_rc "a glob-shaped remote entry is NOT excepted" 1 "$GUARD_RC"
+assert_contains "reports the glob entry itself" "remote resource entry https://*"
+assert_contains "and still reports the row as stale" "glob-victim-marker"
+
 printf '\n== exit 2: an exception row naming no issue ==\n'
 printf 'https://example.invalid/no-issue-marker/x.yaml\t\tmissing the issue column\n' >"$scratch/noissue.tsv"
 fixture "$scratch/noissue.tsv" "no-issue-marker"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The production render pulls two third-party manifests off the internet every time it runs — one of them from a branch that upstream can move at any moment, without a pull request here and without anyone reviewing it. Three things follow, and none of them is currently visible:

- **The render is not reproducible.** The same commit can produce two different results on two different days.
- **Unreviewed third-party content reaches the permissions surface** we have a dedicated check for pinning.
- **A required security gate depends on someone else's CDN.** That is how this was found: the CDN rate-limited us, the render aborted, and four authorization tests failed on a clean `main` with nothing wrong in this repository.

### What this changes

Removing those two dependencies is separate work, already scoped as the next two children of #3196. **This stops the problem growing while that happens.** Today, pasting an upstream URL into a controller directory is silently accepted; after this, it fails the build.

The two known entries are recorded in a reviewed list so the check runs green today rather than turning `main` red. Each row has to name the issue tracking its removal, and a row that outlives its URL is itself a failure — so the list is a shrinking, owned record rather than a place exceptions quietly pile up.

### Worth knowing

- The check runs in the existing `validate` job behind the existing path filter — no new CI surface, no new dependency.
- Once the other two children land, the list is empty. That empty state is explicitly a clean pass, not a failure.

Fixes #3442
Part of #3196
