### PR TITLE
fix(kubescape): deploy short-transaction storage image

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -214,26 +214,29 @@ spec:
     # Run vulnerability collection in a separate authored window. Keep at
     # least the present eight-hour gap: both scans emit high-volume writes, and
     # the compatibility image still has one SQLite writer. Keep bursty scanners
-    # separated to limit write bursts; one deferred maintenance worker keeps
-    # read-heavy consolidation from holding SQLite's sole writer unnecessarily.
+    # separated to limit write bursts; one maintenance worker and short
+    # source-row finalization keep SQLite's writer available between derived
+    # profile writes.
     kubevulnScheduler:
       scanSchedule: "12 1 * * *"
     storage:
       image:
         # Storage v0.0.297 starts two deferred profile-maintenance workers. They
         # can both read and then race while promoting to SQLite's single writer;
-        # a longer busy timeout cannot recover that promotion. Reserving the
-        # writer before their read-heavy work prevents the promotion race but
-        # can starve foreground scan persistence past the scanner's deadline.
+        # a longer busy timeout cannot recover that promotion. One deferred
+        # worker prevents that race, but a transaction spanning all derived
+        # profile writes can still starve foreground scan persistence past the
+        # scanner's deadline.
         # v0.0.303+ removes the ApplicationProfile and NetworkNeighborhood APIs
         # that this deployment still serves with live data. This compatibility
         # image is the exact v0.0.297 source plus the reviewed 60-second busy
-        # timeout and one deferred maintenance writer, with executable
-        # regressions proving both background serialization and foreground write
-        # availability. The main-only publisher attaches SBOM/provenance and
-        # signs the digest before this pin may advance.
+        # timeout, one maintenance worker, autocommitted derived writes, and a
+        # short atomic source-row finalization transaction. Executable failpoints
+        # prove partial passes remain pending and replay to convergence. The
+        # main-only publisher attaches SBOM/provenance and signs the digest
+        # before this pin may advance.
         repository: ghcr.io/devantler-tech/platform-kubescape-storage
-        tag: "v0.0.297-sqlite-contention.3-04c50922ddf1d4a2f9d2030ccc15318036c68b2a@sha256:254b0f74edf4206c623cf6c49a4087a851ee02493433f8220865f42bafffc597"
+        tag: "v0.0.297-sqlite-contention.4-c674d63c1c391b47839a4a6246945b70ddfe1c01@sha256:e21df062e2c3598fec5b8c2170c5cc68ceeceb412379c3aef986b42c9a46241e"
         pullPolicy: IfNotPresent
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.

--- a/scripts/tests/test-kubescape-storage-hotfix.sh
+++ b/scripts/tests/test-kubescape-storage-hotfix.sh
@@ -9,7 +9,7 @@ readonly patch_file="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/
 readonly helm_release="${root_dir}/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml"
 readonly source_commit='b35788b68337134fc2514574cde1ba7f1225fd43'
 readonly image_repository='ghcr.io/devantler-tech/platform-kubescape-storage'
-readonly image_tag='v0.0.297-sqlite-contention.3-04c50922ddf1d4a2f9d2030ccc15318036c68b2a@sha256:254b0f74edf4206c623cf6c49a4087a851ee02493433f8220865f42bafffc597'
+readonly image_tag='v0.0.297-sqlite-contention.4-c674d63c1c391b47839a4a6246945b70ddfe1c01@sha256:e21df062e2c3598fec5b8c2170c5cc68ceeceb412379c3aef986b42c9a46241e'
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1384,19 +1384,20 @@ const (
 //	a015af05c3b1a620ecd6a7990353e9f1db03b7c50d7ceb2edd63e3563a6591d5
 //	026c985d74ec1230e7272488d2a55c028bb78916c4c8362f22c447c862111d78
 //
-// Measured against main 04c50922 for the Kubescape foreground-safe storage
+// Measured against main c674d63c for the Kubescape short-transaction storage
 // deployment: the five production projections retain the same selected
 // identities, every pinned per-identity fingerprint still passes, and the same
 // 35 known Flux substitution diagnostics remain. The authored delta advances
-// one image override in the Kubescape HelmRelease from the immediate-writer
-// build to the signed build that retains deferred transactions and serializes
-// the two profile-maintenance workers into one. The remaining authored changes
-// only correct the adjacent explanation of that behavior. It adds no subject,
-// grant, security context, authorization resource, or rendered object. The
-// previous approved aggregate digest was:
+// one image override in the Kubescape HelmRelease from the one-worker deferred
+// transaction build to the signed build that releases SQLite between derived
+// profile writes, preserves failed work for replay, and atomically finalizes
+// source rows in one short transaction. The remaining authored changes only
+// correct the adjacent explanation of that behavior. It adds no subject, grant,
+// security context, authorization resource, or rendered object. The previous
+// approved aggregate digest was:
 //
-//	010155143ff52d6f576a406ddb891306333bf27eb9d8ed237b215bf8150073b9
-const expectedRenderedSurfaceSHA = "8758aca997ecdf37b536b18420803f46e67e0af05b851fafefbaa83e02b01fe3"
+//	8758aca997ecdf37b536b18420803f46e67e0af05b851fafefbaa83e02b01fe3
+const expectedRenderedSurfaceSHA = "ec7889f10c850126e206c93669adbd2c1406c5f189e07b2cbfe5e63e7d24e287"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- deploy the signed Kubescape storage compatibility image built from the reviewed v0.0.297 source plus the short-transaction recovery fix
- autocommit expensive derived-profile writes while source rows remain pending for retry, then retire only those rows atomically in one short transaction
- pin the immutable digest and update the deployment contract and authorization-surface fingerprint

## Incident evidence

Live acceptance of the `.3` image showed that one deferred maintenance worker could still hold SQLite's sole writer across the complete multi-artifact profile update. A foreground configuration-scan write then timed out while storage reported `database is locked`, leaving detailed posture stale.

The `.4` source fix removes that broad transaction. Failpoints prove failures at the observed, merged, application-profile, and network-neighborhood boundaries leave source rows pending; the next tick replays and converges after the fault clears. Source-row retirement is atomic but confined to one short finalization transaction.

Published artifact:

`ghcr.io/devantler-tech/platform-kubescape-storage:v0.0.297-sqlite-contention.4-c674d63c1c391b47839a4a6246945b70ddfe1c01@sha256:e21df062e2c3598fec5b8c2170c5cc68ceeceb412379c3aef986b42c9a46241e`

The digest was independently verified with Cosign against the repository's trusted protected-main publisher identity. The publisher also attached SBOM and provenance attestations.

## Verification

- `bash scripts/tests/test-kubescape-storage-hotfix.sh`
- `bash scripts/tests/test-kubescape-self-hosted-scan-persistence.sh`
- `shellcheck` for both Kubescape deployment contracts
- `go test ./scripts/validate-eks-ci-role-policy`
- exact approved `kubectl v1.36.2` authorization renderer
- local and production Kustomize renders
- `git diff --check`

Closes the deployment slice of #3275. The incident remains open until this image reconciles in production and a fresh controlled cluster scan proves detailed posture persistence.
