### PR TITLE
fix(deploy): ignore terminating consumers during fan-out bootstrap

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -5308,16 +5308,17 @@ else
       # app namespaces carry prune: disabled and the rollback cannot remove
       # them. Keying the exemption on absence would then refuse every later
       # attempt, deadlocking the very change that introduces the consumer.
-      # Defer while the namespace is absent or still runs no workload: neither
-      # state has a running consumer whose pull credential this staging step
-      # could break. A missing object in a namespace that already runs
-      # workloads is always an incomplete fan-out.
+      # Defer while the namespace is absent or still runs no active workload:
+      # neither state has a consumer whose pull credential this staging step
+      # could break. A missing object in a namespace that already runs an
+      # active workload is always an incomplete fan-out.
       #
-      # The probe asks for RUNNING pods specifically. A candidate that failed
-      # before its ExternalSecret existed can leave a Pod object that never
-      # pulled its image - the missing pull credential is precisely why - and
-      # counting that object as a workload would deny the exemption on every
-      # retry, recreating the deadlock this exemption exists to prevent.
+      # The probe asks for Running Pods and then excludes terminating objects.
+      # A candidate that failed before its ExternalSecret existed can leave a
+      # Pod that never pulled its image, while a rolled-back candidate can
+      # leave a terminating Pod whose last phase is still Running. Counting
+      # either as active would deny the exemption on every retry, recreating
+      # the deadlock this exemption exists to prevent.
       if [[ -n "${record_runtime_proof_path}" ]]; then
         if ! namespace_name="$(kubectl \
           --context "${KUBE_CONTEXT}" \
@@ -5327,19 +5328,40 @@ else
           echo "::error::Could not determine whether namespace ${namespace} exists; refusing to change root Flux auth."
           exit 1
         fi
-        namespace_workloads=""
+        namespace_has_active_workload=false
         if [[ -n "${namespace_name}" ]]; then
-          if ! namespace_workloads="$(kubectl \
-            --context "${KUBE_CONTEXT}" \
-            --namespace "${namespace}" \
-            get pods \
-            --field-selector=status.phase=Running \
-            -o name)"; then
-            echo "::error::Could not determine whether namespace ${namespace} runs a workload; refusing to change root Flux auth."
+          if ! namespace_has_active_workload="$(
+            kubectl \
+              --context "${KUBE_CONTEXT}" \
+              --namespace "${namespace}" \
+              get pods \
+              --field-selector=status.phase=Running \
+              -o json |
+              jq -er '
+                if (.items | type) != "array" or any(.items[];
+                  type != "object"
+                  or (.metadata | type) != "object"
+                  or (.status | type) != "object"
+                  or (.status.phase | type) != "string"
+                  or ((.metadata.deletionTimestamp | type) != "null"
+                    and (.metadata.deletionTimestamp | type) != "string")
+                ) then
+                  error("malformed Pod inventory")
+                elif any(.items[];
+                  .status.phase == "Running"
+                  and .metadata.deletionTimestamp == null
+                ) then
+                  "true"
+                else
+                  "false"
+                end
+              '
+          )"; then
+            echo "::error::Could not determine whether namespace ${namespace} runs an active workload; refusing to change root Flux auth."
             exit 1
           fi
         fi
