### PR TITLE
feat(security): detect the pod-security exception drifting from its mutation's scope

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -298,6 +298,9 @@ jobs:
               # The reviewed disposition list the guard reads: editing a row
               # changes what the guard permits, so it must re-run.
               - 'scripts/render-remote-resource-exceptions.tsv'
+              # Both halves, for the same reason as the guards above.
+              - 'scripts/guard-pod-security-exception-scope.sh'
+              - 'scripts/tests/test-guard-pod-security-exception-scope.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -945,6 +948,27 @@ jobs:
         run: |
           bash scripts/guard-render-remote-resources.sh k8s
           bash scripts/tests/test-guard-render-remote-resources.sh
+
+      - name: 🔗 Validate the pod-security exception still matches its mutation's scope
+        if: needs.changes.outputs.k8s == 'true'
+        # The exception suppresses C-0016/C-0055 everywhere EXCEPT the twelve
+        # namespaces its compensating mutation does not reach. #2824 happened because
+        # those two scopes drifted apart in silence, and the narrowing that fixed it
+        # left the agreement resting on a code comment. Both directions of drift read
+        # as compliance: a namespace added to the mutation's exclusions and not the
+        # exception re-creates the original defect, and one removed from the
+        # exclusions but left in the exception enforces controls where the mutation
+        # now runs, producing findings that are not real gaps.
+        #
+        # The comparison is NOT against the exclusion list: add-pod-security-context
+        # excludes fifteen namespaces, and three of them (cert-manager, keda,
+        # opencost) are reached by the by-name add-imageuid rule. Reading exclusions
+        # alone reports three false differences on a correct tree, and the natural way
+        # to silence that is to add them to the exception — the very drift this
+        # catches (#3224).
+        run: |
+          bash scripts/guard-pod-security-exception-scope.sh
+          bash scripts/tests/test-guard-pod-security-exception-scope.sh
 
       - name: 📐 Validate LimitRange-premised suppressions actually have a LimitRange
         if: needs.changes.outputs.k8s == 'true'

