### PR TITLE
fix(kubescape): deploy serialized-writer storage image

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -213,9 +213,8 @@ spec:
                 keepLocal: true
     # Run vulnerability collection in a separate authored window. Keep at
     # least the present eight-hour gap: both scans emit high-volume writes, and
-    # storage v0.0.297 serializes writers only after a statement reaches the
-    # database, so keep bursty scanners separated even with the compatibility
-    # image's transaction-level serialization.
+    # the compatibility image still has one SQLite writer. Keep bursty scanners
+    # separated to limit write bursts; it reserves the writer before profile reads.
     kubevulnScheduler:
       scanSchedule: "12 1 * * *"
     storage:

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -213,23 +213,24 @@ spec:
                 keepLocal: true
     # Run vulnerability collection in a separate authored window. Keep at
     # least the present eight-hour gap: both scans emit high-volume writes, and
-    # storage v0.0.297 drops a request when another writer holds SQLite beyond
-    # its busy timeout.
+    # storage v0.0.297 serializes writers only after a statement reaches the
+    # database, so keep bursty scanners separated even with the compatibility
+    # image's transaction-level serialization.
     kubevulnScheduler:
       scanSchedule: "12 1 * * *"
     storage:
       image:
-        # Storage v0.0.297 uses SQLite's 10-second default busy timeout, so
-        # concurrent vulnerability/profile writes can make a completed posture
-        # scan lose its detailed result with `database is locked`. The upstream
-        # 60-second fix first ships in v0.0.306, but v0.0.303+ removes the
-        # ApplicationProfile and NetworkNeighborhood APIs that this deployment
-        # still serves with live data. This compatibility image is the exact
-        # v0.0.297 source plus that upstream-reviewed timeout change and its
-        # executable PRAGMA regression test; the main-only publisher attaches
-        # SBOM/provenance and signs the digest before this pin may advance.
+        # Storage v0.0.297 starts deferred transactions, so concurrent profile
+        # workers can both read and then deadlock while promoting to SQLite's
+        # single writer; a longer busy timeout cannot recover that promotion.
+        # v0.0.303+ removes the ApplicationProfile and NetworkNeighborhood APIs
+        # that this deployment still serves with live data. This compatibility
+        # image is the exact v0.0.297 source plus the reviewed 60-second busy
+        # timeout and immediate writer reservation, with executable regressions
+        # for both. The main-only publisher attaches SBOM/provenance and signs
+        # the digest before this pin may advance.
         repository: ghcr.io/devantler-tech/platform-kubescape-storage
-        tag: "v0.0.297-sqlite-busy-timeout.1-6cf966641304389dcc414630ff92ed5876e1d019@sha256:a5abb439496eb1ffdb7c388aa0e4a06f2be70cc2e31e7ab1597b5c5c2a016b52"
+        tag: "v0.0.297-sqlite-contention.2-d6c1111e8c7cc34aab21d55441b0cd5c50e9bbf4@sha256:c20facb86f1ceba7d1769c1bdc383e89a2d9d4f49dc176ef59932d7ec2c6bd01"
         pullPolicy: IfNotPresent
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -9,7 +9,7 @@ readonly patch_file="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/
 readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
 readonly source_commit='b35788b68337134fc2514574cde1ba7f1225fd43'
 readonly image_repository='ghcr.io/devantler-tech/platform-kubescape-storage'
-readonly image_tag='v0.0.297-sqlite-busy-timeout.1-6cf966641304389dcc414630ff92ed5876e1d019@sha256:a5abb439496eb1ffdb7c388aa0e4a06f2be70cc2e31e7ab1597b5c5c2a016b52'
+readonly image_tag='v0.0.297-sqlite-contention.2-d6c1111e8c7cc34aab21d55441b0cd5c50e9bbf4@sha256:c20facb86f1ceba7d1769c1bdc383e89a2d9d4f49dc176ef59932d7ec2c6bd01'
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1384,18 +1384,18 @@ const (
 //	a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5
 //	026c985d74ec1230e7272488d2a55c028bb78916c4c8362f22c447c862111d78
 //
-// Measured against main 1d7e98af for the Kubescape contended-write storage
-// repair: the five production projections retain the same selected identities,
-// every pinned per-identity fingerprint still passes, and the same 35 known
-// Flux substitution diagnostics remain. The authored delta is one image
-// override in the Kubescape HelmRelease, pinning the storage Deployment to the
-// signed digest built from storage v0.0.297 plus the upstream-reviewed
-// 60-second SQLite busy timeout. It adds no subject, grant, security context,
-// authorization resource, or rendered object. The previous approved aggregate
-// digest was:
+// Measured against main d6c1111e for the Kubescape writer-serialization
+// deployment: the five production projections retain the same selected
+// identities, every pinned per-identity fingerprint still passes, and the same
+// 35 known Flux substitution diagnostics remain. The authored delta is one
+// image override in the Kubescape HelmRelease, advancing storage v0.0.297 from
+// the 60-second busy-timeout image to the signed build that also reserves the
+// SQLite writer before each profile transaction. It adds no subject, grant,
+// security context, authorization resource, or rendered object. The previous
+// approved aggregate digest was:
 //
-//	a8f0075fcb41fb5b79c608ee9816bfe3c01062bf7c94696f3a044f2f55336a2a
-const expectedRenderedSurfaceSHA = "c6545d119e6811f72a00783fa66c478ce5e330411a69a87a181ef0111d67479e"
+//	c6545d119e6811f72a00783fa66c478ce5e330411a69a87a181ef0111d67479e
+const expectedRenderedSurfaceSHA = "010155143ff52d6f576a406ddb891306333bf27eb9d8ed237b215bf8150073b9"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Root cause

The first 60-second busy-timeout image still failed the controlled production scan. The scanner completed but timed out persisting detailed results, while storage logged `database is locked` on the detailed posture write. The remaining defect is SQLite lock promotion: v0.0.297 starts deferred profile transactions, allowing concurrent workers to read and then deadlock while both try to become the single writer. SQLite cannot wait out that deadlock, so the timeout alone was insufficient.

## Fix

Pin the immutable compatibility image published by #3441. It keeps the 60-second busy timeout and begins profile consolidation with an immediate transaction, reserving the writer before any transaction reads. The image is built from exact upstream v0.0.297 source, carries SBOM/provenance, and was independently verified against the dedicated main-branch publisher identity.

Image digest: `sha256:c20facb86f1ceba7d1769c1bdc383e89a2d9d4f49dc176ef59932d7ec2c6bd01`

## Proof

- exact publisher run `33237816268` succeeded, including source-patch tests, image build, push, signature, and signature verification
- independent `cosign verify` passed for the exact digest and dedicated workflow identity
- `go test ./scripts/validate-eks-ci-role-policy -count=1`
- exact kubectl v1.36.2 authorization contract run passed
- local and production overlays render
- Kubescape storage-image and self-hosted-persistence contracts pass
- ShellCheck and `git diff --check` pass

After merge, I will rerun the same controlled live scan and close #3275 only when a newer detailed posture record with non-empty controls is stored.

Refs #3275
