### PR TITLE
fix(kubescape): release SQLite writer between maintenance writes

### DIFF
--- a/.github/workflows/publish-kubescape-storage-hotfix.yaml
+++ b/.github/workflows/publish-kubescape-storage-hotfix.yaml
@@ -24,7 +24,7 @@ concurrency:
 env:
   KUBESCAPE_STORAGE_SOURCE_COMMIT: b35788b68337134fc2514574cde1ba7f1225fd43
   IMAGE: ghcr.io/devantler-tech/platform-kubescape-storage
-  IMAGE_TAG: v0.0.297-sqlite-contention.3-${{ github.sha }}
+  IMAGE_TAG: v0.0.297-sqlite-contention.4-${{ github.sha }}
   PATCH_PATH: k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
 
 jobs:

--- a/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
+++ b/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
@@ -1,14 +1,19 @@
 diff --git a/pkg/registry/file/containerprofile_aggregator_test.go b/pkg/registry/file/containerprofile_aggregator_test.go
-index 241cb91e..d50d3728 100644
+index 27fe6a147f8b38fdd4e79da6dbe2f4e23e70fbf9..d714d586fade98701a121df8a759dae3d74fb7a4 100644
 --- a/pkg/registry/file/containerprofile_aggregator_test.go
 +++ b/pkg/registry/file/containerprofile_aggregator_test.go
