### PR TITLE
fix(crossplane): set seccompProfile at pod level in every provider runtime config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,12 @@ jobs:
               - '.github/workflows/validate-image-verifier-liveness.yaml'
               - 'scripts/tests/test-openbao-oidc-role.sh'
               - 'scripts/tests/test-actual-budget-auth-route.sh'
+              # The provider DeploymentRuntimeConfigs, this gate and its kyverno
+              # fixture are one contract: a container-only seccompProfile is
+              # denied by the fail-closed webhook and takes the whole provider
+              # fleet to zero pods on the next revision bump (#3470).
+              - 'scripts/tests/test-provider-drc-pod-seccomp.sh'
+              - 'tests/validate-pod-security-provider-deployment/**'
               - 'scripts/tests/test-pvc-prune-safety.sh'
               - 'scripts/tests/test-headlamp-plugin-removal.sh'
               - 'scripts/tests/test-github-config-role-activation-parity.sh'
@@ -777,6 +783,8 @@ jobs:
           bash scripts/tests/test-tenant-route-hostname-boundary.sh
           shellcheck scripts/tests/test-actual-budget-auth-route.sh
           bash scripts/tests/test-actual-budget-auth-route.sh
+          shellcheck scripts/tests/test-provider-drc-pod-seccomp.sh
+          bash scripts/tests/test-provider-drc-pod-seccomp.sh
 
       - name: 🚦 Validate default-off Cilium bandwidth manager
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
@@ -9,6 +9,16 @@ spec:
       selector: {}
       template:
         spec:
+          # validate-pod-security's require-seccomp-profile asserts the POD-level
+          # path, and Crossplane's package manager creates this Deployment
+          # directly, so the container-level value below does not satisfy it and
+          # the create is denied by the fail-closed webhook. add-security-context
+          # cannot fill the gap either: its match/exclude carry pod selectors, so
+          # Kyverno generates no pod-controller rules for it and it never sees a
+          # Deployment. The DRC therefore has to state this itself.
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: package-runtime
               # IAM is global, but the provider validates credentials through

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
@@ -16,7 +16,16 @@ spec:
           # cannot fill the gap either: its match/exclude carry pod selectors, so
           # Kyverno generates no pod-controller rules for it and it never sees a
           # Deployment. The DRC therefore has to state this itself.
+          #
+          # The package manager applies its pod-level defaults only when the DRC
+          # provides no securityContext at all, so this block has to restate
+          # them verbatim (runAsNonRoot/runAsUser/runAsGroup = Crossplane's
+          # documented 2000) — adding seccompProfile alone would drop the uid
+          # the provider images run as.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
@@ -18,7 +18,16 @@ spec:
           # cannot fill the gap either: its match/exclude carry pod selectors, so
           # Kyverno generates no pod-controller rules for it and it never sees a
           # Deployment. The DRC therefore has to state this itself.
+          #
+          # The package manager applies its pod-level defaults only when the DRC
+          # provides no securityContext at all, so this block has to restate
+          # them verbatim (runAsNonRoot/runAsUser/runAsGroup = Crossplane's
+          # documented 2000) — adding seccompProfile alone would drop the uid
+          # the provider images run as.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
@@ -11,6 +11,16 @@ spec:
       selector: {}
       template:
         spec:
+          # validate-pod-security's require-seccomp-profile asserts the POD-level
+          # path, and Crossplane's package manager creates this Deployment
+          # directly, so the container-level value below does not satisfy it and
+          # the create is denied by the fail-closed webhook. add-security-context
+          # cannot fill the gap either: its match/exclude carry pod selectors, so
+          # Kyverno generates no pod-controller rules for it and it never sees a
+          # Deployment. The DRC therefore has to state this itself.
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: package-runtime
               # Kubescape C-0017 (immutable container filesystem) + the hardening

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
@@ -12,6 +12,16 @@ spec:
       selector: {}
       template:
         spec:
+          # validate-pod-security's require-seccomp-profile asserts the POD-level
+          # path, and Crossplane's package manager creates this Deployment
+          # directly, so the container-level value below does not satisfy it and
+          # the create is denied by the fail-closed webhook. add-security-context
+          # cannot fill the gap either: its match/exclude carry pod selectors, so
+          # Kyverno generates no pod-controller rules for it and it never sees a
+          # Deployment. The DRC therefore has to state this itself.
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: package-runtime
               # Kubescape C-0017 (immutable container filesystem) + the hardening

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
@@ -19,7 +19,16 @@ spec:
           # cannot fill the gap either: its match/exclude carry pod selectors, so
           # Kyverno generates no pod-controller rules for it and it never sees a
           # Deployment. The DRC therefore has to state this itself.
