### PR TITLE
fix(ci): refuse stale scanner-version evidence instead of reporting it as drift

### DIFF
--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -308,7 +308,29 @@ jobs:
         # a token a fork PR does not have, and version drift is slow-moving, so
         # per-PR is the wrong cadence. The offline parsing contract IS gated on
         # PRs, in ci.yaml.
+        #
+        # Exit 1 (measured drift) fails: the constants are wrong and #2787's counts cannot be read
+        # until they are corrected. Exit 2 (could not verify) warns instead, because it is not a
+        # statement about this repository at all — the managed workflow runs on its own path filter
+        # and can simply go quiet here for longer than the bounded scan window reaches back. This
+        # job runs after merge and gates nothing, so holding main red on another repository's
+        # pipeline cadence costs the whole repository a red default branch while telling nobody
+        # anything actionable. The warning is visible in the run summary and the next genuine run
+        # resolves it either way.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: bash scripts/check-megalinter-version-drift.sh
+        run: |
+          set +e
+          bash scripts/check-megalinter-version-drift.sh
+          rc=$?
+          set -e
+          case "$rc" in
+            0) ;;
+            2)
+              echo "::warning title=Scanner versions unverified::Could not establish the live \
+          MegaLinter scanner versions (exit 2). The recorded constants are unchanged and no drift \
+          is claimed; see the step log for which evidence was refused."
+              ;;
+            *) exit "$rc" ;;
+          esac

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -328,9 +328,13 @@ jobs:
           case "$rc" in
             0) ;;
             2)
-              echo "::warning title=Scanner versions unverified::Could not establish the live \
-          MegaLinter scanner versions (exit 2). The recorded constants are unchanged and no drift \
-          is claimed; see the step log for which evidence was refused."
+              # Built up in parts rather than one continued string: a backslash-continuation inside
+              # double quotes keeps the next line's YAML indentation, which lands as a run of spaces
+              # in the middle of the annotation.
+              msg="Could not establish the live MegaLinter scanner versions (exit 2)."
+              msg="$msg The recorded constants are unchanged and no drift is claimed;"
+              msg="$msg see the step log for which evidence was refused."
+              echo "::warning title=Scanner versions unverified::$msg"
               ;;
             *) exit "$rc" ;;
           esac

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -51,6 +51,30 @@ RUNS_PER_PAGE=100
 MAX_RUN_PAGES=5
 MAX_RUNS=$((RUNS_PER_PAGE * MAX_RUN_PAGES))
 
+# The scan window above bounds HOW FAR BACK we look; this bounds HOW OLD the evidence may be. They
+# are different limits, and only the second makes the answer true: a run reachable inside the window
+# can still be weeks old, and the versions it printed say nothing about the pin today. Without this
+# the guard degrades silently as the managed workflow goes quiet — reaching further and further
+# back, then reporting the difference as drift. Widening the window makes that worse, not better.
+# 14 days is far longer than the normal gap between runs of that workflow here, so a healthy
+# repository never trips it.
+MAX_EVIDENCE_AGE_DAYS="${DRIFT_MAX_EVIDENCE_AGE_DAYS:-14}"
+# GNU and BSD `date` spell relative arithmetic differently and neither accepts the other's flag, so
+# try both rather than assuming the platform (CI is Linux, the pre-push path is macOS). A cutoff
+# that cannot be computed is fatal: skipping the bound would silently restore the stale-evidence
+# behaviour it exists to prevent.
+EVIDENCE_CUTOFF="$(
+  date -u -d "${MAX_EVIDENCE_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -v"-${MAX_EVIDENCE_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    true
+)"
+if [ -z "$EVIDENCE_CUTOFF" ]; then
+  printf 'CANNOT VERIFY: could not compute the %s-day evidence cutoff with either GNU or BSD date.\n' \
+    "$MAX_EVIDENCE_AGE_DAYS" >&2
+  exit 2
+fi
+readonly MAX_EVIDENCE_AGE_DAYS EVIDENCE_CUTOFF
+
 # The org-managed workflow that runs mega-linter for this repository. Binding to it is a PROVENANCE
 # check, not decoration: the job is selected out of arbitrary recent runs, and a job's display name
 # is attacker-controllable — a pull request can add a workflow with a job called "mega-linter" that