-        if [[ -z "${namespace_name}" || -z "${namespace_workloads}" ]]; then
+        if [[ -z "${namespace_name}" || "${namespace_has_active_workload}" != "true" ]]; then
           echo "::notice::Deferring new GHCR fan-out target ${namespace}/ghcr-auth until the candidate reconciles it; the post-reconcile reassertion remains mandatory."
           continue
         fi

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1344,7 +1344,8 @@ func fakeInventoryNode(
 }
 
 func fakeKubectlGetPods(args []string) int {
-	if containsSequence(args, "-o", "name") || containsArg(args, "-o=name") {
+	if containsSequence(args, "-o", "name") || containsArg(args, "-o=name") ||
+		flagValue(args, "--field-selector") == "status.phase=Running" {
 		return fakeKubectlGetNamespaceWorkloads(args, flagValue(args, "--namespace"))
 	}
 	nodeName := flagValue(args, "--field-selector")
@@ -2432,21 +2433,45 @@ func anySlice(value any) []any {
 // unless the fixture explicitly declares a running workload.
 //
 // A failed candidate can also leave a Pod OBJECT behind that never reached
-// Running (the ghcr-auth ExternalSecret it needed was missing, so its image
-// pull never succeeded). That pod is not a consumer whose pull credential this
-// staging step could break, so it is reported only when the probe asks for
-// every Pod rather than for running ones.
+// Running, or a terminating Pod whose last phase is still Running. Neither is
+// an active consumer whose pull credential this staging step could break.
 func fakeKubectlGetNamespaceWorkloads(args []string, namespace string) int {
 	if namespace == "" {
 		return 0
 	}
+	outputJSON := containsSequence(args, "-o", "json") || containsArg(args, "-o=json")
+	fieldSelector := flagValue(args, "--field-selector")
+	items := []any{}
 	if namespace == os.Getenv("FAKE_NAMESPACE_WITH_WORKLOAD") {
-		fmt.Printf("pod/%s-0\n", namespace)
-		return 0
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": namespace + "-0"},
+			"status":   map[string]any{"phase": "Running"},
+		})
 	}
 	if namespace == os.Getenv("FAKE_NAMESPACE_WITH_NONRUNNING_POD") &&
-		!strings.Contains(flagValue(args, "--field-selector"), "status.phase=Running") {
-		fmt.Printf("pod/%s-0\n", namespace)
+		fieldSelector != "status.phase=Running" {
+		items = append(items, map[string]any{
+			"metadata": map[string]any{"name": namespace + "-0"},
+			"status":   map[string]any{"phase": "Pending"},
+		})
+	}
+	if namespace == os.Getenv("FAKE_NAMESPACE_WITH_TERMINATING_RUNNING_POD") {
+		items = append(items, map[string]any{
+			"metadata": map[string]any{
+				"name":              namespace + "-0",
+				"deletionTimestamp": "2026-09-01T00:00:00Z",
+			},
+			"status": map[string]any{"phase": "Running"},
+		})
+	}
+	if outputJSON {
+		fmt.Println(encodeJSON(map[string]any{"items": items}))
+		return 0
+	}
+	for _, item := range items {
+		pod, _ := item.(map[string]any)
+		metadata, _ := pod["metadata"].(map[string]any)
+		fmt.Printf("pod/%s\n", metadata["name"])
 	}
 	return 0
 }

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1345,6 +1345,8 @@ func fakeInventoryNode(
 	}
 }
 
+// fakeKubectlGetPods dispatches Pod inventory requests either to the namespace
+// workload probe or to the node-scoped runtime probe used by the bridge tests.
 func fakeKubectlGetPods(args []string) int {
 	if containsSequence(args, "-o", "name") || containsArg(args, "-o=name") ||
 		flagValue(args, "--field-selector") == "status.phase=Running" {
@@ -2421,6 +2423,7 @@ func wordListContains(list, target string) bool {
 	return false
 }
 
+// anySlice returns value as a generic slice, or nil when it is absent or not a slice.
 func anySlice(value any) []any {
 	if value == nil {
 		return nil
@@ -2435,8 +2438,8 @@ func anySlice(value any) []any {
 // unless the fixture explicitly declares a running workload.
 //
 // A failed candidate can also leave a Pod OBJECT behind that never reached
-// Running, or a terminating Pod whose last phase is still Running. Neither is
-// an active consumer whose pull credential this staging step could break.
+// A non-Running Pod, or a terminating Pod whose last phase is still Running.
+// Neither is an active consumer whose pull credential this staging step could break.
 func fakeKubectlGetNamespaceWorkloads(args []string, namespace string) int {
 	if namespace == "" {
 		return 0

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -16,6 +16,8 @@ type jsonPatchOperation struct {
 	Value     any    `json:"value"`
 }
 
+// fakeKubectlImplementation dispatches the kubectl operations exercised by the
+// production-auth bridge tests against their filesystem-backed fake cluster.
 func fakeKubectlImplementation(args []string) int {
 	if flagValue(args, "--context") != "admin@prod" {
 		return commandFailure(91, "kubectl must use the production context")

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -2437,9 +2437,9 @@ func anySlice(value any) []any {
 // left behind by a failed candidate still runs nothing, so it reports empty
 // unless the fixture explicitly declares a running workload.
 //
-// A failed candidate can also leave a Pod OBJECT behind that never reached
-// A non-Running Pod, or a terminating Pod whose last phase is still Running.
-// Neither is an active consumer whose pull credential this staging step could break.
+// A failed candidate can also leave a Pod OBJECT behind that never reached Running,
+// or a terminating Pod whose last phase is still Running. Neither is an active
+// consumer whose pull credential this staging step could break.
 func fakeKubectlGetNamespaceWorkloads(args []string, namespace string) int {
 	if namespace == "" {
 		return 0

--- a/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
@@ -573,12 +573,9 @@ func TestPrepublishStagingStillFailsClosedForAnEstablishedConsumer(t *testing.T)
 	requireWrapperPathExists(t, f.patchCapture, false)
 }
 
-// A failed candidate that got as far as creating its workload leaves a Pod
-// object behind that never reached Running, because the ghcr-auth
-// ExternalSecret it needed is exactly what is missing. Keying the exemption on
-// Pod existence would let that leftover deny every retry, deadlocking the very
-// change that introduces the consumer - the same deadlock namespace-presence
-// keying caused, one level down.
+// TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftANonRunningPod verifies
+// that a failed candidate's non-running Pod cannot deny every retry when the
+// missing ghcr-auth ExternalSecret is what prevented that Pod from starting.
 func TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftANonRunningPod(t *testing.T) {
 	f := newFixture(t)
 	result := f.runHelper(
@@ -597,8 +594,8 @@ func TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftANonRunningPod(t *tes
 	requireNotContains(t, fanout, "externalsecret/ascoachingogvaner/ghcr-auth")
 }
 
-// Kubernetes leaves a terminating Pod's phase at Running until the object is
-// reaped. That leftover is no longer an active consumer and must not recreate
+// TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftATerminatingRunningPod
+// verifies that a terminating Pod whose phase remains Running cannot recreate
 // the retry deadlock while its deletion grace period elapses.
 func TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftATerminatingRunningPod(t *testing.T) {
 	f := newFixture(t)

--- a/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
@@ -555,6 +555,8 @@ func TestFirstDeployStagesNewConsumerWhoseNamespaceSurvivedAFailedAttempt(t *tes
 	requireNotContains(t, fanout, "externalsecret/ascoachingogvaner/ghcr-auth")
 }
 
+// TestPrepublishStagingStillFailsClosedForAnEstablishedConsumer verifies that
+// an active consumer without ghcr-auth blocks the pre-publish credential change.
 func TestPrepublishStagingStillFailsClosedForAnEstablishedConsumer(t *testing.T) {
 	f := newFixture(t)
 	result := f.runHelper(

--- a/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/wrapper_test.go
@@ -596,3 +596,24 @@ func TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftANonRunningPod(t *tes
 	fanout := mustRead(f.fanoutLog)
 	requireNotContains(t, fanout, "externalsecret/ascoachingogvaner/ghcr-auth")
 }
+
+// Kubernetes leaves a terminating Pod's phase at Running until the object is
+// reaped. That leftover is no longer an active consumer and must not recreate
+// the retry deadlock while its deletion grace period elapses.
+func TestFirstDeployStagesNewConsumerWhoseFailedAttemptLeftATerminatingRunningPod(t *testing.T) {
+	f := newFixture(t)
+	result := f.runHelper(
+		validConfig(),
+		[]string{"--record-runtime-proof", f.workspace + "/runtime-proof.json"},
+		map[string]string{
+			"FAKE_MISSING_FANOUT_RESOURCE":                "externalsecret/ascoachingogvaner/ghcr-auth",
+			"FAKE_NAMESPACE_WITH_TERMINATING_RUNNING_POD": "ascoachingogvaner",
+		},
+	)
+
+	requireWrapperExitCode(t, result, 0)
+	requireWrapperPathExists(t, f.patchCapture, true)
+	requireWrapperPathExists(t, f.variablesPatchCapture, true)
+	fanout := mustRead(f.fanoutLog)
+	requireNotContains(t, fanout, "externalsecret/ascoachingogvaner/ghcr-auth")
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer (Codex lane)\n\n## Why\n\nA failed deployment can leave a terminating Pod whose phase remains Running until the object is reaped. The pre-publish GHCR fan-out probe treated that leftover as an established consumer, so a retry could deadlock even though no active workload remained.\n\n## What\n\n- read the Running-Pod inventory as JSON and fail closed on malformed shapes\n- count only Running Pods without metadata.deletionTimestamp as active consumers\n- extend the fake cluster with Pending, active Running, and terminating Running states\n- add a regression proving a terminating leftover does not block first-deploy staging\n\n## Evidence\n\n- RED: the new terminating-Pod test failed with exit code 1 and the fan-out-incomplete refusal on the predecessor logic\n- GREEN: the focused stale-namespace, established, Pending, and terminating cases pass\n- ablation: removing only the deletionTimestamp conjunct makes the new test fail again\n- full bridge Go suite: PASS (153.680s)\n- bash syntax, ShellCheck, stable-endpoint tests, and GHCR auth safety tests: PASS\n\nFixes #3487