+          #
+          # The package manager applies its pod-level defaults only when the DRC
+          # provides no securityContext at all, so this block has to restate
+          # them verbatim (runAsNonRoot/runAsUser/runAsGroup = Crossplane's
+          # documented 2000) — adding seccompProfile alone would drop the uid
+          # the provider images run as.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
@@ -12,6 +12,16 @@ spec:
       selector: {}
       template:
         spec:
+          # validate-pod-security's require-seccomp-profile asserts the POD-level
+          # path, and Crossplane's package manager creates this Deployment
+          # directly, so the container-level value below does not satisfy it and
+          # the create is denied by the fail-closed webhook. add-security-context
+          # cannot fill the gap either: its match/exclude carry pod selectors, so
+          # Kyverno generates no pod-controller rules for it and it never sees a
+          # Deployment. The DRC therefore has to state this itself.
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: package-runtime
               # Kubescape C-0017 (immutable container filesystem) + the hardening

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
@@ -19,7 +19,16 @@ spec:
           # cannot fill the gap either: its match/exclude carry pod selectors, so
           # Kyverno generates no pod-controller rules for it and it never sees a
           # Deployment. The DRC therefore has to state this itself.
+          #
+          # The package manager applies its pod-level defaults only when the DRC
+          # provides no securityContext at all, so this block has to restate
+          # them verbatim (runAsNonRoot/runAsUser/runAsGroup = Crossplane's
+          # documented 2000) — adding seccompProfile alone would drop the uid
+          # the provider images run as.
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/scripts/tests/test-provider-drc-pod-seccomp.sh
+++ b/scripts/tests/test-provider-drc-pod-seccomp.sh
@@ -1,32 +1,46 @@
 #!/usr/bin/env bash
 #
-# Every Crossplane provider DeploymentRuntimeConfig must set seccompProfile at
-# the POD level of its deployment template.
+# Every Crossplane provider must end up with a complete POD-level
+# securityContext on the Deployment its package manager generates.
 #
 # validate-pod-security/require-seccomp-profile asserts the pod-level path, and
-# Kyverno auto-generates that rule for pod controllers — so the Deployment that
-# Crossplane's package manager builds from a DRC is validated against it. The
-# add-security-context mutate policy cannot supply the value: its match/exclude
-# carry pod selectors, so Kyverno generates no pod-controller rules for it and
-# it never sees a Deployment. A DRC that sets seccompProfile only on the
-# container is therefore denied by the fail-closed webhook at create time.
+# Kyverno auto-generates that rule for pod controllers, so the generated
+# Deployment is validated against it. The add-security-context mutate policy
+# cannot supply the value: its match/exclude carry pod selectors, so Kyverno
+# generates no pod-controller rules for it and it never sees a Deployment.
 #
-# The failure mode is silent and delayed: a running provider Deployment is not
+# Two ways to get this wrong, and both end in the same place:
+#
+#   * a DeploymentRuntimeConfig that sets seccompProfile only on the container,
+#     which does not satisfy a pod-level pattern; or
+#   * a Provider with no runtimeConfigRef at all, since Crossplane's own pod
+#     defaults are runAsNonRoot/runAsUser/runAsGroup and carry no profile.
+#
+# The failure is silent and delayed. A running provider Deployment is not
 # re-admitted, so the denial only surfaces when a revision bump forces a
 # recreate — at which point the whole provider fleet goes to zero pods
-# (platform#3470). This gate keeps that from regressing.
+# (platform#3470).
 #
-# It also pins the rest of the pod securityContext. Crossplane applies its own
-# pod-level defaults ONLY when the DRC supplies no securityContext at all, so a
-# DRC that declares seccompProfile alone silently drops runAsNonRoot and the
-# uid/gid the provider images run as. The block has to stay complete.
+# The gate also pins the rest of the pod securityContext, because Crossplane
+# applies its defaults ONLY when the DRC supplies no securityContext at all: a
+# DRC declaring seccompProfile alone silently drops runAsNonRoot and the
+# uid/gid the provider images run as.
 
 set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly root_dir
 readonly drc_dir="${root_dir}/k8s/providers/hetzner/infrastructure/crossplane"