@@ -188,18 +212,35 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
   # preserving newest-first order. Process each page before fetching the next so valid evidence is
   # returned immediately and cannot be discarded by a later, unnecessary API failure.
   saw_managed=no
+  saw_stale=no
   page=1
   while [ "$page" -le "$MAX_RUN_PAGES" ]; do
     page_runs="$(gh api \
       "repos/$REPO/actions/runs?event=pull_request&per_page=$RUNS_PER_PAGE&page=$page" \
-      --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha)\"" \
+      --jq ".workflow_runs[] | select(.path == \"$MANAGED_WORKFLOW_PATH\") | \"\(.id) \(.head_sha) \(.created_at)\"" \
       2>/dev/null)" ||
       die_unverifiable "could not list recent runs page $page for $REPO"
     if [ -n "$page_runs" ]; then
       saw_managed=yes
     fi
-    while read -r run_id head_sha; do
+    while read -r run_id head_sha created_at; do
       [ -n "$run_id" ] || continue
+      # An OLD run is not evidence of what CI runs TODAY. The scan window is bounded, so on a busy
+      # repository the newest genuine run can age out of it while older ones remain reachable —
+      # and the versions those printed are then reported as "live", which is a drift claim about a
+      # scanner pin that may have moved several times since. Measured 2026-08-31 on this
+      # repository: the 06:46Z run read a two-day-old run and agreed with the constants; the 08:43Z
+      # and 08:53Z runs, with no code change between them, reached a run from 2026-08-09 — eight
+      # days before the pin moved to 10.0.0 — and reported its 9.6.0 as drift, wedging main. Worse,
+      # the remedy that failure prints is to record those stale versions, which would have made the
+      # constants wrong in a way the next genuine run would flag all over again.
+      if [ -z "$created_at" ] || [ "$created_at" \< "$EVIDENCE_CUTOFF" ]; then
+        printf 'Skipping run %s: it ran at %s, before the %s-day evidence cutoff %s, so its log\n' \
+          "$run_id" "${created_at:-unknown}" "$MAX_EVIDENCE_AGE_DAYS" "$EVIDENCE_CUTOFF" >&2
+        printf '  states versions that may since have moved.\n' >&2
+        saw_stale=yes
+        continue
+      fi
       if ! managed_path_absent_at "$head_sha"; then
         printf 'Skipping run %s: %s is not provably absent at its revision %s, so that run is not\n' \
           "$run_id" "$MANAGED_WORKFLOW_PATH" "$head_sha" >&2
@@ -226,6 +267,11 @@ EOF
   done
   [ "$saw_managed" = yes ] ||
     die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS pull_request runs of $REPO"
+  [ "$saw_stale" = no ] ||
+    die_unverifiable "every reachable '$MEGALINTER_JOB_MATCH' job predates the $MAX_EVIDENCE_AGE_DAYS-day
+evidence cutoff $EVIDENCE_CUTOFF. $MANAGED_WORKFLOW_PATH runs only on its own path filter, so it can go
+quiet on this repository for longer than the bounded scan window reaches back. That is not drift, and
+recording the versions such a run printed would make the constants wrong."
   die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job from a provably org-managed run in the
 last $MAX_RUNS pull_request runs of $REPO"
 }

--- a/scripts/check-megalinter-version-drift.sh
+++ b/scripts/check-megalinter-version-drift.sh
@@ -213,6 +213,7 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
   # returned immediately and cannot be discarded by a later, unnecessary API failure.
   saw_managed=no
   saw_stale=no
+  saw_fresh=no
   page=1
   while [ "$page" -le "$MAX_RUN_PAGES" ]; do
     page_runs="$(gh api \
@@ -241,6 +242,7 @@ prove org-managed provenance. Re-establish how the mega-linter job is identified
         saw_stale=yes
         continue
       fi
+      saw_fresh=yes
       if ! managed_path_absent_at "$head_sha"; then
         printf 'Skipping run %s: %s is not provably absent at its revision %s, so that run is not\n' \
           "$run_id" "$MANAGED_WORKFLOW_PATH" "$head_sha" >&2