-@@ -17,13 +17,15 @@ import (
+@@ -17,13 +17,20 @@ import (
  // fakeStorage implements ContainerProfileStorage with minimal behavior for tests.
  // Only GetContainerProfileMetadata is used by ComputeAggregatedData; other methods are stubs.
  type fakeStorage struct {
 -	profiles map[string]softwarecomposition.ContainerProfile
-+	profiles              map[string]softwarecomposition.ContainerProfile
-+	beginTransactionCalls int
++	profiles               map[string]softwarecomposition.ContainerProfile
++	beginTransactionCalls  int
++	replaceTimeSeriesCalls int
++	saveContainerErr       error
++	deleteMergedErr        error
++	updateApplicationErr   error
++	updateNetworkErr       error
  }
  
  func (f *fakeStorage) WithConnection(ctx context.Context) (context.Context, func(), error) {
@@ -19,8 +24,42 @@ index 241cb91e..d50d3728 100644
  	return func(*error) {}, nil
  }
  
+@@ -41,6 +48,7 @@ func (f *fakeStorage) DeleteTimeSeriesContainerEntries(ctx context.Context, key
+ 	return nil
+ }
+ func (f *fakeStorage) ReplaceTimeSeriesContainerEntries(ctx context.Context, key, seriesID string, deleteTimeSeries []string, newTimeSeries []softwarecomposition.TimeSeriesContainers) error {
++	f.replaceTimeSeriesCalls++
+ 	return nil
+ }
+ 
+@@ -66,7 +74,7 @@ func (f *fakeStorage) GetTsContainerProfile(ctx context.Context, key string) (so
+ 	return softwarecomposition.ContainerProfile{}, nil
+ }
+ func (f *fakeStorage) SaveContainerProfile(ctx context.Context, key string, profile *softwarecomposition.ContainerProfile) error {
+-	return nil
++	return f.saveContainerErr
+ }
+ func (f *fakeStorage) SaveMergedContainerProfile(ctx context.Context, observedKey string, profile *softwarecomposition.ContainerProfile) error {
+ 	return nil
+@@ -75,13 +83,13 @@ func (f *fakeStorage) GetMergedContainerProfile(ctx context.Context, observedKey
+ 	return softwarecomposition.ContainerProfile{}, storage.NewKeyNotFoundError(observedKey, 0)
+ }
+ func (f *fakeStorage) DeleteMergedContainerProfile(ctx context.Context, observedKey string) error {
+-	return nil
++	return f.deleteMergedErr
+ }
+ func (f *fakeStorage) UpdateApplicationProfile(ctx context.Context, key, prefix, root string, id armotypes.ProfileIdentifier, slug, wlid string, instanceID interface{ GetStringNoContainer() string }, profile *softwarecomposition.ContainerProfile, creationTimestamp metav1.Time) error {
+-	return nil
++	return f.updateApplicationErr
+ }
+ func (f *fakeStorage) UpdateNetworkNeighborhood(ctx context.Context, key, prefix, root string, id armotypes.ProfileIdentifier, slug, wlid string, instanceID interface{ GetStringNoContainer() string }, profile *softwarecomposition.ContainerProfile, creationTimestamp metav1.Time) error {
+-	return nil
++	return f.updateNetworkErr
+ }
+ func (f *fakeStorage) GetStorageImpl() *StorageImpl {
+ 	return nil
 diff --git a/pkg/registry/file/containerprofile_processor.go b/pkg/registry/file/containerprofile_processor.go
-index db4a8ee1..255f6e9c 100644
+index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f2ed1efd5 100644
 --- a/pkg/registry/file/containerprofile_processor.go
 +++ b/pkg/registry/file/containerprofile_processor.go
 @@ -75,7 +75,7 @@ func NewContainerProfileProcessor(cfg config.Config, cleanupHandler *ResourcesCl
@@ -32,7 +71,32 @@ index db4a8ee1..255f6e9c 100644
  	}
  }
  
-@@ -383,6 +383,16 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
+@@ -341,9 +341,9 @@ func (a *ContainerProfileProcessor) ConsolidateTimeSeries(ctx context.Context) e
+ 	// Use a plain errgroup.Group (NOT errgroup.WithContext) and pass the PARENT
+ 	// ctx to every worker. WithConnection -> pool.Take binds each connection's
+ 	// interrupt to the passed ctx; a cancel-on-first-error group context would
+-	// interrupt and roll back every other worker's in-flight transaction. A
+-	// zero-value Group still returns the first error from Wait but never cancels,
+-	// so each key's transaction commits or fails independently.
++	// interrupt every other worker's in-flight database operation. A zero-value
++	// Group still returns the first error from Wait but never cancels, so each
++	// key's maintenance pass completes or fails independently.
+ 	consolidate := a.consolidateKeyTimeSeries
+ 	if a.consolidateKey != nil {
+ 		consolidate = a.consolidateKey
+@@ -366,7 +366,7 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
+ 	logger.L().Debug("ContainerProfileProcessor.consolidateKeyTimeSeries - consolidating data for key", loggerhelpers.String("key", key), loggerhelpers.Interface("expired", expired))
+ 
+ 	// Each unit of work owns its own pool connection so keys can be consolidated
+-	// concurrently, each transaction running on its own *sqlite.Conn.
++	// concurrently, with each autocommit operation using its own *sqlite.Conn.
+ 	ctx, cleanup, err := a.ContainerProfileStorage.WithConnection(ctx)
+ 	if err != nil {
+ 		return fmt.Errorf("failed to take connection for key %s: %w", key, err)
+@@ -383,9 +383,20 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
+ 		return err
+ 	}
+ 
 -	processed, err := a.processTimeSeriesInTransaction(ctx, timeSeries, key, profile, prefix, root, id, expired)
 +	// Do not wrap the complete cross-artifact update in one SQLite transaction.
 +	// updateProfile performs expensive aggregation between its observed,
@@ -40,10 +104,11 @@ index db4a8ee1..255f6e9c 100644
 +	// the first write upgrades a deferred transaction, SQLite's sole writer stays
 +	// reserved until all of that work finishes; a live configuration scan can
 +	// then miss its request deadline even with one maintenance worker and a long
-+	// busy timeout. Each storage write is idempotent and the maintenance loop
-+	// retries incomplete work on its next tick, while the payload files were
-+	// never covered by the SQLite rollback in the first place. Let each write
-+	// autocommit so foreground persistence can run between maintenance writes.
++	// busy timeout. Each profile write is idempotent, and updateProfile leaves
++	// source time series pending until all profile writes succeed so a partial
++	// pass is retried on the next tick. The payload files were never covered by
++	// SQLite rollback in the first place. Let each write autocommit so foreground
++	// persistence can run between maintenance writes.
 +	processed, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
  	if err != nil {
 -		return err
@@ -51,7 +116,10 @@ index db4a8ee1..255f6e9c 100644
  	}
  
  	// Send consolidated slug to channel before deleting processed time series
-@@ -479,22 +489,3 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
+@@ -479,25 +490,6 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
+ 	return profile, id, prefix, root, err
+ }
+ 
 -// processTimeSeriesInTransaction processes time series data within a database transaction
 -func (a *ContainerProfileProcessor) processTimeSeriesInTransaction(ctx context.Context,
 -	timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string,
@@ -74,8 +142,160 @@ index db4a8ee1..255f6e9c 100644
  // deleteProcessedTimeSeries removes processed time series profiles from storage.
  // Treats "key not found" as success (idempotent delete): the profile may already have been
  // deleted by a concurrent consolidation run for the same customer/cluster.
+@@ -518,6 +510,7 @@ func (a *ContainerProfileProcessor) deleteProcessedTimeSeries(ctx context.Contex
+ 
+ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string, profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, error) {
+ 	var processed []string
++	var pendingUpdates []timeSeriesProcessResult
+ 	creationTimestamp := metav1.Now()
+ 	var newData bool
+ 
+@@ -527,6 +520,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+ 		if err != nil {
+ 			return nil, err
+ 		}
++		pendingUpdates = append(pendingUpdates, processResult)
+ 		processed = append(processed, processResult.processed...)
+ 		if processResult.hasNewData {
+ 			newData = true
+@@ -540,6 +534,9 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+ 		// Without an InstanceID annotation we cannot derive the workload slug,
+ 		// so neither the observed save nor the merged refresh have a target.
+ 		logger.L().Debug("ContainerProfileProcessor.updateProfile - skip saving invalid profile", loggerhelpers.String("key", key), loggerhelpers.Interface("profile", profile))
++		if err := a.finalizeTimeSeriesUpdates(ctx, key, pendingUpdates); err != nil {
++			return nil, err
++		}
+ 		return processed, nil
+ 	}
+ 
+@@ -564,9 +561,8 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+ 	// from (observed, ug-AP, ug-NN), so retractions land naturally.
+ 	effective, err := a.refreshMergedProfile(ctx, &profile, id, key)
+ 	if err != nil {
+-		// Refresh failures are surfaced so the transaction rolls back; a half-
+-		// applied merged write paired with a successful observed save would be
+-		// worse than retrying the whole tick.
++		// Source time-series rows are not retired until this succeeds. Surface the
++		// failure so the complete idempotent profile update retries next tick.
+ 		return nil, err
+ 	}
+ 
+@@ -581,9 +577,31 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+ 		}
+ 	}
+ 
++	// Retire source rows only after every derived profile write succeeds. An
++	// earlier failure leaves the original hasData rows and payload files intact,
++	// making the complete idempotent profile update retryable on the next tick.
++	if err := a.finalizeTimeSeriesUpdates(ctx, key, pendingUpdates); err != nil {
++		return nil, err
++	}
++
+ 	return processed, nil
+ }
+ 
++func (a *ContainerProfileProcessor) finalizeTimeSeriesUpdates(ctx context.Context, key string, updates []timeSeriesProcessResult) error {
++	for _, update := range updates {
++		if update.deleteAll {
++			if err := a.ContainerProfileStorage.DeleteTimeSeriesContainerEntries(ctx, key); err != nil {
++				return fmt.Errorf("failed to delete time series data: %w", err)
++			}
++			return nil
++		}
++		if err := a.ContainerProfileStorage.ReplaceTimeSeriesContainerEntries(ctx, key, update.seriesID, update.deleteTimeSeries, update.newTimeSeries); err != nil {
++			return fmt.Errorf("failed to replace consolidated time series data: %w", err)
++		}
++	}
++	return nil
++}
++
+ // refreshMergedProfile rebuilds the merged (effective) ContainerProfile from
+ // the observed CP plus the live user-managed (ug-) AP/NN overlay, and
+ // reconciles the persisted merged artifact with the result:
+@@ -609,9 +627,9 @@ func (a *ContainerProfileProcessor) refreshMergedProfile(ctx context.Context, ob
+ 		// lock-free existence probe and treats not-found as success), so the
+ 		// common no-merged-yet path is quiet — no error log and no futile
+ 		// delete — without a separate existence probe here. A genuine delete
+-		// failure is surfaced as a hard error so the tick rolls back and retries
+-		// rather than leaving consumers reading a merged view the ug- overlay no
+-		// longer backs.
++		// failure is surfaced before source time series are retired, so the tick
++		// retries rather than leaving consumers reading a merged view the ug-
++		// overlay no longer backs.
+ 		if delErr := a.ContainerProfileStorage.DeleteMergedContainerProfile(ctx, observedKey); delErr != nil {
+ 			return observed, fmt.Errorf("failed to delete stale merged container profile: %w", delErr)
+ 		}
+@@ -629,6 +647,10 @@ type timeSeriesProcessResult struct {
+ 	processed             []string
+ 	hasNewData            bool
+ 	skipFurtherProcessing bool
++	seriesID              string
++	deleteTimeSeries      []string
++	newTimeSeries         []softwarecomposition.TimeSeriesContainers
++	deleteAll             bool
+ }
+ 
+ // processTimeSeries processes a single time series and returns the result
+@@ -636,7 +658,7 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
+ 	timeSeries map[string][]softwarecomposition.TimeSeriesContainers, seriesID, key string,
+ 	profile *softwarecomposition.ContainerProfile, creationTimestamp *metav1.Time, expired bool) (timeSeriesProcessResult, error) {
+ 
+-	result := timeSeriesProcessResult{}
++	result := timeSeriesProcessResult{seriesID: seriesID}
+ 
+ 	// Merge time series data
+ 	deleteTimeSeries, processed, hasNewData := a.mergeTimeSeriesData(ctx, timeSeries[seriesID], key, profile)
+@@ -652,11 +674,9 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
+ 		return result, err
+ 	}
+ 	result.skipFurtherProcessing = skipFurtherProcessing
+-
+-	// Write consolidated data back to database
+-	if err := a.ContainerProfileStorage.ReplaceTimeSeriesContainerEntries(ctx, key, seriesID, deleteTimeSeries, newTimeSeries); err != nil {
+-		return result, fmt.Errorf("failed to replace consolidated time series data: %w", err)
+-	}
++	result.deleteTimeSeries = deleteTimeSeries
++	result.newTimeSeries = newTimeSeries
++	result.deleteAll = skipFurtherProcessing
+ 
+ 	return result, nil
+ }
+@@ -734,6 +754,7 @@ func (a *ContainerProfileProcessor) consolidateContinuousTimeSeries(
+ // Returns true if further processing should be skipped (e.g., profile is fully completed).
+ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key, seriesID string,
+ 	profile *softwarecomposition.ContainerProfile, newTimeSeries []softwarecomposition.TimeSeriesContainers, expired bool) ([]softwarecomposition.TimeSeriesContainers, bool, error) {
++	_ = ctx
+ 
+ 	// If the time series is expired, we finalize it as Completed/Partial (unless it is already Completed/Full)
+ 	// and clear the time series data so we don't leak zombie records.
+@@ -748,10 +769,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
+ 			logger.L().Debug("ContainerProfileProcessor.updateProfileStatus - expired profile is completed/full, skipping further processing",
+ 				loggerhelpers.String("key", key), loggerhelpers.String("seriesID", seriesID))
+ 
+-			// Remove all time series data
+-			if err := a.ContainerProfileStorage.DeleteTimeSeriesContainerEntries(ctx, key); err != nil {
+-				return newTimeSeries, false, fmt.Errorf("failed to delete time series data: %w", err)
+-			}
++			// Defer removing time series data until every derived profile write
++			// succeeds, so a partial pass remains retryable.
+ 			return newTimeSeries[:0], true, nil
+ 		}
+ 
+@@ -777,10 +796,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
+ 			logger.L().Debug("ContainerProfileProcessor.updateProfileStatus - profile is completed/full, skipping further processing",
+ 				loggerhelpers.String("key", key), loggerhelpers.String("seriesID", seriesID))
+ 
+-			// Remove all time series data
+-			if err := a.ContainerProfileStorage.DeleteTimeSeriesContainerEntries(ctx, key); err != nil {
+-				return newTimeSeries, false, fmt.Errorf("failed to delete time series data: %w", err)
+-			}
++			// Defer removing time series data until every derived profile write
++			// succeeds, so a partial pass remains retryable.
+ 			return newTimeSeries[:0], true, nil
+ 		}
+ 		// Clear this time series as it is finished
 diff --git a/pkg/registry/file/containerprofile_processor_test.go b/pkg/registry/file/containerprofile_processor_test.go