-readonly pod_path='.spec.deploymentTemplate.spec.template.spec.securityContext.seccompProfile.type'
+readonly sc_path='.spec.deploymentTemplate.spec.template.spec.securityContext'
+
+# Crossplane's documented pod-level defaults, which declaring a securityContext
+# suppresses, plus the profile the policy actually asserts.
+readonly -a required_fields=(
+  'runAsNonRoot:true'
+  'runAsUser:2000'
+  'runAsGroup:2000'
+  'seccompProfile.type:RuntimeDefault'
+)
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -36,55 +50,66 @@ fail() {
 command -v yq >/dev/null 2>&1 || fail 'yq is required but not installed'
 [ -d "${drc_dir}" ] || fail "provider directory not found: ${drc_dir}"
 
-# Enumerate first and check the enumeration, so a failed find cannot render as
-# "nothing to check" and pass vacuously.
+# Enumerate first and check the enumeration, so a failed find renders as an
+# error rather than as "nothing to check".
 files=()
 while IFS= read -r f; do
   files+=("$f")
 done < <(find "${drc_dir}" -maxdepth 1 -type f -name '*.yaml' | sort)
 [ "${#files[@]}" -gt 0 ] || fail "no YAML files found under ${drc_dir}"
 
-checked=0
+# Index every DeploymentRuntimeConfig by name, across every document of every
+# file — a DRC sharing a file with other resources must not be skipped.
+drc_files=''
 for f in "${files[@]}"; do
-  kind="$(yq -r '.kind // ""' "$f" 2>/dev/null || true)"
-  [ "${kind}" = 'DeploymentRuntimeConfig' ] || continue
-
-  name="$(yq -r '.metadata.name // ""' "$f")"
-  [ -n "${name}" ] || fail "$(basename "$f"): DeploymentRuntimeConfig has no metadata.name"
-
-  pod_value="$(yq -r "${pod_path} // \"\"" "$f")"
-  case "${pod_value}" in
-    RuntimeDefault | Localhost) ;;
-    '')
-      fail "${name} ($(basename "$f")): no pod-level seccompProfile.type at ${pod_path}
-       Kyverno's require-seccomp-profile asserts the POD path, and no mutate
-       policy reaches a Deployment, so this provider's Deployment is denied on
-       its next revision bump. Add:
-           template:
-             spec:
-               securityContext:
-                 seccompProfile:
-                   type: RuntimeDefault"
-      ;;
-    *)
-      fail "${name} ($(basename "$f")): pod-level seccompProfile.type is '${pod_value}'; must be RuntimeDefault or Localhost"
-      ;;
-  esac
-
-  # Crossplane's package-manager defaults are applied only when the DRC gives no
-  # securityContext at all, so declaring one makes these our responsibility.
-  for field in runAsNonRoot:true runAsUser:2000 runAsGroup:2000; do
-    key="${field%%:*}"
-    want="${field#*:}"
-    got="$(yq -r ".spec.deploymentTemplate.spec.template.spec.securityContext.${key} // \"\"" "$f")"
-    [ "${got}" = "${want}" ] || fail "${name} ($(basename "$f")): pod-level ${key} is '${got}', expected '${want}'
-       Declaring a pod securityContext suppresses Crossplane's own defaults, so
-       the DRC must restate them or the provider silently changes uid."
-  done
-
-  checked=$((checked + 1))
+  while IFS= read -r drc_name; do
+    [ -n "${drc_name}" ] || continue
+    drc_files="${drc_files}${drc_name} ${f}"$'\n'
+  done < <(yq -r 'select(.kind == "DeploymentRuntimeConfig") | .metadata.name // ""' "$f")
 done
 
-[ "${checked}" -gt 0 ] || fail "no DeploymentRuntimeConfig found under ${drc_dir} — the gate asserted nothing"
+drc_file_for() {
+  printf '%s' "${drc_files}" | awk -v want="$1" '$1 == want { print $2; exit }'
+}
 