@@ -267,11 +269,18 @@ EOF
   done
   [ "$saw_managed" = yes ] ||
     die_unverifiable "no recent runs of $MANAGED_WORKFLOW_PATH in the last $MAX_RUNS pull_request runs of $REPO"
-  [ "$saw_stale" = no ] ||
-    die_unverifiable "every reachable '$MEGALINTER_JOB_MATCH' job predates the $MAX_EVIDENCE_AGE_DAYS-day
-evidence cutoff $EVIDENCE_CUTOFF. $MANAGED_WORKFLOW_PATH runs only on its own path filter, so it can go
-quiet on this repository for longer than the bounded scan window reaches back. That is not drift, and
-recording the versions such a run printed would make the constants wrong."
+  # Blame the cutoff only when it is the WHOLE story. A stale candidate alongside a fresh one that
+  # was refused for another reason — a provenance taint, an unresolvable revision — leaves both
+  # exiting 2, so the only thing that differs is what the operator is told to do next. "Everything
+  # aged out" invites widening the cutoff, which restores the stale-evidence bug; and it buries the
+  # provenance refusal, which is the finding that actually mattered. Fall through to the generic
+  # refusal whenever any candidate survived the age gate.
+  if [ "$saw_stale" = yes ] && [ "$saw_fresh" = no ]; then
+    die_unverifiable "every reachable run of $MANAGED_WORKFLOW_PATH predates the $MAX_EVIDENCE_AGE_DAYS-day
+evidence cutoff $EVIDENCE_CUTOFF. It runs only on its own path filter, so it can go quiet on this
+repository for longer than the bounded scan window reaches back. That is not drift, and recording the
+versions such a run printed would make the constants wrong."
+  fi
   die_unverifiable "no completed '$MEGALINTER_JOB_MATCH' job from a provably org-managed run in the
 last $MAX_RUNS pull_request runs of $REPO"
 }

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -433,6 +433,45 @@ else
   printf 'ok: control — the cutoff refuses stale evidence without disabling drift detection\n'
 fi
 
+# A stale candidate sitting alongside a fresh one that was refused for a DIFFERENT reason must not
+# be summarised as "every reachable run predates the cutoff". Both paths refuse (exit 2), so the
+# behaviour is identical and only the diagnosis differs — which is precisely what this guard exists
+# to get right, because the operator's next action follows the message. Told that all the evidence
+# aged out, the reasonable response is to widen the cutoff, which restores the stale-evidence bug
+# this file was written to close; and the real cause — a run whose own revision defines the managed
+# workflow, i.e. a provenance refusal — has meanwhile been hidden behind it.
+: >"$scratch/unresolvable.txt"
+printf '%s\n' "$tainted_sha" >"$scratch/tainted.txt"
+make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
+printf '111 %s '"$stale_ts"'\n222 %s '"$fresh_ts"'\n' "$genuine_sha" "$tainted_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 2 ]; then
+  printf 'FAIL: mixed refusals — expected exit 2, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+elif printf '%s' "$out" | grep -qF 'predates the'; then
+  printf 'FAIL: mixed refusals — blamed the cutoff, but a fresh candidate was refused for provenance\n%s\n' \
+    "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: a stale candidate does not mask a fresh one refused for another reason\n'
+fi
+
+# CONTROL — with the fresh provenance-refused candidate removed, the cutoff really IS the whole
+# story, and the message must still say so. Without this the case above would pass just as well if
+# the stale-specific diagnosis had simply been deleted.
+: >"$scratch/tainted.txt"
+printf '111 %s '"$stale_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 2 ]; then
+  printf 'FAIL: control — stale-only candidate should still refuse, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$out" | grep -qF 'predates the'; then
+  printf 'FAIL: control — stale-only candidate no longer names the cutoff as the reason\n%s\n' \
+    "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: control — a stale-only refusal still names the cutoff\n'
+fi
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2
   exit 1

--- a/scripts/tests/test-check-megalinter-version-drift.sh
+++ b/scripts/tests/test-check-megalinter-version-drift.sh
@@ -229,6 +229,19 @@ export GH_STUB_MIN_PER_PAGE=0
 tainted_sha='deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
 genuine_sha='cafebabecafebabecafebabecafebabecafebabe'
 
