### PR TITLE
fix(crossplane): name the AWS family provider as Crossplane derives it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,6 +301,9 @@ jobs:
               # Both halves, for the same reason as the guards above.
               - 'scripts/guard-pod-security-exception-scope.sh'
               - 'scripts/tests/test-guard-pod-security-exception-scope.sh'
+              # Both halves, for the same reason as the guards above.
+              - 'scripts/guard-crossplane-provider-name-parity.sh'
+              - 'scripts/tests/test-guard-crossplane-provider-name-parity.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -969,6 +972,28 @@ jobs:
         run: |
           bash scripts/guard-pod-security-exception-scope.sh
           bash scripts/tests/test-guard-pod-security-exception-scope.sh
+
+      - name: 🧬 Validate Crossplane provider names match their derived names
+        if: needs.changes.outputs.k8s == 'true'
+        # A Crossplane Provider declared under a shortened alias instead of the name
+        # Crossplane derives from its package (`<org>-<repo>`) is invisible until
+        # something depends on it — then the dependency manager, which resolves by
+        # derived NAME while the Lock is keyed by package SOURCE, creates a SECOND
+        # Provider for a source already present. Building the dependency graph then
+        # fails with `node <source> already exists`, which marks EVERY provider
+        # Unhealthy and stops all Crossplane reconciliation, not just the duplicated
+        # one. That is #3454: it went live 21 seconds into the 2.3.4 -> 2.4.0 bump and
+        # ran for 15 hours, because nothing in GitHub can see a dead provider fleet.
+        #
+        # The same guard pins the other half, which the rename itself breaks: provider
+        # RBAC is named after the revision (`crossplane:provider:<name>-<hash>:system`),
+        # so two Kubescape exception lists match the provider name by anchored regex.
+        # Renaming without updating both fails nothing — the manifests build, the
+        # provider runs, and a C-0015 finding just reappears days later. Those two
+        # lists are synced by hand, so one-updated-one-forgotten is the realistic drift.
+        run: |
+          bash scripts/guard-crossplane-provider-name-parity.sh k8s
+          bash scripts/tests/test-guard-crossplane-provider-name-parity.sh
 
       - name: 📐 Validate LimitRange-premised suppressions actually have a LimitRange
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml
@@ -156,7 +156,7 @@ spec:
         name: ^crossplane:provider:provider-aws-iam-[0-9a-f]+:system$
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: ^crossplane:provider:provider-family-aws-[0-9a-f]+:system$
+        name: ^crossplane:provider:upbound-provider-family-aws-[0-9a-f]+:system$
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: ^crossplane:provider:provider-upjet-github-[0-9a-f]+:system$

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -963,7 +963,7 @@ data:
             "designatorType": "Attributes",
             "attributes": {
               "kind": "^ClusterRole$",
-              "name": "^crossplane:provider:provider-family-aws-[0-9a-f]+:system$"
+              "name": "^crossplane:provider:upbound-provider-family-aws-[0-9a-f]+:system$"
             }
           },
           {

--- a/k8s/providers/hetzner/infrastructure/crossplane/provider-family-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/provider-family-aws.yaml
@@ -6,9 +6,21 @@
 # controllers/crossplane/ installs first. Prod-only (Crossplane is Hetzner-only).
 #
 # provider-family-aws ships the shared AWS ProviderConfig CRD consumed by every
-# family member. Crossplane would auto-resolve it as a dependency of provider-aws-iam,
-# but it is declared explicitly so its version is pinned and its runtime pod is
-# resource-bounded (see deployment-runtime-config-family-aws.yaml).
+# family member. It is a DEPENDENCY of provider-aws-iam, and is declared explicitly
+# here so its version is pinned and its runtime pod is resource-bounded (see
+# deployment-runtime-config-family-aws.yaml).
+#
+# 🔴 THE NAME IS LOAD-BEARING — it must be the name Crossplane derives from the
+# package (`<org>-<repo>`, here `upbound-provider-family-aws`), NOT a shortened
+# alias. Crossplane's dependency manager resolves a declared dependency by looking
+# for a Provider with that derived NAME and creating one when it is absent, while
+# the Lock is keyed by package SOURCE. Under a shorter alias the lookup misses, a
+# second Provider is created for a source the Lock already holds, and building the
+# dependency graph then fails with `node <source> already exists` — which marks
+# EVERY provider in the cluster Unhealthy, not just this one, and stops all
+# Crossplane reconciliation (platform#3454; hit live on the 2.3.4 → 2.4.0 bump,
+# where the duplicate appeared 21 seconds after the new core rolled out).
+# scripts/guard-crossplane-provider-name-parity.sh pins this.
 #
 # No ProviderConfig/credentials yet: a Provider package becomes Healthy on its own;
 # credentials are only consulted when reconciling managed resources. SafeStart +
@@ -20,7 +32,7 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-family-aws
+  name: upbound-provider-family-aws
 spec:
   package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
   runtimeConfigRef:

--- a/scripts/guard-crossplane-provider-name-parity.sh
+++ b/scripts/guard-crossplane-provider-name-parity.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Fail when a Crossplane Provider's NAME stops agreeing with the two places that
+# depend on it: the name Crossplane derives from its package, and the Kubescape
+# secret-reader exceptions that match its generated ClusterRole by regex.
+#
+# WHY THE NAME MATTERS (platform#3454, a live prod outage).
+#
+# Crossplane's dependency manager resolves a declared dependency by looking for a
+# Provider with the name it DERIVES from the package reference (`<org>-<repo>`),
+# and creates one when that name is absent. The Lock, however, is keyed by package
+# SOURCE. Declare a dependency package under a shortened alias and the two disagree:
+# the name lookup misses, Crossplane creates a second Provider for a source the Lock
+# already holds, and building the dependency graph then fails with
+#
+#     cannot initialize dependency graph from the packages in the lock:
+#     node <source> already exists
+#
+# That failure is not scoped to the duplicated package — it marks EVERY provider in
+# the cluster Unhealthy and stops all Crossplane reconciliation. It went live on the
+# Crossplane 2.3.4 -> 2.4.0 bump: the duplicate appeared 21 seconds after the new core
+# rolled out, and the fleet stayed dead for 15 hours because nothing in GitHub can see
+# it.
+#
+# WHY THE EXCEPTIONS MATTER (the same rename breaks them, silently).
+#
+# Crossplane names a provider's generated RBAC after the provider REVISION —
+# `crossplane:provider:<provider-name>-<package-hash>:system` — so the provider name
+# is a prefix of a cluster-scoped ClusterRole name. Two Kubescape exception lists
+# match that ClusterRole by anchored regex to suppress C-0015 ("List Kubernetes
+# secrets") for providers that read credential Secrets by design. Renaming a provider
+# without updating both regexes does not fail anything: the manifests still build, the
+# provider still runs, and the only symptom is a C-0015 finding reappearing days later
+# with no obvious cause. The two lists are kept in sync BY HAND (their own headers say
+# so), which is exactly the arrangement that drifts.
+#
+# 🔴 FAIL CLOSED. Every input this guard cannot read is exit 2, never a quiet pass.
+# An empty provider set compared against empty exception files is the failure mode
+# that makes a guard look green forever, so the provider set and both exception files
+# are required to be non-empty before any comparison happens.
+#
+# 🔴 SCOPE BY apiVersion, NOT BY `kind: Provider`. `notification.toolkit.fluxcd.io`
+# also has a `Provider` kind (the Flux alert Provider, e.g. `slack`), which has no
+# package, no derived name and no generated ClusterRole. Matching on kind alone pulls
+# it in and reports a false failure on a correct tree.
+#
+# Exit codes:
+#   0  every pkg.crossplane.io Provider is canonically named (or explicitly
+#      dispositioned below) and carries its ClusterRole regex in both exception lists
+#   1  a drift was found
+#   2  an input could not be read, or a required set was empty
+
+set -euo pipefail
+
+root="${1:-k8s}"
+
+secret_reader="$root/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml"
+headlamp_mirror="$root/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml"
+
+die() {
+  printf 'guard-crossplane-provider-name-parity: %s\n' "$1" >&2
+  exit 2
+}
+
+[ -d "$root" ] || die "root '$root' is not a directory"
+[ -r "$secret_reader" ] || die "cannot read the secret-reader exception '$secret_reader'"
+[ -r "$headlamp_mirror" ] || die "cannot read the Headlamp exception mirror '$headlamp_mirror'"
+[ -s "$secret_reader" ] || die "the secret-reader exception '$secret_reader' is empty"
+[ -s "$headlamp_mirror" ] || die "the Headlamp exception mirror '$headlamp_mirror' is empty"
+
+# Providers deliberately NOT carrying their derived name. Each is safe ONLY while no
+# installed package declares it as a dependency: nothing resolves them by name today,
+# so no duplicate is created. Adding a package that depends on one of these re-creates
+# platform#3454 — rename it here rather than extending this list. Draining this list is
+# tracked separately; a NEW provider must be canonically named.
+noncanonical_disposition="
+provider-aws-iam
+provider-upjet-github
+provider-upjet-unifi
+"
+
+# Emit "<name>\t<package>\t<file>" for every pkg.crossplane.io Provider document.
+# shellcheck disable=SC2016  # the awk program is data; the shell must not expand it.
+providers="$(
+  find "$root" -type f -name '*.yaml' -print0 |
+    xargs -0 awk '
+      function flush() {
+        if (is_xp && is_provider && name != "" && pkg != "")
+          printf "%s\t%s\t%s\n", name, pkg, srcfile
+        is_xp = 0; is_provider = 0; name = ""; pkg = ""; srcfile = ""
+      }
+      FNR == 1 { flush() }
+      /^---[[:space:]]*$/ { flush(); next }
+      /^apiVersion:[[:space:]]*pkg\.crossplane\.io\// { is_xp = 1; srcfile = FILENAME }
+      /^kind:[[:space:]]*Provider[[:space:]]*$/ { is_provider = 1; srcfile = FILENAME }
+      /^  name:[[:space:]]*[^[:space:]]/ { if (name == "") { name = $2; if (srcfile == "") srcfile = FILENAME } }
+      /^  package:[[:space:]]*[^[:space:]]/ { if (pkg == "") { pkg = $2; if (srcfile == "") srcfile = FILENAME } }
+      END { flush() }
+    '
+)" || die 'failed to enumerate Provider manifests'
+
+[ -n "$providers" ] || die "found no pkg.crossplane.io Provider manifests under '$root' — refusing to pass vacuously"
+
+# Derive the name Crossplane generates from a package reference:
+#   xpkg.upbound.io/upbound/provider-family-aws:v2.6.1 -> upbound-provider-family-aws
+# Strips any digest and any tag on the final path segment, drops the registry host
+# (the first segment, when it looks like a host), and joins the rest with '-'.
+derive_name() {
+  local ref="$1" path host rest
+  ref="${ref%%@*}"
+  path="${ref%/*}"
+  local last="${ref##*/}"
+  last="${last%%:*}"
+  if [ "$path" = "$ref" ]; then
+    printf '%s\n' "$last"
+    return
+  fi
+  host="${path%%/*}"
+  rest="${path#*/}"
+  case "$host" in
+    *.* | *:* | localhost) ;;
+    *) rest="$path" ;;
+  esac
+  if [ "$rest" = "$path" ] && [ "$host" = "$path" ]; then
+    printf '%s\n' "$last"
+    return
+  fi
+  printf '%s\n' "$(printf '%s/%s' "$rest" "$last" | tr '/' '-')"
+}
+
+status=0
+checked=0
+
+while IFS="$(printf '\t')" read -r name pkg file; do
+  [ -n "$name" ] || continue
+  checked=$((checked + 1))
+
+  derived="$(derive_name "$pkg")"
+  if [ "$name" != "$derived" ]; then
+    if printf '%s\n' "$noncanonical_disposition" | grep -qxF -- "$name"; then
+      printf 'guard-crossplane-provider-name-parity: NOTE %s is not canonically named (derived: %s) — dispositioned; safe only while nothing depends on it\n' \
+        "$name" "$derived"
+    else
+      printf 'guard-crossplane-provider-name-parity: %s (%s) is named "%s" but Crossplane derives "%s" from its package.\n' \
+        "${file}" "$pkg" "$name" "$derived" >&2
+      printf '  A dependent package would make Crossplane create a SECOND Provider for this source, poisoning the lock dependency graph and marking every provider Unhealthy (platform#3454).\n' >&2
+      printf '  Rename it to "%s", or add it to this guard'"'"'s reviewed disposition list with the reason.\n' "$derived" >&2
+      status=1
+    fi
+  fi
+
+  regex="^crossplane:provider:${name}-[0-9a-f]+:system\$"
+  for f in "$secret_reader" "$headlamp_mirror"; do
+    if ! grep -qF -- "$regex" "$f"; then
+      printf 'guard-crossplane-provider-name-parity: %s has no secret-reader exception entry in %s\n' "$name" "$f" >&2
+      printf '  Expected the anchored ClusterRole pattern: %s\n' "$regex" >&2
+      printf '  Crossplane names provider RBAC after the revision, so renaming a provider silently orphans its exception and C-0015 reappears with no failing check.\n' >&2
+      status=1
+    fi
+  done
+done <<EOF
+$providers
+EOF
+
+[ "$checked" -gt 0 ] || die 'parsed no providers out of a non-empty manifest set — the parser is broken, not the tree'
+
+if [ "$status" -ne 0 ]; then
+  printf 'guard-crossplane-provider-name-parity: provider naming and its dependents have drifted\n' >&2
+  exit 1
+fi
+
+printf 'guard-crossplane-provider-name-parity: OK — %d Crossplane Provider(s) checked; names agree with their derived names and both exception lists\n' "$checked"

