### PR TITLE
fix(kubescape): deploy foreground-safe storage image

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -214,22 +214,26 @@ spec:
     # Run vulnerability collection in a separate authored window. Keep at
     # least the present eight-hour gap: both scans emit high-volume writes, and
     # the compatibility image still has one SQLite writer. Keep bursty scanners
-    # separated to limit write bursts; it reserves the writer before profile reads.
+    # separated to limit write bursts; one deferred maintenance worker keeps
+    # read-heavy consolidation from holding SQLite's sole writer unnecessarily.
     kubevulnScheduler:
       scanSchedule: "12 1 * * *"
     storage:
       image:
-        # Storage v0.0.297 starts deferred transactions, so concurrent profile
-        # workers can both read and then deadlock while promoting to SQLite's
-        # single writer; a longer busy timeout cannot recover that promotion.
+        # Storage v0.0.297 starts two deferred profile-maintenance workers. They
+        # can both read and then race while promoting to SQLite's single writer;
+        # a longer busy timeout cannot recover that promotion. Reserving the
+        # writer before their read-heavy work prevents the promotion race but
+        # can starve foreground scan persistence past the scanner's deadline.
         # v0.0.303+ removes the ApplicationProfile and NetworkNeighborhood APIs
         # that this deployment still serves with live data. This compatibility
         # image is the exact v0.0.297 source plus the reviewed 60-second busy
-        # timeout and immediate writer reservation, with executable regressions
-        # for both. The main-only publisher attaches SBOM/provenance and signs
-        # the digest before this pin may advance.
+        # timeout and one deferred maintenance writer, with executable
+        # regressions proving both background serialization and foreground write
+        # availability. The main-only publisher attaches SBOM/provenance and
+        # signs the digest before this pin may advance.
         repository: ghcr.io/devantler-tech/platform-kubescape-storage
-        tag: "v0.0.297-sqlite-contention.2-d6c1111e8c7cc34aab21d55441b0cd5c50e9bbf4@sha256:c20facb86f1ceba7d1769c1bdc383e89a2d9d4f49dc176ef59932d7ec2c6bd01"
+        tag: "v0.0.297-sqlite-contention.3-04c50922ddf1d4a2f9d2030ccc15318036c68b2a@sha256:254b0f74edf4206c623cf6c49a4087a851ee02493433f8220865f42bafffc597"
         pullPolicy: IfNotPresent
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -9,7 +9,7 @@ readonly patch_file="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/
 readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
 readonly source_commit='b35788b68337134fc2514574cde1ba7f1225fd43'
 readonly image_repository='ghcr.io/devantler-tech/platform-kubescape-storage'
-readonly image_tag='v0.0.297-sqlite-contention.2-d6c1111e8c7cc34aab21d55441b0cd5c50e9bbf4@sha256:c20facb86f1ceba7d1769c1bdc383e89a2d9d4f49dc176ef59932d7ec2c6bd01'
+readonly image_tag='v0.0.297-sqlite-contention.3-04c50922ddf1d4a2f9d2030ccc15318036c68b2a@sha256:254b0f74edf4206c623cf6c49a4087a851ee02493433f8220865f42bafffc597'
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1384,18 +1384,19 @@ const (
 //	a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5
 //	026c985d74ec1230e7272488d2a55c028bb78916c4c8362f22c447c862111d78
 //
-// Measured against main d6c1111e for the Kubescape writer-serialization
+// Measured against main 04c50922 for the Kubescape foreground-safe storage
 // deployment: the five production projections retain the same selected
 // identities, every pinned per-identity fingerprint still passes, and the same
-// 35 known Flux substitution diagnostics remain. The authored delta is one
-// image override in the Kubescape HelmRelease, advancing storage v0.0.297 from
-// the 60-second busy-timeout image to the signed build that also reserves the
-// SQLite writer before each profile transaction. It adds no subject, grant,
-// security context, authorization resource, or rendered object. The previous
-// approved aggregate digest was:
+// 35 known Flux substitution diagnostics remain. The authored delta advances
+// one image override in the Kubescape HelmRelease from the immediate-writer
+// build to the signed build that retains deferred transactions and serializes
+// the two profile-maintenance workers into one. The remaining authored changes
+// only correct the adjacent explanation of that behavior. It adds no subject,
+// grant, security context, authorization resource, or rendered object. The
+// previous approved aggregate digest was:
 //
-//	c6545d119e6811f72a00783fa66c478ce5e330411a69a87a181ef0111d67479e
-const expectedRenderedSurfaceSHA = "010155143ff52d6f576a406ddb891306333bf27eb9d8ed237b215bf8150073b9"
+//	010155143ff52d6f576a406ddb891306333bf27eb9d8ed237b215bf8150073b9
+const expectedRenderedSurfaceSHA = "8758aca997ecdf37b536b18420803f46e67e0af05b851fafefbaa83e02b01fe3"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- deploy the signed Kubescape storage compatibility image built from the reviewed v0.0.297 source plus the foreground-write-safe SQLite fix
- retain deferred transactions and serialize the two profile-maintenance workers into one, avoiding both lock-promotion races and long writer reservation
- pin the immutable digest and update the deployment contract and authorization-surface fingerprint

## Incident evidence

The first writer-serialization image removed the two-worker lock-promotion race, but live acceptance showed it could reserve SQLite's sole writer throughout minutes of profile reads and starve the foreground configuration-scan persistence request beyond its deadline. This revision keeps the 60-second busy timeout, restores deferred transactions, and uses one maintenance writer. Focused regressions prove both background serialization and foreground write availability.

Published artifact:

`ghcr.io/devantler-tech/platform-kubescape-storage:v0.0.297-sqlite-contention.3-04c50922ddf1d4a2f9d2030ccc15318036c68b2a@sha256:254b0f74edf4206c623cf6c49a4087a851ee02493433f8220865f42bafffc597`

The digest was independently verified with Cosign against the repository's trusted main-branch publisher identity. The publisher also attached SBOM and provenance attestations.

## Verification

- `bash scripts/tests/test-kubescape-storage-hotfix.sh`
- `bash scripts/tests/test-kubescape-self-hosted-scan-persistence.sh`
- `shellcheck scripts/tests/test-kubescape-storage-hotfix.sh`
- `go test ./scripts/validate-eks-ci-role-policy`
- exact approved `kubectl v1.36.2` authorization renderer
- local and production Kustomize renders
- `git diff --check`

Closes the deployment slice of #3275. The incident remains open until the merged image is reconciled and a fresh live-cluster scan proves detailed posture persistence.
