### PR TITLE
fix(security): seed the LimitRange guard from Flux layer roots, not find

### DIFF
--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -83,10 +83,46 @@ canonicalize() { # <dir> <entry>
 # Every filesystem path a provider's kustomize graph reaches, one per line.
 reachable_files() { # <provider-dir>
   local provider=$1 queue seen_k="" files="" k dir entry target
-  # Seed with every kustomization under the provider. Flux applies each layer
-  # separately, so a LimitRange reached by ANY of them lands on that cluster.
-  queue=$(find "$provider" -name kustomization.yaml -type f 2>/dev/null)
-  [ -n "$queue" ] && queue="$queue"$'\n'
+  local lroot lpath lfile seeded=0 layer_defs=0
+  # SEED FROM THE FLUX LAYER ROOTS, NEVER FROM `find`.
+  #
+  # Flux does not apply "every kustomization under the provider" — each layer
+  # Kustomization in clusters/base targets ONE path, and a subtree that no layer
+  # root reaches through its resources/components graph is NOT deployed. Seeding
+  # with `find` swept those in, and because extra subtrees can only ADD LimitRange
+  # namespaces, the error was fail-open: an unreferenced opt-in overlay could
+  # supply the only LimitRange for a premised skip and the guard would approve a
+  # suppression nothing actually shields. `providers/docker/infrastructure/
+  # controllers/minio/` is exactly that shape — referenced only from comments.
+  #
+  # The roots are READ from clusters/base rather than hardcoded, so adding a layer
+  # widens this guard automatically instead of silently narrowing it.
+  for lfile in "$root"/clusters/base/flux-kustomization-*.yaml; do
+    [ -f "$lfile" ] || continue
+    layer_defs=$((layer_defs + 1))
+    lpath=$(yq -r '.spec.path // ""' "$lfile" 2>/dev/null) ||
+      die "could not parse layer definition $lfile"
+    [ -n "$lpath" ] || continue
+    # Only provider-scoped layers seed a provider walk. `bootstrap` targets
+    # clusters/__CLUSTER__/bootstrap — a different tree that ships no provider
+    # overlay — so substituting a provider name into it would name nothing.
+    case $lpath in
+      providers/__PROVIDER__ | providers/__PROVIDER__/*) ;;
+      *) continue ;;
+    esac
+    lroot="$root/${lpath//__PROVIDER__/$(basename "$provider")}"
+    [ -f "$lroot/kustomization.yaml" ] || continue
+    queue="${queue}$lroot/kustomization.yaml"$'\n'
+    seeded=$((seeded + 1))
+  done
+  # A guard that cannot find the layer definitions cannot know what is deployed,
+  # and must not report a clean tree. Distinguish the two causes: no definitions
+  # at all is a broken/unknown checkout, while definitions that name no existing
+  # path for THIS provider is a provider that ships nothing through any layer.
+  if [ "$layer_defs" -eq 0 ]; then
+    die "no clusters/base/flux-kustomization-*.yaml layer definitions under $root; cannot determine what each provider deploys"
+  fi
+  [ "$seeded" -gt 0 ] || return 0
   while [ -n "$queue" ]; do
     k=${queue%%$'\n'*}
     if [ "$k" = "$queue" ]; then queue=""; else queue=${queue#*$'\n'}; fi

--- a/scripts/guard-limitrange-premise.sh
+++ b/scripts/guard-limitrange-premise.sh
@@ -82,7 +82,7 @@ canonicalize() { # <dir> <entry>
 
 # Every filesystem path a provider's kustomize graph reaches, one per line.
 reachable_files() { # <provider-dir>
-  local provider=$1 queue seen_k="" files="" k dir entry target
+  local provider=$1 queue="" seen_k="" files="" k dir entry target
   local lroot lpath lfile seeded=0 layer_defs=0
   # SEED FROM THE FLUX LAYER ROOTS, NEVER FROM `find`.
   #

--- a/scripts/tests/test-guard-limitrange-premise.sh
+++ b/scripts/tests/test-guard-limitrange-premise.sh
@@ -68,10 +68,38 @@ spec:
 YAML
 }
 
+# The Flux layer roots the guard seeds its walk from. Every fixture needs these:
+# the guard reads clusters/base rather than hardcoding the layers, so a tree with
+# no layer definition is "cannot determine what is deployed" (exit 2), not clean.
+# Only the `infrastructure` layer is declared here because that is the path every
+# fixture's provider overlay lives at; `bootstrap` is deliberately included with a
+# cluster-scoped path so the fixtures also pin that a NON-provider layer is skipped
+# rather than having a provider name substituted into it.
+make_layer_roots() { # <root>
+  mkdir -p "$1/clusters/base"
+  cat >"$1/clusters/base/flux-kustomization-infrastructure.yaml" <<YAML
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure
+spec:
+  path: providers/__PROVIDER__/infrastructure
+YAML
+  cat >"$1/clusters/base/flux-kustomization-bootstrap.yaml" <<YAML
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: bootstrap
+spec:
+  path: clusters/__CLUSTER__/bootstrap
+YAML
+}
+
 # One provider shipping one annotated workload. <extra> is spliced into the
 # overlay's resource list, so neighbouring cases differ in exactly one line.
 make_provider() { # <root> <provider> <workload-basename> <namespace> <skip-reason> <extra-resource>
   local root=$1 prov=$2 base=$3 ns=$4 reason=$5 extra=$6
+  make_layer_roots "$root"
   mkdir -p "$root/providers/$prov/infrastructure"
   {
     printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n'
@@ -170,6 +198,7 @@ expect 'unrelated-skip-is-not-matched' 0 "$unrelated" 'no suppression'
 
 # --- 6. ANTI-VACUITY: no suppression at all --------------------------------
 bare="$scratch/bare"
+make_layer_roots "$bare"
 mkdir -p "$bare/providers/barelike/infrastructure"
 cat >"$bare/providers/barelike/infrastructure/kustomization.yaml" <<'YAML'
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -193,6 +222,7 @@ expect 'missing-providers-dir-is-exit-2' 2 "$noprov" 'providers'
 
 # --- 9. COULD-NOT-CHECK: premised skip on a namespace-less resource --------
 nons="$scratch/nons"
+make_layer_roots "$nons"
 mkdir -p "$nons/providers/nonslike/infrastructure"
 cat >"$nons/providers/nonslike/infrastructure/kustomization.yaml" <<'YAML'
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -260,6 +290,7 @@ expect 'absolute-resources-entry-resolves' 0 "$absentry" 'absolute-dns'
 # in document 1 states `multidoc-ns`, where the LimitRange is shipped. The correct
 # verdict is exit 0.
 multidoc="$scratch/multidoc"
+make_layer_roots "$multidoc"
 mkdir -p "$multidoc/providers/multidoclike/infrastructure"
 {
   printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n'
@@ -319,5 +350,73 @@ spec:
         memory: 1Gi
 YAML
 expect 'limitrange-without-default-cpu-fails' 1 "$capless" 'capless-dns'
+# --- 16. THE DEFECT THIS FIX CLOSES: a LimitRange in an UNREFERENCED subtree ---
+# The overlay ships the annotated workload but does NOT reference limit-ranges/.
+# `find` reaches that subtree's kustomization.yaml, the Flux layer graph does not.
+# Seeding from `find` therefore credited the provider with a LimitRange it never
+# deploys and PASSED — a fail-open suppression. Seeded from the layer root, the
+# subtree is correctly invisible and the premise is reported as unshielded.
+unref="$scratch/unref"
+make_provider "$unref" unreflike orphan-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" ""
+mkdir -p "$unref/providers/unreflike/infrastructure/opt-in"
+cat >"$unref/providers/unreflike/infrastructure/opt-in/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - range.yaml
+YAML
+cat >"$unref/providers/unreflike/infrastructure/opt-in/range.yaml" <<'YAML'
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: kube-system
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+YAML
+expect 'unreferenced-subtree-limitrange-does-not-shield' 1 "$unref" 'orphan-dns'
+
+# --- 17. THE PAIRED CONTROL: the SAME subtree, now REFERENCED, does shield ----
+# Differs from case 16 in exactly one line — the overlay's `resources:` entry — so
+# a pass here can only be attributed to reachability, not to the fixture shape.
+refd="$scratch/refd"
+make_provider "$refd" refdlike adopted-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" "opt-in"
+mkdir -p "$refd/providers/refdlike/infrastructure/opt-in"
+cat >"$refd/providers/refdlike/infrastructure/opt-in/kustomization.yaml" <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - range.yaml
+YAML
+cat >"$refd/providers/refdlike/infrastructure/opt-in/range.yaml" <<'YAML'
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: kube-system
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+YAML
+expect 'referenced-subtree-limitrange-does-shield' 0 "$refd" 'adopted-dns'
+
+# --- 18. COULD-NOT-CHECK: no Flux layer definitions to seed from -------------
+# Without clusters/base the guard cannot know which paths a provider deploys.
+# That must be exit 2, never a clean 0: an unknown deployment surface and a clean
+# tree would otherwise be indistinguishable — the property this guard's header
+# calls out explicitly.
+nolayer="$scratch/nolayer"
+make_provider "$nolayer" nolayerlike blind-dns kube-system \
+  "CKV_K8S_11=the kube-system default-limitrange supplies the CPU limit at admission" ""
+rm -rf "$nolayer/clusters"
+expect 'missing-layer-definitions-is-exit-2' 2 "$nolayer" 'flux-kustomization'
+
 printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
 [ "$failures" -eq 0 ] || exit 1

--- a/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
+++ b/scripts/tests/test-trivyignore-vendored-operator-boundary.sh
@@ -302,8 +302,23 @@ else
   # Capture the guard's status DIRECTLY rather than reading $? after an `if` compound, which
   # yields the compound's status (0 when the condition merely failed) and would collapse
   # "could not check" into "checked".
+  # NOTE: set -e defeats that on its own. A command substitution in an assignment is itself
+  # a simple command, so a non-zero guard aborts this script AT the assignment - before
+  # premise_rc is read and before either branch below can print premise_out. The whole
+  # guard diagnosis lives in that variable, so a guard failure surfaced as a silent exit 1
+  # with no output at all, which is unactionable. Disable errexit across the capture only.
+  set +e
   premise_out="$(cd "$repo_root" && "$premise_guard" k8s 2>&1)"
   premise_rc=$?
+  set -e
+  # A non-zero guard already explained itself on its own stderr, and that text is the
+  # evidence for every verdict below. Echo it whenever the guard did not exit clean, so a
+  # CI failure carries the reason and not just the conclusion. rc 2 is handled separately
+  # below, where it means UNCHECKABLE rather than a violation.
+  if [ "$premise_rc" -ne 0 ] && [ "$premise_rc" -ne 2 ]; then
+    printf %s\\n "guard-limitrange-premise.sh exited $premise_rc; its report follows:" >&2
+    printf %s\\n "$premise_out" >&2
+  fi
   if [ "$premise_rc" -eq 2 ]; then
     printf 'ADMISSION PREMISE UNCHECKABLE: guard-limitrange-premise.sh exited 2, so an absent verdict below would mean nothing rather than a broken premise\n' >&2
     printf '%s\n' "$premise_out" >&2


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A guard that is supposed to catch unsupported security suppressions could be talked out of it by a
directory nobody deploys.

Several checkov suppressions in this tree are justified not as "we accept the risk" but as "a
LimitRange supplies this at admission, so the finding is not real". That reasoning is only sound where
the LimitRange actually applies, and `guard-limitrange-premise.sh` exists to prove it does. It was
deciding what a provider ships by listing every directory under it — but Flux only deploys what its
layer roots reach. So an opt-in directory nobody references could supply the missing LimitRange, and
the guard would sign off on a suppression that shields nothing in the real cluster.

The error only ever ran in the unsafe direction: extra directories can add evidence, never remove it,
so this could only turn a violation into a pass. Nothing is wrongly approved today — no unreferenced
directory currently ships a LimitRange — so this closes the hole before it is stepped in, not after.

### What

The guard now works out what a provider deploys the same way Flux does: from the layer definitions,
following each one through its own resource graph. Those layers are read from the cluster config
rather than written into the script, so adding one widens the guard automatically instead of quietly
narrowing it. A checkout with no layer definitions is now reported as "could not check" rather than
"clean" — the distinction this guard already treats as load-bearing.

Fixes #3270