-index 384d059e..054a28e2 100644
+index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0da3b7b3be 100644
 --- a/pkg/registry/file/containerprofile_processor_test.go
 +++ b/pkg/registry/file/containerprofile_processor_test.go
 @@ -12,6 +12,7 @@ import (
@@ -86,7 +306,7 @@ index 384d059e..054a28e2 100644
  	"github.com/kubescape/storage/pkg/generated/clientset/versioned/scheme"
  	"github.com/kubescape/storage/pkg/utils"
  	"github.com/spf13/afero"
-@@ -23,6 +24,24 @@ import (
+@@ -23,6 +24,64 @@ import (
  	"zombiezen.com/go/sqlite/sqlitemigration"
  )
  
@@ -108,74 +328,62 @@ index 384d059e..054a28e2 100644
 +		"profile maintenance must not hold SQLite's sole writer across multi-artifact processing")
 +}
 +
++func TestUpdateProfileKeepsTimeSeriesPendingUntilAllProfileWritesSucceed(t *testing.T) {
++	tests := []struct {
++		name        string
++		storage     *fakeStorage
++		wantErr     string
++		wantReplace int
++	}{
++		{name: "observed save", storage: &fakeStorage{saveContainerErr: errors.New("observed save failed")}, wantErr: "observed save failed"},
++		{name: "merged refresh", storage: &fakeStorage{deleteMergedErr: errors.New("merged refresh failed")}, wantErr: "merged refresh failed"},
++		{name: "application profile", storage: &fakeStorage{updateApplicationErr: errors.New("application profile failed")}, wantErr: "application profile failed"},
++		{name: "network neighborhood", storage: &fakeStorage{updateNetworkErr: errors.New("network neighborhood failed")}, wantErr: "network neighborhood failed"},
++		{name: "all profile writes succeed", storage: &fakeStorage{}, wantReplace: 1},
++	}
++
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			processor := &ContainerProfileProcessor{ContainerProfileStorage: tt.storage}
++			profile := softwarecomposition.ContainerProfile{
++				ObjectMeta: metav1.ObjectMeta{
++					Annotations: map[string]string{
++						helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-default/kind-ReplicaSet/name-example/containerName-app",
++					},
++				},
++			}
++			timeSeries := map[string][]softwarecomposition.TimeSeriesContainers{
++				"series": {{TsSuffix: "pending", HasData: true}},
++			}
++
++			_, err := processor.updateProfile(context.Background(), timeSeries, "key", profile, "", "", armotypes.ProfileIdentifier{}, false)
++			if tt.wantErr != "" {
++				require.ErrorContains(t, err, tt.wantErr)
++			} else {
++				require.NoError(t, err)
++			}
++			require.Equal(t, tt.wantReplace, tt.storage.replaceTimeSeriesCalls,
++				"source rows must be retired only after every profile write succeeds")
++		})
++	}
++}
++
  func TestConsolidateData(t *testing.T) {
  	// Prepare pool and connection
  	pool := NewTestPool("/tmp")
-diff --git a/pkg/registry/file/sqlite.go b/pkg/registry/file/sqlite.go
-index 3d706533..c219537a 100644
---- a/pkg/registry/file/sqlite.go
-+++ b/pkg/registry/file/sqlite.go
-@@ -61,6 +61,14 @@ func NewPool(path string, size int) *sqlitemigration.Pool {
- 		},
- 		sqlitemigration.Options{
- 			PoolSize: size,
-+			// Under write bursts (per-container profile churn plus the
-+			// RogueArtifact class) a writer can hold the lock beyond the
-+			// driver's 10s default busy timeout on slow disks, surfacing raw
-+			// "database is locked" to API clients. Wait instead of failing.
-+			PrepareConn: func(conn *sqlite.Conn) error {
-+				conn.SetBusyTimeout(60 * time.Second)
-+				return nil
-+			},
- 		})
+@@ -571,8 +630,7 @@ func TestUpdateProfileStatusExpiredFull(t *testing.T) {
+ 	assert.NoError(t, err)
+ 	assert.True(t, skip)
+ 	assert.Len(t, res, 0) // should be cleared
+-	assert.True(t, mockStorage.deleteCalled)
+-	assert.Equal(t, "test-key", mockStorage.deleteKey)
++	assert.False(t, mockStorage.deleteCalled, "deletion is finalized only after every profile write succeeds")
+ 	assert.Equal(t, helpersv1.Completed, profile.Annotations[helpersv1.StatusMetadataKey])
+ 	assert.Equal(t, helpersv1.Full, profile.Annotations[helpersv1.CompletionMetadataKey])
  }
