### PR TITLE
security(kubescape): opt the namespace into the baseline security-context mutation

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/namespace.yaml
@@ -5,3 +5,15 @@ metadata:
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    # kubescape is excluded from add-pod-security-context / add-container-security-context
+    # because its workloads need elevated privilege by design. fsGroupChangePolicy and
+    # seLinuxOptions are not privilege fields — the first governs volume ownership
+    # relabelling, the second is a documented no-op on this AppArmor cluster kept for
+    # CIS-5.7.3 — so the blanket exclusion suppressed two C-0211 controls it never
+    # needed to. This label opts the namespace into add-baseline-context-optin-*, which
+    # supplies only those two through conditional anchors and touches no user, group or
+    # privilege field. Second namespace opted in, after velero: measured against live
+    # prod specs on 2026-08-31, none of kubescape's pods carried either field, while
+    # every velero pod created since that namespace opted in carried both and none
+    # failed to start.
+    pod-security.devantler.tech/baseline-context: enabled

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -139,7 +139,7 @@ check podlevel-partial-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' 
 #
 # Each namespace is opted in only after its live workloads are measured to still
 # start; see the rationale recorded on the namespace manifest itself.
-expected_optin="velero"
+expected_optin="kubescape,velero"
 
 # grep only prefilters candidate files; yq decides, so a mention in a comment or
 # in the policy that DEFINES the label cannot be counted as an opted-in namespace.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Two Kubescape C-0211 controls were being reported as failing across a set of namespaces that never
actually needed to fail them. Those namespaces are excluded from the security-context mutations
because their workloads genuinely require elevated privilege — but the two fields in question grant
nothing: one only governs how volume ownership is relabelled, and the other is a documented no-op on
this cluster, kept for compliance. So the exclusion was suppressing two controls as collateral.

The mechanism to fix this already merged, switched off. `velero` was the first namespace switched on,
and the live cluster now shows it working with no fallout. This turns it on for the next one.

## What

Opts the `kubescape` namespace into the existing, already-reviewed mutation by adding the same label
`velero` carries. No policy logic changes, and nothing about privilege, user or group is touched.

`kubescape` was chosen as the smallest remaining population that is not on the delivery path — the
GitOps and core-system namespaces are deliberately left for last.

**Rollout note:** the mutation applies when a pod is created, so existing pods keep their current
spec until they are next recreated. That is the same behaviour observed on `velero` and is expected,
not a gap.

Part of #3239.