-printf 'PASS: %d provider DeploymentRuntimeConfig(s) declare a complete pod securityContext.\n' "${checked}"
+check_drc() {
+  local drc_name="$1" provider="$2" file
+  file="$(drc_file_for "${drc_name}")"
+  [ -n "${file}" ] || fail "provider ${provider}: runtimeConfigRef names '${drc_name}', but no DeploymentRuntimeConfig with that name exists under ${drc_dir}"
+
+  local spec key want got
+  for spec in "${required_fields[@]}"; do
+    key="${spec%%:*}"
+    want="${spec#*:}"
+    got="$(yq -r "select(.kind == \"DeploymentRuntimeConfig\" and .metadata.name == \"${drc_name}\") | ${sc_path}.${key} // \"\"" "${file}")"
+    [ "${got}" = "${want}" ] || fail "provider ${provider} via ${drc_name} ($(basename "${file}")): pod-level ${key} is '${got}', expected '${want}'
+       Kyverno's require-seccomp-profile asserts the POD path and no mutate policy
+       reaches a Deployment, so an incomplete block is denied on the next revision
+       bump. Declaring a pod securityContext also suppresses Crossplane's own
+       defaults, so all of these must be stated together:
+           securityContext:
+             runAsNonRoot: true
+             runAsUser: 2000
+             runAsGroup: 2000
+             seccompProfile:
+               type: RuntimeDefault"
+  done
+}
+
+checked=0
+for f in "${files[@]}"; do
+  while IFS= read -r provider; do
+    [ -n "${provider}" ] || continue
+    ref="$(yq -r "select(.kind == \"Provider\" and .metadata.name == \"${provider}\") | .spec.runtimeConfigRef.name // \"\"" "$f")"
+    [ -n "${ref}" ] || fail "provider ${provider} ($(basename "$f")): no spec.runtimeConfigRef
+       Without one, Crossplane's pod defaults apply and they carry no
+       seccompProfile, so the generated Deployment is denied by the fail-closed
+       webhook. Add a DeploymentRuntimeConfig and reference it."
+    check_drc "${ref}" "${provider}"
+    checked=$((checked + 1))
+  done < <(yq -r 'select(.kind == "Provider") | .metadata.name // ""' "$f")
+done
+
+[ "${checked}" -gt 0 ] || fail "no Provider found under ${drc_dir} — the gate asserted nothing"
+
+printf 'PASS: %d Crossplane provider(s) resolve to a DeploymentRuntimeConfig with a complete pod securityContext.\n' "${checked}"

--- a/scripts/tests/test-provider-drc-pod-seccomp.sh
+++ b/scripts/tests/test-provider-drc-pod-seccomp.sh
@@ -15,6 +15,11 @@
 # re-admitted, so the denial only surfaces when a revision bump forces a
 # recreate — at which point the whole provider fleet goes to zero pods
 # (platform#3470). This gate keeps that from regressing.
+#
+# It also pins the rest of the pod securityContext. Crossplane applies its own
+# pod-level defaults ONLY when the DRC supplies no securityContext at all, so a
+# DRC that declares seccompProfile alone silently drops runAsNonRoot and the
+# uid/gid the provider images run as. The block has to stay complete.
 
 set -euo pipefail
 
@@ -66,9 +71,20 @@ for f in "${files[@]}"; do
       ;;
   esac
 
+  # Crossplane's package-manager defaults are applied only when the DRC gives no
+  # securityContext at all, so declaring one makes these our responsibility.
+  for field in runAsNonRoot:true runAsUser:2000 runAsGroup:2000; do
+    key="${field%%:*}"
+    want="${field#*:}"
+    got="$(yq -r ".spec.deploymentTemplate.spec.template.spec.securityContext.${key} // \"\"" "$f")"
+    [ "${got}" = "${want}" ] || fail "${name} ($(basename "$f")): pod-level ${key} is '${got}', expected '${want}'
+       Declaring a pod securityContext suppresses Crossplane's own defaults, so
+       the DRC must restate them or the provider silently changes uid."
+  done
+
   checked=$((checked + 1))
 done
 
 [ "${checked}" -gt 0 ] || fail "no DeploymentRuntimeConfig found under ${drc_dir} — the gate asserted nothing"
 
-printf 'PASS: %d provider DeploymentRuntimeConfig(s) set a pod-level seccompProfile.\n' "${checked}"
+printf 'PASS: %d provider DeploymentRuntimeConfig(s) declare a complete pod securityContext.\n' "${checked}"