- 
-diff --git a/pkg/registry/file/sqlite_test.go b/pkg/registry/file/sqlite_test.go
-index 9a1ba4ed..fb1e6a80 100644
---- a/pkg/registry/file/sqlite_test.go
-+++ b/pkg/registry/file/sqlite_test.go
-@@ -2,15 +2,39 @@ package file
- 
- import (
- 	"context"
-+	"path/filepath"
- 	"testing"
- 
- 	"github.com/stretchr/testify/assert"
- 	"github.com/stretchr/testify/require"
- 	v1 "k8s.io/api/core/v1"
- 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-+	"zombiezen.com/go/sqlite"
- 	"zombiezen.com/go/sqlite/sqlitemigration"
-+	"zombiezen.com/go/sqlite/sqlitex"
- )
- 
-+func TestNewPoolSetsBusyTimeout(t *testing.T) {
-+	pool := NewPool(filepath.Join(t.TempDir(), "busy-timeout.sq3"), 1)
-+	require.NotNil(t, pool)
-+	defer func() {
-+		assert.NoError(t, pool.Close())
-+	}()
-+
-+	conn, err := pool.Take(context.Background())
-+	require.NoError(t, err)
-+	defer pool.Put(conn)
-+
-+	var busyTimeoutMilliseconds int64
-+	require.NoError(t, sqlitex.Execute(conn, "PRAGMA busy_timeout;", &sqlitex.ExecOptions{
-+		ResultFunc: func(stmt *sqlite.Stmt) error {
-+			busyTimeoutMilliseconds = stmt.ColumnInt64(0)
-+			return nil
-+		},
-+	}))
-+	assert.Equal(t, int64(60000), busyTimeoutMilliseconds)
-+}
-+
- func TestMemoryConn(t *testing.T) {
- 	pod := v1.Pod{
- 		ObjectMeta: metav1.ObjectMeta{
 diff --git a/pkg/registry/file/containerprofile_storage_test.go b/pkg/registry/file/containerprofile_storage_test.go
 new file mode 100644
+index 0000000000000000000000000000000000000000..76f4c666c0068a18c862026f682e2840eea119c3
 --- /dev/null
 +++ b/pkg/registry/file/containerprofile_storage_test.go
 @@ -0,0 +1,41 @@
@@ -220,3 +428,66 @@ new file mode 100644
 +	finishFirst(&firstErr)
 +	require.NoError(t, firstErr)
 +}
+diff --git a/pkg/registry/file/sqlite.go b/pkg/registry/file/sqlite.go
+index 3d706533fe9ec5913ea53e4bf43780fd4ec36a70..c219537a8f2f6225b12c311c46db1f0d66a8a0e8 100644
+--- a/pkg/registry/file/sqlite.go
++++ b/pkg/registry/file/sqlite.go
+@@ -61,6 +61,14 @@ func NewPool(path string, size int) *sqlitemigration.Pool {
+ 		},
+ 		sqlitemigration.Options{
+ 			PoolSize: size,
++			// Under write bursts (per-container profile churn plus the
++			// RogueArtifact class) a writer can hold the lock beyond the
++			// driver's 10s default busy timeout on slow disks, surfacing raw
++			// "database is locked" to API clients. Wait instead of failing.
++			PrepareConn: func(conn *sqlite.Conn) error {
++				conn.SetBusyTimeout(60 * time.Second)
++				return nil
++			},
+ 		})
+ }
+ 
+diff --git a/pkg/registry/file/sqlite_test.go b/pkg/registry/file/sqlite_test.go
+index 9a1ba4ed0a45122c16de30876e2e9c536b16d75f..fb1e6a804bfc09570b49bbf72a0c889ebe2c417b 100644
+--- a/pkg/registry/file/sqlite_test.go
++++ b/pkg/registry/file/sqlite_test.go
+@@ -2,15 +2,39 @@ package file
+ 
+ import (
+ 	"context"
++	"path/filepath"
+ 	"testing"
+ 
+ 	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+ 	v1 "k8s.io/api/core/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"zombiezen.com/go/sqlite"
+ 	"zombiezen.com/go/sqlite/sqlitemigration"
++	"zombiezen.com/go/sqlite/sqlitex"
+ )
+ 
++func TestNewPoolSetsBusyTimeout(t *testing.T) {
++	pool := NewPool(filepath.Join(t.TempDir(), "busy-timeout.sq3"), 1)
++	require.NotNil(t, pool)
++	defer func() {
++		assert.NoError(t, pool.Close())
++	}()
++
++	conn, err := pool.Take(context.Background())
++	require.NoError(t, err)
++	defer pool.Put(conn)
++
++	var busyTimeoutMilliseconds int64
++	require.NoError(t, sqlitex.Execute(conn, "PRAGMA busy_timeout;", &sqlitex.ExecOptions{
++		ResultFunc: func(stmt *sqlite.Stmt) error {
++			busyTimeoutMilliseconds = stmt.ColumnInt64(0)
++			return nil
++		},
++	}))
++	assert.Equal(t, int64(60000), busyTimeoutMilliseconds)
++}
++
+ func TestMemoryConn(t *testing.T) {
+ 	pod := v1.Pod{
+ 		ObjectMeta: metav1.ObjectMeta{

--- a/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
+++ b/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
@@ -1,5 +1,26 @@
+diff --git a/pkg/registry/file/containerprofile_aggregator_test.go b/pkg/registry/file/containerprofile_aggregator_test.go
+index 241cb91e..d50d3728 100644
+--- a/pkg/registry/file/containerprofile_aggregator_test.go
++++ b/pkg/registry/file/containerprofile_aggregator_test.go
+@@ -17,13 +17,15 @@ import (
+ // fakeStorage implements ContainerProfileStorage with minimal behavior for tests.
+ // Only GetContainerProfileMetadata is used by ComputeAggregatedData; other methods are stubs.
+ type fakeStorage struct {
+-	profiles map[string]softwarecomposition.ContainerProfile
++	profiles              map[string]softwarecomposition.ContainerProfile
++	beginTransactionCalls int
+ }
+ 
+ func (f *fakeStorage) WithConnection(ctx context.Context) (context.Context, func(), error) {
+ 	return ctx, func() {}, nil
+ }
+ func (f *fakeStorage) BeginTransaction(ctx context.Context) (func(*error), error) {
++	f.beginTransactionCalls++
+ 	return func(*error) {}, nil
+ }
+ 
 diff --git a/pkg/registry/file/containerprofile_processor.go b/pkg/registry/file/containerprofile_processor.go
-index db4a8ee1..f31119a7 100644
+index db4a8ee1..255f6e9c 100644
 --- a/pkg/registry/file/containerprofile_processor.go
 +++ b/pkg/registry/file/containerprofile_processor.go
 @@ -75,7 +75,7 @@ func NewContainerProfileProcessor(cfg config.Config, cleanupHandler *ResourcesCl
@@ -11,8 +32,50 @@ index db4a8ee1..f31119a7 100644
  	}
  }
  
+@@ -383,6 +383,16 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
+-	processed, err := a.processTimeSeriesInTransaction(ctx, timeSeries, key, profile, prefix, root, id, expired)
++	// Do not wrap the complete cross-artifact update in one SQLite transaction.
++	// updateProfile performs expensive aggregation between its observed,
++	// ApplicationProfile, NetworkNeighborhood, and merged-profile writes. Once
++	// the first write upgrades a deferred transaction, SQLite's sole writer stays
++	// reserved until all of that work finishes; a live configuration scan can
++	// then miss its request deadline even with one maintenance worker and a long
++	// busy timeout. Each storage write is idempotent and the maintenance loop
++	// retries incomplete work on its next tick, while the payload files were
++	// never covered by the SQLite rollback in the first place. Let each write
++	// autocommit so foreground persistence can run between maintenance writes.
++	processed, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
+ 	if err != nil {
+-		return err
++		return fmt.Errorf("failed to process time series data for key %s: %w", key, err)
+ 	}
+ 
+ 	// Send consolidated slug to channel before deleting processed time series
+@@ -479,22 +489,3 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
+-// processTimeSeriesInTransaction processes time series data within a database transaction
+-func (a *ContainerProfileProcessor) processTimeSeriesInTransaction(ctx context.Context,
+-	timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string,
+-	profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, error) {
+-
+-	endFn, err := a.ContainerProfileStorage.BeginTransaction(ctx)
+-	if err != nil {
+-		return nil, fmt.Errorf("failed to begin nested transaction: %w", err)
+-	}
+-	processed, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
+-	endFn(&err)
+-
+-	if err != nil {
+-		return nil, fmt.Errorf("failed to process time series data for key %s (transaction rolled back): %w", key, err)
+-	}
+-
+-	return processed, nil
+-}
+-
+ // deleteProcessedTimeSeries removes processed time series profiles from storage.
+ // Treats "key not found" as success (idempotent delete): the profile may already have been
+ // deleted by a concurrent consolidation run for the same customer/cluster.
 diff --git a/pkg/registry/file/containerprofile_processor_test.go b/pkg/registry/file/containerprofile_processor_test.go
-index 384d059e..b9b57458 100644
+index 384d059e..054a28e2 100644
 --- a/pkg/registry/file/containerprofile_processor_test.go
 +++ b/pkg/registry/file/containerprofile_processor_test.go
 @@ -12,6 +12,7 @@ import (
@@ -23,7 +86,7 @@ index 384d059e..b9b57458 100644
  	"github.com/kubescape/storage/pkg/generated/clientset/versioned/scheme"
  	"github.com/kubescape/storage/pkg/utils"
  	"github.com/spf13/afero"
-@@ -23,6 +24,12 @@ import (
+@@ -23,6 +24,24 @@ import (
  	"zombiezen.com/go/sqlite/sqlitemigration"
  )
  
@@ -31,6 +94,18 @@ index 384d059e..b9b57458 100644
 +	processor := NewContainerProfileProcessor(config.Config{}, nil)
 +	require.Equal(t, 1, processor.Workers,
 +		"multiple background writers can continuously hand off SQLite's writer lock and starve REST persistence")
++}
++
++func TestConsolidateKeyDoesNotHoldWriterAcrossProfileProcessing(t *testing.T) {
++	storage := &fakeStorage{}
++	processor := &ContainerProfileProcessor{
++		ContainerProfileStorage: storage,
++	}
++
++	key := K8sKeysToPath("", "spdx.softwarecomposition.kubescape.io", "containerprofile", "", "default", "example")
++	require.NoError(t, processor.consolidateKeyTimeSeries(context.Background(), key, false))
++	require.Zero(t, storage.beginTransactionCalls,
++		"profile maintenance must not hold SQLite's sole writer across multi-artifact processing")
 +}
 +
  func TestConsolidateData(t *testing.T) {

--- a/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
+++ b/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
@@ -59,7 +59,7 @@ index 27fe6a147f8b38fdd4e79da6dbe2f4e23e70fbf9..d714d586fade98701a121df8a759dae3
  func (f *fakeStorage) GetStorageImpl() *StorageImpl {
  	return nil
 diff --git a/pkg/registry/file/containerprofile_processor.go b/pkg/registry/file/containerprofile_processor.go
-index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f2ed1efd5 100644
+index db4a8ee109787ad75e0c5333046832ea53322637..610b7cd097d8242bb21b8980c231cf4420f4f4b8 100644
 --- a/pkg/registry/file/containerprofile_processor.go
 +++ b/pkg/registry/file/containerprofile_processor.go
 @@ -75,7 +75,7 @@ func NewContainerProfileProcessor(cfg config.Config, cleanupHandler *ResourcesCl
@@ -93,7 +93,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  	ctx, cleanup, err := a.ContainerProfileStorage.WithConnection(ctx)
  	if err != nil {
  		return fmt.Errorf("failed to take connection for key %s: %w", key, err)
-@@ -383,9 +383,20 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
+@@ -383,9 +383,21 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
  		return err
  	}
  
@@ -107,7 +107,8 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
 +	// busy timeout. Each profile write is idempotent, and updateProfile leaves
 +	// source time series pending until all profile writes succeed so a partial
 +	// pass is retried on the next tick. The payload files were never covered by
-+	// SQLite rollback in the first place. Let each write autocommit so foreground
++	// SQLite rollback in the first place. Let each profile write autocommit, then
++	// finalize only the source rows in one short transaction, so foreground
 +	// persistence can run between maintenance writes.
 +	processed, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
  	if err != nil {
@@ -116,7 +117,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  	}
  
  	// Send consolidated slug to channel before deleting processed time series
-@@ -479,25 +490,6 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
+@@ -479,25 +491,6 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
  	return profile, id, prefix, root, err
  }
  
@@ -142,7 +143,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  // deleteProcessedTimeSeries removes processed time series profiles from storage.
  // Treats "key not found" as success (idempotent delete): the profile may already have been
  // deleted by a concurrent consolidation run for the same customer/cluster.
-@@ -518,6 +510,7 @@ func (a *ContainerProfileProcessor) deleteProcessedTimeSeries(ctx context.Contex
+@@ -518,6 +511,7 @@ func (a *ContainerProfileProcessor) deleteProcessedTimeSeries(ctx context.Contex
  
  func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string, profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, error) {
  	var processed []string
@@ -150,7 +151,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  	creationTimestamp := metav1.Now()
  	var newData bool
  
-@@ -527,6 +520,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+@@ -527,6 +521,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
  		if err != nil {
  			return nil, err
  		}
@@ -158,7 +159,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  		processed = append(processed, processResult.processed...)
  		if processResult.hasNewData {
  			newData = true
-@@ -540,6 +534,9 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+@@ -540,6 +535,9 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
  		// Without an InstanceID annotation we cannot derive the workload slug,
  		// so neither the observed save nor the merged refresh have a target.
  		logger.L().Debug("ContainerProfileProcessor.updateProfile - skip saving invalid profile", loggerhelpers.String("key", key), loggerhelpers.Interface("profile", profile))
@@ -168,7 +169,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  		return processed, nil
  	}
  
-@@ -564,9 +561,8 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+@@ -564,9 +562,8 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
  	// from (observed, ug-AP, ug-NN), so retractions land naturally.
  	effective, err := a.refreshMergedProfile(ctx, &profile, id, key)
  	if err != nil {
@@ -180,7 +181,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  		return nil, err
  	}
  
-@@ -581,9 +577,31 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
+@@ -581,9 +578,41 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
  		}
  	}
  
@@ -194,7 +195,17 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  	return processed, nil
  }
  
-+func (a *ContainerProfileProcessor) finalizeTimeSeriesUpdates(ctx context.Context, key string, updates []timeSeriesProcessResult) error {
++func (a *ContainerProfileProcessor) finalizeTimeSeriesUpdates(ctx context.Context, key string, updates []timeSeriesProcessResult) (err error) {
++	if len(updates) == 0 {
++		return nil
++	}
++
++	endFn, err := a.ContainerProfileStorage.BeginTransaction(ctx)
++	if err != nil {
++		return fmt.Errorf("failed to begin time series finalization transaction: %w", err)
++	}
++	defer endFn(&err)
++
 +	for _, update := range updates {
 +		if update.deleteAll {
 +			if err := a.ContainerProfileStorage.DeleteTimeSeriesContainerEntries(ctx, key); err != nil {
@@ -212,7 +223,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  // refreshMergedProfile rebuilds the merged (effective) ContainerProfile from
  // the observed CP plus the live user-managed (ug-) AP/NN overlay, and
  // reconciles the persisted merged artifact with the result:
-@@ -609,9 +627,9 @@ func (a *ContainerProfileProcessor) refreshMergedProfile(ctx context.Context, ob
+@@ -609,9 +638,9 @@ func (a *ContainerProfileProcessor) refreshMergedProfile(ctx context.Context, ob
  		// lock-free existence probe and treats not-found as success), so the
  		// common no-merged-yet path is quiet — no error log and no futile
  		// delete — without a separate existence probe here. A genuine delete
@@ -225,7 +236,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  		if delErr := a.ContainerProfileStorage.DeleteMergedContainerProfile(ctx, observedKey); delErr != nil {
  			return observed, fmt.Errorf("failed to delete stale merged container profile: %w", delErr)
  		}
-@@ -629,6 +647,10 @@ type timeSeriesProcessResult struct {
+@@ -629,6 +658,10 @@ type timeSeriesProcessResult struct {
  	processed             []string
  	hasNewData            bool
  	skipFurtherProcessing bool
@@ -236,7 +247,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  }
  
  // processTimeSeries processes a single time series and returns the result
-@@ -636,7 +658,7 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
+@@ -636,7 +669,7 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
  	timeSeries map[string][]softwarecomposition.TimeSeriesContainers, seriesID, key string,
  	profile *softwarecomposition.ContainerProfile, creationTimestamp *metav1.Time, expired bool) (timeSeriesProcessResult, error) {
  
@@ -245,7 +256,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  
  	// Merge time series data
  	deleteTimeSeries, processed, hasNewData := a.mergeTimeSeriesData(ctx, timeSeries[seriesID], key, profile)
-@@ -652,11 +674,9 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
+@@ -652,11 +685,9 @@ func (a *ContainerProfileProcessor) processTimeSeries(ctx context.Context,
  		return result, err
  	}
  	result.skipFurtherProcessing = skipFurtherProcessing
@@ -260,7 +271,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  
  	return result, nil
  }
-@@ -734,6 +754,7 @@ func (a *ContainerProfileProcessor) consolidateContinuousTimeSeries(
+@@ -734,6 +765,7 @@ func (a *ContainerProfileProcessor) consolidateContinuousTimeSeries(
  // Returns true if further processing should be skipped (e.g., profile is fully completed).
  func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key, seriesID string,
  	profile *softwarecomposition.ContainerProfile, newTimeSeries []softwarecomposition.TimeSeriesContainers, expired bool) ([]softwarecomposition.TimeSeriesContainers, bool, error) {
@@ -268,7 +279,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  
  	// If the time series is expired, we finalize it as Completed/Partial (unless it is already Completed/Full)
  	// and clear the time series data so we don't leak zombie records.
-@@ -748,10 +769,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
+@@ -748,10 +780,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
  			logger.L().Debug("ContainerProfileProcessor.updateProfileStatus - expired profile is completed/full, skipping further processing",
  				loggerhelpers.String("key", key), loggerhelpers.String("seriesID", seriesID))
  
@@ -281,7 +292,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  			return newTimeSeries[:0], true, nil
  		}
  
-@@ -777,10 +796,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
+@@ -777,10 +807,8 @@ func (a *ContainerProfileProcessor) updateProfileStatus(ctx context.Context, key
  			logger.L().Debug("ContainerProfileProcessor.updateProfileStatus - profile is completed/full, skipping further processing",
  				loggerhelpers.String("key", key), loggerhelpers.String("seriesID", seriesID))
  
@@ -295,7 +306,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..dfe389f7d653dd9e489449eabb6b4b1f
  		}
  		// Clear this time series as it is finished
 diff --git a/pkg/registry/file/containerprofile_processor_test.go b/pkg/registry/file/containerprofile_processor_test.go
-index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0da3b7b3be 100644
+index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524735ca9b5 100644
 --- a/pkg/registry/file/containerprofile_processor_test.go
 +++ b/pkg/registry/file/containerprofile_processor_test.go
 @@ -12,6 +12,7 @@ import (
@@ -306,7 +317,7 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0d
  	"github.com/kubescape/storage/pkg/generated/clientset/versioned/scheme"
  	"github.com/kubescape/storage/pkg/utils"
  	"github.com/spf13/afero"
-@@ -23,6 +24,64 @@ import (
+@@ -23,6 +24,67 @@ import (
  	"zombiezen.com/go/sqlite/sqlitemigration"
  )
  
@@ -334,12 +345,13 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0d
 +		storage     *fakeStorage
 +		wantErr     string
 +		wantReplace int
++		wantBegin   int
 +	}{
 +		{name: "observed save", storage: &fakeStorage{saveContainerErr: errors.New("observed save failed")}, wantErr: "observed save failed"},
 +		{name: "merged refresh", storage: &fakeStorage{deleteMergedErr: errors.New("merged refresh failed")}, wantErr: "merged refresh failed"},
 +		{name: "application profile", storage: &fakeStorage{updateApplicationErr: errors.New("application profile failed")}, wantErr: "application profile failed"},
 +		{name: "network neighborhood", storage: &fakeStorage{updateNetworkErr: errors.New("network neighborhood failed")}, wantErr: "network neighborhood failed"},
-+		{name: "all profile writes succeed", storage: &fakeStorage{}, wantReplace: 1},
++		{name: "all profile writes succeed", storage: &fakeStorage{}, wantReplace: 1, wantBegin: 1},
 +	}
 +
 +	for _, tt := range tests {
@@ -364,6 +376,8 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0d
 +			}
 +			require.Equal(t, tt.wantReplace, tt.storage.replaceTimeSeriesCalls,
 +				"source rows must be retired only after every profile write succeeds")
++			require.Equal(t, tt.wantBegin, tt.storage.beginTransactionCalls,
++				"the short source-row finalization transaction must start only after every profile write succeeds")
 +		})
 +	}
 +}
@@ -371,7 +385,7 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..fb398d32b6079ad042a48d56c0949f0d
  func TestConsolidateData(t *testing.T) {
  	// Prepare pool and connection
  	pool := NewTestPool("/tmp")
-@@ -571,8 +630,7 @@ func TestUpdateProfileStatusExpiredFull(t *testing.T) {
+@@ -571,8 +633,7 @@ func TestUpdateProfileStatusExpiredFull(t *testing.T) {
  	assert.NoError(t, err)
  	assert.True(t, skip)
  	assert.Len(t, res, 0) // should be cleared

--- a/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
+++ b/k8s/bases/infrastructure/controllers/kubescape/storage-v0.0.297-sqlite-contention.patch
@@ -306,7 +306,7 @@ index db4a8ee109787ad75e0c5333046832ea53322637..610b7cd097d8242bb21b8980c231cf44
  		}
  		// Clear this time series as it is finished
 diff --git a/pkg/registry/file/containerprofile_processor_test.go b/pkg/registry/file/containerprofile_processor_test.go
-index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524735ca9b5 100644
+index 384d059e98f73e9a97dbceb79912f489f13476e9..8815cbb7db803cf5ab92544fc34215f2473900f5 100644
 --- a/pkg/registry/file/containerprofile_processor_test.go
 +++ b/pkg/registry/file/containerprofile_processor_test.go
 @@ -12,6 +12,7 @@ import (
@@ -317,7 +317,7 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524
  	"github.com/kubescape/storage/pkg/generated/clientset/versioned/scheme"
  	"github.com/kubescape/storage/pkg/utils"
  	"github.com/spf13/afero"
-@@ -23,6 +24,67 @@ import (
+@@ -23,6 +24,84 @@ import (
  	"zombiezen.com/go/sqlite/sqlitemigration"
  )
  
@@ -357,18 +357,23 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524
 +	for _, tt := range tests {
 +		t.Run(tt.name, func(t *testing.T) {
 +			processor := &ContainerProfileProcessor{ContainerProfileStorage: tt.storage}
-+			profile := softwarecomposition.ContainerProfile{
-+				ObjectMeta: metav1.ObjectMeta{
-+					Annotations: map[string]string{
-+						helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-default/kind-ReplicaSet/name-example/containerName-app",
++			runUpdate := func() error {
++				profile := softwarecomposition.ContainerProfile{
++					ObjectMeta: metav1.ObjectMeta{
++						Annotations: map[string]string{
++							helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-default/kind-ReplicaSet/name-example/containerName-app",
++						},
 +					},
-+				},
-+			}
-+			timeSeries := map[string][]softwarecomposition.TimeSeriesContainers{
-+				"series": {{TsSuffix: "pending", HasData: true}},
++				}
++				timeSeries := map[string][]softwarecomposition.TimeSeriesContainers{
++					"series": {{TsSuffix: "pending", HasData: true}},
++				}
++
++				_, err := processor.updateProfile(context.Background(), timeSeries, "key", profile, "", "", armotypes.ProfileIdentifier{}, false)
++				return err
 +			}
 +
-+			_, err := processor.updateProfile(context.Background(), timeSeries, "key", profile, "", "", armotypes.ProfileIdentifier{}, false)
++			err := runUpdate()
 +			if tt.wantErr != "" {
 +				require.ErrorContains(t, err, tt.wantErr)
 +			} else {
@@ -378,6 +383,18 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524
 +				"source rows must be retired only after every profile write succeeds")
 +			require.Equal(t, tt.wantBegin, tt.storage.beginTransactionCalls,
 +				"the short source-row finalization transaction must start only after every profile write succeeds")
++
++			if tt.wantErr != "" {
++				tt.storage.saveContainerErr = nil
++				tt.storage.deleteMergedErr = nil
++				tt.storage.updateApplicationErr = nil
++				tt.storage.updateNetworkErr = nil
++				require.NoError(t, runUpdate(), "the next maintenance tick must replay and converge after the failed write clears")
++				require.Equal(t, 1, tt.storage.replaceTimeSeriesCalls,
++					"the replay must retire the still-pending source row after convergence")
++				require.Equal(t, 1, tt.storage.beginTransactionCalls,
++					"the replay must finalize source rows in one short transaction")
++			}
 +		})
 +	}
 +}
@@ -385,7 +402,7 @@ index 384d059e98f73e9a97dbceb79912f489f13476e9..67b10aa4d957038f35fc6d0c1314e524
  func TestConsolidateData(t *testing.T) {
  	// Prepare pool and connection
  	pool := NewTestPool("/tmp")
-@@ -571,8 +633,7 @@ func TestUpdateProfileStatusExpiredFull(t *testing.T) {
+@@ -571,8 +650,7 @@ func TestUpdateProfileStatusExpiredFull(t *testing.T) {
  	assert.NoError(t, err)
  	assert.True(t, skip)
  	assert.Len(t, res, 0) // should be cleared

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -121,6 +121,8 @@ grep -qF 'TestUpdateProfileKeepsTimeSeriesPendingUntilAllProfileWritesSucceed' "
   fail 'the compatibility patch must prove every partial profile-write boundary remains retryable'
 grep -qF 'source rows must be retired only after every profile write succeeds' "${patch_file}" ||
   fail 'time-series observations must stay pending until all derived writes succeed'
+grep -qF 'the next maintenance tick must replay and converge after the failed write clears' "${patch_file}" ||
+  fail 'the partial-write failpoints must prove replay convergence, not only row retention'
 grep -qF 'finalize only the source rows in one short transaction' "${patch_file}" ||
   fail 'source-row retirement must remain atomic without spanning derived profile writes'
 grep -qF 'persistence can run between maintenance writes' "${patch_file}" ||

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -117,7 +117,11 @@ grep -qF 'TestBeginTransactionLeavesWriterAvailableDuringReadPhase' "${patch_fil
   fail 'the compatibility patch must prove profile reads do not reserve SQLite write access'
 grep -qF 'TestConsolidateKeyDoesNotHoldWriterAcrossProfileProcessing' "${patch_file}" ||
   fail 'the compatibility patch must prove maintenance does not hold one transaction across artifact processing'
-grep -qF 'autocommit so foreground persistence can run between maintenance writes' "${patch_file}" ||
+grep -qF 'TestUpdateProfileKeepsTimeSeriesPendingUntilAllProfileWritesSucceed' "${patch_file}" ||
+  fail 'the compatibility patch must prove every partial profile-write boundary remains retryable'
+grep -qF 'source rows must be retired only after every profile write succeeds' "${patch_file}" ||
+  fail 'time-series observations must stay pending until all derived writes succeed'
+grep -qF 'persistence can run between maintenance writes' "${patch_file}" ||
   fail 'container-profile maintenance must release SQLite between idempotent artifact writes'
 if grep -qF 'ImmediateTransaction' "${patch_file}"; then
   fail 'read-heavy profile transactions must not reserve SQLite write access before their write phase'

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -35,8 +35,8 @@ command -v yq >/dev/null 2>&1 || fail 'yq v4 is required'
   fail 'the workflow image destination drifted'
 # The literal GitHub expression is the contract.
 # shellcheck disable=SC2016
-[[ "$(yq -er '.env.IMAGE_TAG' "${workflow}")" == 'v0.0.297-sqlite-contention.3-${{ github.sha }}' ]] ||
-  fail 'the workflow image tag must identify the foreground-safe transaction revision'
+[[ "$(yq -er '.env.IMAGE_TAG' "${workflow}")" == 'v0.0.297-sqlite-contention.4-${{ github.sha }}' ]] ||
+  fail 'the workflow image tag must identify the short-transaction revision'
 
 grep -qF 'repository: kubescape/storage' "${workflow}" ||
   fail 'the workflow must check out the upstream storage source explicitly'
@@ -91,7 +91,7 @@ readonly image_build_index
 grep -qF 'cosign sign --yes "${IMAGE}@${DIGEST}"' "${workflow}" ||
   fail 'the published compatibility image must be keylessly signed by digest'
 
-[[ "$(grep -c '^diff --git ' "${patch_file}")" == '5' ]] ||
+[[ "$(grep -c '^diff --git ' "${patch_file}")" == '6' ]] ||
   fail 'the compatibility patch must touch only implementation and regression-test files'
 grep -qF 'diff --git a/pkg/registry/file/sqlite.go b/pkg/registry/file/sqlite.go' "${patch_file}" ||
   fail 'the compatibility patch does not modify SQLite pool setup'
@@ -105,6 +105,8 @@ grep -qF 'diff --git a/pkg/registry/file/containerprofile_processor.go b/pkg/reg
   fail 'the compatibility patch does not bound background SQLite writers'
 grep -qF 'diff --git a/pkg/registry/file/containerprofile_processor_test.go b/pkg/registry/file/containerprofile_processor_test.go' "${patch_file}" ||
   fail 'the compatibility patch lacks a background-writer regression test'
+grep -qF 'diff --git a/pkg/registry/file/containerprofile_aggregator_test.go b/pkg/registry/file/containerprofile_aggregator_test.go' "${patch_file}" ||
+  fail 'the compatibility patch lacks a cross-artifact transaction regression seam'
 grep -qF 'diff --git a/pkg/registry/file/containerprofile_storage_test.go b/pkg/registry/file/containerprofile_storage_test.go' "${patch_file}" ||
   fail 'the compatibility patch lacks a foreground-writer regression test'
 grep -qF 'Workers:                 1' "${patch_file}" ||
@@ -113,6 +115,10 @@ grep -qF 'TestNewContainerProfileProcessorUsesOneMaintenanceWriter' "${patch_fil
   fail 'the compatibility patch must prove background writer concurrency is bounded'
 grep -qF 'TestBeginTransactionLeavesWriterAvailableDuringReadPhase' "${patch_file}" ||
   fail 'the compatibility patch must prove profile reads do not reserve SQLite write access'
+grep -qF 'TestConsolidateKeyDoesNotHoldWriterAcrossProfileProcessing' "${patch_file}" ||
+  fail 'the compatibility patch must prove maintenance does not hold one transaction across artifact processing'
+grep -qF 'autocommit so foreground persistence can run between maintenance writes' "${patch_file}" ||
+  fail 'container-profile maintenance must release SQLite between idempotent artifact writes'
 if grep -qF 'ImmediateTransaction' "${patch_file}"; then
   fail 'read-heavy profile transactions must not reserve SQLite write access before their write phase'
 fi

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -121,6 +121,8 @@ grep -qF 'TestUpdateProfileKeepsTimeSeriesPendingUntilAllProfileWritesSucceed' "
   fail 'the compatibility patch must prove every partial profile-write boundary remains retryable'
 grep -qF 'source rows must be retired only after every profile write succeeds' "${patch_file}" ||
   fail 'time-series observations must stay pending until all derived writes succeed'
+grep -qF 'finalize only the source rows in one short transaction' "${patch_file}" ||
+  fail 'source-row retirement must remain atomic without spanning derived profile writes'
 grep -qF 'persistence can run between maintenance writes' "${patch_file}" ||
   fail 'container-profile maintenance must release SQLite between idempotent artifact writes'
 if grep -qF 'ImmediateTransaction' "${patch_file}"; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Root cause

Production acceptance of #3450 proved that one deferred maintenance worker still holds SQLite's sole writer for too long. The controlled scan completed its evaluation and local result save, then timed out persisting the detailed `WorkloadConfigurationScan`; storage logged `database is locked` for the same foreground write.

The remaining lock window is the container-profile processor's broad transaction. After its first maintenance write upgrades the deferred transaction, it keeps the writer reserved across expensive aggregation and several observed, application-profile, network-neighborhood, and merged-profile writes. That can exceed the foreground request deadline even though maintenance is single-threaded and SQLite waits up to 60 seconds.

## Fix

- Remove the broad cross-artifact maintenance transaction.
- Let each idempotent profile write autocommit, releasing SQLite between writes so foreground posture persistence can run.
- Retire source time-series rows only after every derived write succeeds, preserving the original pending rows and payloads for automatic retry after any partial failure; finalize those rows atomically in one short transaction.
- Keep one maintenance worker and the independently proven 60-second busy timeout.
- Publish a new immutable `sqlite-contention.4` compatibility image from protected `main` only.

The profile payload files were never covered by the old broad SQLite rollback. The explicit pending-row recovery rule now provides durable retry across observed, merged, application-profile, and network-neighborhood write failures, while the short finalization transaction prevents partial source-row retirement without holding SQLite's writer across derived-profile work.

## Proof

- RED: `TestConsolidateKeyDoesNotHoldWriterAcrossProfileProcessing` observed one broad transaction under the exact deployed `.3` design.
- RED: the first short-transaction draft retired a source row before a later profile-write failure, making that partial pass non-retryable.
- GREEN: maintenance now opens zero broad transactions, and a failpoint table proves source rows remain pending across failures at every profile-write boundary, replay converges when the failed write clears, and one short atomic finalization transaction starts only after full success.
- Full `go test ./pkg/registry/file` passes on exact upstream source `b35788b68337134fc2514574cde1ba7f1225fd43` after applying the packaged patch.
- Focused `go test -race` passes.
- Patch apply/check, source-to-package diff, gofmt, ShellCheck, actionlint, the Kubescape hotfix contract, and `git diff --check` pass.

This PR publishes the corrected image. It deliberately does not change the live HelmRelease; deployment and another controlled cluster scan follow only after the protected-main image is signed and independently verified.

Refs #3275.
