### PR TITLE
fix(policy): allow retired routes to be deleted

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-route-hostnames.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-route-hostnames.yaml
@@ -39,7 +39,9 @@
 #
 # Because the excludes match on request.userInfo, the policy is admission-only
 # (background: false); every escalation is a create/update that passes through
-# admission, so enforcement is unaffected.
+# admission, so enforcement is unaffected. DELETE is deliberately excluded:
+# removing a route cannot claim a hostname, and retired tenant resources must
+# remain removable after their allow-list entry is gone.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -70,6 +72,9 @@ spec:
           - resources:
               kinds:
                 - HTTPRoute
+              operations:
+                - CREATE
+                - UPDATE
               namespaces:
                 - wedding-app
       exclude:
@@ -102,6 +107,9 @@ spec:
           - resources:
               kinds:
                 - HTTPRoute
+              operations:
+                - CREATE
+                - UPDATE
               namespaces:
                 - ascoachingogvaner
       exclude:
@@ -138,6 +146,9 @@ spec:
           - resources:
               kinds:
                 - HTTPRoute
+              operations:
+                - CREATE
+                - UPDATE
               namespaceSelector:
                 matchLabels:
                   app.kubernetes.io/managed-by: ksail

--- a/tests/restrict-tenant-route-hostnames-delete/kyverno-test.yaml
+++ b/tests/restrict-tenant-route-hostnames-delete/kyverno-test.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-tenant-route-hostnames-delete
+policies:
+  - >-
+    ../../k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-route-hostnames.yaml
+resources:
+  - resources.yaml
+variables: values.yaml
+userinfo: user-info.yaml
+results:
+  - policy: restrict-tenant-route-hostnames
+    rule: wedding-app-approved-hostnames
+    resources:
+      - wedding-app/retired-route
+    kind: HTTPRoute
+    result: skip
+  - policy: restrict-tenant-route-hostnames
+    rule: ascoachingogvaner-approved-hostnames
+    resources:
+      - ascoachingogvaner/retired-route
+    kind: HTTPRoute
+    result: skip
+  - policy: restrict-tenant-route-hostnames
+    rule: unlisted-tenant-namespace-has-no-approved-hostnames
+    resources:
+      - future-tenant/retired-route
+    kind: HTTPRoute
+    result: skip

--- a/tests/restrict-tenant-route-hostnames-delete/resources.yaml
+++ b/tests/restrict-tenant-route-hostnames-delete/resources.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: retired-route
+  namespace: wedding-app
+spec:
+  hostnames:
+    - retired.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: retired-route
+  namespace: ascoachingogvaner
+spec:
+  hostnames:
+    - retired.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: retired-route
+  namespace: future-tenant
+spec:
+  hostnames:
+    - retired.example.com

--- a/tests/restrict-tenant-route-hostnames-delete/user-info.yaml
+++ b/tests/restrict-tenant-route-hostnames-delete/user-info.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: UserInfo
+metadata:
+  name: tenant-author
+userInfo:
+  username: system:serviceaccount:wedding-app:wedding-app
+  groups:
+    - system:serviceaccounts
+    - system:authenticated

--- a/tests/restrict-tenant-route-hostnames-delete/values.yaml
+++ b/tests/restrict-tenant-route-hostnames-delete/values.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+metadata:
+  name: values
+globalValues:
+  request.operation: DELETE
+namespaceSelector:
+  - name: wedding-app
+    labels:
+      app.kubernetes.io/managed-by: ksail
+  - name: ascoachingogvaner
+    labels:
+      app.kubernetes.io/managed-by: ksail
+  - name: future-tenant
+    labels:
+      app.kubernetes.io/managed-by: ksail


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Summary

- limit the tenant HTTPRoute hostname policy to CREATE and UPDATE operations
- keep DELETE outside the admission boundary so retired routes remain removable after allow-list changes
- add a Kyverno CLI regression suite that covers every hostname rule on DELETE

## Root cause

The policy matched HTTPRoute resources without an operation filter. Kyverno therefore evaluated DELETE requests and could reject removal after a tenant no longer had an allow-list entry. Deletion cannot claim a new hostname, so it is outside this policy's security purpose.

## Verification

- RED: the new DELETE suite failed all 3 rules before the policy change (`Want skip, got fail`)
- GREEN: DELETE suite: 3 passed, 0 failed
- Existing hostname suite: 12 passed, 0 failed
- Full Kyverno suite: 147 passed, 0 failed
- Manifest naming validation passed
- `ksail workload validate` passed
- `ksail --config ksail.prod.yaml workload validate` passed

Closes #3461