--- a/scripts/tests/test-provider-drc-pod-seccomp.sh
+++ b/scripts/tests/test-provider-drc-pod-seccomp.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Every Crossplane provider DeploymentRuntimeConfig must set seccompProfile at
+# the POD level of its deployment template.
+#
+# validate-pod-security/require-seccomp-profile asserts the pod-level path, and
+# Kyverno auto-generates that rule for pod controllers — so the Deployment that
+# Crossplane's package manager builds from a DRC is validated against it. The
+# add-security-context mutate policy cannot supply the value: its match/exclude
+# carry pod selectors, so Kyverno generates no pod-controller rules for it and
+# it never sees a Deployment. A DRC that sets seccompProfile only on the
+# container is therefore denied by the fail-closed webhook at create time.
+#
+# The failure mode is silent and delayed: a running provider Deployment is not
+# re-admitted, so the denial only surfaces when a revision bump forces a
+# recreate — at which point the whole provider fleet goes to zero pods
+# (platform#3470). This gate keeps that from regressing.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly drc_dir="${root_dir}/k8s/providers/hetzner/infrastructure/crossplane"
+readonly pod_path='.spec.deploymentTemplate.spec.template.spec.securityContext.seccompProfile.type'
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail 'yq is required but not installed'
+[ -d "${drc_dir}" ] || fail "provider directory not found: ${drc_dir}"
+
+# Enumerate first and check the enumeration, so a failed find cannot render as
+# "nothing to check" and pass vacuously.
+files=()
+while IFS= read -r f; do
+  files+=("$f")
+done < <(find "${drc_dir}" -maxdepth 1 -type f -name '*.yaml' | sort)
+[ "${#files[@]}" -gt 0 ] || fail "no YAML files found under ${drc_dir}"
+
+checked=0
+for f in "${files[@]}"; do
+  kind="$(yq -r '.kind // ""' "$f" 2>/dev/null || true)"
+  [ "${kind}" = 'DeploymentRuntimeConfig' ] || continue
+
+  name="$(yq -r '.metadata.name // ""' "$f")"
+  [ -n "${name}" ] || fail "$(basename "$f"): DeploymentRuntimeConfig has no metadata.name"
+
+  pod_value="$(yq -r "${pod_path} // \"\"" "$f")"
+  case "${pod_value}" in
+    RuntimeDefault | Localhost) ;;
+    '')
+      fail "${name} ($(basename "$f")): no pod-level seccompProfile.type at ${pod_path}
+       Kyverno's require-seccomp-profile asserts the POD path, and no mutate
+       policy reaches a Deployment, so this provider's Deployment is denied on
+       its next revision bump. Add:
+           template:
+             spec:
+               securityContext:
+                 seccompProfile:
+                   type: RuntimeDefault"
+      ;;
+    *)
+      fail "${name} ($(basename "$f")): pod-level seccompProfile.type is '${pod_value}'; must be RuntimeDefault or Localhost"
+      ;;
+  esac
+
+  checked=$((checked + 1))
+done
+
+[ "${checked}" -gt 0 ] || fail "no DeploymentRuntimeConfig found under ${drc_dir} — the gate asserted nothing"
+
+printf 'PASS: %d provider DeploymentRuntimeConfig(s) set a pod-level seccompProfile.\n' "${checked}"

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1397,7 +1397,27 @@ const (
 // approved aggregate digest was:
 //
 //	8758aca997ecdf37b536b18420803f46e67e0af05b851fafefbaa83e02b01fe3
-const expectedRenderedSurfaceSHA = "ec7889f10c850126e206c93669adbd2c1406c5f189e07b2cbfe5e63e7d24e287"
+//
+// Measured against main 14351b35 for the Crossplane provider pod securityContext
+// (platform#3470). The four provider DeploymentRuntimeConfigs each gain a
+// pod-level securityContext so Kyverno's require-seccomp-profile — which asserts
+// the POD path and is auto-generated for pod controllers — stops denying the
+// Deployment its package manager builds. Crossplane applies its own pod defaults
+// only when the config supplies no securityContext at all, so the block restates
+// runAsNonRoot/runAsUser/runAsGroup 2000 verbatim rather than changing the uid.
+//
+// Conservation, measured by rendering both trees under one renderer and diffing:
+// the full five-projection render differs by exactly 24 lines, all additions, all
+// four copies of that same six-line block, zero deletions. Extracting every
+// grant-bearing object — 78 of them (24 ClusterRole, 12 ClusterRoleBinding, 11
+// Role, 15 RoleBinding, 16 ServiceAccount) with their rules, subjects and roleRef
+// — the two trees are byte-identical, and a perturbed-row negative control fires.
+// It adds no subject, grant, authorization resource, or rendered object; it adds a
+// security context, and that is the entire authored delta. The previous approved
+// aggregate digest was:
+//
+//	ec7889f10c850126e206c93669adbd2c1406c5f189e07b2cbfe5e63e7d24e287
+const expectedRenderedSurfaceSHA = "2bcfef7897832dec241d1a37e70d575f11b0a4e021e610258dee23b04f95644c"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/tests/validate-pod-security-provider-deployment/kyverno-test.yaml
+++ b/tests/validate-pod-security-provider-deployment/kyverno-test.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validate-pod-security-provider-deployment
+policies:
+  - >-
+    ../../k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml
+resources:
+  - resources.yaml
+results:
+  # A container-only seccompProfile does NOT satisfy the pod-level pattern, so
+  # every provider Deployment is denied at create. add-security-context cannot
+  # rescue it: that mutate policy carries match/exclude selectors, so Kyverno
+  # generates no pod-controller rules for it and it never sees a Deployment.
+  - policy: validate-pod-security
+    rule: autogen-require-seccomp-profile
+    resources:
+      - provider-container-seccomp-only
+    kind: Deployment
+    result: fail
+  - policy: validate-pod-security
+    rule: autogen-require-seccomp-profile
+    resources:
+      - provider-pod-seccomp
+    kind: Deployment
+    result: pass
+  - policy: validate-pod-security
+    rule: autogen-validate-container-security
+    resources:
+      - provider-container-seccomp-only
+      - provider-pod-seccomp
+    kind: Deployment
+    result: pass
+  - policy: validate-pod-security
+    rule: autogen-deny-container-seccomp-unconfined
+    resources:
+      - provider-container-seccomp-only
+      - provider-pod-seccomp
+    kind: Deployment
+    result: pass

--- a/tests/validate-pod-security-provider-deployment/resources.yaml
+++ b/tests/validate-pod-security-provider-deployment/resources.yaml
@@ -51,6 +51,9 @@ spec:
         pkg.crossplane.io/revision: provider-pod-seccomp
     spec:
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/tests/validate-pod-security-provider-deployment/resources.yaml
+++ b/tests/validate-pod-security-provider-deployment/resources.yaml
@@ -1,0 +1,69 @@
+---
+# Mirrors the Deployment Crossplane's package manager generates in
+# crossplane-system from a provider DeploymentRuntimeConfig. The DRC only ever
+# supplies a CONTAINER securityContext, so this is the exact shape the admission
+# webhook sees on every provider revision bump.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provider-container-seccomp-only
+  namespace: crossplane-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      pkg.crossplane.io/revision: provider-container-seccomp-only
+  template:
+    metadata:
+      labels:
+        pkg.crossplane.io/revision: provider-container-seccomp-only
+    spec:
+      containers:
+        - name: package-runtime
+          image: xpkg.upbound.io/upbound/provider-aws-iam:v2.4.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            seLinuxOptions:
+              level: s0
+---
+# The same Deployment once the DRC also sets the profile at POD level, which is
+# the path validate-pod-security actually asserts.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: provider-pod-seccomp
+  namespace: crossplane-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      pkg.crossplane.io/revision: provider-pod-seccomp
+  template:
+    metadata:
+      labels:
+        pkg.crossplane.io/revision: provider-pod-seccomp
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: package-runtime
+          image: xpkg.upbound.io/upbound/provider-aws-iam:v2.4.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            seLinuxOptions:
+              level: s0


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Every Crossplane provider on prod is down — zero provider pods, four providers `Healthy=False`. Kyverno's pod-security policy checks that a workload asks for the safe seccomp profile, but it checks for it on the *pod*, while our provider configs only declare it on the *container*. So the admission webhook refuses to create any provider Deployment, and because that webhook fails closed, nothing gets in.

This stayed hidden for a long time: already-running providers were never re-checked, so it only surfaced the moment something forced them to be recreated. It is a trap on every future provider version bump, not a one-off of this incident.

### What

Declares the seccomp profile at pod level in all four provider runtime configs, so the control is genuinely satisfied rather than worked around. Adds two checks so it cannot regress: a policy fixture pinning both the broken and fixed shapes, and a gate asserting every provider config keeps the pod-level value. Both are wired into the change filter so touching either one re-runs its own check.

Fixes #3470
