### PR TITLE
feat(security): opt velero into the baseline security-context mutation

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/namespace.yaml
@@ -7,3 +7,13 @@ metadata:
     # for file-level PVC backup — requires privileged PSS.
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    # velero is excluded from add-pod-security-context / add-container-security-context
+    # because its workloads need elevated privilege by design. fsGroupChangePolicy and
+    # seLinuxOptions are not privilege fields — the first governs volume ownership
+    # relabelling, the second is a documented no-op on this AppArmor cluster kept for
+    # CIS-5.7.3 — so the blanket exclusion suppressed two C-0211 controls it never
+    # needed to. This label opts the namespace into add-baseline-context-optin-*, which
+    # supplies only those two through conditional anchors and touches no user, group or
+    # privilege field. velero is the first namespace opted in: two workloads (velero,
+    # node-agent), both measured missing both fields on 2026-08-30.
+    pod-security.devantler.tech/baseline-context: enabled

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -130,6 +130,36 @@ check podlevel-partial-mutated.yaml '.spec.initContainers[0].securityContext.seL
   null "initContainer-level injection replaced the partial pod-level SELinux object"
 check podlevel-partial-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "pod-level rule did not fire on the podlevel-partial fixture"
+# ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
+# in the cluster is decided entirely by which namespaces carry the opt-in label —
+# a fact no mutation fixture can see. Without this gate, widening the rollout from
+# one namespace to all twelve is a one-line diff with no test signal at all, and a
+# dropped label silently reverts the feature while every assertion above still
+# passes. Pin the inventory so each namespace is added deliberately and reviewed.
+#
+# Each namespace is opted in only after its live workloads are measured to still
+# start; see the rationale recorded on the namespace manifest itself.
+expected_optin="velero"
+
+# grep only prefilters candidate files; yq decides, so a mention in a comment or
+# in the policy that DEFINES the label cannot be counted as an opted-in namespace.
+actual_optin="$(
+  grep -rl 'pod-security.devantler.tech/baseline-context' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null |
+    while IFS= read -r f; do
+      yq -N '
+        select(.kind == "Namespace" and
+               .metadata.labels."pod-security.devantler.tech/baseline-context" == "enabled") |
+        .metadata.name
+      ' "${f}" 2>/dev/null
+    done | awk 'NF' | LC_ALL=C sort -u | paste -sd, -
+)"
+
+if [ "${actual_optin}" != "${expected_optin}" ]; then
+  echo "::error::baseline-context opt-in inventory changed: expected '${expected_optin}', got '${actual_optin}'"
+  echo "::error::add or remove a namespace here only together with its measured rollout evidence"
+  fail=1
+fi
+
 if [ "${fail}" -ne 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Twelve namespaces are excluded from our security-context defaults because their workloads genuinely need elevated privilege. That exclusion is right about privilege — but it also suppressed two hardening controls that have nothing to do with privilege, so those namespaces have been failing a CIS check they could always have passed.

The mutation that supplies just those two fields already shipped, deliberately switched off, so that namespaces could be turned on one at a time rather than all twelve at once. Nothing has been turned on yet, so the capability currently does nothing.

### Description

Turns it on for the first namespace, velero, and adds a guard so the list of switched-on namespaces can only change deliberately rather than as an unreviewed one-line edit.

Verified against velero's real production workloads: with the switch on, both fields appear on every pod; with it off, neither does. No user, group, or privilege setting changes in either state — which is what makes this safe for a namespace that is privileged by design.

Part of #3239