--- a/scripts/guard-pod-security-exception-scope.sh
+++ b/scripts/guard-pod-security-exception-scope.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Fail when the pod-security exception's scope stops matching the mutation it names
+# as its compensating control.
+#
+# #2824 exists because these two scopes drifted apart in silence: the exception
+# suppressed C-0016/C-0055 cluster-wide while the Kyverno mutation it cites,
+# `add-security-context`, does not run in twelve namespaces. The narrowing made them
+# agree — and left that agreement resting on a code comment. Both directions of drift
+# read as compliance:
+#
+#   * a namespace ADDED to the mutation's exclusions but not to the exception ⇒ the
+#     exception suppresses controls where nothing injects the fields. That is the
+#     original defect, reintroduced.
+#   * a namespace REMOVED from the mutation's exclusions but left in the exception ⇒
+#     controls stay enforced where the mutation now runs, producing findings that are
+#     not real gaps and inviting someone to "fix" them by widening the exception.
+#
+# Neither shows up as a failing check anywhere else, which is why this guard exists.
+#
+# 🔴 THE EXCLUSION LIST IS NOT THE ANSWER — READ THE MATCH BLOCKS TOO.
+#
+# `add-pod-security-context` excludes FIFTEEN namespaces, not twelve: the twelve plus
+# cert-manager, keda and opencost. Those three are excluded there only because
+# `add-imageuid-pod-security-context` matches them BY NAME and supplies the same
+# pod-level fields, so the mutation does reach them and the exception correctly does
+# not list them. A guard that compares the exception against the exclusion list alone
+# reports three false differences on a correct tree, and the natural way to silence it
+# is to add those three to the exception — which is precisely the drift it is meant to
+# catch. So the set this guard compares is:
+#
+#     namespaces the mutation does NOT reach
+#       = exclusions(add-pod-security-context) MINUS matches(add-imageuid-pod-security-context)
+#
+# `add-container-security-context` excludes the twelve directly and is not used to
+# derive the set: it supplies container-level fields, while the exception's rationale
+# is about the pod-level ones. It is cross-checked instead, because a divergence
+# between the two mutation rules is its own drift and would otherwise be invisible.
+#
+# 🔴 FAIL CLOSED. Every input this guard cannot read is exit 2, never a quiet pass. An
+# empty set compared against an empty set is the failure mode that makes a guard look
+# green forever, so each of the three lists is required to be non-empty before any
+# comparison happens.
+#
+# Exit codes:
+#   0  the two sets are equal
+#   1  they diverge — the differing namespaces and their side are named
+#   2  cannot check: bad usage, a missing or unparseable file, a rule or expression
+#      that has moved, or any list that came back empty
+
+set -uo pipefail
+
+die() {
+  printf 'guard-pod-security-exception-scope: %s\n' "$*" >&2
+  exit 2
+}
+
+[ "$#" -le 2 ] || die "usage: $0 [<policy-file> <exception-file>]"
+command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" ||
+  die "could not resolve the repository root"
+
+policy_file="${1:-$repo_root/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml}"
+exception_file="${2:-$repo_root/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml}"
+
+[ -f "$policy_file" ] || die "mutation policy '$policy_file' not found"
+[ -f "$exception_file" ] || die "exception '$exception_file' not found"
+
+# Each read is asserted separately. A combined pipeline would let one silent empty
+# result be absorbed by the next stage, which is the shape this guard fails closed on.
+read_list() { # <label> <file> <yq-expression>
+  local label="$1" file="$2" expr="$3" out
+  out="$(yq -r "$expr" "$file" 2>/dev/null | grep -v '^null$' | sed '/^[[:space:]]*$/d' | sort -u)" ||
+    die "could not read $label from '$file' — unparseable YAML, or the expression no longer matches"
+  [ -n "$out" ] ||
+    die "$label came back EMPTY in '$file'; refusing to compare an empty set, which would pass vacuously"
+  printf '%s\n' "$out"
+}
+
+pod_rule_exclusions="$(read_list \
+  'the add-pod-security-context exclusions' "$policy_file" \
+  '.spec.rules[] | select(.name == "add-pod-security-context") | .exclude.any[].resources.namespaces[]')" || exit 2
+
+imageuid_rule_matches="$(read_list \
+  'the add-imageuid-pod-security-context matched namespaces' "$policy_file" \
+  '.spec.rules[] | select(.name == "add-imageuid-pod-security-context") | .match.any[].resources.namespaces[]')" || exit 2
+
+container_rule_exclusions="$(read_list \
+  'the add-container-security-context exclusions' "$policy_file" \
+  '.spec.rules[] | select(.name == "add-container-security-context") | .exclude.any[].resources.namespaces[]')" || exit 2
+
+exception_not_in="$(read_list \
+  'the exception NotIn namespace set' "$exception_file" \
+  '.spec.match.namespaceSelector.matchExpressions[] | select(.key == "kubernetes.io/metadata.name" and .operator == "NotIn") | .values[]')" || exit 2
+
+unreached="$(comm -23 \
+  <(printf '%s\n' "$pod_rule_exclusions") \
+  <(printf '%s\n' "$imageuid_rule_matches"))"
+[ -n "$unreached" ] ||
+  die "every excluded namespace is matched by add-imageuid-pod-security-context, leaving nothing for the exception to cover — that is not a state this repository has ever been in, so it is treated as a broken read"
+
+status=0
+
+report_diff() { # <label> <left> <right> <left-name> <right-name>
+  local only_left only_right
+  only_left="$(comm -23 <(printf '%s\n' "$2") <(printf '%s\n' "$3"))"
+  only_right="$(comm -13 <(printf '%s\n' "$2") <(printf '%s\n' "$3"))"
+  [ -z "$only_left" ] && [ -z "$only_right" ] && return 0
+  printf 'guard-pod-security-exception-scope: %s\n' "$1" >&2
+  if [ -n "$only_left" ]; then
+    printf '  only in %s:\n' "$4" >&2
+    printf '%s\n' "$only_left" | sed 's/^/    - /' >&2
+  fi
+  if [ -n "$only_right" ]; then
+    printf '  only in %s:\n' "$5" >&2
+    printf '%s\n' "$only_right" | sed 's/^/    - /' >&2
+  fi
+  return 1
+}
+
+report_diff \
+  'the exception no longer covers exactly the namespaces the mutation does not reach' \
+  "$unreached" "$exception_not_in" \
+  'the mutation-unreached set (add-pod-security-context exclusions minus add-imageuid-pod-security-context matches)' \
+  "the exception's NotIn values" || status=1
+
+# A cross-check, not the primary comparison: the two mutation rules exclude the same
+# twelve today, and a divergence between them means one of the two field sets is being
+# injected where the other is not — which changes what the exception is compensating
+# for without touching the exception at all.
+report_diff \
+  'the two add-security-context rules no longer exclude the same namespaces' \
+  "$unreached" "$container_rule_exclusions" \
+  'the pod-level unreached set' \
+  'the add-container-security-context exclusions' || status=1
+
+if [ "$status" -ne 0 ]; then
+  printf 'guard-pod-security-exception-scope: the exception and its compensating mutation have drifted; fix whichever side is wrong rather than widening the exception\n' >&2
+  exit 1
+fi
+
+printf 'guard-pod-security-exception-scope: OK — %d namespace(s) unreached by the mutation, matched exactly by the exception\n' \
+  "$(printf '%s\n' "$unreached" | wc -l | tr -d ' ')"

