### PR TITLE
fix(ci): scope the MegaLinter drift scan to pull_request runs

### DIFF
--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -37,12 +37,18 @@ set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-devantler-tech/platform}"
 MEGALINTER_JOB_MATCH='mega-linter'
-# A burst of dependency updates can emit several workflows per pull request; 40 repository-wide
-# runs buried a valid MegaLinter job even though it was less than an hour old (observed 2026-08-22),
-# and one full 100-result page can be exhausted just as easily. Walk a bounded three pages in newest-
-# first order. The cap prevents an unbounded historical scan; exhausting it still fails closed below.
+# The listing is scoped to pull_request runs, and that scope is what makes the bounded budget
+# viable. mega-linter is skipped on main, so push, merge_group, dynamic and schedule runs can never
+# supply an executed job — they can only crowd one out. Measured 2026-08-30: 300 repository-wide
+# runs spanned ~23 hours and held a single run of the managed workflow whose mega-linter job was
+# skipped, while the newest executed job sat at ordinal ~305, just past the cap; main went red on a
+# check that had nothing to compare. Filtering to pull_request removed ~61% of that window.
+# A burst of dependency updates can still emit several workflows per pull request, and one full
+# 100-result page is exhausted easily, so walk a bounded five pages in newest-first order. Pages are
+# fetched only until evidence is found, so the extra depth costs nothing in the common case. The cap
+# prevents an unbounded historical scan; exhausting it still fails closed below.
 RUNS_PER_PAGE=100
-MAX_RUN_PAGES=3
+MAX_RUN_PAGES=5
 MAX_RUNS=$((RUNS_PER_PAGE * MAX_RUN_PAGES))
 
 # The org-managed workflow that runs mega-linter for this repository. Binding to it is a PROVENANCE
@@ -185,7 +191,7 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
   page=1
   while [ "$page" -le "$MAX_RUN_PAGES" ]; do
     page_runs="$(gh api \
-      "repos/$REPO/actions/runs?per_page=$RUNS_PER_PAGE&page=$page" \
+      "repos/$REPO/actions/runs?event=pull_request&per_page=$RUNS_PER_PAGE&page=$page" \
       --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha)\"" \
       2>/dev/null)" ||
       die_unverifiable "could not list recent runs page $page for $REPO"

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -225,9 +225,9 @@ EOF
     page=$((page + 1))
   done
   [ "$saw_managed" = yes ] ||
-    die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS runs of $REPO"
+    die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS pull_request runs of $REPO"
   die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job from a provably org-managed run in the
-last $MAX_RUNS runs of $REPO"
+last $MAX_RUNS pull_request runs of $REPO"
 }
 
 ci_megalinter="$(read_const CI_MEGALINTER_VERSION)"

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -181,6 +181,7 @@ case "$args" in
     run="${run%%/jobs*}"
     printf 'job%s\n' "$run" ;;
   *actions/runs*per_page*)
+    [ -z "${GH_STUB_RUNS_URL_LOG:-}" ] || printf '%s\n' "$args" >>"$GH_STUB_RUNS_URL_LOG"
     per_page="${args#*per_page=}"
     per_page="${per_page%%&*}"
     per_page="${per_page%% *}"
@@ -349,6 +350,33 @@ else
   printf 'ok: a candidate whose revision does not resolve is not trusted\n'
 fi
 : >"$scratch/unresolvable.txt"
+
+# The repository emits enough workflow runs that an unfiltered newest-first walk cannot reach an
+# EXECUTED mega-linter job at all. Measured 2026-08-30: 300 repository-wide runs spanned only ~23
+# hours and contained a single run of the managed workflow, whose mega-linter job was `skipped`;
+# the newest executed one sat at ordinal ~305 and main went red. mega-linter is skipped on main, so
+# every push, merge_group, dynamic and schedule run is noise that can only crowd out the evidence.
+# Scoping the query to pull_request runs is what keeps the bounded budget spent on candidates.
+: >"$scratch/tainted.txt"
+: >"$scratch/unresolvable.txt"
+make_log "$ci_megalinter" "$ci_checkov" "$ci_trivy" "$scratch/logs/job111.log"
+printf '111 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+GH_STUB_RUNS_URL_LOG="$scratch/runs-urls.txt"
+: >"$GH_STUB_RUNS_URL_LOG"
+export GH_STUB_RUNS_URL_LOG
+run_live
+if [ ! -s "$GH_STUB_RUNS_URL_LOG" ]; then
+  printf 'FAIL: run-listing query was never issued, so the event scope cannot be asserted\n%s\n' \
+    "$out" >&2
+  failures=$((failures + 1))
+elif ! grep -qF 'event=pull_request' "$GH_STUB_RUNS_URL_LOG"; then
+  printf 'FAIL: run listing is not scoped to pull_request runs\n%s\n' \
+    "$(cat "$GH_STUB_RUNS_URL_LOG")" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: the run listing is scoped to pull_request runs\n'
+fi
+unset GH_STUB_RUNS_URL_LOG
 
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

`main` is red. The `Validate Main` check `🔢 Validate Scanner Versions` started failing and will
keep failing on every future push until this lands.

It is **not** a real version drift — nothing is out of date. The guard simply could not find any
MegaLinter job to compare against, so it correctly refused rather than guessing. The cause is
volume: this repository now produces so many workflow runs that the evidence the check needs falls
outside the window it looks in, and each new push pushes it further away.

### What

Narrows where the check looks so the evidence stays reachable, and gives it a little more depth.
The extra depth is only used when needed, so the normal cost is unchanged, and when it genuinely
cannot verify something it still refuses instead of passing.

Confirmed against the live API: the check now passes and reports every scanner version as in sync,
so no recorded version needed changing. The previous code, run moments later, still reproduced the
exact failure now on `main`.