+# Candidate runs carry a creation timestamp, and the guard refuses evidence older than its cutoff.
+# Every existing case is about selection rather than age, so they all use a run made "now"; the
+# staleness cases below set their own. Computed the same both-dialects way the guard uses.
+fresh_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+stale_ts="$(
+  date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -v-90d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+)"
+if [ -z "$fresh_ts" ] || [ -z "$stale_ts" ]; then
+  printf 'FAIL: could not compute test timestamps with either GNU or BSD date\n' >&2
+  exit 1
+fi
+
 # Run 111 is attacker-controlled: its revision defines the managed workflow, and its log states
 # versions that do NOT match the constants — so trusting it is visible as drift.
 make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
@@ -240,7 +253,7 @@ run_live() {
 }
 
 # A tainted run as the ONLY candidate must never have its log consumed.
-printf '111 %s\n' "$tainted_sha" >"$scratch/runs.txt"
+printf '111 %s '"$fresh_ts"'\n' "$tainted_sha" >"$scratch/runs.txt"
 run_live
 if [ "$rc" -ne 2 ]; then
   printf 'FAIL: tainted-only candidate — expected exit 2, got %d (its log was trusted)\n%s\n' \
@@ -271,7 +284,7 @@ fi
 # at ordinal 99 even though it was less than an hour old. The selector must use the API's full
 # single-page capacity so unrelated workflows do not make recent evidence unreachable.
 GH_STUB_MIN_PER_PAGE=100
-printf '111 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+printf '111 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
 run_live
 if [ "$rc" -ne 0 ]; then
   printf 'FAIL: busy repository history — expected recent genuine run to be reachable, got %d\n%s\n' \
@@ -288,7 +301,7 @@ GH_STUB_MIN_PER_PAGE=0
 # bounded multi-page lookup reaches the same genuine, provenance-checked candidate.
 mkdir -p "$scratch/run-pages"
 : >"$scratch/run-pages/1"
-printf '111 %s\n' "$genuine_sha" >"$scratch/run-pages/2"
+printf '111 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/run-pages/2"
 : >"$scratch/run-pages/3"
 GH_STUB_RUN_PAGES_DIR="$scratch/run-pages"
 export GH_STUB_RUN_PAGES_DIR
@@ -305,7 +318,7 @@ unset GH_STUB_RUN_PAGES_DIR
 # Once a usable candidate on page one has passed every provenance check, later pages are irrelevant.
 # A transient failure fetching page two must not discard that already-validated evidence. The eager
 # collector does exactly that; processing each page before requesting the next one returns first.
-printf '111 %s\n' "$genuine_sha" >"$scratch/run-pages/1"
+printf '111 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/run-pages/1"
 : >"$scratch/run-pages/2"
 GH_STUB_RUN_PAGES_DIR="$scratch/run-pages"
 GH_STUB_FAIL_RUNS_PAGE=2
@@ -325,7 +338,7 @@ unset GH_STUB_RUN_PAGES_DIR GH_STUB_FAIL_RUNS_PAGE
 # closed (exit 2), so only skipping-and-continuing yields exit 0.
 make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
 printf '%s\n' "$tainted_sha" >"$scratch/tainted.txt"
-printf '111 %s\n222 %s\n' "$tainted_sha" "$genuine_sha" >"$scratch/runs.txt"
+printf '111 %s '"$fresh_ts"'\n222 %s '"$fresh_ts"'\n' "$tainted_sha" "$genuine_sha" >"$scratch/runs.txt"
 run_live
 if [ "$rc" -ne 0 ]; then
   printf 'FAIL: discrimination — expected exit 0 from the genuine run, got %d\n%s\n' "$rc" "$out" >&2
@@ -340,7 +353,7 @@ fi
 printf '%s\n' "$genuine_sha" >"$scratch/unresolvable.txt"
 : >"$scratch/tainted.txt"
 make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job222.log"
-printf '222 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+printf '222 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
 run_live
 if [ "$rc" -ne 2 ]; then
   printf 'FAIL: unresolvable revision — expected exit 2, got %d (its log was trusted)\n%s\n' \