--- a/scripts/tests/test-guard-pod-security-exception-scope.sh
+++ b/scripts/tests/test-guard-pod-security-exception-scope.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Pins guard-pod-security-exception-scope.sh in all THREE directions.
+#
+#   exit 0  the exception covers exactly the namespaces the mutation does not reach
+#   exit 1  the two have drifted, in either direction
+#   exit 2  the guard could not check — a missing file, a rule that moved, or any
+#           list that came back empty
+#
+# The assertions that matter are not the happy path. Three of these exist because the
+# obvious implementation gets them wrong:
+#
+#   * THE IMAGEUID CARVE-OUT. add-pod-security-context excludes fifteen namespaces,
+#     and three of them (cert-manager, keda, opencost) ARE reached, by the by-name
+#     add-imageuid-pod-security-context rule. A guard that reads only the exclusion
+#     list reports three false differences on a correct tree.
+#   * A MISSING RULE IS NOT AN EMPTY SET. If add-imageuid-pod-security-context is
+#     renamed away, subtracting nothing leaves all fifteen "unreached" — a plausible
+#     number that silently changes the invariant. That must be exit 2, not exit 1.
+#   * A VACUOUS PASS. An empty NotIn compared against anything must not read as
+#     agreement, and an empty-vs-empty comparison must never be reported as OK.
+#
+# Every fixture is derived from the REAL files and mutates exactly one thing, so a
+# failure can only be caused by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-pod-security-exception-scope.sh"
+policy_src="$repo_root/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml"
+exception_src="$repo_root/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <policy> <exception>
+  if GUARD_OUT="$("$guard" "$1" "$2" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
+}
+
+assert_rc() { # <label> <expected> <actual>
+  assertions=$((assertions + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s (exit %s)\n' "$1" "$3"
+  else
+    printf '  FAIL %s: expected exit %s, got %s\n' "$1" "$2" "$3"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_mentions() { # <label> <needle>
+  assertions=$((assertions + 1))
+  if printf '%s\n' "$GUARD_OUT" | grep -Fq -- "$2"; then
+    printf '  ok   %s (names %s)\n' "$1" "$2"
+  else
+    printf '  FAIL %s: output does not name %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+# A fixture that failed to BUILD is the trap that makes an ablation look clean: the
+# file is unchanged, the guard passes, and the assertion reads as robustness. Every
+# fixture below is therefore diffed against its source and must actually differ.
+assert_fixture_changed() { # <label> <src> <fixture>
+  assertions=$((assertions + 1))
+  if cmp -s "$2" "$3"; then
+    printf '  FAIL %s: fixture is byte-identical to its source, so this case never ran\n' "$1"
+    failures=$((failures + 1))
+    return 1
+  fi
+  printf '  ok   %s (fixture built)\n' "$1"
+  return 0
+}
+
+printf 'guard-pod-security-exception-scope\n'
+
+# --------------------------------------------------------------- the real tree --
+run_guard "$policy_src" "$exception_src"
+assert_rc 'the committed tree agrees' 0 "$GUARD_RC"
+assert_mentions 'reports the unreached count' '12 namespace(s) unreached'
+
+# cert-manager/keda/opencost are in the exclusion list and MUST NOT be reported. This
+# is the imageuid carve-out, asserted on the real files rather than a fixture.
+for ns in cert-manager keda opencost; do
+  assertions=$((assertions + 1))
+  if printf '%s\n' "$GUARD_OUT" | grep -Fq -- "$ns"; then
+    printf '  FAIL imageuid carve-out: %s was reported as a difference\n' "$ns"
+    failures=$((failures + 1))
+  else
+    printf '  ok   imageuid carve-out: %s not reported\n' "$ns"
+  fi
+done
+
+# ------------------------------------------------- drift: mutation side gains a ns --
+fixture="$scratch/policy-extra-exclusion.yaml"
+yq '(.spec.rules[] | select(.name == "add-pod-security-context") | .exclude.any[0].resources.namespaces) += ["guard-fixture-added-to-mutation"] |
+    (.spec.rules[] | select(.name == "add-container-security-context") | .exclude.any[0].resources.namespaces) += ["guard-fixture-added-to-mutation"]' \
+  "$policy_src" >"$fixture"
+if assert_fixture_changed 'mutation-gains-a-namespace' "$policy_src" "$fixture"; then
+  run_guard "$fixture" "$exception_src"
+  assert_rc 'a namespace excluded by the mutation but absent from the exception fails' 1 "$GUARD_RC"
+  assert_mentions 'names the added namespace' 'guard-fixture-added-to-mutation'
+fi
+
+# ------------------------------------------ drift: mutation drops a ns, exception keeps it --
+fixture="$scratch/policy-dropped-exclusion.yaml"
+yq '(.spec.rules[] | select(.name == "add-pod-security-context") | .exclude.any[0].resources.namespaces) |= map(select(. != "velero")) |
+    (.spec.rules[] | select(.name == "add-container-security-context") | .exclude.any[0].resources.namespaces) |= map(select(. != "velero"))' \
+  "$policy_src" >"$fixture"
+if assert_fixture_changed 'mutation-drops-a-namespace' "$policy_src" "$fixture"; then
+  run_guard "$fixture" "$exception_src"
+  assert_rc 'a namespace the mutation now reaches but the exception still excludes fails' 1 "$GUARD_RC"
+  assert_mentions 'names the dropped namespace' 'velero'
+fi
+
+# ------------------------------------------------- drift between the two mutation rules --
+fixture="$scratch/policy-rules-disagree.yaml"
+yq '(.spec.rules[] | select(.name == "add-container-security-context") | .exclude.any[0].resources.namespaces) |= map(select(. != "velero"))' \
+  "$policy_src" >"$fixture"
+if assert_fixture_changed 'mutation-rules-disagree' "$policy_src" "$fixture"; then
+  run_guard "$fixture" "$exception_src"
+  assert_rc 'the two mutation rules excluding different sets fails' 1 "$GUARD_RC"
+  assert_mentions 'names the rule divergence' 'no longer exclude the same namespaces'
+fi
+
+# ------------------------------------------------------ fail-closed: the rule moved --
+fixture="$scratch/policy-imageuid-renamed.yaml"
+yq '(.spec.rules[] | select(.name == "add-imageuid-pod-security-context") | .name) = "add-imageuid-pod-security-context-renamed"' \
+  "$policy_src" >"$fixture"
+if assert_fixture_changed 'imageuid-rule-renamed' "$policy_src" "$fixture"; then
+  run_guard "$fixture" "$exception_src"
+  assert_rc 'a renamed imageuid rule is UNCHECKABLE, not a 15-namespace difference' 2 "$GUARD_RC"
+  assert_mentions 'names the list it could not resolve' 'add-imageuid-pod-security-context matched namespaces'
+fi
+
+# ---------------------------------------------------- fail-closed: empty NotIn set --
+fixture="$scratch/exception-empty-notin.yaml"
+yq '(.spec.match.namespaceSelector.matchExpressions[] | select(.key == "kubernetes.io/metadata.name" and .operator == "NotIn") | .values) = []' \
+  "$exception_src" >"$fixture"
+if assert_fixture_changed 'exception-empty-notin' "$exception_src" "$fixture"; then
+  run_guard "$policy_src" "$fixture"
+  assert_rc 'an empty NotIn is UNCHECKABLE, never a vacuous pass' 2 "$GUARD_RC"
+fi
+
+# -------------------------------------------- fail-closed: the NotIn expression moved --
+fixture="$scratch/exception-operator-changed.yaml"
+yq '(.spec.match.namespaceSelector.matchExpressions[] | select(.operator == "NotIn") | .operator) = "In"' \
+  "$exception_src" >"$fixture"
+if assert_fixture_changed 'exception-operator-changed' "$exception_src" "$fixture"; then
+  run_guard "$policy_src" "$fixture"
+  assert_rc 'a NotIn that became In is UNCHECKABLE' 2 "$GUARD_RC"
+fi
+
+# ------------------------------------------------------- fail-closed: unreadable input --
+printf 'this: [is: not: valid: yaml\n' >"$scratch/broken.yaml"
+run_guard "$scratch/broken.yaml" "$exception_src"
+assert_rc 'unparseable policy is exit 2' 2 "$GUARD_RC"
+
+run_guard "$scratch/does-not-exist.yaml" "$exception_src"
+assert_rc 'a missing policy file is exit 2' 2 "$GUARD_RC"
+assert_mentions 'says the file is missing' 'not found'
+
+run_guard "$policy_src" "$scratch/does-not-exist.yaml"
+assert_rc 'a missing exception file is exit 2' 2 "$GUARD_RC"
+
+printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
+[ "$failures" -eq 0 ]


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A cluster-security exception turns off two checks everywhere except the namespaces where a Kyverno rule already supplies the settings those checks look for. Those two lists have to agree, and last time they quietly stopped agreeing the exception was switching checks off in places where nothing was compensating for them — the problem #2824 was opened for.

That was fixed, but nothing watches it. The agreement is currently held together by a comment, and drift in either direction looks like everything is fine: one way silently re-creates the original hole, the other way starts reporting problems that are not real, which invites someone to "fix" it by widening the exception again.

### What

Adds a check that fails the build when the two lists stop matching, naming exactly which namespaces differ and which side they are on. It runs in CI on any change to the manifests, needs no cluster, and passes on the tree as it stands today.

Fixes #3224
Part of #2824