--- a/scripts/guard-crossplane-provider-name-parity.sh
+++ b/scripts/guard-crossplane-provider-name-parity.sh
@@ -84,9 +84,17 @@ provider-upjet-unifi
 providers="$(
   find "$root" -type f -name '*.yaml' -print0 |
     xargs -0 awk '
-      function flush() {
-        if (is_xp && is_provider && name != "" && pkg != "")
-          printf "%s\t%s\t%s\n", name, pkg, srcfile
+      function flush(  where) {
+        if (is_xp && is_provider) {
+          where = (srcfile == "" ? FILENAME : srcfile)
+          if (name != "" && pkg != "")
+            printf "%s\t%s\t%s\n", name, pkg, where
+          else
+            # A Provider this line-oriented parser cannot read is NOT skipped: a
+            # silently omitted document is exactly how an aliased provider would
+            # slip past a guard that still exits 0 on its neighbours.
+            printf "!unparseable\t%s\t%s\n", (name == "" ? "metadata.name" : "spec.package"), where
+        }
         is_xp = 0; is_provider = 0; name = ""; pkg = ""; srcfile = ""
       }
       FNR == 1 { flush() }
@@ -133,6 +141,11 @@ checked=0
 
 while IFS="$(printf '\t')" read -r name pkg file; do
   [ -n "$name" ] || continue
+
+  if [ "$name" = "!unparseable" ]; then
+    die "$(printf '%s declares a pkg.crossplane.io Provider whose %s this guard could not read.\n  Refusing to pass: an unreadable Provider is indistinguishable from an aliased one, and skipping it is how platform#3454 would recur.\n  Write it in block style (the shape the rest of the tree uses), or teach this parser the shape.' "$file" "$pkg")"
+  fi
+
   checked=$((checked + 1))
 
   derived="$(derive_name "$pkg")"

--- a/scripts/tests/test-guard-crossplane-provider-name-parity.sh
+++ b/scripts/tests/test-guard-crossplane-provider-name-parity.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# Pins the Crossplane provider-name parity guard's verdict in all THREE directions.
+#
+#   exit 0  every pkg.crossplane.io Provider carries the name Crossplane derives from
+#           its package (or is explicitly dispositioned) AND its generated ClusterRole
+#           regex appears in both Kubescape secret-reader exception lists
+#   exit 1  a name drifted from its derived name, or an exception entry is orphaned
+#   exit 2  the guard could not check — missing root, unreadable/empty exception list,
+#           or NO pkg.crossplane.io Provider found at all
+#
+# Three of these are anti-vacuity or scoping cases rather than behaviours:
+#
+#   * A tree with no Crossplane Provider must be exit 2, NOT a clean exit 0. A
+#     selector that matched nothing looks exactly like a healthy tree, which is the
+#     failure class the guard exists to prevent.
+#   * `notification.toolkit.fluxcd.io` ALSO has a `Provider` kind (the Flux alert
+#     provider). It has no package and no generated ClusterRole, so matching on
+#     `kind: Provider` alone would report a false failure on a correct tree. The
+#     mixed fixture asserts the reported count excludes it.
+#   * An orphaned exception must be caught in EACH list independently — the two are
+#     synced by hand, so the realistic drift is one updated and the other forgotten.
+#
+# Every fixture carries its OWN provider name, so an assertion can only be satisfied
+# by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-crossplane-provider-name-parity.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <root>
+  # Capture the status with `if` rather than toggling `set -e`: this file runs under
+  # `set -uo pipefail` with NO errexit, so `set -e` here would enable a mode the
+  # script never had.
+  if GUARD_OUT="$("$guard" "$1" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
+}
+
+assert_rc() { # <label> <expected-rc> <actual-rc>
+  assertions=$((assertions + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s (exit %s)\n' "$1" "$3"
+  else
+    printf '  FAIL %s: expected exit %s, got %s\n' "$1" "$2" "$3"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() { # <label> <needle>
+  assertions=$((assertions + 1))
+  # A here-string, NOT a pipe: `grep -q` exits on the first match, and the SIGPIPE
+  # that gives the upstream `printf` becomes the pipeline status under `pipefail`.
+  if grep -qF -- "$2" <<<"$GUARD_OUT"; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: output did not contain %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_not_contains() { # <label> <needle>
+  assertions=$((assertions + 1))
+  if grep -qF -- "$2" <<<"$GUARD_OUT"; then
+    printf '  FAIL %s: output unexpectedly contained %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  else
+    printf '  ok   %s\n' "$1"
+  fi
+}
+
+# new_tree <name> -> echoes a root with both exception lists present but EMPTY of
+# crossplane entries; callers add providers and the matching exception lines.
+new_tree() {
+  local root="$scratch/$1"
+  mkdir -p "$root/bases/infrastructure/cluster-security-exceptions" \
+    "$root/bases/infrastructure/controllers/kubescape" \
+    "$root/providers/hetzner/infrastructure/crossplane"
+  printf 'apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1\nkind: ClusterSecurityException\n' \
+    >"$root/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml"
+  printf 'apiVersion: v1\nkind: ConfigMap\n' \
+    >"$root/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml"
+  printf '%s\n' "$root"
+}
+
+add_provider() { # <root> <name> <package>
+  cat >"$1/providers/hetzner/infrastructure/crossplane/$2.yaml" <<YAML
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: $2
+spec:
+  package: $3
+  runtimeConfigRef:
+    name: $2
+YAML
+}
+
+add_exception() { # <root> <provider-name> <which: both|secret-reader|headlamp>
+  local line="^crossplane:provider:$2-[0-9a-f]+:system\$"
+  case "$3" in
+    both | secret-reader)
+      printf '        name: %s\n' "$line" \
+        >>"$1/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml"
+      ;;
+  esac
+  case "$3" in
+    both | headlamp)
+      printf '              "name": "%s"\n' "$line" \
+        >>"$1/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml"
+      ;;
+  esac
+}
+
+printf 'test-guard-crossplane-provider-name-parity\n'
+
+# --- 1. clean: canonical name, both exception lists carry it -------------------
+t="$(new_tree clean)"
+add_provider "$t" upbound-provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" upbound-provider-family-aws both
+run_guard "$t"
+assert_rc 'canonical name with both exceptions passes' 0 "$GUARD_RC"
+assert_contains 'reports the number checked' '1 Crossplane Provider(s) checked'
+
+# --- 2. the platform#3454 drift: a shortened alias, exceptions consistent ------
+# This is the pre-fix tree: the name is internally consistent everywhere, so nothing
+# else in the repo fails. Only the derived-name comparison catches it.
+t="$(new_tree alias)"
+add_provider "$t" provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" provider-family-aws both
+run_guard "$t"
+assert_rc 'a shortened alias is refused' 1 "$GUARD_RC"
+assert_contains 'names the derived name it expected' 'upbound-provider-family-aws'
+assert_contains 'explains the lock-poisoning consequence' 'poisoning the lock dependency graph'
+
+# --- 3. orphaned exception, secret-reader list only ----------------------------
+t="$(new_tree orphan-secret-reader)"
+add_provider "$t" upbound-provider-orphan-a xpkg.upbound.io/upbound/provider-orphan-a:v1.0.0
+add_exception "$t" upbound-provider-orphan-a headlamp
+run_guard "$t"
+assert_rc 'a missing secret-reader entry is refused' 1 "$GUARD_RC"
+assert_contains 'names the secret-reader list' 'secret-reader-rbac.yaml'
+assert_not_contains 'does not blame the mirror that is correct' 'no secret-reader exception entry in '"$t"'/bases/infrastructure/controllers/kubescape'
+
+# --- 4. orphaned exception, Headlamp mirror only -------------------------------
+t="$(new_tree orphan-headlamp)"
+add_provider "$t" upbound-provider-orphan-b xpkg.upbound.io/upbound/provider-orphan-b:v1.0.0
+add_exception "$t" upbound-provider-orphan-b secret-reader
+run_guard "$t"
+assert_rc 'a missing Headlamp mirror entry is refused' 1 "$GUARD_RC"
+assert_contains 'names the Headlamp mirror' 'config-map-headlamp-exceptions.yaml'
+
+# --- 5. the Flux Provider kind is not a Crossplane Provider --------------------
+t="$(new_tree flux-mixed)"
+add_provider "$t" upbound-provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" upbound-provider-family-aws both
+mkdir -p "$t/providers/hetzner/infrastructure/flux-notifications"
+cat >"$t/providers/hetzner/infrastructure/flux-notifications/provider.yaml" <<'YAML'
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack
+spec:
+  type: slack
+YAML
+run_guard "$t"
+assert_rc 'a Flux alert Provider does not make the tree fail' 0 "$GUARD_RC"
+assert_contains 'and is not counted as a Crossplane provider' '1 Crossplane Provider(s) checked'
+
+# --- 6. anti-vacuity: no Crossplane Provider at all ----------------------------
+t="$(new_tree empty)"
+run_guard "$t"
+assert_rc 'a tree with no Crossplane Provider is exit 2, never a clean pass' 2 "$GUARD_RC"
+assert_contains 'says it refused to pass vacuously' 'refusing to pass vacuously'
+
+# --- 7. fail closed on an unreadable exception list ----------------------------
+t="$(new_tree unreadable)"
+add_provider "$t" upbound-provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" upbound-provider-family-aws both
+rm -f "$t/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml"
+run_guard "$t"
+assert_rc 'a missing exception list is exit 2, not a drift verdict' 2 "$GUARD_RC"
+
+# --- 8. fail closed on a root that does not exist ------------------------------
+run_guard "$scratch/does-not-exist"
+assert_rc 'a missing root is exit 2' 2 "$GUARD_RC"
+
+# --- 9. an empty exception list is not silently "no entries to check" ----------
+t="$(new_tree empty-exception)"
+add_provider "$t" upbound-provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+: >"$t/bases/infrastructure/cluster-security-exceptions/secret-reader-rbac.yaml"
+run_guard "$t"
+assert_rc 'an empty exception list is exit 2' 2 "$GUARD_RC"
+
+# --- 10. a dispositioned non-canonical name passes, but says so ----------------
+t="$(new_tree dispositioned)"
+add_provider "$t" provider-upjet-github ghcr.io/crossplane-contrib/provider-upjet-github:v0.19.1
+add_exception "$t" provider-upjet-github both
+run_guard "$t"
+assert_rc 'a reviewed non-canonical name passes' 0 "$GUARD_RC"
+assert_contains 'but is reported rather than hidden' 'is not canonically named'
+
+# --- 11. the failure names the file the provider is IN --------------------------
+# Regression: the parser flushes a completed document at FNR==1 of the NEXT file, by
+# which time awk's FILENAME has already advanced — so the message blamed whichever
+# file happened to be read next. That misdirects whoever has to fix it, and on the
+# real tree it pointed at deployment-runtime-config.yaml instead of the provider.
+t="$(new_tree filename-attribution)"
+add_provider "$t" provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" provider-family-aws both
+add_provider "$t" upbound-provider-zzz-later xpkg.upbound.io/upbound/provider-zzz-later:v1.0.0
+add_exception "$t" upbound-provider-zzz-later both
+run_guard "$t"
+assert_rc 'still refuses the aliased provider alongside a correct one' 1 "$GUARD_RC"
+assert_contains 'blames the file the aliased provider is in' 'crossplane/provider-family-aws.yaml'
+assert_not_contains 'does not blame the innocent later file' 'crossplane/upbound-provider-zzz-later.yaml ('
+
+printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
+[ "$failures" -eq 0 ]

--- a/scripts/tests/test-guard-crossplane-provider-name-parity.sh
+++ b/scripts/tests/test-guard-crossplane-provider-name-parity.sh
@@ -226,5 +226,29 @@ assert_rc 'still refuses the aliased provider alongside a correct one' 1 "$GUARD
 assert_contains 'blames the file the aliased provider is in' 'crossplane/provider-family-aws.yaml'
 assert_not_contains 'does not blame the innocent later file' 'crossplane/upbound-provider-zzz-later.yaml ('
 
+# --- 12. a Provider this parser cannot read is exit 2, never a silent skip ------
+# Regression: flush() emitted a record only when BOTH name and package matched its
+# narrow block-style patterns, and dropped the document otherwise. A flow-style
+# Provider therefore vanished while its neighbours still parsed, so `checked` stayed
+# non-zero, the anti-vacuity backstop never fired, and the guard exited 0 over
+# exactly the aliased shape it exists to catch — the platform#3454 outage, re-armed.
+t="$(new_tree unparseable)"
+add_provider "$t" upbound-provider-family-aws xpkg.upbound.io/upbound/provider-family-aws:v2.6.1
+add_exception "$t" upbound-provider-family-aws both
+run_guard "$t"
+# Negative control FIRST: without the unreadable document this very tree passes, so
+# the assertion below can only be satisfied by the document the case is about.
+assert_rc 'control: the same tree without the unreadable document passes' 0 "$GUARD_RC"
+cat >"$t/providers/hetzner/infrastructure/crossplane/flow-style.yaml" <<'YAML'
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata: { name: sneaky-alias }
+spec: { package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.1 }
+YAML
+run_guard "$t"
+assert_rc 'an unreadable Provider is exit 2, not a silent skip' 2 "$GUARD_RC"
+assert_contains 'blames the file it could not read' 'flow-style.yaml'
+assert_contains 'names the field it could not read' 'metadata.name'
+
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ]

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1397,7 +1397,42 @@ const (
 // approved aggregate digest was:
 //
 //	8758aca997ecdf37b536b18420803f46e67e0af05b851fafefbaa83e02b01fe3
-const expectedRenderedSurfaceSHA = "ec7889f10c850126e206c93669adbd2c1406c5f189e07b2cbfe5e63e7d24e287"
+//
+// Moved again by the Crossplane provider rename that fixes the dead provider
+// fleet (#3454): provider-family-aws becomes upbound-provider-family-aws, the
+// name Crossplane derives from its package, so the dependency manager stops
+// creating a duplicate Provider for a source the lock already holds.
+//
+// Measured against main 14351b35 by rendering all five roots from both trees
+// with ONE renderer, so renderer differences cancel: 544 documents on main and
+// 544 on this branch. Neither side carries a duplicate apiVersion|kind|
+// namespace|name identity, so the pairing is one-to-one. Set difference in BOTH
+// directions returns exactly one document each way — the rename, and nothing
+// else:
+//
+//	removed  pkg.crossplane.io/v1  Provider  provider-family-aws
+//	added    pkg.crossplane.io/v1  Provider  upbound-provider-family-aws
+//
+// A Crossplane Provider is not a grant-bearing kind, and the grant-bearing
+// counts confirm nothing moved: Role / ClusterRole / RoleBinding /
+// ClusterRoleBinding / ServiceAccount are 11/24/15/12/16 on BOTH sides.
+//
+// Exactly two surviving documents change content, both because provider RBAC is
+// named after the provider revision, so the rename moves the ClusterRole these
+// two match by anchored regex:
+//
+//	kubescape.io/v1beta1  ClusterSecurityException  secret-reader-rbac
+//	v1                    ConfigMap                 kubescape/headlamp-exceptions
+//
+// Both are byte-identical to main after un-substituting the rename in the
+// rendered output, so the regex is their ONLY change; the negative control (the
+// same comparison without that substitution) reports a difference, so the check
+// is not vacuous. No subject, grant, security context, or authorization
+// resource is added, removed or widened. The previous approved aggregate digest
+// was:
+//
+//	ec7889f10c850126e206c93669adbd2c1406c5f189e07b2cbfe5e63e7d24e287
+const expectedRenderedSurfaceSHA = "a3199d02a7c8b32c0c82bd6a619ea020993d0e37f2dc1e4fe1b23e96d3a91f5d"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Every Crossplane provider in prod has been unhealthy since yesterday evening, and all Crossplane reconciliation has been stopped for about 15 hours. Nothing in GitHub can see this — CI is green across the portfolio.

The trigger was the routine Crossplane 2.3.4 → 2.4.0 bump. The new core looks up a package's declared dependency by the name it *derives* from the package reference, but the cluster's lock file is keyed by the package *address*. Our AWS family provider was declared under a shortened alias, so the lookup missed, Crossplane installed a second copy of the same package under its own name 21 seconds later, and the lock then held one address twice. Every provider fails to start from that point — not just the duplicated one, so the GitHub and UniFi providers went down as collateral.

Existing managed resources kept running throughout; what stopped was reconciliation, so drift is no longer corrected.

### What this changes

Renames the provider to the name Crossplane derives, which makes the lookup hit so no second copy is created, and lets GitOps adopt the stray one and remove the alias — leaving a single lock entry. The pinned version and the resource limits on the provider's pod are unchanged.

The rename also moves the permissions object that two Kubescape exception lists match by name, so both are updated here. That pairing is the quiet part: it is maintained by hand, and missing it breaks nothing visible — the manifests build, the provider runs, and a security finding simply reappears days later with no obvious cause.

A new check pins both halves so neither can drift again. Three other providers are not named this way; nothing currently depends on them, so they are recorded as a reviewed exception rather than renamed under an outage, and a follow-up will drain that list.

### Operational note

This is the fix for a live prod degradation, so it wants merging promptly. Recovery is expected on the next reconcile after merge and is verifiable directly on the cluster.

Fixes #3454