@@ -360,7 +373,7 @@ fi
 : >"$scratch/tainted.txt"
 : >"$scratch/unresolvable.txt"
 make_log "$ci_megalinter" "$ci_checkov" "$ci_trivy" "$scratch/logs/job111.log"
-printf '111 %s\n' "$genuine_sha" >"$scratch/runs.txt"
+printf '111 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
 GH_STUB_RUNS_URL_LOG="$scratch/runs-urls.txt"
 : >"$GH_STUB_RUNS_URL_LOG"
 export GH_STUB_RUNS_URL_LOG
@@ -377,6 +390,48 @@ else
   printf 'ok: the run listing is scoped to pull_request runs\n'
 fi
 unset GH_STUB_RUNS_URL_LOG
+
+# ---- EVIDENCE STALENESS ------------------------------------------------------------------------
+# The scan window bounds how far back the walk reaches; it does not bound how OLD the winning run
+# may be. On a busy repository the newest genuine run ages out of the window while older ones stay
+# reachable, and their versions are then reported as live. Measured 2026-08-31 on this repository:
+# with no code change between them, one run read a two-day-old job and agreed with the constants
+# while the next reached a job from 2026-08-09 — before the pin moved — and reported its versions as
+# drift, wedging main. The remedy that failure prints is to record those stale versions, which would
+# have made the constants wrong.
+#
+# So a stale candidate must produce CANNOT VERIFY (2), never drift (1). Exit 1 is the dangerous
+# answer precisely because it is actionable and its action is wrong.
+: >"$scratch/tainted.txt"
+: >"$scratch/unresolvable.txt"
+make_log '9.9.9' '9.9.9' '9.9.9' "$scratch/logs/job111.log"
+printf '111 %s '"$stale_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -eq 1 ]; then
+  printf 'FAIL: stale evidence — reported DRIFT from a %s run; recording those versions would be wrong\n%s\n' \
+    "$stale_ts" "$out" >&2
+  failures=$((failures + 1))
+elif [ "$rc" -ne 2 ]; then
+  printf 'FAIL: stale evidence — expected exit 2, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$out" | grep -qF 'evidence cutoff'; then
+  printf 'FAIL: stale evidence — exit 2 but the refusal does not name the cutoff\n%s\n' "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: evidence older than the cutoff is refused rather than reported as drift\n'
+fi
+
+# CONTROL — the same log at the same versions, from a run made NOW, must still be reachable and
+# still be reported as drift. Without this the case above would pass just as well if the guard had
+# stopped selecting runs altogether.
+printf '111 %s '"$fresh_ts"'\n' "$genuine_sha" >"$scratch/runs.txt"
+run_live
+if [ "$rc" -ne 1 ]; then
+  printf 'FAIL: control — a fresh run stating 9.9.9 should still be drift, got %d\n%s\n' "$rc" "$out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok: control — the cutoff refuses stale evidence without disabling drift detection\n'
+fi
 
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

`main` has been red since 08:43Z on a scanner-version check that was reporting a problem that does
not exist. The check compares the scanner versions we record against the ones CI actually runs, and
it learns the live ones by reading a recent MegaLinter job log. It bounds how far back it searches,
but not how old the run it settles on may be — so once the repository gets busy and the newest
suitable run drops out of that search window, it quietly falls back to a much older one and reports
that run's versions as current.

That is what happened. With no code change in between, one run read a two-day-old job and agreed
with our constants; the next reached a job from three weeks earlier — from before the scanner pin
moved — and called the difference drift.

The expensive part is the advice it then prints: record those older versions. Doing that would have
made our constants wrong, and turned the branch red again the next time a genuine run appeared. The
recorded versions were correct throughout.

### What this does

Bounds how old the evidence may be, not just how far back to look. Anything older than two weeks is
now refused as "could not verify" instead of being compared. Real drift is unaffected — a current
run stating different versions still fails, and a test control asserts that, so the new bound cannot
pass simply by having stopped looking.

It also downgrades "could not verify" from a failure to a warning on this one check. That state is
not a statement about this repository — it means another repository's pipeline has not run here
recently — and this check runs after merge and gates nothing, so it should not hold the default
branch red. Genuine drift still fails.

Verified against the live repository: the check now reads current evidence and reports in sync.

Fixes #3494
