### PR TITLE
fix(ci): constrain isolated chart child namespaces

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -138,6 +138,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .github/scripts/setup-ksail.sh
 
+      - name: 🔐 Validate isolated chart child namespaces
+        # Manual recovery deploys may not bypass the rendered namespace proof
+        # simply because the staged component is absent from the deploy overlay.
+        timeout-minutes: 10
+        run: |
+          shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh
+          bash scripts/tests/test-isolated-chart-namespace-rules.sh
+
       - name: 🔐 Validate Helm-rendered production authorization controls
         # Same reasoning as the identical step in ci.yaml: this reaches every
         # upstream chart registry, so an unreachable registry would otherwise

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1768,6 +1768,27 @@ jobs:
           shellcheck scripts/scan-rgd-templates.sh scripts/tests/test-rgd-template-static-scan.sh
           bash scripts/tests/test-rgd-template-static-scan.sh
 
+      - name: ⚙️ Setup KSail for effective authorization validation
+        shell: bash
+        env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
+          KSAIL_VERSION: "7.180.1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/setup-ksail.sh
+
+      - name: 🔐 Validate isolated chart child namespaces on main
+        # Same reason as the RGD scan above, for the other gate this job's
+        # publish depends on. `validate-eks-authorization` rendered the chart on
+        # the SPECULATIVE merge ref; this job publishes `ref: main`, which may
+        # have advanced since. Without this step the isolated-chart exemption
+        # would be relied on for a revision no render ever inspected — and the
+        # per-workflow coverage guard would still read ci.yaml as gated, because
+        # a sibling job ran the validator on a different commit.
+        timeout-minutes: 10
+        run: |
+          shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh
+          bash scripts/tests/test-isolated-chart-namespace-rules.sh
+
       - name: 🩹 Re-deploy main to Production
         # Reuse the shared deploy composite (push → sign → attest → reconcile →
         # cluster update) against main's checkout, so the restored artifact is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,6 +331,8 @@ jobs:
               - 'scripts/guard-ghcr-fanout-component-gate.sh'
               - 'scripts/tests/test-guard-ghcr-fanout-component-gate.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
+              - 'scripts/tests/isolated-chart-namespace-rules.yaml'
+              - 'scripts/tests/test-isolated-chart-namespace-rules.sh'
               - 'scripts/tests/production-authorization-rules.yaml'
               - 'scripts/tests/test-production-authorization-rules.sh'
               - 'tests/**'
@@ -569,6 +571,16 @@ jobs:
           KSAIL_VERSION: "7.180.1"
           GITHUB_TOKEN: ${{ github.token }}
         run: .github/scripts/setup-ksail.sh
+
+      - name: 🔐 Validate isolated chart child namespaces
+        # The data-product-controller component remains outside the deploy
+        # overlay. Render its immutable chart explicitly so every child with a
+        # namespace is proven local before the isolated-chart exemption can be
+        # relied on by this PR or speculative merge-group revision.
+        timeout-minutes: 10
+        run: |
+          shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh
+          bash scripts/tests/test-isolated-chart-namespace-rules.sh
 
       - name: 🔐 Validate the production authorization rule suite
         # Split from the render below so the job summary attributes a failure to

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -173,6 +173,20 @@ jobs:
         run: |
           .github/scripts/setup-ksail.sh
 
+      - name: 🔐 Validate isolated chart child namespaces
+        # Recovery is a deployment route like any other: it publishes a mutable
+        # tag and reconciles the selected revision, so it must prove the same
+        # rendered-child property the pull-request, push and manual-deploy
+        # routes prove. Placed before cluster creation so a foreign-namespace
+        # render is refused while nothing has been provisioned yet, and directly
+        # after the KSail install this needs. This workflow already gates
+        # recovery on registry reachability (the RGD template scan above and the
+        # Flux GHCR preflight below), so the check adds no new dependency class.
+        timeout-minutes: 10
+        run: |
+          shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh
+          bash scripts/tests/test-isolated-chart-namespace-rules.sh
+
       - name: ⚙️ Setup talosctl
         # The GHCR bridge verifies RegistryAuthConfig on each stale node.
         run: |

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -79,6 +79,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: .github/scripts/setup-ksail.sh
 
+      - name: 🔐 Validate isolated chart child namespaces
+        # Direct pushes must prove the same exact staged-off chart property as
+        # pull requests and merge groups before main is accepted as healthy.
+        timeout-minutes: 10
+        run: |
+          shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh
+          bash scripts/tests/test-isolated-chart-namespace-rules.sh
+
       - name: 🔐 Validate Helm-rendered production authorization controls
         # Same reasoning as the identical step in ci.yaml: this reaches every
         # upstream chart registry, so an unreachable registry would otherwise

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -15,31 +15,40 @@ rules:
     # A binding must additionally reference the reviewed ClusterRole and carry
     # only subjects in the release namespace; one with no subjects at all fails
     # closed, because `all` over an absent field cannot be evaluated.
+    #
+    # The branch is chosen by KIND, never by whether a namespace field is
+    # present. `metadata.namespace` is silently ignored by the API server on a
+    # cluster-scoped object, so a namespace-presence test lets a rendered
+    # ClusterRoleBinding declare the release namespace and satisfy the
+    # namespaced branch without ever reaching the pinned name, roleRef, and
+    # subject checks — a cluster-admin grant to a foreign subject would pass.
+    # Dispatching on kind first makes that shape unreachable, and a
+    # cluster-scoped object carrying a namespace field is rejected outright
+    # rather than silently accepted on a field that does not survive apply.
     expression: >-
       has(object.metadata) &&
-      ((has(object.metadata.namespace) &&
-        object.metadata.namespace == 'data-product-controller') ||
-       (!has(object.metadata.namespace) &&
-        ((has(object.kind) &&
-          object.kind == 'ClusterRole' &&
-          has(object.metadata.name) &&
-          object.metadata.name == 'data-product-controller') ||
-         (has(object.kind) &&
-          object.kind == 'ClusterRoleBinding' &&
-          has(object.metadata.name) &&
-          object.metadata.name == 'data-product-controller' &&
-          has(object.roleRef) &&
-          has(object.roleRef.kind) &&
-          object.roleRef.kind == 'ClusterRole' &&
-          has(object.roleRef.name) &&
-          object.roleRef.name == 'data-product-controller' &&
-          has(object.subjects) &&
-          object.subjects.all(s,
-            has(s.namespace) && s.namespace == 'data-product-controller')) ||
-         (has(object.kind) &&
-          object.kind == 'Namespace' &&
-          has(object.metadata.name) &&
-          object.metadata.name == 'data-product-controller'))))
+      has(object.kind) &&
+      (object.kind in ['ClusterRole', 'ClusterRoleBinding', 'Namespace']
+        ? (!has(object.metadata.namespace) &&
+           ((object.kind == 'ClusterRole' &&
+             has(object.metadata.name) &&
+             object.metadata.name == 'data-product-controller') ||
+            (object.kind == 'ClusterRoleBinding' &&
+             has(object.metadata.name) &&
+             object.metadata.name == 'data-product-controller' &&
+             has(object.roleRef) &&
+             has(object.roleRef.kind) &&
+             object.roleRef.kind == 'ClusterRole' &&
+             has(object.roleRef.name) &&
+             object.roleRef.name == 'data-product-controller' &&
+             has(object.subjects) &&
+             object.subjects.all(s,
+               has(s.namespace) && s.namespace == 'data-product-controller')) ||
+            (object.kind == 'Namespace' &&
+             has(object.metadata.name) &&
+             object.metadata.name == 'data-product-controller')))
+        : (has(object.metadata.namespace) &&
+           object.metadata.namespace == 'data-product-controller'))
     message: >-
       data-product-controller chart children must remain in the reviewed
       data-product-controller namespace

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -72,6 +72,24 @@ rules:
     # wildcard-only check accepts every one of them. RBAC access is therefore
     # narrowed to read verbs, and the escalation verbs are refused outright
     # whatever resource they name.
+    #
+    # THE REVIEWED HelmRelease MUST NOT TAKE VALUE INPUTS THIS RENDER CANNOT
+    # SEE. Containment here rests on a filesystem render of the pinned artifact:
+    # every child it produces is evaluated by this rule, and the component is
+    # staged off every deploy overlay, so cluster admission never re-checks it.
+    # That makes the render the ONLY control, and it is sound only while what it
+    # renders is what Flux installs. `spec.valuesFrom` breaks exactly that: it
+    # resolves a Secret or ConfigMap in-cluster, so the render sees chart
+    # defaults while Flux sees another value set — and values decide which
+    # templates render at all, so a runtime value can enable RBAC or a
+    # foreign-namespace child that neither the render nor this rule inspected.
+    # Inline `spec.values` stays permitted: it travels in this manifest, so the
+    # render resolves the same values Flux will.
+    # `spec.postRenderers` is deliberately NOT refused here. The reviewed chart
+    # uses it to add imagePullSecrets and topology constraints to its own
+    # Deployments, so a blanket refusal rejects the real component; whether a
+    # post-render patch can move a child across namespaces after this rule has
+    # accepted it is a separate question needing its own proof.
     expression: >-
       has(object.metadata) &&
       has(object.kind) &&
@@ -119,6 +137,9 @@ rules:
            (object.kind != 'Kustomization' ||
             (has(object.spec) && has(object.spec.targetNamespace) &&
              object.spec.targetNamespace == 'data-product-controller')) &&
+           (object.kind != 'HelmRelease' ||
+            !has(object.spec) ||
+            !has(object.spec.valuesFrom)) &&
            (object.kind != 'RoleBinding' ||
             (has(object.subjects) &&
              object.subjects.all(s,

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -1,0 +1,23 @@
+rules:
+  - name: restrict-data-product-controller-rendered-child-namespaces
+    # This rule is deliberately path-scoped by its caller to the reviewed
+    # data-product-controller component. That gives every rendered child the
+    # chart provenance which a cluster-wide admission rule cannot recover from
+    # the final object alone. Namespace, ClusterRole, and ClusterRoleBinding are
+    # the only reviewed cluster-scoped shapes in the exact pinned render; every
+    # namespaced child must declare the release namespace explicitly.
+    expression: >-
+      has(object.metadata) &&
+      ((has(object.metadata.namespace) &&
+        object.metadata.namespace == 'data-product-controller') ||
+       (!has(object.metadata.namespace) &&
+        ((has(object.kind) &&
+          object.kind in ['ClusterRole', 'ClusterRoleBinding']) ||
+         (has(object.kind) &&
+          object.kind == 'Namespace' &&
+          has(object.metadata.name) &&
+          object.metadata.name == 'data-product-controller'))))
+    message: >-
+      data-product-controller chart children must remain in the reviewed
+      data-product-controller namespace
+    severity: error

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -47,9 +47,11 @@ rules:
     #     but its controller reconciles grandchildren that are not part of this
     #     render at all and can carry `spec.targetNamespace` anywhere. Those
     #     grandchildren never reach this rule, so the emitter itself must be
-    #     refused. The kind list mirrors `isAuthorizationKind` in
-    #     scripts/validate-eks-ci-role-policy/main.go, which already classifies
-    #     exactly these as able to redirect, emit, or grant authorization.
+    #     refused. `isAuthorizationKind` in
+    #     scripts/validate-eks-ci-role-policy/main.go classifies exactly these
+    #     as able to redirect, emit, or grant authorization; here the allowlist
+    #     below reaches the same verdict by admitting only the two reconciler
+    #     kinds the reviewed render contains.
     #
     # The reviewed emitters are PINNED BY NAME, exactly as the cluster-scoped
     # RBAC shapes are, rather than refused wholesale. The component's own
@@ -58,11 +60,11 @@ rules:
     # is installed; a blanket refusal of emitter kinds rejects the real render.
     # A reviewed emitter must additionally not redirect: `spec.targetNamespace`
     # is what sends reconciled grandchildren somewhere else, and those never
-    # reach this rule. For a Kustomization that field must be present and
-    # correct rather than merely not-wrong: Flux preserves the namespaces the
-    # remote artifact declares when it is omitted, so an absent targetNamespace
-    # reconciles grandchildren anywhere the artifact likes. A HelmRelease is
-    # left alone here because it defaults to its own namespace instead.
+    # reach this rule. A HelmRelease is held to it only as a redirect check,
+    # because it defaults to its own namespace when the field is absent. The
+    # only two emitter kinds the allowlist admits are the component's own
+    # OCIRepository and HelmRelease; every other reconciler kind, Kustomization
+    # included, is refused by the kind set rather than conditioned here.
     #
     # The ClusterRole branch refuses more than wildcards. `bind` and `escalate`
     # on rbac.authorization.k8s.io are privilege-escalation primitives in their
@@ -90,6 +92,36 @@ rules:
     # Deployments, so a blanket refusal rejects the real component; whether a
     # post-render patch can move a child across namespaces after this rule has
     # accepted it is a separate question needing its own proof.
+    #
+    # THE KIND SET IS AN ALLOWLIST, NOT A LIST OF REFUSALS. Scope is not
+    # recoverable from a rendered object: `metadata.namespace` is accepted and
+    # then ignored by the API server on every cluster-scoped kind, so a
+    # CustomResourceDefinition or MutatingWebhookConfiguration carrying the
+    # release namespace satisfies a containment test while landing cluster-wide.
+    # Enumerating the cluster-scoped kinds to refuse cannot close that — the next
+    # unlisted kind passes exactly as the last one did. The render is pinned by
+    # digest and its kinds are therefore known, so the branch instead names the
+    # kinds the reviewed artifact actually produces and refuses everything else.
+    # A digest bump that introduces a new kind fails this rule until the kind is
+    # read and added, which is the review this containment bound depends on.
+    #
+    # Kustomization is deliberately absent from that set. The reviewed render
+    # contains none, and a Kustomization cannot be contained by this rule even
+    # when its own object is local and its `spec.targetNamespace` is correct:
+    # targetNamespace relocates namespaced grandchildren only, so a source
+    # carrying a ClusterRoleBinding still reconciles it cluster-wide, and no
+    # grandchild is ever presented here. Refusing the kind is the only bound
+    # this rule can actually enforce.
+    #
+    # THE RENDERED Namespace IS PINNED BY ITS ENFORCEMENT LABEL, not by name
+    # alone. The reviewed base declares `pod-security.kubernetes.io/enforce:
+    # restricted`, and a chart that renders the same-named Namespace overwrites
+    # that object on apply. Accepting it on name would let a future digest ship
+    # `enforce: privileged` — or drop the label, which is the same admission
+    # outcome by omission — and every workload in the isolated namespace would
+    # run unrestricted while this rule stayed green. An absent or non-restricted
+    # label is refused; the component is staged off every deploy overlay, so no
+    # cluster admission control re-checks it afterwards.
     expression: >-
       has(object.metadata) &&
       has(object.kind) &&
@@ -123,20 +155,23 @@ rules:
                has(s.namespace) && s.namespace == 'data-product-controller')) ||
             (object.kind == 'Namespace' &&
              has(object.metadata.name) &&
-             object.metadata.name == 'data-product-controller')))
-        : (has(object.metadata.namespace) &&
+             object.metadata.name == 'data-product-controller' &&
+             has(object.metadata.labels) &&
+             'pod-security.kubernetes.io/enforce' in object.metadata.labels &&
+             object.metadata.labels['pod-security.kubernetes.io/enforce'] ==
+               'restricted')))
+        : (object.kind in ['CiliumNetworkPolicy', 'DataProduct', 'Deployment',
+                           'ExternalSecret', 'HTTPRoute', 'HelmRelease',
+                           'NetworkPolicy', 'OCIRepository',
+                           'PodDisruptionBudget', 'Role', 'RoleBinding',
+                           'Service', 'ServiceAccount'] &&
+           has(object.metadata.namespace) &&
            object.metadata.namespace == 'data-product-controller' &&
-           (!(object.kind in ['Kustomization', 'HelmRelease', 'OCIRepository',
-                              'GitRepository', 'Bucket', 'HelmRepository',
-                              'ExternalArtifact', 'Provider', 'Function',
-                              'Configuration', 'DeploymentRuntimeConfig']) ||
+           (!(object.kind in ['HelmRelease', 'OCIRepository']) ||
             (has(object.metadata.name) &&
              object.metadata.name == 'data-product-controller' &&
              (!has(object.spec) || !has(object.spec.targetNamespace) ||
               object.spec.targetNamespace == 'data-product-controller'))) &&
-           (object.kind != 'Kustomization' ||
-            (has(object.spec) && has(object.spec.targetNamespace) &&
-             object.spec.targetNamespace == 'data-product-controller')) &&
            (object.kind != 'HelmRelease' ||
             !has(object.spec) ||
             !has(object.spec.valuesFrom)) &&

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -58,7 +58,11 @@ rules:
     # is installed; a blanket refusal of emitter kinds rejects the real render.
     # A reviewed emitter must additionally not redirect: `spec.targetNamespace`
     # is what sends reconciled grandchildren somewhere else, and those never
-    # reach this rule.
+    # reach this rule. For a Kustomization that field must be present and
+    # correct rather than merely not-wrong: Flux preserves the namespaces the
+    # remote artifact declares when it is omitted, so an absent targetNamespace
+    # reconciles grandchildren anywhere the artifact likes. A HelmRelease is
+    # left alone here because it defaults to its own namespace instead.
     #
     # The ClusterRole branch refuses more than wildcards. `bind` and `escalate`
     # on rbac.authorization.k8s.io are privilege-escalation primitives in their
@@ -112,6 +116,9 @@ rules:
              object.metadata.name == 'data-product-controller' &&
              (!has(object.spec) || !has(object.spec.targetNamespace) ||
               object.spec.targetNamespace == 'data-product-controller'))) &&
+           (object.kind != 'Kustomization' ||
+            (has(object.spec) && has(object.spec.targetNamespace) &&
+             object.spec.targetNamespace == 'data-product-controller')) &&
            (object.kind != 'RoleBinding' ||
             (has(object.subjects) &&
              object.subjects.all(s,

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -6,13 +6,36 @@ rules:
     # the final object alone. Namespace, ClusterRole, and ClusterRoleBinding are
     # the only reviewed cluster-scoped shapes in the exact pinned render; every
     # namespaced child must declare the release namespace explicitly.
+    #
+    # The two cluster-scoped RBAC shapes are pinned by name rather than by kind
+    # alone. A bare `kind in ['ClusterRole', 'ClusterRoleBinding']` branch
+    # accepts EVERY cluster-scoped role and binding the chart can render, so a
+    # chart revision granting cluster-admin to a subject in another namespace
+    # would satisfy it — which is the whole property this rule exists to deny.
+    # A binding must additionally reference the reviewed ClusterRole and carry
+    # only subjects in the release namespace; one with no subjects at all fails
+    # closed, because `all` over an absent field cannot be evaluated.
     expression: >-
       has(object.metadata) &&
       ((has(object.metadata.namespace) &&
         object.metadata.namespace == 'data-product-controller') ||
        (!has(object.metadata.namespace) &&
         ((has(object.kind) &&
-          object.kind in ['ClusterRole', 'ClusterRoleBinding']) ||
+          object.kind == 'ClusterRole' &&
+          has(object.metadata.name) &&
+          object.metadata.name == 'data-product-controller') ||
+         (has(object.kind) &&
+          object.kind == 'ClusterRoleBinding' &&
+          has(object.metadata.name) &&
+          object.metadata.name == 'data-product-controller' &&
+          has(object.roleRef) &&
+          has(object.roleRef.kind) &&
+          object.roleRef.kind == 'ClusterRole' &&
+          has(object.roleRef.name) &&
+          object.roleRef.name == 'data-product-controller' &&
+          has(object.subjects) &&
+          object.subjects.all(s,
+            has(s.namespace) && s.namespace == 'data-product-controller')) ||
          (has(object.kind) &&
           object.kind == 'Namespace' &&
           has(object.metadata.name) &&

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -59,6 +59,15 @@ rules:
     # A reviewed emitter must additionally not redirect: `spec.targetNamespace`
     # is what sends reconciled grandchildren somewhere else, and those never
     # reach this rule.
+    #
+    # The ClusterRole branch refuses more than wildcards. `bind` and `escalate`
+    # on rbac.authorization.k8s.io are privilege-escalation primitives in their
+    # own right, and `create` on clusterrolebindings lets the controller mint a
+    # binding at runtime — an object that reaches the cluster without passing
+    # through either chart validation. None of those shapes needs a `*`, so a
+    # wildcard-only check accepts every one of them. RBAC access is therefore
+    # narrowed to read verbs, and the escalation verbs are refused outright
+    # whatever resource they name.
     expression: >-
       has(object.metadata) &&
       has(object.kind) &&
@@ -72,7 +81,13 @@ rules:
              object.rules.all(r,
                (!has(r.apiGroups) || !('*' in r.apiGroups)) &&
                (!has(r.resources) || !('*' in r.resources)) &&
-               (!has(r.verbs) || !('*' in r.verbs)))) ||
+               (!has(r.verbs) || !('*' in r.verbs)) &&
+               (!has(r.verbs) ||
+                !r.verbs.exists(v, v in ['escalate', 'bind', 'impersonate'])) &&
+               (!has(r.apiGroups) ||
+                !('rbac.authorization.k8s.io' in r.apiGroups) ||
+                (has(r.verbs) &&
+                 r.verbs.all(v, v in ['get', 'list', 'watch']))))) ||
             (object.kind == 'ClusterRoleBinding' &&
              has(object.metadata.name) &&
              object.metadata.name == 'data-product-controller' &&

--- a/scripts/tests/isolated-chart-namespace-rules.yaml
+++ b/scripts/tests/isolated-chart-namespace-rules.yaml
@@ -25,6 +25,40 @@ rules:
     # Dispatching on kind first makes that shape unreachable, and a
     # cluster-scoped object carrying a namespace field is rejected outright
     # rather than silently accepted on a field that does not survive apply.
+    #
+    # NAME IS NOT ENOUGH FOR THE ClusterRole EITHER. Pinning only the name lets
+    # a chart revision keep `data-product-controller` while widening its rules
+    # to `*`, and the reviewed ClusterRoleBinding then grants that cluster-wide
+    # power to the controller — containment defeated without a single foreign
+    # name appearing. An `aggregationRule` is the same escape by another route:
+    # the rules are absent at render time and filled in later by the controller
+    # from cluster-wide labels, so what was reviewed is not what is granted.
+    # Both are rejected. This is a containment bound, not a full fingerprint of
+    # the reviewed permissions; a digest bump still needs its rules read.
+    #
+    # A NAMESPACED CHILD IS NOT AUTOMATICALLY CONTAINED. Two shapes escape the
+    # namespace while carrying it:
+    #   * a RoleBinding whose SUBJECT lives elsewhere pulls a foreign identity
+    #     INTO the isolated namespace, so the subject check the reviewed
+    #     ClusterRoleBinding already carries applies to it too, fail-closed on
+    #     an absent `subjects` for the same reason;
+    #   * a Flux or Crossplane reconciler — Kustomization, HelmRelease, source
+    #     and package kinds — is an INDIRECT emitter: its own object is local,
+    #     but its controller reconciles grandchildren that are not part of this
+    #     render at all and can carry `spec.targetNamespace` anywhere. Those
+    #     grandchildren never reach this rule, so the emitter itself must be
+    #     refused. The kind list mirrors `isAuthorizationKind` in
+    #     scripts/validate-eks-ci-role-policy/main.go, which already classifies
+    #     exactly these as able to redirect, emit, or grant authorization.
+    #
+    # The reviewed emitters are PINNED BY NAME, exactly as the cluster-scoped
+    # RBAC shapes are, rather than refused wholesale. The component's own
+    # `OCIRepository/data-product-controller` and `HelmRelease/data-product-
+    # controller` ARE the reviewed, digest-pinned mechanism by which this chart
+    # is installed; a blanket refusal of emitter kinds rejects the real render.
+    # A reviewed emitter must additionally not redirect: `spec.targetNamespace`
+    # is what sends reconciled grandchildren somewhere else, and those never
+    # reach this rule.
     expression: >-
       has(object.metadata) &&
       has(object.kind) &&
@@ -32,7 +66,13 @@ rules:
         ? (!has(object.metadata.namespace) &&
            ((object.kind == 'ClusterRole' &&
              has(object.metadata.name) &&
-             object.metadata.name == 'data-product-controller') ||
+             object.metadata.name == 'data-product-controller' &&
+             !has(object.aggregationRule) &&
+             has(object.rules) &&
+             object.rules.all(r,
+               (!has(r.apiGroups) || !('*' in r.apiGroups)) &&
+               (!has(r.resources) || !('*' in r.resources)) &&
+               (!has(r.verbs) || !('*' in r.verbs)))) ||
             (object.kind == 'ClusterRoleBinding' &&
              has(object.metadata.name) &&
              object.metadata.name == 'data-product-controller' &&
@@ -48,7 +88,19 @@ rules:
              has(object.metadata.name) &&
              object.metadata.name == 'data-product-controller')))
         : (has(object.metadata.namespace) &&
-           object.metadata.namespace == 'data-product-controller'))
+           object.metadata.namespace == 'data-product-controller' &&
+           (!(object.kind in ['Kustomization', 'HelmRelease', 'OCIRepository',
+                              'GitRepository', 'Bucket', 'HelmRepository',
+                              'ExternalArtifact', 'Provider', 'Function',
+                              'Configuration', 'DeploymentRuntimeConfig']) ||
+            (has(object.metadata.name) &&
+             object.metadata.name == 'data-product-controller' &&
+             (!has(object.spec) || !has(object.spec.targetNamespace) ||
+              object.spec.targetNamespace == 'data-product-controller'))) &&
+           (object.kind != 'RoleBinding' ||
+            (has(object.subjects) &&
+             object.subjects.all(s,
+               has(s.namespace) && s.namespace == 'data-product-controller')))))
     message: >-
       data-product-controller chart children must remain in the reviewed
       data-product-controller namespace

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly root_dir
 readonly rules_path="${root_dir}/scripts/tests/isolated-chart-namespace-rules.yaml"
+readonly prod_rules_path="${root_dir}/scripts/tests/production-authorization-rules.yaml"
 readonly component_path="${root_dir}/k8s/bases/apps/data-product-controller"
 
 test_root="$(mktemp -d /tmp/isolated-chart-namespace-rules.XXXXXX)"
@@ -114,6 +115,111 @@ spec:
         - name: controller
           image: example.invalid/controller:test'
 
+# The cluster-scoped RBAC branch is the one an attacker-shaped chart revision
+# would aim at: it is the only branch that accepts an object carrying no
+# namespace at all. Each fixture below moves exactly ONE field away from the
+# reviewed shape, so a rule that stops pinning that field fails precisely one
+# of them rather than the whole group.
+
+assert_accepted 'reviewed-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]'
+
+assert_accepted 'reviewed-cluster-role-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-product-controller
+subjects:
+  - kind: ServiceAccount
+    name: data-product-controller
+    namespace: data-product-controller'
+
+assert_rejected 'foreign-named-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-admin-shadow
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]'
+
+assert_rejected 'privileged-role-ref-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: data-product-controller
+    namespace: data-product-controller'
+
+assert_rejected 'external-subject-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-product-controller
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system'
+
+# A binding whose subject list mixes one reviewed subject with one foreign
+# subject proves the check is `all`, not `exists`.
+assert_rejected 'mixed-subject-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-product-controller
+subjects:
+  - kind: ServiceAccount
+    name: data-product-controller
+    namespace: data-product-controller
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system'
+
+# A cluster-scoped subject carries no namespace at all. It must fail closed
+# rather than pass vacuously.
+assert_rejected 'cluster-scoped-subject-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-product-controller
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:authenticated'
+
+assert_rejected 'subjectless-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: data-product-controller'
+
 # This is the enabled control: KSail resolves the immutable OCI digest from the
 # staged-off component, Helm-renders that exact artifact, and evaluates every
 # child under the same rule without adding the component to the deploy overlay.
@@ -126,4 +232,20 @@ if ! output="$(
   exit 1
 fi
 
-printf 'PASS: isolated chart children are namespace-local and the exact pinned chart renders cleanly\n'
+# Second control, against the repository's PRODUCTION authorization rule suite
+# rather than this file's bespoke namespace rule. While the component is staged
+# off, it is absent from every deploy overlay, so cluster admission never
+# evaluates it and the namespace rule above would otherwise be the ONLY control
+# standing over these manifests. Rendering the same pinned artifact through the
+# production suite means the staged-off chart is held to the same authorization
+# controls as everything that is actually deployed.
+if ! output="$(
+  ksail --config "${root_dir}/ksail.prod.yaml" workload validate "${component_path}" \
+    --rules "${prod_rules_path}" 2>&1
+)"; then
+  printf 'FAIL: the pinned data-product-controller chart failed production authorization validation\n' >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+printf 'PASS: isolated chart children are namespace-local, and the exact pinned chart renders cleanly under both the namespace rule and the production authorization suite\n'

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -357,9 +357,13 @@ spec:
     kind: OCIRepository
     name: data-product-controller'
 
-# The negative control: an explicit, correct targetNamespace is what the
-# emitter exception is actually for, and must keep passing.
-assert_accepted 'same-name-kustomization-with-target-namespace' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
+# A correct targetNamespace is NOT sufficient, and this fixture is why the kind
+# is refused outright rather than conditioned. targetNamespace relocates the
+# NAMESPACED grandchildren a source renders; a ClusterRoleBinding in that same
+# source still reconciles cluster-wide, and no grandchild is ever presented to
+# this rule. The reviewed render contains no Kustomization at all, so refusing
+# the kind costs nothing real and is the only bound this rule can enforce.
+assert_rejected 'same-name-kustomization-with-target-namespace' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: data-product-controller
@@ -495,6 +499,77 @@ spec:
   values:
     controller:
       replicas: 2'
+
+# A CLUSTER-SCOPED KIND OUTSIDE THE REVIEWED SET CANNOT BE CONTAINED BY A
+# NAMESPACE FIELD. The API server accepts and then ignores `metadata.namespace`
+# on every cluster-scoped object, so before the kind allowlist these two
+# satisfied the namespaced branch on a field that does not survive apply and
+# landed cluster-wide. Enumerating cluster-scoped kinds to refuse cannot close
+# this — the next unlisted kind passes exactly as these did — so the branch
+# names the kinds the pinned render actually produces and refuses the rest.
+assert_rejected 'unreviewed-cluster-scoped-crd' 'apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: evilthings.example.invalid
+  namespace: data-product-controller
+spec:
+  group: example.invalid
+  names:
+    kind: EvilThing
+    plural: evilthings
+  scope: Cluster
+  versions: []'
+
+assert_rejected 'unreviewed-mutating-webhook' 'apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: hijack-everything
+  namespace: data-product-controller
+webhooks: []'
+
+# A namespaced kind the reviewed render does not produce is refused by the same
+# allowlist. This is the control proving the clause above is a KIND test and not
+# a cluster-scope test: nothing about a ConfigMap escapes the namespace, and it
+# is refused anyway, because an unreviewed kind in a digest bump is exactly what
+# the containment bound requires someone to read before it ships.
+assert_rejected 'unreviewed-namespaced-kind' 'apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+data:
+  key: value'
+
+# THE RENDERED Namespace OVERWRITES THE REVIEWED ONE ON APPLY, so accepting it
+# by name alone let a future digest ship a weaker enforcement label — and every
+# workload in the isolated namespace would then run unrestricted while this rule
+# stayed green. The component is staged off every deploy overlay, so no cluster
+# admission control re-checks it afterwards.
+assert_rejected 'privileged-rendered-namespace' 'apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-product-controller
+  labels:
+    pod-security.kubernetes.io/enforce: privileged'
+
+# Omitting the label is the same admission outcome by another route, so it fails
+# closed rather than being read as "unchanged".
+assert_rejected 'unlabelled-rendered-namespace' 'apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-product-controller'
+
+# The negative control for both: the reviewed namespace, exactly as the base
+# declares it, must keep passing. Without this a blanket refusal of rendered
+# Namespaces would satisfy the two assertions above while rejecting the real
+# component.
+assert_accepted 'reviewed-restricted-namespace' 'apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-product-controller
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest'
 
 # This is the enabled control: KSail resolves the immutable OCI digest from the
 # staged-off component, Helm-renders that exact artifact, and evaluates every

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -152,6 +152,50 @@ rules:
     resources: ["*"]
     verbs: ["*"]'
 
+# A wildcard is not the only way to reach cluster-admin. `bind` and `escalate`
+# on rbac.authorization.k8s.io are privilege-escalation primitives in their own
+# right, and `create` on clusterrolebindings lets the controller mint a binding
+# at runtime — an object that never passes through either chart validation.
+# These fixtures carry no `*` at all, so they pass every wildcard check.
+
+assert_rejected 'rbac-write-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings"]
+    verbs: ["create"]'
+
+assert_rejected 'rbac-bind-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["bind"]'
+
+assert_rejected 'escalate-verb-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["escalate"]'
+
+# The negative control for the three above: a read-only RBAC grant carries none
+# of that power, so tightening the rule must not sweep it up.
+assert_accepted 'rbac-read-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["get", "list", "watch"]'
+
 assert_rejected 'privileged-role-ref-binding' 'apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Proves that the isolated data-product-controller chart cannot render a child
+# into another namespace while retaining the EKS authorization exemption.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly rules_path="${root_dir}/scripts/tests/isolated-chart-namespace-rules.yaml"
+readonly component_path="${root_dir}/k8s/bases/apps/data-product-controller"
+
+test_root="$(mktemp -d /tmp/isolated-chart-namespace-rules.XXXXXX)"
+readonly test_root
+cleanup() {
+  rm -rf "${test_root}"
+}
+trap cleanup EXIT
+
+run_fixture() {
+  local path="$1"
+  ksail --config "${root_dir}/ksail.prod.yaml" workload validate "${path}" \
+    --skip-helm-render \
+    --rules "${rules_path}" 2>&1
+}
+
+assert_accepted() {
+  local name="$1"
+  local manifest="$2"
+  local path="${test_root}/${name}.yaml"
+  local output
+  printf '%s\n' "${manifest}" >"${path}"
+  if ! output="$(run_fixture "${path}")"; then
+    printf 'FAIL: namespace-local fixture %s was rejected\n' "${name}" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+assert_rejected() {
+  local name="$1"
+  local manifest="$2"
+  local path="${test_root}/${name}.yaml"
+  local output
+  printf '%s\n' "${manifest}" >"${path}"
+  if output="$(run_fixture "${path}")"; then
+    printf 'FAIL: foreign-namespace fixture %s passed isolated-chart validation\n' "${name}" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "${output}" | grep -qF \
+    'rule "restrict-data-product-controller-rendered-child-namespaces"'; then
+    printf 'FAIL: fixture %s was refused, but not by the rendered-child namespace rule\n' "${name}" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+assert_accepted 'namespace-local-deployment' 'apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  selector:
+    matchLabels:
+      app: data-product-controller
+  template:
+    metadata:
+      labels:
+        app: data-product-controller
+    spec:
+      containers:
+        - name: controller
+          image: example.invalid/controller:test'
+
+assert_rejected 'foreign-namespace-deployment' 'apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-product-controller
+  namespace: aws
+spec:
+  selector:
+    matchLabels:
+      app: data-product-controller
+  template:
+    metadata:
+      labels:
+        app: data-product-controller
+    spec:
+      containers:
+        - name: controller
+          image: example.invalid/controller:test'
+
+assert_rejected 'foreign-namespace-declaration' 'apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws'
+
+assert_rejected 'namespace-omitted-workload' 'apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-product-controller
+spec:
+  selector:
+    matchLabels:
+      app: data-product-controller
+  template:
+    metadata:
+      labels:
+        app: data-product-controller
+    spec:
+      containers:
+        - name: controller
+          image: example.invalid/controller:test'
+
+# This is the enabled control: KSail resolves the immutable OCI digest from the
+# staged-off component, Helm-renders that exact artifact, and evaluates every
+# child under the same rule without adding the component to the deploy overlay.
+if ! output="$(
+  ksail --config "${root_dir}/ksail.prod.yaml" workload validate "${component_path}" \
+    --rules "${rules_path}" 2>&1
+)"; then
+  printf 'FAIL: the pinned data-product-controller chart failed namespace validation\n' >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+printf 'PASS: isolated chart children are namespace-local and the exact pinned chart renders cleanly\n'

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -340,6 +340,38 @@ roleRef:
   kind: Role
   name: data-product-controller-leader-election'
 
+# A Kustomization that OMITS targetNamespace is not thereby namespace-local.
+# Flux preserves whatever namespaces the remote artifact declares, so this
+# reconciles grandchildren into `aws`, `flux-system` or cluster scope — and
+# none of those objects is ever presented to this rule. Sharing the reviewed
+# name is what previously carried it past the emitter exception.
+assert_rejected 'same-name-kustomization-without-target-namespace' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  prune: false
+  sourceRef:
+    kind: OCIRepository
+    name: data-product-controller'
+
+# The negative control: an explicit, correct targetNamespace is what the
+# emitter exception is actually for, and must keep passing.
+assert_accepted 'same-name-kustomization-with-target-namespace' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  prune: false
+  sourceRef:
+    kind: OCIRepository
+    name: data-product-controller
+  targetNamespace: data-product-controller'
+
 assert_rejected 'namespaced-flux-kustomization' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -420,6 +420,82 @@ spec:
     kind: OCIRepository
     name: data-product-controller'
 
+# A reviewed emitter must not take VALUE INPUTS THIS RENDER CANNOT SEE. The
+# proof below is a filesystem render of the pinned artifact: it resolves chart
+# defaults plus the inline `spec.values` carried in this manifest, and every
+# child it produces is evaluated by the rule above. `spec.valuesFrom` points at
+# a Secret or ConfigMap materialized only in the cluster, so Flux renders a
+# DIFFERENT value set from the one proved here — and this component ships an
+# ExternalSecret, so such a Secret genuinely exists. Values decide which
+# templates render at all, so a runtime value can enable RBAC or a
+# foreign-namespace child that neither this render nor the rule ever inspected.
+# The component is staged off every deploy overlay, so cluster admission never
+# re-checks it: this render is the ONLY control standing over these manifests,
+# and it must therefore be proof about what is actually installed.
+#
+assert_rejected 'reviewed-emitter-runtime-values-from' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: data-product-controller
+  valuesFrom:
+    - kind: Secret
+      name: data-product-controller-runtime-values'
+
+# Negative control: the reviewed chart REALLY USES postRenderers, to add
+# imagePullSecrets and topology constraints to its own Deployments. Refusing
+# runtime value sources must not take this shape with it — an earlier draft of
+# the clause above refused `postRenderers` too and rejected the live component,
+# which only the pinned render at the end of this file caught. Whether a
+# post-render patch can move a child across namespaces after the rule has
+# accepted it is a real question, but it needs its own proof, not a blanket
+# refusal of the mechanism the component depends on.
+assert_accepted 'reviewed-emitter-post-renderer-local' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: data-product-controller
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: data-product-controller
+            patch: |
+              - op: add
+                path: /spec/template/spec/imagePullSecrets
+                value:
+                  - name: ghcr-auth'
+
+
+# Negative control: INLINE values are the mechanism the reviewed chart actually
+# uses, and this render can see them, so the clause above must not refuse them.
+# Without this control a blanket refusal of value configuration would satisfy
+# every other assertion in this file while breaking the real component.
+assert_accepted 'reviewed-emitter-inline-values' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: data-product-controller
+  values:
+    controller:
+      replicas: 2'
+
 # This is the enabled control: KSail resolves the immutable OCI digest from the
 # staged-off component, Helm-renders that exact artifact, and evaluates every
 # child under the same rule without adding the component to the deploy overlay.

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -239,6 +239,111 @@ roleRef:
   kind: ClusterRole
   name: data-product-controller'
 
+assert_rejected 'wildcard-verb-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]'
+
+assert_rejected 'aggregated-cluster-role' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: data-product-controller
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules: []'
+
+assert_accepted 'local-subject-role-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: data-product-controller-leader-election
+  namespace: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: data-product-controller-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: data-product-controller
+    namespace: data-product-controller'
+
+assert_rejected 'foreign-subject-role-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: data-product-controller-edit
+  namespace: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system'
+
+assert_rejected 'subjectless-role-binding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: data-product-controller-edit
+  namespace: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: data-product-controller-leader-election'
+
+assert_rejected 'namespaced-flux-kustomization' 'apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nested
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  prune: false
+  sourceRef:
+    kind: OCIRepository
+    name: nested
+  targetNamespace: aws'
+
+assert_rejected 'namespaced-helm-release' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nested
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  targetNamespace: flux-system
+  chartRef:
+    kind: OCIRepository
+    name: nested'
+
+assert_accepted 'reviewed-name-emitter-local' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: data-product-controller'
+
+assert_rejected 'reviewed-name-emitter-redirecting' 'apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: data-product-controller
+  namespace: data-product-controller
+spec:
+  interval: 10m
+  targetNamespace: flux-system
+  chartRef:
+    kind: OCIRepository
+    name: data-product-controller'
+
 # This is the enabled control: KSail resolves the immutable OCI digest from the
 # staged-off component, Helm-renders that exact artifact, and evaluates every
 # child under the same rule without adding the component to the deploy overlay.

--- a/scripts/tests/test-isolated-chart-namespace-rules.sh
+++ b/scripts/tests/test-isolated-chart-namespace-rules.sh
@@ -196,6 +196,25 @@ subjects:
     name: kustomize-controller
     namespace: flux-system'
 
+# A cluster-scoped binding that DECLARES the release namespace. The API server
+# silently discards `metadata.namespace` on a cluster-scoped object, so this
+# object reaches the cluster as an unreviewed cluster-admin grant to a subject
+# in another namespace. It must be judged by kind — never accepted on the
+# strength of a field that does not survive apply.
+assert_rejected 'namespaced-clusterrolebinding' 'apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: totally-unreviewed-escalation
+  namespace: data-product-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system'
+
 # A cluster-scoped subject carries no namespace at all. It must fail closed
 # rather than pass vacuously.
 assert_rejected 'cluster-scoped-subject-binding' 'apiVersion: rbac.authorization.k8s.io/v1

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -234,184 +234,64 @@ func runsCommand(script, needle string) bool {
 // assertion about a GATE needs failure propagation, so only those opt in.
 func runsGate(script, needle string) bool {
 	return scanCommandRuns(script, needle, func(end int) bool {
-		return !errexitDisabledAt(script, end) && failurePropagates(script, end)
+		return failurePropagates(script, end) && isFinalCommand(script, end)
 	})
 }
 
-// errexitDisabledAt reports whether a `set` builtin earlier in this same script
-// has switched errexit OFF and not switched it back on before the command whose
-// word ends at upto.
+// isFinalCommand reports whether the command whose word ends at i is the LAST
+// command the block runs, so that the step's exit status IS that command's.
 //
-// The shell a step runs under is only half of the question shellKeepsErrexit
-// answers. `shell: bash` still invokes the block with `-e`, but the block can
-// turn that off for itself: under `set +e; <gate>; echo done` the gate runs, its
-// failure no longer aborts the block, and the step's status becomes `echo`'s
-// zero. Every operator around the gate is innocent — the terminator really is a
-// newline — so failurePropagates is satisfied while the gate is defused. That is
-// the same hole as `|| true`, reached through shell state instead of an operator.
+// This is what makes a gate enforcing WITHOUT reasoning about errexit at all.
+// A block's status is the status of its last command, so when the gate is last
+// no shell-option manipulation anywhere before it can hide a failure. Measured
+// under `bash -e`: `set +e; false` exits 1, and so do the `eval "set +e"` and
+// `builtin set +e` variants — every one of them, because `false` is last. Add
+// one `echo` after it and all of them exit 0.
 //
-// The LAST toggle before the gate wins, because a block may legitimately drop
-// errexit for one fallible probe and restore it before the gate.
+// The earlier model asked the opposite question — whether anything before the
+// gate had switched errexit off — and that is not decidable from the script
+// text. Four review rounds each found another spelling: a literal `set +e`, a
+// quoted or expanded operand, `builtin`/`command`/`eval` wrappers, and an alias
+// under `shopt -s expand_aliases`. Shell functions and indirect expansion were
+// still open. Requiring the gate to be last replaces that whole search with a
+// property the shell guarantees, and every gate step in this repository already
+// satisfies it.
 //
-// Deliberately blind to subshell and function scope: `( set +e; ... )` restores
-// errexit at the closing paren, and this reads it as still disabled. That errs
-// toward calling a sound gate UNCOVERED, which fails the build loudly and is
-// recoverable — the same strict direction failurePropagates takes with pipelines.
-func errexitDisabledAt(script string, upto int) bool {
-	if upto > len(script) {
-		upto = len(script)
-	}
-	prefix := script[:upto]
-
-	// Every toggle is recorded with its position, because more than one scan
-	// contributes and only the LAST one before the gate is in force.
-	type toggle struct {
-		at  int
-		off bool
-	}
-	var seen []toggle
-
-	scanCommandRuns(prefix, "set", func(end int) bool {
-		if off, toggles := setTogglesErrexit(prefix[end:]); toggles {
-			seen = append(seen, toggle{at: end, off: off})
-		}
-		// Never accept: scanning must reach every candidate before the gate so
-		// the last one decides. Returning true here would stop at the first.
-		return false
-	})
-	// A transparent wrapper runs its operand as a builtin in THIS shell, so
-	// resolve through it to whatever it actually invokes.
-	for _, wrapper := range []string{"builtin", "command"} {
-		scanCommandRuns(prefix, wrapper, func(end int) bool {
-			if off, toggles := wrappedTogglesErrexit(prefix[end:]); toggles {
-				seen = append(seen, toggle{at: end, off: off})
-			}
-			return false
-		})
-	}
-	// An opaque construct can also run `set` in this shell, but what it runs
-	// cannot be read from the script text.
-	for _, opaque := range []string{"eval", "source", ".", "exec", "trap"} {
-		scanCommandRuns(prefix, opaque, func(end int) bool {
-			seen = append(seen, toggle{at: end, off: true})
-			return false
-		})
-	}
-
-	last, disabled := -1, false
-	for _, t := range seen {
-		if t.at > last {
-			last, disabled = t.at, t.off
-		}
-	}
-	return disabled
-}
-
-// wrappedTogglesErrexit reads the operands of a `builtin` or `command` word,
-// which begin at args, and reports the effect on errexit of whatever that
-// wrapper actually invokes.
-//
-// Both wrappers execute a builtin in the CURRENT shell, so `builtin set +e` and
-// `command set +e` disable errexit exactly as a bare `set +e` does — verified
-// under `bash -e`, where each prints `continued` and exits 0 with the gate
-// failing. They are resolved through rather than refused outright, because
-// `command -v ksail` is an ordinary lookup that cannot touch shell options and
-// refusing it would call sound gate steps UNCOVERED for no reason.
-//
-// A `-v` or `-V` option makes the word a query rather than an invocation. Any
-// other non-literal or unrecognised operand is treated as disabling, on the
-// same unreadable-means-unsafe rule applied to `set` itself.
-func wrappedTogglesErrexit(args string) (off bool, toggles bool) {
-	i := 0
-	for i < len(args) {
-		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
-			i++
-		}
-		if i >= len(args) || endsCommand(args[i]) {
-			return false, false
-		}
-		start := i
-		for i < len(args) && !endsWord(args[i]) {
-			i++
-		}
-		word := args[start:i]
-		if strings.ContainsAny(word, "'\"$`\\") {
-			// The invoked word cannot be read without a shell.
-			return true, true
-		}
-		switch {
-		case word == "-v", word == "-V":
-			// A lookup, not an invocation: it cannot change shell options.
-			return false, false
-		case strings.HasPrefix(word, "-"):
-			// Another wrapper option (`-p`); keep looking for the command word.
-			continue
-		case word == "set":
-			return setTogglesErrexit(args[i:])
-		case word == "builtin", word == "command":
-			// Wrappers nest: `builtin command set +e` reaches `set` too.
-			return wrappedTogglesErrexit(args[i:])
+// Trailing blanks, comments and empty statements do not make a later command,
+// so they are skipped; anything else does.
+func isFinalCommand(script string, i int) bool {
+	// Walk to the end of this command's own words first.
+	for i < len(script) {
+		switch c := script[i]; {
+		case c == '\\':
+			i += 2
+		case c == '<' && i+1 < len(script) && script[i+1] == '<':
+			i = skipHeredoc(script, i)
+		case c == '\'', c == '"':
+			i = skipQuoted(script, i)
+		case endsCommand(c):
+			goto tail
 		default:
-			// Any other builtin cannot disable errexit for the block.
-			return false, false
+			i++
 		}
 	}
-	return false, false
-}
+	return true
 
-// setTogglesErrexit reads the argument words of a `set` builtin, whose operands
-// begin at args, and reports whether it changes errexit and to what.
-//
-// Both spellings count, and a cluster carries its flags together: `-e`, `+ex`
-// and `-euo pipefail` all name errexit, while `+o pipefail` and `+x` do not. An
-// `o` in a cluster consumes the following word as its option name, so
-// `+eo pipefail` is read as errexit off rather than as an option named `e`.
-func setTogglesErrexit(args string) (off bool, toggles bool) {
-	i := 0
-	for i < len(args) {
-		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+tail:
+	// Only separators, blanks and comments may follow.
+	for i < len(script) {
+		switch c := script[i]; {
+		case c == ' ', c == '\t', c == '\n', c == ';', c == '\r':
 			i++
-		}
-		if i >= len(args) || endsCommand(args[i]) {
-			break
-		}
-		start := i
-		for i < len(args) && !endsWord(args[i]) {
-			i++
-		}
-		word := args[start:i]
-		if strings.ContainsAny(word, "'\"$`\\") {
-			// A `set` operand is not its literal text: quote removal and
-			// parameter expansion both happen before `set` sees the word, so
-			// `set "+e"` and `set +${option}` switch errexit off while carrying
-			// no literal `+e` for this scanner to find. Both were verified to
-			// exit 0 under `bash -e` with the gate failing. The word cannot be
-			// resolved here without a shell, so it is read as disabling —
-			// unreadable means unsafe, the same strict direction taken above.
-			off, toggles = true, true
-			continue
-		}
-		if len(word) < 2 || (word[0] != '-' && word[0] != '+') {
-			continue
-		}
-		flags := word[1:]
-		if strings.ContainsRune(flags, 'e') {
-			off, toggles = word[0] == '+', true
-		}
-		if strings.ContainsRune(flags, 'o') {
-			for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+		case c == '#' && startsShellComment(script, i):
+			for i < len(script) && script[i] != '\n' {
 				i++
 			}
-			ns := i
-			for i < len(args) && !endsWord(args[i]) {
-				i++
-			}
-			if args[ns:i] == "errexit" {
-				off, toggles = word[0] == '+', true
-			}
+		default:
+			return false
 		}
 	}
-	return off, toggles
+	return true
 }
 
 // failurePropagates reports whether the command whose word ends at i can still
@@ -1192,47 +1072,41 @@ func TestRunsCommandMatchesTheOtherGateInvocations(t *testing.T) {
 	}
 }
 
-// TestRunsGateRequiresFailurePropagation pins the distinction runsGate adds
-// over runsCommand: the gate must not only run, but be able to fail the step.
-// Each defused form below RUNS the gate — runsCommand accepts every one of
-// them — so this table is what separates "invoked" from "enforcing".
+// TestRunsGateRequiresFailurePropagation pins the two things runsGate adds over
+// runsCommand: the gate must not only run, but its failure must reach the step.
+//
+// Every script below RUNS the gate — runsCommand accepts all of them — so this
+// table is what separates "invoked" from "enforcing".
+//
+// The second condition is structural rather than a search for defusing tricks: a
+// block's exit status is the status of its LAST command, so a gate that is last
+// cannot be defused by anything before it. `set +e; false` exits 1; so do the
+// `eval "set +e"`, `builtin set +e` and aliased variants, all measured under
+// `bash -e`. Add one `echo` after and every one of them exits 0.
 func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 	const gate = isolatedChartNamespaceValidatorInvocation
 
 	enforcing := []string{
 		gate,
 		gate + " .",
+		gate + " ;",
+		gate + "\n",
+		gate + " # done",
 		"shellcheck x.sh\n" + gate,
-		gate + " ; echo done",
-		gate + " && echo ok",
-		gate + " && echo a && echo b",
-		gate + "\necho after",
-		// An AND-OR list that continues across a newline, with no `||` anywhere
-		// in it, still lets the gate fail the step. Without these the fix below
-		// could read every post-newline continuation as defused.
-		gate + " &&\n  echo ok",
-		gate + " && # note\n  echo ok",
-		// A comment after a COMPLETE command: the newline still terminates it.
-		gate + " # done\necho after",
-		// The step's shell keeps errexit and the block does not take it away,
-		// so the gate still aborts on failure. `set +x` and `+o pipefail` name
-		// other options entirely, and a `set +e` that is restored before the
-		// gate leaves errexit on — without these controls the clause below
-		// could read any `set` at all as a defused gate.
+		// The gate is last, so errexit is IRRELEVANT to whether its failure
+		// reaches the step — these all exit non-zero on a failing gate. An
+		// earlier model refused them, which was over-strict: it was answering
+		// "was errexit disturbed" when the structural answer makes the question
+		// moot. These are the controls for that, and they must keep passing.
+		"set +e\n" + gate,
+		"set +o errexit\n" + gate,
+		"builtin set +e\n" + gate,
+		"command set +e\n" + gate,
+		"eval 'set +e'\n" + gate,
+		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
 		"set -e\n" + gate,
-		"set -euo pipefail\n" + gate,
-		"set +x\n" + gate,
-		"set +o pipefail\n" + gate,
-		"set +e\ncurl -f probe || true\nset -e\n" + gate,
-		// The inversion must not swallow ordinary steps. `command -v` is a
-		// lookup rather than an invocation, `builtin echo` is a builtin that
-		// cannot touch shell options, and `./script.sh` is not the `.` builtin —
-		// without these controls the clause above would call sound gates
-		// UNCOVERED and this table would not notice.
 		"command -v ksail\n" + gate,
-		"builtin echo hello\n" + gate,
 		"./scripts/setup.sh\n" + gate,
-		"command ksail version\n" + gate,
 	}
 	for _, script := range enforcing {
 		if !runsGate(script, gate) {
@@ -1241,6 +1115,7 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 	}
 
 	defused := []string{
+		// Operators that discard the gate's status outright.
 		gate + " || true",
 		gate + " || :",
 		gate + " || echo ignored",
@@ -1248,38 +1123,33 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " &",
 		"( " + gate + " ) || true",
 		gate + " && echo ok || true",
-		// `&&` at end of line continues the AND-OR list, so the `||` on the
-		// next line still discards the gate's verdict. Treating that newline as
-		// a terminator read a defused gate as enforcing.
 		gate + " &&\n  echo ok || true",
-		// Bash strips the comment BEFORE evaluating the list, so this is exactly
-		// the line above with a comment in the middle.
 		gate + " && # report success\n  echo ok || true",
-		// Errexit switched off inside the block. Every operator around the gate
-		// is innocent here — the terminator really is a newline — so this is
-		// defused by shell STATE rather than by punctuation, and the step's
-		// status becomes that of the last command instead of the gate's.
+		// A later command REPLACES the step's status with its own, so the gate
+		// is only enforcing while errexit holds — and whether it holds is not
+		// decidable from the script text. Four review rounds each found another
+		// way to switch it off (a literal `set +e`, a quoted or expanded
+		// operand, `builtin`/`command`/`eval`, an alias under
+		// `shopt -s expand_aliases`), with shell functions and indirect
+		// expansion still open. All of these are therefore refused, which makes
+		// a genuine gate read UNCOVERED and fail loudly — recoverable, unlike
+		// passing a defused one in silence.
+		gate + " ; echo done",
+		gate + " && echo ok",
+		gate + " && echo a && echo b",
+		gate + "\necho after",
+		gate + " &&\n  echo ok",
+		gate + " && # note\n  echo ok",
+		gate + " # done\necho after",
+		// The measured bypasses, each verified under `bash -e` to print
+		// `continued` and exit 0 with the gate failing.
 		"set +e\n" + gate + "\necho continued",
-		"set +e\n" + gate,
-		"set +o errexit\n" + gate,
-		"set +ex\n" + gate,
-		"set +eo pipefail\n" + gate,
-		// The LAST toggle before the gate is the one in force.
-		"set -e\nset +e\n" + gate,
-		// A `set` operand is not its literal text. Bash performs quote removal
-		// and parameter expansion BEFORE `set` sees the word, so both of these
-		// disable errexit while carrying no literal `+e` for a scanner to find.
-		// Verified with `bash -e`: each prints `continued` and exits 0.
 		"set \"+e\"\n" + gate + "\necho continued",
 		"option=e\nset +${option}\n" + gate + "\necho continued",
-		// `builtin` and `command` run `set` in THIS shell, and `eval` can run
-		// anything at all. Verified under `bash -e`: each prints `continued` and
-		// exits 0 with the gate failing.
 		"builtin set +e\n" + gate + "\necho continued",
 		"command set +e\n" + gate + "\necho continued",
 		"eval 'set +e'\n" + gate + "\necho continued",
-		"builtin command set +e\n" + gate + "\necho continued",
-		". ./lib.sh\n" + gate + "\necho continued",
+		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate + "\necho continued",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -234,8 +234,88 @@ func runsCommand(script, needle string) bool {
 // assertion about a GATE needs failure propagation, so only those opt in.
 func runsGate(script, needle string) bool {
 	return scanCommandRuns(script, needle, func(end int) bool {
-		return failurePropagates(script, end)
+		return !errexitDisabledAt(script, end) && failurePropagates(script, end)
 	})
+}
+
+// errexitDisabledAt reports whether a `set` builtin earlier in this same script
+// has switched errexit OFF and not switched it back on before the command whose
+// word ends at upto.
+//
+// The shell a step runs under is only half of the question shellKeepsErrexit
+// answers. `shell: bash` still invokes the block with `-e`, but the block can
+// turn that off for itself: under `set +e; <gate>; echo done` the gate runs, its
+// failure no longer aborts the block, and the step's status becomes `echo`'s
+// zero. Every operator around the gate is innocent — the terminator really is a
+// newline — so failurePropagates is satisfied while the gate is defused. That is
+// the same hole as `|| true`, reached through shell state instead of an operator.
+//
+// The LAST toggle before the gate wins, because a block may legitimately drop
+// errexit for one fallible probe and restore it before the gate.
+//
+// Deliberately blind to subshell and function scope: `( set +e; ... )` restores
+// errexit at the closing paren, and this reads it as still disabled. That errs
+// toward calling a sound gate UNCOVERED, which fails the build loudly and is
+// recoverable — the same strict direction failurePropagates takes with pipelines.
+func errexitDisabledAt(script string, upto int) bool {
+	if upto > len(script) {
+		upto = len(script)
+	}
+	prefix := script[:upto]
+	disabled := false
+	scanCommandRuns(prefix, "set", func(end int) bool {
+		if off, toggles := setTogglesErrexit(prefix[end:]); toggles {
+			disabled = off
+		}
+		// Never accept: scanning must reach every `set` before the gate so the
+		// last one decides. Returning true here would stop at the first.
+		return false
+	})
+	return disabled
+}
+
+// setTogglesErrexit reads the argument words of a `set` builtin, whose operands
+// begin at args, and reports whether it changes errexit and to what.
+//
+// Both spellings count, and a cluster carries its flags together: `-e`, `+ex`
+// and `-euo pipefail` all name errexit, while `+o pipefail` and `+x` do not. An
+// `o` in a cluster consumes the following word as its option name, so
+// `+eo pipefail` is read as errexit off rather than as an option named `e`.
+func setTogglesErrexit(args string) (off bool, toggles bool) {
+	i := 0
+	for i < len(args) {
+		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+			i++
+		}
+		if i >= len(args) || endsCommand(args[i]) {
+			break
+		}
+		start := i
+		for i < len(args) && !endsWord(args[i]) {
+			i++
+		}
+		word := args[start:i]
+		if len(word) < 2 || (word[0] != '-' && word[0] != '+') {
+			continue
+		}
+		flags := word[1:]
+		if strings.ContainsRune(flags, 'e') {
+			off, toggles = word[0] == '+', true
+		}
+		if strings.ContainsRune(flags, 'o') {
+			for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+				i++
+			}
+			ns := i
+			for i < len(args) && !endsWord(args[i]) {
+				i++
+			}
+			if args[ns:i] == "errexit" {
+				off, toggles = word[0] == '+', true
+			}
+		}
+	}
+	return off, toggles
 }
 
 // failurePropagates reports whether the command whose word ends at i can still
@@ -1038,6 +1118,16 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " && # note\n  echo ok",
 		// A comment after a COMPLETE command: the newline still terminates it.
 		gate + " # done\necho after",
+		// The step's shell keeps errexit and the block does not take it away,
+		// so the gate still aborts on failure. `set +x` and `+o pipefail` name
+		// other options entirely, and a `set +e` that is restored before the
+		// gate leaves errexit on — without these controls the clause below
+		// could read any `set` at all as a defused gate.
+		"set -e\n" + gate,
+		"set -euo pipefail\n" + gate,
+		"set +x\n" + gate,
+		"set +o pipefail\n" + gate,
+		"set +e\ncurl -f probe || true\nset -e\n" + gate,
 	}
 	for _, script := range enforcing {
 		if !runsGate(script, gate) {
@@ -1060,6 +1150,17 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		// Bash strips the comment BEFORE evaluating the list, so this is exactly
 		// the line above with a comment in the middle.
 		gate + " && # report success\n  echo ok || true",
+		// Errexit switched off inside the block. Every operator around the gate
+		// is innocent here — the terminator really is a newline — so this is
+		// defused by shell STATE rather than by punctuation, and the step's
+		// status becomes that of the last command instead of the gate's.
+		"set +e\n" + gate + "\necho continued",
+		"set +e\n" + gate,
+		"set +o errexit\n" + gate,
+		"set +ex\n" + gate,
+		"set +eo pipefail\n" + gate,
+		// The LAST toggle before the gate is the one in force.
+		"set -e\nset +e\n" + gate,
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -295,6 +295,17 @@ func setTogglesErrexit(args string) (off bool, toggles bool) {
 			i++
 		}
 		word := args[start:i]
+		if strings.ContainsAny(word, "'\"$`\\") {
+			// A `set` operand is not its literal text: quote removal and
+			// parameter expansion both happen before `set` sees the word, so
+			// `set "+e"` and `set +${option}` switch errexit off while carrying
+			// no literal `+e` for this scanner to find. Both were verified to
+			// exit 0 under `bash -e` with the gate failing. The word cannot be
+			// resolved here without a shell, so it is read as disabling —
+			// unreadable means unsafe, the same strict direction taken above.
+			off, toggles = true, true
+			continue
+		}
 		if len(word) < 2 || (word[0] != '-' && word[0] != '+') {
 			continue
 		}
@@ -1161,6 +1172,12 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"set +eo pipefail\n" + gate,
 		// The LAST toggle before the gate is the one in force.
 		"set -e\nset +e\n" + gate,
+		// A `set` operand is not its literal text. Bash performs quote removal
+		// and parameter expansion BEFORE `set` sees the word, so both of these
+		// disable errexit while carrying no literal `+e` for a scanner to find.
+		// Verified with `bash -e`: each prints `continued` and exits 0.
+		"set \"+e\"\n" + gate + "\necho continued",
+		"option=e\nset +${option}\n" + gate + "\necho continued",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -204,6 +204,75 @@ func assignmentPrefix(s string) int {
 // an unrecognised wrapper makes a covered gate read as UNCOVERED, failing the
 // build loudly, rather than passing an absent gate silently.
 func runsCommand(script, needle string) bool {
+	return scanCommandRuns(script, needle, nil)
+}
+
+// runsGate reports whether script runs needle AS A GATE: at a command word,
+// and with its failure status still able to fail the step.
+//
+// runsCommand alone cannot answer that. `bash <gate>.sh || true` executes the
+// gate and then throws its verdict away, so a neutralised gate reads as
+// covered. That is the same hole as a gate which is merely mentioned, one
+// level down: the command runs, and nothing it discovers can stop the build.
+// A gate whose failure cannot fail the step is not a gate.
+//
+// Kept separate from runsCommand deliberately. Most callers are asking the
+// plain question "does this script invoke X" — a setup step, for instance,
+// where the answer is about presence rather than enforcement. Only a coverage
+// assertion about a GATE needs failure propagation, so only those opt in.
+func runsGate(script, needle string) bool {
+	return scanCommandRuns(script, needle, func(end int) bool {
+		return failurePropagates(script, end)
+	})
+}
+
+// failurePropagates reports whether the command whose word ends at i can still
+// fail its step. It walks that command's remaining arguments and inspects the
+// operator that terminates it.
+//
+// `||` discards the failure outright. A single `|` hands the step the status of
+// the LAST pipeline stage instead — GitHub Actions runs a `run:` block under
+// `bash -e`, without `pipefail` — so an earlier stage's failure is lost. A
+// trailing `&` backgrounds the command, and its status is never waited for.
+// `;`, `&&`, a newline, a closing paren, and end-of-script all leave the
+// failure intact.
+//
+// Strict in the same direction as the scanner above: a pipeline is refused
+// even where the script does set pipefail, because deciding that reliably
+// means tracking shell options across the block. Refusing makes a genuine gate
+// read as UNCOVERED and fails the build loudly, which is recoverable; the
+// other direction passes a defused gate in silence.
+func failurePropagates(script string, i int) bool {
+	for i < len(script) {
+		switch c := script[i]; {
+		case c == '\\':
+			i += 2
+		case c == '<' && i+1 < len(script) && script[i+1] == '<':
+			i = skipHeredoc(script, i)
+		case c == '\'', c == '"':
+			i = skipQuoted(script, i)
+		case c == '|':
+			// `||` swallows the failure; a lone `|` hides it behind the
+			// last stage of the pipeline.
+			return false
+		case c == '&':
+			// `&&` runs on SUCCESS, so a failure still stops the chain and
+			// reaches the step. A lone `&` backgrounds the command.
+			return i+1 < len(script) && script[i+1] == '&'
+		case c == ';', c == '\n', c == ')':
+			return true
+		default:
+			i++
+		}
+	}
+	return true
+}
+
+// scanCommandRuns walks script for needle at a command word. accept, when
+// non-nil, is offered the index just past each match and decides whether that
+// occurrence counts; scanning continues past a rejected one, so one defused
+// invocation does not mask a sound one elsewhere in the same block.
+func scanCommandRuns(script, needle string, accept func(end int) bool) bool {
 	if needle == "" {
 		return false
 	}
@@ -241,9 +310,12 @@ func runsCommand(script, needle string) bool {
 			continue
 		case atCommandStart:
 			if strings.HasPrefix(script[i:], needle) {
-				rest := script[i+len(needle):]
+				end := i + len(needle)
+				rest := script[end:]
 				if rest == "" || endsWord(rest[0]) {
-					return true
+					if accept == nil || accept(end) {
+						return true
+					}
 				}
 			}
 			if n := assignmentPrefix(script[i:]); n > 0 {
@@ -337,7 +409,7 @@ func skipHeredoc(script string, i int) int {
 func (w workflow) runsValidator() bool {
 	for _, job := range w.Jobs {
 		for _, step := range job.Steps {
-			if runsCommand(step.Run, validatorInvocation) {
+			if runsGate(step.Run, validatorInvocation) {
 				return true
 			}
 		}
@@ -356,7 +428,7 @@ func (w workflow) runsIsolatedChartNamespaceValidator() bool {
 				ksailReady = true
 			}
 			if ksailReady && step.If == "" && step.TimeoutMinutes.is(10) &&
-				runsCommand(step.Run, isolatedChartNamespaceValidatorInvocation) {
+				runsGate(step.Run, isolatedChartNamespaceValidatorInvocation) {
 				return true
 			}
 		}
@@ -482,6 +554,17 @@ func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 			t.Fatal("merely mentioning the validator must not count as running it")
 		}
 	})
+
+	t.Run("a defused gate does not count", func(t *testing.T) {
+		perturbed := covering
+		perturbed.Jobs = map[string]job{
+			"gate": {Steps: []step{{Run: validatorInvocation + " . || true"}}},
+		}
+		if perturbed.coversPushToMain() {
+			t.Fatal("`|| true` discards the gate's verdict, so the step passes " +
+				"however the gate rules — that must not count as coverage")
+		}
+	})
 }
 
 // TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute prevents the
@@ -561,6 +644,22 @@ func TestIsolatedChartNamespaceGateCoverageIsNotVacuous(t *testing.T) {
 			t.Fatal("an unbounded chart render must not satisfy the namespace gate")
 		}
 	})
+
+	t.Run("defused gate", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{
+				{Run: ".github/scripts/setup-ksail.sh"},
+				{
+					Run:            isolatedChartNamespaceValidatorInvocation + " || true",
+					TimeoutMinutes: templatableInt{Value: 10, IsLiteral: true},
+				},
+			}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("a gate whose failure is discarded by `|| true` runs but " +
+				"cannot fail the step, so it must not satisfy the coverage guard")
+		}
+	})
 }
 
 // TestRunsCommandRejectsInertMentions is the non-vacuity proof for the
@@ -636,5 +735,44 @@ func TestRunsCommandMatchesTheOtherGateInvocations(t *testing.T) {
 	if runsCommand("# bash scripts/tests/test-isolated-chart-namespace-rules.sh",
 		isolatedChartNamespaceValidatorInvocation) {
 		t.Error("a commented-out isolated-chart invocation was reported as executed")
+	}
+}
+
+// TestRunsGateRequiresFailurePropagation pins the distinction runsGate adds
+// over runsCommand: the gate must not only run, but be able to fail the step.
+// Each defused form below RUNS the gate — runsCommand accepts every one of
+// them — so this table is what separates "invoked" from "enforcing".
+func TestRunsGateRequiresFailurePropagation(t *testing.T) {
+	const gate = isolatedChartNamespaceValidatorInvocation
+
+	enforcing := []string{
+		gate,
+		gate + " .",
+		"shellcheck x.sh\n" + gate,
+		gate + " ; echo done",
+		gate + " && echo ok",
+		gate + "\necho after",
+	}
+	for _, script := range enforcing {
+		if !runsGate(script, gate) {
+			t.Errorf("a gate whose failure reaches the step must count: %q", script)
+		}
+	}
+
+	defused := []string{
+		gate + " || true",
+		gate + " || :",
+		gate + " || echo ignored",
+		gate + " | tee gate.log",
+		gate + " &",
+	}
+	for _, script := range defused {
+		if !runsCommand(script, gate) {
+			t.Fatalf("precondition: runsCommand must still see the gate run in %q — "+
+				"otherwise this case proves nothing about failure propagation", script)
+		}
+		if runsGate(script, gate) {
+			t.Errorf("a gate that cannot fail the step must not count: %q", script)
+		}
 	}
 }

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,11 +44,47 @@ type job struct {
 }
 
 type step struct {
-	Run            string     `yaml:"run"`
-	Uses           string     `yaml:"uses"`
-	TimeoutMinutes int        `yaml:"timeout-minutes"`
-	With           stepInputs `yaml:"with"`
+	Run            string         `yaml:"run"`
+	Uses           string         `yaml:"uses"`
+	If             string         `yaml:"if"`
+	TimeoutMinutes templatableInt `yaml:"timeout-minutes"`
+	With           stepInputs     `yaml:"with"`
 }
+
+// templatableInt decodes an Actions integer field that MAY be written as an
+// expression. `timeout-minutes: ${{ fromJSON(inputs.t) }}` is a YAML string,
+// so decoding straight into an int fails — and because every guard in this file
+// shares ONE loader, that failure aborts all of them at once rather than failing
+// the single contract the offending workflow touches. A guard suite that one
+// unrelated workflow edit can silently switch off is worse than no guard, so an
+// expression decodes cleanly and simply satisfies no numeric contract.
+type templatableInt struct {
+	Value     int
+	IsLiteral bool
+}
+
+func (t *templatableInt) UnmarshalYAML(node *yaml.Node) error {
+	var n int
+	if err := node.Decode(&n); err == nil {
+		t.Value, t.IsLiteral = n, true
+
+		return nil
+	}
+
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return fmt.Errorf("timeout-minutes is neither an integer nor an expression: %w", err)
+	}
+
+	t.Value, t.IsLiteral = 0, false
+
+	return nil
+}
+
+// is reports whether the field is a literal equal to want. An expression is
+// never equal to a reviewed constant: its value is not knowable until the
+// runner resolves it, so a contract pinning a timeout must not treat it as met.
+func (t templatableInt) is(want int) bool { return t.IsLiteral && t.Value == want }
 
 // stepInputs is the slice of an action's `with:` block these contracts read.
 // Actions inputs are heterogenous, so unknown keys are simply ignored.
@@ -318,7 +355,8 @@ func (w workflow) runsIsolatedChartNamespaceValidator() bool {
 			if runsCommand(step.Run, ".github/scripts/setup-ksail.sh") {
 				ksailReady = true
 			}
-			if ksailReady && step.TimeoutMinutes == 10 && runsCommand(step.Run, isolatedChartNamespaceValidatorInvocation) {
+			if ksailReady && step.If == "" && step.TimeoutMinutes.is(10) &&
+				runsCommand(step.Run, isolatedChartNamespaceValidatorInvocation) {
 				return true
 			}
 		}
@@ -474,7 +512,7 @@ func TestIsolatedChartNamespaceGateCoverageIsNotVacuous(t *testing.T) {
 	covered := workflow{Jobs: map[string]job{
 		"gate": {Steps: []step{
 			{Run: ".github/scripts/setup-ksail.sh"},
-			{Run: isolatedChartNamespaceValidatorInvocation, TimeoutMinutes: 10},
+			{Run: isolatedChartNamespaceValidatorInvocation, TimeoutMinutes: templatableInt{Value: 10, IsLiteral: true}},
 		}},
 	}}
 	if !covered.runsIsolatedChartNamespaceValidator() {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -234,8 +234,108 @@ func runsCommand(script, needle string) bool {
 // assertion about a GATE needs failure propagation, so only those opt in.
 func runsGate(script, needle string) bool {
 	return scanCommandRuns(script, needle, func(end int) bool {
-		return failurePropagates(script, end) && isFinalCommand(script, end)
+		return failurePropagates(script, end) &&
+			isFinalCommand(script, end) &&
+			prefixPreservesStatus(script[:end])
 	})
+}
+
+// statusSettingBuiltins are the ONLY constructs that make a block's exit status
+// differ from the status of its last command. `exit` sets it outright, a `trap`
+// on ERR or EXIT can run `exit` after the last command has already failed, and
+// `exec` replaces the shell so nothing after it is this block at all.
+//
+// Measured under `bash -e`, each with the gate LAST and failing:
+// `trap 'exit 0' ERR` exits 0, `trap 'exit 0' EXIT` exits 0, and a preceding
+// `exit 0` exits 0 — against a control with no prefix, which exits 1.
+//
+// Unlike the errexit question this set is closed rather than open-ended: it is
+// not a list of ways to spell one trick, it is the complete set of shell
+// features that assign an exit status. A block whose prefix contains none of
+// them exits with its last command's status by construction.
+var statusSettingBuiltins = []string{"trap", "exit", "exec"}
+
+// statusOpaqueBuiltins can run any of the above without naming them in the
+// script text, so a prefix containing one cannot be cleared by reading it.
+var statusOpaqueBuiltins = []string{"eval", "source", "."}
+
+// prefixPreservesStatus reports whether everything before the gate leaves the
+// block's exit status to be decided by its last command.
+//
+// isFinalCommand alone is not sufficient: it proves the gate is last, but a
+// `trap 'exit 0' ERR` set earlier still replaces that command's failure. The
+// two conditions are complementary — one fixes WHICH command decides the
+// status, this one ensures nothing else overrides it.
+func prefixPreservesStatus(prefix string) bool {
+	safe := true
+	for _, name := range statusSettingBuiltins {
+		if scanCommandRuns(prefix, name, func(int) bool { return true }) {
+			safe = false
+		}
+	}
+	for _, name := range statusOpaqueBuiltins {
+		if scanCommandRuns(prefix, name, func(int) bool { return true }) {
+			safe = false
+		}
+	}
+	// `builtin` and `command` run a builtin in this shell, so resolve through
+	// them rather than refusing outright — `command -v ksail` is an ordinary
+	// lookup that cannot set a status, and refusing it would call sound gate
+	// steps UNCOVERED.
+	for _, wrapper := range []string{"builtin", "command"} {
+		if scanCommandRuns(prefix, wrapper, func(end int) bool {
+			return wrapperReachesStatusSetter(prefix[end:])
+		}) {
+			safe = false
+		}
+	}
+	return safe
+}
+
+// wrapperReachesStatusSetter reports whether the operands of a `builtin` or
+// `command` word, beginning at args, invoke something that can set an exit
+// status. An operand that cannot be read without a shell counts as unsafe, on
+// the same rule applied everywhere else here.
+func wrapperReachesStatusSetter(args string) bool {
+	i := 0
+	for i < len(args) {
+		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+			i++
+		}
+		if i >= len(args) || endsCommand(args[i]) {
+			return false
+		}
+		start := i
+		for i < len(args) && !endsWord(args[i]) {
+			i++
+		}
+		word := args[start:i]
+		if strings.ContainsAny(word, "'\"$`\\") {
+			return true
+		}
+		switch {
+		case word == "-v", word == "-V":
+			// A lookup, not an invocation.
+			return false
+		case strings.HasPrefix(word, "-"):
+			continue
+		case word == "builtin", word == "command":
+			return wrapperReachesStatusSetter(args[i:])
+		default:
+			for _, name := range statusSettingBuiltins {
+				if word == name {
+					return true
+				}
+			}
+			for _, name := range statusOpaqueBuiltins {
+				if word == name {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return false
 }
 
 // isFinalCommand reports whether the command whose word ends at i is the LAST
@@ -1102,7 +1202,6 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"set +o errexit\n" + gate,
 		"builtin set +e\n" + gate,
 		"command set +e\n" + gate,
-		"eval 'set +e'\n" + gate,
 		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
 		"set -e\n" + gate,
 		"command -v ksail\n" + gate,
@@ -1150,6 +1249,24 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"command set +e\n" + gate + "\necho continued",
 		"eval 'set +e'\n" + gate + "\necho continued",
 		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate + "\necho continued",
+		// A `trap` can run `exit` AFTER the last command has already failed, and
+		// an `exit` or `exec` before the gate settles the status without it.
+		// isFinalCommand alone does not see these: the gate really is last, and
+		// its failure is still discarded. Verified under `bash -e` with the gate
+		// failing and LAST — each exits 0, against a control with no prefix that
+		// exits 1.
+		"trap 'exit 0' ERR\n" + gate,
+		"trap 'exit 0' EXIT\n" + gate,
+		"exit 0\n" + gate,
+		"exec 2>/dev/null\n" + gate,
+		"builtin trap 'exit 0' ERR\n" + gate,
+		"eval \"trap 'exit 0' ERR\"\n" + gate,
+		// Conservatively refused rather than measured. `eval "set +e"` with the
+		// gate last really does exit 1, but the model cannot read an `eval`
+		// body, and the same construct can just as easily carry `trap 'exit 0'
+		// ERR`. Unreadable means unsafe, so this loses a little precision in the
+		// direction that fails loudly.
+		"eval 'set +e'\n" + gate,
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -232,166 +232,97 @@ func runsCommand(script, needle string) bool {
 // plain question "does this script invoke X" — a setup step, for instance,
 // where the answer is about presence rather than enforcement. Only a coverage
 // assertion about a GATE needs failure propagation, so only those opt in.
+// runsGate reports whether script runs needle AS A GATE: the step's exit status
+// is that of needle, so a failure there fails the step.
+//
+// This is a POSITIVE grammar over the run block rather than a search for ways to
+// defuse a gate. Seven review rounds established that the search cannot be won:
+// `set +e`, then a quoted or expanded operand, then `builtin`/`command`/`eval`,
+// then an alias, then `trap`/`exit`/`exec`, then a one-line function body, then
+// a leading redirection, then a compound command hiding a `trap` after `then`.
+// Each was real and each fix was correct, but shell offers unbounded ways to
+// bind a name to a command or to hide one from a lexical scan, so every answer
+// bought exactly one spelling.
+//
+// The grammar inverts that. A block qualifies only when EVERY line is a simple
+// command written in a restricted character set, and the LAST such line is the
+// gate. Anything else — an operator, a quote, an expansion, a redirection, a
+// compound command, an assignment, a reserved word, or a builtin that can bind a
+// name or set an exit status — falls outside the grammar and the gate reads as
+// UNCOVERED. A shell feature nobody has thought of yet fails the same way, which
+// is the property the previous seven rounds could not have.
+//
+// Soundness rests on one fact: a block's exit status is the status of its last
+// command. Within this grammar nothing can reassign it, so a failing gate on the
+// last line fails the step.
+//
+// Both gate steps in this repository already satisfy it — each is two plain
+// command lines — so the grammar costs nothing real. See platform#3526.
 func runsGate(script, needle string) bool {
-	return scanCommandRuns(script, needle, func(end int) bool {
-		return failurePropagates(script, end) &&
-			isFinalCommand(script, end) &&
-			prefixPreservesStatus(script[:end])
-	})
-}
-
-// statusSettingBuiltins are the ONLY constructs that make a block's exit status
-// differ from the status of its last command. `exit` sets it outright, a `trap`
-// on ERR or EXIT can run `exit` after the last command has already failed, and
-// `exec` replaces the shell so nothing after it is this block at all.
-//
-// Measured under `bash -e`, each with the gate LAST and failing:
-// `trap 'exit 0' ERR` exits 0, `trap 'exit 0' EXIT` exits 0, and a preceding
-// `exit 0` exits 0 — against a control with no prefix, which exits 1.
-//
-// Unlike the errexit question this set is closed rather than open-ended: it is
-// not a list of ways to spell one trick, it is the complete set of shell
-// features that assign an exit status. A block whose prefix contains none of
-// them exits with its last command's status by construction.
-var statusSettingBuiltins = []string{"trap", "exit", "exec"}
-
-// statusOpaqueBuiltins can run any of the above without naming them in the
-// script text, so a prefix containing one cannot be cleared by reading it.
-var statusOpaqueBuiltins = []string{"eval", "source", ".", "alias", "shopt", "function"}
-
-// prefixPreservesStatus reports whether everything before the gate leaves the
-// block's exit status to be decided by its last command.
-//
-// isFinalCommand alone is not sufficient: it proves the gate is last, but a
-// `trap 'exit 0' ERR` set earlier still replaces that command's failure. The
-// two conditions are complementary — one fixes WHICH command decides the
-// status, this one ensures nothing else overrides it.
-func prefixPreservesStatus(prefix string) bool {
-	safe := true
-	for _, name := range statusSettingBuiltins {
-		if scanCommandRuns(prefix, name, func(int) bool { return true }) {
-			safe = false
-		}
-	}
-	for _, name := range statusOpaqueBuiltins {
-		if scanCommandRuns(prefix, name, func(int) bool { return true }) {
-			safe = false
-		}
-	}
-	// `builtin` and `command` run a builtin in this shell, so resolve through
-	// them rather than refusing outright — `command -v ksail` is an ordinary
-	// lookup that cannot set a status, and refusing it would call sound gate
-	// steps UNCOVERED.
-	for _, wrapper := range []string{"builtin", "command"} {
-		if scanCommandRuns(prefix, wrapper, func(end int) bool {
-			return wrapperReachesStatusSetter(prefix[end:])
-		}) {
-			safe = false
-		}
-	}
-	return safe
-}
-
-// wrapperReachesStatusSetter reports whether the operands of a `builtin` or
-// `command` word, beginning at args, invoke something that can set an exit
-// status. An operand that cannot be read without a shell counts as unsafe, on
-// the same rule applied everywhere else here.
-func wrapperReachesStatusSetter(args string) bool {
-	i := 0
-	for i < len(args) {
-		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
-			i++
-		}
-		if i >= len(args) || endsCommand(args[i]) {
-			return false
-		}
-		start := i
-		for i < len(args) && !endsWord(args[i]) {
-			i++
-		}
-		word := args[start:i]
-		if strings.ContainsAny(word, "'\"$`\\") {
-			return true
-		}
-		switch {
-		case word == "-v", word == "-V":
-			// A lookup, not an invocation.
-			return false
-		case strings.HasPrefix(word, "-"):
+	last := ""
+	for _, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
-		case word == "builtin", word == "command":
-			return wrapperReachesStatusSetter(args[i:])
-		default:
-			for _, name := range statusSettingBuiltins {
-				if word == name {
-					return true
-				}
-			}
-			for _, name := range statusOpaqueBuiltins {
-				if word == name {
-					return true
-				}
-			}
+		}
+		if !isSimpleCommandLine(trimmed) {
 			return false
 		}
+		last = trimmed
 	}
-	return false
+	if last == "" {
+		return false
+	}
+	return last == needle || strings.HasPrefix(last, needle+" ")
 }
 
-// isFinalCommand reports whether the command whose word ends at i is the LAST
-// command the block runs, so that the step's exit status IS that command's.
+// gateGrammarRefusedWords are the leading words a simple command may not have.
 //
-// This is what makes a gate enforcing WITHOUT reasoning about errexit at all.
-// A block's status is the status of its last command, so when the gate is last
-// no shell-option manipulation anywhere before it can hide a failure. Measured
-// under `bash -e`: `set +e; false` exits 1, and so do the `eval "set +e"` and
-// `builtin set +e` variants — every one of them, because `false` is last. Add
-// one `echo` after it and all of them exit 0.
+// The reserved words introduce compound commands, whose bodies this line-based
+// grammar does not read — `if true; then trap 'exit 0' ERR; fi` is refused here
+// rather than parsed. The rest either assign an exit status (`exit`, `exec`,
+// `trap`), or bind a name to a command that could (`eval`, `source`, `.`,
+// `alias`, `shopt`, `function`, `builtin`, `command`).
 //
-// The earlier model asked the opposite question — whether anything before the
-// gate had switched errexit off — and that is not decidable from the script
-// text. Four review rounds each found another spelling: a literal `set +e`, a
-// quoted or expanded operand, `builtin`/`command`/`eval` wrappers, and an alias
-// under `shopt -s expand_aliases`. Shell functions and indirect expansion were
-// still open. Requiring the gate to be last replaces that whole search with a
-// property the shell guarantees, and every gate step in this repository already
-// satisfies it.
-//
-// Trailing blanks, comments and empty statements do not make a later command,
-// so they are skipped; anything else does.
-func isFinalCommand(script string, i int) bool {
-	// Walk to the end of this command's own words first.
-	for i < len(script) {
-		switch c := script[i]; {
-		case c == '\\':
-			i += 2
-		case c == '<' && i+1 < len(script) && script[i+1] == '<':
-			i = skipHeredoc(script, i)
-		case c == '\'', c == '"':
-			i = skipQuoted(script, i)
-		case endsCommand(c):
-			goto tail
-		default:
-			i++
-		}
-	}
-	return true
+// `command -v ksail` is refused with them, which is a real loss of precision: it
+// is an ordinary lookup that cannot affect the status. Resolving through the
+// wrapper is exactly the kind of special case this grammar exists to stop
+// accumulating, so it is refused and the step can be written without it.
+var gateGrammarRefusedWords = map[string]bool{
+	"if": true, "then": true, "else": true, "elif": true, "fi": true,
+	"case": true, "esac": true, "for": true, "select": true, "while": true,
+	"until": true, "do": true, "done": true, "in": true, "time": true,
+	"coproc": true, "function": true,
+	"exit": true, "exec": true, "trap": true,
+	"eval": true, "source": true, ".": true,
+	"alias": true, "shopt": true, "builtin": true, "command": true, "set": true,
+}
 
-tail:
-	// Only separators, blanks and comments may follow.
-	for i < len(script) {
-		switch c := script[i]; {
-		case c == ' ', c == '\t', c == '\n', c == ';', c == '\r':
-			i++
-		case c == '#' && startsShellComment(script, i):
-			for i < len(script) && script[i] != '\n' {
-				i++
-			}
+// isSimpleCommandLine reports whether one line is a simple command this grammar
+// admits: words drawn from a restricted character set, with a leading word that
+// is not refused above.
+//
+// The character set is the whole defence against shell syntax. It admits what
+// real invocations need — letters, digits, and `_ . / : @ + , -` — and nothing
+// that can quote, expand, redirect, group, background, or chain. A metacharacter
+// anywhere on the line refuses it, so no part of shell grammar has to be
+// modelled.
+func isSimpleCommandLine(line string) bool {
+	for _, r := range line {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == ' ', r == '\t':
+		case r == '_', r == '.', r == '/', r == ':', r == '@', r == '+',
+			r == ',', r == '-':
 		default:
 			return false
 		}
 	}
-	return true
+	first := line
+	if i := strings.IndexAny(line, " \t"); i >= 0 {
+		first = line[:i]
+	}
+	return !gateGrammarRefusedWords[first]
 }
 
 // failurePropagates reports whether the command whose word ends at i can still
@@ -1193,39 +1124,29 @@ func TestRunsCommandMatchesTheOtherGateInvocations(t *testing.T) {
 	}
 }
 
-// TestRunsGateRequiresFailurePropagation pins the two things runsGate adds over
-// runsCommand: the gate must not only run, but its failure must reach the step.
+// TestRunsGateRequiresFailurePropagation pins the grammar runsGate admits.
 //
-// Every script below RUNS the gate — runsCommand accepts all of them — so this
-// table is what separates "invoked" from "enforcing".
+// runsCommand answers "does this block invoke the gate". This answers the
+// stronger question "does the block's exit status BECOME the gate's" — and it
+// answers it by admitting only a restricted shape rather than by hunting for
+// ways to defuse a gate, which seven review rounds showed cannot be won.
 //
-// The second condition is structural rather than a search for defusing tricks: a
-// block's exit status is the status of its LAST command, so a gate that is last
-// cannot be defused by anything before it. `set +e; false` exits 1; so do the
-// `eval "set +e"`, `builtin set +e` and aliased variants, all measured under
-// `bash -e`. Add one `echo` after and every one of them exits 0.
+// Every script in both tables RUNS the gate, so the tables separate "invoked"
+// from "enforcing" and never merely "matched".
 func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 	const gate = isolatedChartNamespaceValidatorInvocation
 
 	enforcing := []string{
 		gate,
 		gate + " .",
-		gate + " ;",
 		gate + "\n",
-		gate + " # done",
-		"shellcheck x.sh\n" + gate,
-		// The gate is last, so errexit is IRRELEVANT to whether its failure
-		// reaches the step — these all exit non-zero on a failing gate. An
-		// earlier model refused them, which was over-strict: it was answering
-		// "was errexit disturbed" when the structural answer makes the question
-		// moot. These are the controls for that, and they must keep passing.
-		"set +e\n" + gate,
-		"set +o errexit\n" + gate,
-		"builtin set +e\n" + gate,
-		"command set +e\n" + gate,
-		"set -e\n" + gate,
-		"command -v ksail\n" + gate,
+		"\n" + gate + "\n",
+		"# lint first\nshellcheck x.sh\n" + gate,
+		// The shape both real gate steps use.
+		"shellcheck scripts/tests/test-isolated-chart-namespace-rules.sh\n" + gate,
+		"go test ./scripts/validate-eks-ci-role-policy\n" + gate,
 		"./scripts/setup.sh\n" + gate,
+		"ksail version\n" + gate,
 	}
 	for _, script := range enforcing {
 		if !runsGate(script, gate) {
@@ -1234,7 +1155,7 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 	}
 
 	defused := []string{
-		// Operators that discard the gate's status outright.
+		// Operators that discard or replace the gate's status.
 		gate + " || true",
 		gate + " || :",
 		gate + " || echo ignored",
@@ -1242,68 +1163,41 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " &",
 		"( " + gate + " ) || true",
 		gate + " && echo ok || true",
-		gate + " &&\n  echo ok || true",
-		gate + " && # report success\n  echo ok || true",
-		// A later command REPLACES the step's status with its own, so the gate
-		// is only enforcing while errexit holds — and whether it holds is not
-		// decidable from the script text. Four review rounds each found another
-		// way to switch it off (a literal `set +e`, a quoted or expanded
-		// operand, `builtin`/`command`/`eval`, an alias under
-		// `shopt -s expand_aliases`), with shell functions and indirect
-		// expansion still open. All of these are therefore refused, which makes
-		// a genuine gate read UNCOVERED and fail loudly — recoverable, unlike
-		// passing a defused one in silence.
+		// A later command supplies the step's status instead of the gate.
 		gate + " ; echo done",
 		gate + " && echo ok",
-		gate + " && echo a && echo b",
 		gate + "\necho after",
-		gate + " &&\n  echo ok",
-		gate + " && # note\n  echo ok",
-		gate + " # done\necho after",
-		// The measured bypasses, each verified under `bash -e` to print
-		// `continued` and exit 0 with the gate failing.
+		// Every bypass the seven review rounds produced. None is matched by a
+		// rule naming it: each fails the grammar because it needs a
+		// metacharacter or a refused leading word.
 		"set +e\n" + gate + "\necho continued",
 		"set \"+e\"\n" + gate + "\necho continued",
 		"option=e\nset +${option}\n" + gate + "\necho continued",
 		"builtin set +e\n" + gate + "\necho continued",
 		"command set +e\n" + gate + "\necho continued",
 		"eval 'set +e'\n" + gate + "\necho continued",
-		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate + "\necho continued",
-		// A `trap` can run `exit` AFTER the last command has already failed, and
-		// an `exit` or `exec` before the gate settles the status without it.
-		// isFinalCommand alone does not see these: the gate really is last, and
-		// its failure is still discarded. Verified under `bash -e` with the gate
-		// failing and LAST — each exits 0, against a control with no prefix that
-		// exits 1.
+		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
+		"shopt -s expand_aliases\nalias t=\"trap 'exit 0' ERR\"\nt\n" + gate,
+		"f() { trap 'exit 0' ERR; }\nf\n" + gate,
 		"trap 'exit 0' ERR\n" + gate,
 		"trap 'exit 0' EXIT\n" + gate,
 		"exit 0\n" + gate,
 		"exec 2>/dev/null\n" + gate,
-		"builtin trap 'exit 0' ERR\n" + gate,
-		"eval \"trap 'exit 0' ERR\"\n" + gate,
-		// Also conservatively refused. `alias d="set +e"; d` with the gate last
-		// does exit 1, but an alias body is quoted text this walker skips, and
-		// the same shape carries `trap 'exit 0' ERR` — which does NOT exit 1.
-		// The name binding is what makes it unreadable, not the body that
-		// happens to be behind it here.
-		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
-		// The reported bypass: an alias installing the trap.
-		"shopt -s expand_aliases\nalias t=\"trap 'exit 0' ERR\"\nt\n" + gate,
-		// A one-line function body binds a name the same way. The `{` re-arm in
-		// scanCommandRuns is what puts `trap` at a command word here; without it
-		// this body is invisible to every scan built on that walker.
-		"f() { trap 'exit 0' ERR; }\nf\n" + gate,
-		// A redirection may precede the command name, so the command position
-		// survives it. Both forms verified under `bash -e` with the gate last
-		// and failing: each exits 0.
 		"> /dev/null trap 'exit 0' ERR\n" + gate,
 		"2>/dev/null trap 'exit 0' ERR\n" + gate,
-		// Conservatively refused rather than measured. `eval "set +e"` with the
-		// gate last really does exit 1, but the model cannot read an `eval`
-		// body, and the same construct can just as easily carry `trap 'exit 0'
-		// ERR`. Unreadable means unsafe, so this loses a little precision in the
-		// direction that fails loudly.
-		"eval 'set +e'\n" + gate,
+		"if true; then trap 'exit 0' ERR; fi\n" + gate,
+		// CONSERVATIVE REFUSALS — each of these is genuinely enforcing when run,
+		// and the grammar refuses it anyway. That cost is the point: admitting
+		// them means resolving `set` operands, wrappers and lookups, which is
+		// the special-casing the previous seven rounds accumulated and never
+		// finished. A step written without them is accepted, and both real gate
+		// steps already are.
+		"set -e\n" + gate,
+		"set +e\n" + gate,
+		"command -v ksail\n" + gate,
+		"builtin echo hello\n" + gate,
+		gate + " ;",
+		gate + " # done",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -23,6 +24,11 @@ const validatorInvocation = "go run ./scripts/validate-eks-ci-role-policy"
 // chart and checks every child namespace. It is a separate command because the
 // static Go validator runs before KSail is installed in each workflow.
 const isolatedChartNamespaceValidatorInvocation = "bash scripts/tests/test-isolated-chart-namespace-rules.sh"
+
+// prodDeployComposite is the shared publish-sign-attest-reconcile action.
+// Every route that reaches production goes through it or one of its nested
+// sub-actions, which is what makes it a sound proxy for "this job deploys".
+const prodDeployComposite = "./.github/actions/deploy-prod"
 
 // workflow is the narrow slice of Actions schema this contract needs.
 //
@@ -91,6 +97,11 @@ func (t templatableInt) is(want int) bool { return t.IsLiteral && t.Value == wan
 // Actions inputs are heterogenous, so unknown keys are simply ignored.
 type stepInputs struct {
 	Category string `yaml:"category"`
+	// Ref is the revision an `actions/checkout` step re-points to. Its
+	// ABSENCE is the meaningful state: a checkout without it takes the
+	// workflow's own triggering revision, which a sibling gate job in the
+	// same workflow has already validated.
+	Ref string `yaml:"ref"`
 }
 
 // triggerSet is the `on:` block. GitHub accepts three spellings — a mapping
@@ -453,21 +464,58 @@ func (w workflow) runsValidator() bool {
 	return false
 }
 
-// runsIsolatedChartNamespaceValidator reports whether one job installs KSail
+// runsIsolatedChartNamespaceValidator reports whether THIS job installs KSail
 // before executing the rendered-child namespace gate. Keeping both steps in
 // the same job matters: setup in another job does not share the runner.
+func (j job) runsIsolatedChartNamespaceValidator() bool {
+	ksailReady := false
+	for _, step := range j.Steps {
+		if runsCommand(step.Run, ".github/scripts/setup-ksail.sh") {
+			ksailReady = true
+		}
+		if ksailReady && step.If == "" && step.TimeoutMinutes.is(10) &&
+			shellKeepsErrexit(step.Shell) &&
+			runsGate(step.Run, isolatedChartNamespaceValidatorInvocation) {
+			return true
+		}
+	}
+	return false
+}
+
+// deploysProd reports whether THIS job publishes to production through the
+// shared deploy composite, in any of its forms. Matching the composite rather
+// than a job name is what keeps the guard attached to the deployment ROUTE: a
+// renamed or newly added job that reaches production still has to satisfy it.
+func (j job) deploysProd() bool {
+	for _, step := range j.Steps {
+		if step.Uses == prodDeployComposite ||
+			strings.HasPrefix(step.Uses, prodDeployComposite+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// checksOutExplicitRef reports whether THIS job re-points its checkout at a
+// revision other than the one that triggered the workflow. That is the
+// property deciding whether a sibling gate job can vouch for what this job
+// deploys: with no explicit ref they share a revision, and with one they do
+// not.
+func (j job) checksOutExplicitRef() bool {
+	for _, step := range j.Steps {
+		if strings.HasPrefix(step.Uses, "actions/checkout@") && step.With.Ref != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// runsIsolatedChartNamespaceValidator reports whether ONE job installs KSail
+// before executing the rendered-child namespace gate.
 func (w workflow) runsIsolatedChartNamespaceValidator() bool {
 	for _, job := range w.Jobs {
-		ksailReady := false
-		for _, step := range job.Steps {
-			if runsCommand(step.Run, ".github/scripts/setup-ksail.sh") {
-				ksailReady = true
-			}
-			if ksailReady && step.If == "" && step.TimeoutMinutes.is(10) &&
-				shellKeepsErrexit(step.Shell) &&
-				runsGate(step.Run, isolatedChartNamespaceValidatorInvocation) {
-				return true
-			}
+		if job.runsIsolatedChartNamespaceValidator() {
+			return true
 		}
 	}
 	return false
@@ -637,6 +685,122 @@ func TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute(t *testing.T) {
 			t.Errorf("%s must install KSail and then run %q in the same job", name, isolatedChartNamespaceValidatorInvocation)
 		}
 	}
+}
+
+// sortedKeys yields map keys in a stable order so a failure names the same
+// job every run rather than whichever one Go happened to visit first.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// TestIsolatedChartNamespaceGateCoversARepointedProdDeploy binds the gate to
+// the exact checkout it certifies, which the per-workflow guard above cannot
+// do.
+//
+// That guard is satisfied when SOME job in a workflow runs the validator, so a
+// workflow holding two deployment routes on two DIFFERENT revisions passes on
+// the strength of the first. `ci.yaml` is exactly that shape: the merge-group
+// deploy runs on the speculative merge ref, while `heal-prod-on-failure`
+// checks out `ref: main` — a revision that may have advanced since — and
+// republishes it through the same composite. A chart reaching `main` by a
+// route the speculative scan never saw could therefore be published by the
+// heal path with its rendered children unchecked, while the per-workflow guard
+// still read as covered.
+//
+// The discriminator is the CHECKOUT, not the job. A deploy job that takes the
+// workflow's own revision is already vouched for by the sibling gate job on
+// that same revision; requiring every deploy job to re-render the chart would
+// duplicate an expensive render and say nothing new. A job that re-points to
+// another ref has no such sibling, so it must render on its own checkout. The
+// heal job already applies exactly this reasoning to the RGD scan, so this
+// extends an established rule to the gate that was missing it.
+func TestIsolatedChartNamespaceGateCoversARepointedProdDeploy(t *testing.T) {
+	workflows := loadWorkflows(t)
+	repointed := 0
+	for _, name := range sortedKeys(workflows) {
+		for _, jobName := range sortedKeys(workflows[name].Jobs) {
+			parsedJob := workflows[name].Jobs[jobName]
+			if !parsedJob.deploysProd() || !parsedJob.checksOutExplicitRef() {
+				continue
+			}
+			repointed++
+			if !parsedJob.runsIsolatedChartNamespaceValidator() {
+				t.Errorf("%s job %q deploys a re-pointed checkout but does not run %q on it",
+					name, jobName, isolatedChartNamespaceValidatorInvocation)
+			}
+		}
+	}
+	// Fail closed: a renamed composite, or a heal path that stopped pinning its
+	// ref, would otherwise leave every assertion above vacuous while the test
+	// still passed.
+	if repointed == 0 {
+		t.Fatalf("found no job combining %q with an explicit checkout ref — this guard is now inert", prodDeployComposite)
+	}
+}
+
+// TestRepointedProdDeployGuardIsNotVacuous ablates each conjunct of the guard
+// above independently, so it cannot pass for the wrong reason — and pins the
+// case it must NOT flag.
+func TestRepointedProdDeployGuardIsNotVacuous(t *testing.T) {
+	gateSteps := []step{
+		{Run: ".github/scripts/setup-ksail.sh"},
+		{Run: isolatedChartNamespaceValidatorInvocation, TimeoutMinutes: templatableInt{Value: 10, IsLiteral: true}},
+	}
+	checkoutMain := step{Uses: "actions/checkout@v7.0.1", With: stepInputs{Ref: "main"}}
+	checkoutDefault := step{Uses: "actions/checkout@v7.0.1"}
+	deployStep := step{Uses: prodDeployComposite}
+
+	covered := job{Steps: append([]step{checkoutMain, deployStep}, gateSteps...)}
+	if !(covered.deploysProd() && covered.checksOutExplicitRef() && covered.runsIsolatedChartNamespaceValidator()) {
+		t.Fatal("positive control failed: a re-pointed deploy job carrying the gate must satisfy all three conjuncts")
+	}
+
+	t.Run("a re-pointed deploy without the gate is caught", func(t *testing.T) {
+		ablated := job{Steps: []step{checkoutMain, deployStep}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("a job with no gate step must not report the gate as run")
+		}
+		if !ablated.deploysProd() || !ablated.checksOutExplicitRef() {
+			t.Fatal("the guard must still select this job — otherwise the gap goes unreported")
+		}
+	})
+
+	// This is the over-strictness control. An earlier draft of the guard keyed
+	// on deploysProd alone and flagged ci.yaml/cd.yaml `deploy-prod`, demanding
+	// a duplicate render of the very revision a sibling gate job had already
+	// validated. Selecting this shape is a bug, not extra safety.
+	t.Run("a deploy on the workflow's own revision is not selected", func(t *testing.T) {
+		sameRevision := job{Steps: []step{checkoutDefault, deployStep}}
+		if sameRevision.checksOutExplicitRef() {
+			t.Fatal("a checkout with no ref takes the workflow's revision and must not count as re-pointed")
+		}
+	})
+
+	t.Run("a re-pointed job that does not deploy is not selected", func(t *testing.T) {
+		nonDeploy := job{Steps: []step{checkoutMain, {Run: "echo hello"}}}
+		if nonDeploy.deploysProd() {
+			t.Fatal("a job that never uses the deploy composite must not be selected")
+		}
+	})
+
+	t.Run("a nested sub-action of the composite still counts as deploying", func(t *testing.T) {
+		nested := job{Steps: []step{checkoutMain, {Uses: prodDeployComposite + "/publish-platform-manifests"}}}
+		if !nested.deploysProd() {
+			t.Fatal("a nested sub-action reaches production too and must be selected")
+		}
+	})
+
+	t.Run("a lookalike composite path does not count", func(t *testing.T) {
+		lookalike := job{Steps: []step{checkoutMain, {Uses: prodDeployComposite + "-staging"}}}
+		if lookalike.deploysProd() {
+			t.Fatal("prefix matching must respect the path boundary, or an unrelated action would be selected")
+		}
+	})
 }
 
 // TestIsolatedChartNamespaceGateCoverageIsNotVacuous ablates the ordering and

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -257,7 +257,7 @@ var statusSettingBuiltins = []string{"trap", "exit", "exec"}
 
 // statusOpaqueBuiltins can run any of the above without naming them in the
 // script text, so a prefix containing one cannot be cleared by reading it.
-var statusOpaqueBuiltins = []string{"eval", "source", "."}
+var statusOpaqueBuiltins = []string{"eval", "source", ".", "alias", "shopt", "function"}
 
 // prefixPreservesStatus reports whether everything before the gate leaves the
 // block's exit status to be decided by its last command.
@@ -525,6 +525,14 @@ func scanCommandRuns(script, needle string, accept func(end int) bool) bool {
 			continue
 		case c == ' ', c == '\t':
 			// Leading blanks do not end the pending command position.
+			i++
+			continue
+		case c == '{', c == '}':
+			// A group opens a new command position, so `f() { trap ... ; }`
+			// puts `trap` at a command word exactly as a newline would. Without
+			// this the body of a one-line function definition is invisible to
+			// every scan built on this walker.
+			atCommandStart = true
 			i++
 			continue
 		case endsCommand(c):
@@ -1202,7 +1210,6 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"set +o errexit\n" + gate,
 		"builtin set +e\n" + gate,
 		"command set +e\n" + gate,
-		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
 		"set -e\n" + gate,
 		"command -v ksail\n" + gate,
 		"./scripts/setup.sh\n" + gate,
@@ -1261,6 +1268,18 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"exec 2>/dev/null\n" + gate,
 		"builtin trap 'exit 0' ERR\n" + gate,
 		"eval \"trap 'exit 0' ERR\"\n" + gate,
+		// Also conservatively refused. `alias d="set +e"; d` with the gate last
+		// does exit 1, but an alias body is quoted text this walker skips, and
+		// the same shape carries `trap 'exit 0' ERR` — which does NOT exit 1.
+		// The name binding is what makes it unreadable, not the body that
+		// happens to be behind it here.
+		"shopt -s expand_aliases\nalias d=\"set +e\"\nd\n" + gate,
+		// The reported bypass: an alias installing the trap.
+		"shopt -s expand_aliases\nalias t=\"trap 'exit 0' ERR\"\nt\n" + gate,
+		// A one-line function body binds a name the same way. The `{` re-arm in
+		// scanCommandRuns is what puts `trap` at a command word here; without it
+		// this body is invisible to every scan built on that walker.
+		"f() { trap 'exit 0' ERR; }\nf\n" + gate,
 		// Conservatively refused rather than measured. `eval "set +e"` with the
 		// gate last really does exit 1, but the model cannot read an `eval`
 		// body, and the same construct can just as easily carry `trap 'exit 0'

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -527,6 +527,19 @@ func scanCommandRuns(script, needle string, accept func(end int) bool) bool {
 			// Leading blanks do not end the pending command position.
 			i++
 			continue
+		case atCommandStart && redirectionPrefix(script, i) > 0:
+			// A redirection may PRECEDE the command name — `> /dev/null trap …`
+			// and `2>/dev/null trap …` are both ordinary bash — so the command
+			// position survives it. Clearing it here hid a status-setting
+			// builtin behind a leading redirect from every scan on this walker.
+			i += redirectionPrefix(script, i)
+			for i < len(script) && (script[i] == ' ' || script[i] == '\t') {
+				i++
+			}
+			for i < len(script) && !endsWord(script[i]) {
+				i++
+			}
+			continue
 		case c == '{', c == '}':
 			// A group opens a new command position, so `f() { trap ... ; }`
 			// puts `trap` at a command word exactly as a newline would. Without
@@ -1280,6 +1293,11 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		// scanCommandRuns is what puts `trap` at a command word here; without it
 		// this body is invisible to every scan built on that walker.
 		"f() { trap 'exit 0' ERR; }\nf\n" + gate,
+		// A redirection may precede the command name, so the command position
+		// survives it. Both forms verified under `bash -e` with the gate last
+		// and failing: each exits 0.
+		"> /dev/null trap 'exit 0' ERR\n" + gate,
+		"2>/dev/null trap 'exit 0' ERR\n" + gate,
 		// Conservatively refused rather than measured. `eval "set +e"` with the
 		// gate last really does exit 1, but the model cannot read an `eval`
 		// body, and the same construct can just as easily carry `trap 'exit 0'
@@ -1296,4 +1314,25 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 			t.Errorf("a gate that cannot fail the step must not count: %q", script)
 		}
 	}
+}
+
+// redirectionPrefix returns the length of a redirection operator starting at i,
+// including any leading file-descriptor digits, or 0 when there is none.
+//
+// The digits matter: `2>/dev/null trap …` puts `trap` at a command word exactly
+// as `> /dev/null trap …` does, but consuming `2` as an ordinary word first
+// clears the command position and hides it.
+func redirectionPrefix(script string, i int) int {
+	j := i
+	for j < len(script) && script[j] >= '0' && script[j] <= '9' {
+		j++
+	}
+	if j >= len(script) || (script[j] != '<' && script[j] != '>') {
+		return 0
+	}
+	j++
+	for j < len(script) && (script[j] == '<' || script[j] == '>' || script[j] == '&') {
+		j++
+	}
+	return j - i
 }

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -47,6 +47,7 @@ type step struct {
 	Run            string         `yaml:"run"`
 	Uses           string         `yaml:"uses"`
 	If             string         `yaml:"if"`
+	Shell          string         `yaml:"shell"`
 	TimeoutMinutes templatableInt `yaml:"timeout-minutes"`
 	With           stepInputs     `yaml:"with"`
 }
@@ -410,12 +411,31 @@ func skipHeredoc(script string, i int) int {
 	return len(script)
 }
 
+// shellKeepsErrexit reports whether a step's `shell:` still aborts on a failed
+// command. A gate can be defused by the shell it runs under, not only by the
+// operators around it: `shell: bash {0}` is a custom template with no `-e`, so a
+// failing validator followed by any successful command leaves the step green.
+//
+// Allow-listed rather than deny-listed, and matched on the documented keywords
+// GitHub maps to an errexit invocation: the default (`bash -e`), `bash`
+// (`bash --noprofile --norc -eo pipefail`), and `sh` (`sh -e`). Anything else —
+// another interpreter, or any custom template carrying `{0}` — reads as
+// UNCOVERED and fails the build loudly, which is the same strict direction the
+// rest of this file takes.
+func shellKeepsErrexit(shell string) bool {
+	switch shell {
+	case "", "bash", "sh":
+		return true
+	}
+	return false
+}
+
 // runsValidator reports whether any job in the workflow actually executes the
 // gate.
 func (w workflow) runsValidator() bool {
 	for _, job := range w.Jobs {
 		for _, step := range job.Steps {
-			if runsGate(step.Run, validatorInvocation) {
+			if shellKeepsErrexit(step.Shell) && runsGate(step.Run, validatorInvocation) {
 				return true
 			}
 		}
@@ -434,6 +454,7 @@ func (w workflow) runsIsolatedChartNamespaceValidator() bool {
 				ksailReady = true
 			}
 			if ksailReady && step.If == "" && step.TimeoutMinutes.is(10) &&
+				shellKeepsErrexit(step.Shell) &&
 				runsGate(step.Run, isolatedChartNamespaceValidatorInvocation) {
 				return true
 			}
@@ -561,6 +582,20 @@ func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 		}
 	})
 
+	t.Run("a shell without errexit does not count", func(t *testing.T) {
+		perturbed := covering
+		perturbed.Jobs = map[string]job{
+			"gate": {Steps: []step{{
+				Run:   validatorInvocation + " .\necho continued",
+				Shell: "bash {0}",
+			}}},
+		}
+		if perturbed.coversPushToMain() {
+			t.Fatal("`shell: bash {0}` is a custom template with no `-e`, so a failing " +
+				"gate followed by a successful command leaves the step green")
+		}
+	})
+
 	t.Run("a defused gate does not count", func(t *testing.T) {
 		perturbed := covering
 		perturbed.Jobs = map[string]job{
@@ -648,6 +683,23 @@ func TestIsolatedChartNamespaceGateCoverageIsNotVacuous(t *testing.T) {
 		}}
 		if ablated.runsIsolatedChartNamespaceValidator() {
 			t.Fatal("an unbounded chart render must not satisfy the namespace gate")
+		}
+	})
+
+	t.Run("shell without errexit", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{
+				{Run: ".github/scripts/setup-ksail.sh"},
+				{
+					Run:            isolatedChartNamespaceValidatorInvocation + "\necho continued",
+					Shell:          "bash {0}",
+					TimeoutMinutes: templatableInt{Value: 10, IsLiteral: true},
+				},
+			}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("a gate under a shell template without `-e` cannot fail its step, " +
+				"so it must not satisfy the coverage guard")
 		}
 	})
 

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -448,11 +448,14 @@ func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 
 // TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute prevents the
 // reviewed isolated-chart allowlist from outliving the rendered-child proof it
-// depends on. These three workflows cover pull requests and merge groups,
-// direct pushes to main, and the manual production deployment respectively.
+// depends on. These four workflows cover pull requests and merge groups,
+// direct pushes to main, the manual production deployment, and the
+// disaster-recovery rebuild respectively. Recovery publishes and reconciles a
+// revision, so omitting it left a real deployment route ungated while the test
+// name claimed otherwise.
 func TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute(t *testing.T) {
 	workflows := loadWorkflows(t)
-	for _, name := range []string{"ci.yaml", "validate-main.yaml", "cd.yaml"} {
+	for _, name := range []string{"ci.yaml", "validate-main.yaml", "cd.yaml", "dr-rebuild.yaml"} {
 		parsed, ok := workflows[name]
 		if !ok {
 			t.Errorf("required workflow %s is missing", name)

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -234,8 +234,8 @@ func runsGate(script, needle string) bool {
 // the LAST pipeline stage instead — GitHub Actions runs a `run:` block under
 // `bash -e`, without `pipefail` — so an earlier stage's failure is lost. A
 // trailing `&` backgrounds the command, and its status is never waited for.
-// `;`, `&&`, a newline, a closing paren, and end-of-script all leave the
-// failure intact.
+// `;`, `&&`, a newline, and end-of-script all leave the
+// failure intact; a closing paren does not, because the subshell continues outside it.
 //
 // Strict in the same direction as the scanner above: a pipeline is refused
 // even where the script does set pipefail, because deciding that reliably
@@ -259,8 +259,14 @@ func failurePropagates(script string, i int) bool {
 			// `&&` runs on SUCCESS, so a failure still stops the chain and
 			// reaches the step. A lone `&` backgrounds the command.
 			return i+1 < len(script) && script[i+1] == '&'
-		case c == ';', c == '\n', c == ')':
+		case c == ';', c == '\n':
 			return true
+		case c == ')':
+			// A subshell hands its status to whatever follows the ')', which this
+			// scan has not looked at: `( gate ) || true` discards it out there.
+			// Refusing keeps the strict direction — a genuinely enforcing subshell
+			// reads as UNCOVERED and fails loudly.
+			return false
 		default:
 			i++
 		}
@@ -765,6 +771,7 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " || echo ignored",
 		gate + " | tee gate.log",
 		gate + " &",
+		"( " + gate + " ) || true",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -235,8 +235,11 @@ func runsGate(script, needle string) bool {
 // the LAST pipeline stage instead — GitHub Actions runs a `run:` block under
 // `bash -e`, without `pipefail` — so an earlier stage's failure is lost. A
 // trailing `&` backgrounds the command, and its status is never waited for.
-// `;`, `&&`, a newline, and end-of-script all leave the
-// failure intact; a closing paren does not, because the subshell continues outside it.
+// `&&` settles nothing on its own — the AND-OR list continues, and a `||`
+// reached later at the same level still discards the failure, so
+// `gate && echo ok || true` exits 0 — hence the scan walks past it rather than
+// accepting there. `;`, a newline, and end-of-script all leave the failure
+// intact; a closing paren does not, because the subshell continues outside it.
 //
 // Strict in the same direction as the scanner above: a pipeline is refused
 // even where the script does set pipefail, because deciding that reliably
@@ -257,9 +260,16 @@ func failurePropagates(script string, i int) bool {
 			// last stage of the pipeline.
 			return false
 		case c == '&':
-			// `&&` runs on SUCCESS, so a failure still stops the chain and
-			// reaches the step. A lone `&` backgrounds the command.
-			return i+1 < len(script) && script[i+1] == '&'
+			if i+1 >= len(script) || script[i+1] != '&' {
+				// A lone `&` backgrounds the command, so the step never
+				// waits for its status.
+				return false
+			}
+			// `&&` does not settle the question. The AND-OR list continues,
+			// and a `||` later at this level still discards the failure:
+			// `gate && echo ok || true` exits 0. Keep scanning the remainder
+			// rather than accepting the gate here.
+			i += 2
 		case c == ';', c == '\n':
 			return true
 		case c == ')':
@@ -809,6 +819,7 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"shellcheck x.sh\n" + gate,
 		gate + " ; echo done",
 		gate + " && echo ok",
+		gate + " && echo a && echo b",
 		gate + "\necho after",
 	}
 	for _, script := range enforcing {
@@ -824,6 +835,7 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " | tee gate.log",
 		gate + " &",
 		"( " + gate + " ) || true",
+		gate + " && echo ok || true",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -258,14 +258,24 @@ func runsGate(script, needle string) bool {
 // read as UNCOVERED and fails the build loudly, which is recoverable; the
 // other direction passes a defused gate in silence.
 func failurePropagates(script string, i int) bool {
+	// pending is true while an AND-OR list is waiting for its next command.
+	// `&&` at the end of a line continues the list, so the newline after it is
+	// NOT a terminator — and bash strips a trailing comment before evaluating
+	// the list, so `gate && # note` continues too. Treating either newline as a
+	// terminator accepted `gate &&\n echo ok || true`, whose `|| true` still
+	// discards the gate's verdict.
+	pending := false
 	for i < len(script) {
 		switch c := script[i]; {
 		case c == '\\':
 			i += 2
+			pending = false
 		case c == '<' && i+1 < len(script) && script[i+1] == '<':
 			i = skipHeredoc(script, i)
+			pending = false
 		case c == '\'', c == '"':
 			i = skipQuoted(script, i)
+			pending = false
 		case c == '|':
 			// `||` swallows the failure; a lone `|` hides it behind the
 			// last stage of the pipeline.
@@ -281,7 +291,24 @@ func failurePropagates(script string, i int) bool {
 			// `gate && echo ok || true` exits 0. Keep scanning the remainder
 			// rather than accepting the gate here.
 			i += 2
-		case c == ';', c == '\n':
+			pending = true
+		case c == '#' && startsShellComment(script, i):
+			// Bash removes the comment before evaluating the list, so it
+			// settles nothing on its own. Skip its bytes and let the newline
+			// that ends it be judged by `pending`, exactly as if the comment
+			// were not there.
+			for i < len(script) && script[i] != '\n' {
+				i++
+			}
+		case c == ';':
+			return true
+		case c == '\n':
+			if pending {
+				// The list continues on the next line; this newline ends no
+				// command. Stay pending until a command word appears.
+				i++
+				continue
+			}
 			return true
 		case c == ')':
 			// A subshell hands its status to whatever follows the ')', which this
@@ -289,11 +316,30 @@ func failurePropagates(script string, i int) bool {
 			// Refusing keeps the strict direction — a genuinely enforcing subshell
 			// reads as UNCOVERED and fails loudly.
 			return false
+		case c == ' ', c == '\t':
+			// Blanks separate words without starting one, so they neither end
+			// a pending continuation nor begin a new command.
+			i++
 		default:
 			i++
+			pending = false
 		}
 	}
 	return true
+}
+
+// startsShellComment reports whether the '#' at i begins a comment rather than
+// sitting inside a word. Bash only treats '#' as a comment at the start of a
+// word, so `curl host/path#frag` and `echo a#b` carry no comment at all.
+func startsShellComment(script string, i int) bool {
+	if i == 0 {
+		return true
+	}
+	switch script[i-1] {
+	case ' ', '\t', '\n', ';', '&', '|', '(':
+		return true
+	}
+	return false
 }
 
 // scanCommandRuns walks script for needle at a command word. accept, when
@@ -985,6 +1031,13 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " && echo ok",
 		gate + " && echo a && echo b",
 		gate + "\necho after",
+		// An AND-OR list that continues across a newline, with no `||` anywhere
+		// in it, still lets the gate fail the step. Without these the fix below
+		// could read every post-newline continuation as defused.
+		gate + " &&\n  echo ok",
+		gate + " && # note\n  echo ok",
+		// A comment after a COMPLETE command: the newline still terminates it.
+		gate + " # done\necho after",
 	}
 	for _, script := range enforcing {
 		if !runsGate(script, gate) {
@@ -1000,6 +1053,13 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		gate + " &",
 		"( " + gate + " ) || true",
 		gate + " && echo ok || true",
+		// `&&` at end of line continues the AND-OR list, so the `||` on the
+		// next line still discards the gate's verdict. Treating that newline as
+		// a terminator read a defused gate as enforcing.
+		gate + " &&\n  echo ok || true",
+		// Bash strips the comment BEFORE evaluating the list, so this is exactly
+		// the line above with a comment in the middle.
+		gate + " && # report success\n  echo ok || true",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -105,12 +105,202 @@ func (t *triggerSpec) UnmarshalYAML(value *yaml.Node) error {
 	return value.Decode((*rawTrigger)(t))
 }
 
+// endsCommand reports whether b terminates a command, so that the next word
+// begins a new one. `&&` and `||` are repeats of these single bytes, so
+// treating each byte independently is sufficient here.
+func endsCommand(b byte) bool {
+	switch b {
+	case ';', '&', '|', '\n', '(', ')':
+		return true
+	}
+	return false
+}
+
+// endsWord reports whether b terminates a word, so a needle followed by b was
+// matched whole rather than as the prefix of a longer token.
+func endsWord(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', ';', '&', '|', ')', '<', '>':
+		return true
+	}
+	return false
+}
+
+// assignmentPrefix returns the length of a leading `NAME=value` word, or 0.
+// A command may be preceded by any number of these, and the command word is
+// still the one after them.
+func assignmentPrefix(s string) int {
+	i := 0
+	for i < len(s) && (s[i] == '_' ||
+		(s[i] >= 'a' && s[i] <= 'z') || (s[i] >= 'A' && s[i] <= 'Z') ||
+		(i > 0 && s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+	if i == 0 || i >= len(s) || s[i] != '=' {
+		return 0
+	}
+	for i < len(s) && s[i] != ' ' && s[i] != '\t' && s[i] != '\n' {
+		if s[i] == '\'' || s[i] == '"' {
+			return 0 // quoted value: too subtle to skip safely, so decline
+		}
+		i++
+	}
+	return i
+}
+
+// runsCommand reports whether script EXECUTES needle, rather than merely
+// mentioning it.
+//
+// strings.Contains cannot answer that question. It matches a path named in an
+// `echo`, sitting in a shell comment, or handed to a different tool as an
+// argument — `shellcheck .github/scripts/setup-ksail.sh` is a live example in
+// this repository's own ci.yaml. A guard built on it therefore reports a gate
+// as covered when nothing runs it, which is exactly the failure this file's
+// header comment says the YAML parse exists to prevent: the parse stops a
+// workflow's YAML comments from satisfying the guard, but not a shell comment
+// or an echo inside the `run:` block it hands back.
+//
+// The test is positional rather than a deny-list of inert commands: needle must
+// begin at a COMMAND WORD. That admits every executable spelling without
+// enumerating the text-emitting builtins (`echo`, `printf`, `:`, a heredoc),
+// and it stays correct when a new one is invented. It is deliberately strict —
+// an unrecognised wrapper makes a covered gate read as UNCOVERED, failing the
+// build loudly, rather than passing an absent gate silently.
+func runsCommand(script, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	atCommandStart := true
+	for i := 0; i < len(script); {
+		switch c := script[i]; {
+		case c == '\\':
+			// An escape consumes the next byte, a line continuation
+			// included, and never begins a command word.
+			atCommandStart = false
+			i += 2
+			continue
+		case c == '<' && i+1 < len(script) && script[i+1] == '<':
+			i = skipHeredoc(script, i)
+			atCommandStart = false
+			continue
+		case c == '\'', c == '"':
+			i = skipQuoted(script, i)
+			atCommandStart = false
+			continue
+		case c == ' ', c == '\t':
+			// Leading blanks do not end the pending command position.
+			i++
+			continue
+		case endsCommand(c):
+			atCommandStart = true
+			i++
+			continue
+		case atCommandStart && c == '#':
+			// A comment runs to the newline, which then re-arms the
+			// command position on the next iteration.
+			for i < len(script) && script[i] != '\n' {
+				i++
+			}
+			continue
+		case atCommandStart:
+			if strings.HasPrefix(script[i:], needle) {
+				rest := script[i+len(needle):]
+				if rest == "" || endsWord(rest[0]) {
+					return true
+				}
+			}
+			if n := assignmentPrefix(script[i:]); n > 0 {
+				i += n // still at a command position
+				continue
+			}
+		}
+		atCommandStart = false
+		i++
+	}
+	return false
+}
+
+// skipQuoted returns the index just past the quoted run starting at i. An
+// unterminated quote consumes the remainder, which keeps the scan total.
+func skipQuoted(script string, i int) int {
+	quote := script[i]
+	for i++; i < len(script); i++ {
+		if quote == '"' && script[i] == '\\' {
+			i++
+			continue
+		}
+		if script[i] == quote {
+			return i + 1
+		}
+	}
+	return len(script)
+}
+
+// skipHeredoc returns the index just past a heredoc introduced at i, where
+// script[i:i+2] is "<<". A heredoc body is inert text, but every line of it
+// starts where a command word would, so without this the body of a
+// `cat <<'EOF' ... EOF` block reads as a sequence of commands. A here-string
+// ("<<<") introduces no body and is left to the ordinary scan. When the
+// terminator is missing the remainder is consumed, which keeps the scan total.
+func skipHeredoc(script string, i int) int {
+	j := i + 2
+	if j < len(script) && script[j] == '<' {
+		return i + 2 // here-string, not a heredoc
+	}
+	stripTabs := false
+	if j < len(script) && script[j] == '-' {
+		stripTabs = true
+		j++
+	}
+	for j < len(script) && (script[j] == ' ' || script[j] == '\t') {
+		j++
+	}
+	var delim strings.Builder
+	for j < len(script) {
+		c := script[j]
+		if c == '\'' || c == '"' {
+			j++ // quoting only disables expansion; the word is the same
+			continue
+		}
+		if c == ' ' || c == '\t' || c == '\n' || endsCommand(c) {
+			break
+		}
+		delim.WriteByte(c)
+		j++
+	}
+	if delim.Len() == 0 {
+		return i + 2
+	}
+	// The body starts on the line after the one introducing the heredoc.
+	for j < len(script) && script[j] != '\n' {
+		j++
+	}
+	for j < len(script) {
+		j++ // step past the newline onto the next line
+		start := j
+		for j < len(script) && script[j] != '\n' {
+			j++
+		}
+		line := script[start:j]
+		if stripTabs {
+			line = strings.TrimLeft(line, "\t")
+		}
+		if line == delim.String() {
+			return j
+		}
+		if j >= len(script) {
+			break
+		}
+	}
+	return len(script)
+}
+
 // runsValidator reports whether any job in the workflow actually executes the
 // gate.
 func (w workflow) runsValidator() bool {
 	for _, job := range w.Jobs {
 		for _, step := range job.Steps {
-			if strings.Contains(step.Run, validatorInvocation) {
+			if runsCommand(step.Run, validatorInvocation) {
 				return true
 			}
 		}
@@ -125,10 +315,10 @@ func (w workflow) runsIsolatedChartNamespaceValidator() bool {
 	for _, job := range w.Jobs {
 		ksailReady := false
 		for _, step := range job.Steps {
-			if strings.Contains(step.Run, ".github/scripts/setup-ksail.sh") {
+			if runsCommand(step.Run, ".github/scripts/setup-ksail.sh") {
 				ksailReady = true
 			}
-			if ksailReady && step.TimeoutMinutes == 10 && strings.Contains(step.Run, isolatedChartNamespaceValidatorInvocation) {
+			if ksailReady && step.TimeoutMinutes == 10 && runsCommand(step.Run, isolatedChartNamespaceValidatorInvocation) {
 				return true
 			}
 		}
@@ -330,4 +520,80 @@ func TestIsolatedChartNamespaceGateCoverageIsNotVacuous(t *testing.T) {
 			t.Fatal("an unbounded chart render must not satisfy the namespace gate")
 		}
 	})
+}
+
+// TestRunsCommandRejectsInertMentions is the non-vacuity proof for the
+// coverage guards above. Every case here names the gate exactly as an
+// executable invocation would, and none of them runs it — so a guard built on
+// strings.Contains passes all of them while the gate is absent. The
+// `shellcheck` case is not hypothetical: ci.yaml really does pass this script
+// to shellcheck as an argument in a step that never executes it.
+func TestRunsCommandRejectsInertMentions(t *testing.T) {
+	const needle = ".github/scripts/setup-ksail.sh"
+	for name, script := range map[string]string{
+		"echoed":              "echo .github/scripts/setup-ksail.sh",
+		"echoed quoted":       "echo \".github/scripts/setup-ksail.sh\"",
+		"echoed single quote": "echo '.github/scripts/setup-ksail.sh'",
+		"printed":             "printf '%s\\n' .github/scripts/setup-ksail.sh",
+		"whole-line comment":  "# .github/scripts/setup-ksail.sh\ntrue",
+		"indented comment":    "  \t# .github/scripts/setup-ksail.sh",
+		"comment after cmd":   "true # .github/scripts/setup-ksail.sh",
+		"comment after &&":    "true && # .github/scripts/setup-ksail.sh",
+		"argument to a tool":  "shellcheck .github/scripts/setup-ksail.sh scripts/tests/test-setup-ksail.sh",
+		"inside a longer arg": "cat prefix.github/scripts/setup-ksail.sh",
+		"prefix of a token":   ".github/scripts/setup-ksail.sh.bak",
+		"heredoc body":        "cat <<'EOF'\n.github/scripts/setup-ksail.sh\nEOF",
+	} {
+		if runsCommand(script, needle) {
+			t.Errorf("%s: reported as executed, but %q only MENTIONS the gate", name, script)
+		}
+	}
+}
+
+// TestRunsCommandAcceptsExecutableForms is the other half: the guard must stay
+// true for every spelling a workflow legitimately uses, or tightening it would
+// simply move the failure from silent-pass to false-alarm.
+func TestRunsCommandAcceptsExecutableForms(t *testing.T) {
+	const needle = ".github/scripts/setup-ksail.sh"
+	for name, script := range map[string]string{
+		"bare":             ".github/scripts/setup-ksail.sh",
+		"trailing newline": ".github/scripts/setup-ksail.sh\n",
+		"with arguments":   ".github/scripts/setup-ksail.sh --verbose",
+		"indented":         "  .github/scripts/setup-ksail.sh",
+		"after a newline":  "set -euo pipefail\n.github/scripts/setup-ksail.sh",
+		"after &&":         "true && .github/scripts/setup-ksail.sh",
+		"after ||":         "false || .github/scripts/setup-ksail.sh",
+		"after ;":          "true; .github/scripts/setup-ksail.sh",
+		"after a pipe":     "true | .github/scripts/setup-ksail.sh",
+		"after a comment":  "# install ksail\n.github/scripts/setup-ksail.sh",
+		"env prefix":       "KSAIL_VERSION=1.2.3 .github/scripts/setup-ksail.sh",
+		"two env prefixes": "A=1 B=2 .github/scripts/setup-ksail.sh",
+		"redirected":       ".github/scripts/setup-ksail.sh >/dev/null",
+		"after a subshell": "(true) && .github/scripts/setup-ksail.sh",
+		"after an echo":    "echo installing\n.github/scripts/setup-ksail.sh",
+	} {
+		if !runsCommand(script, needle) {
+			t.Errorf("%s: reported as absent, but %q EXECUTES the gate", name, script)
+		}
+	}
+}
+
+// TestRunsCommandMatchesTheOtherGateInvocations keeps the two multi-word
+// needles honest: they contain spaces, so a whole-word check has to compare the
+// needle as a phrase rather than a single token.
+func TestRunsCommandMatchesTheOtherGateInvocations(t *testing.T) {
+	if !runsCommand("go run ./scripts/validate-eks-ci-role-policy .", validatorInvocation) {
+		t.Error("the real validator invocation was not recognised as executed")
+	}
+	if runsCommand("echo go run ./scripts/validate-eks-ci-role-policy", validatorInvocation) {
+		t.Error("an echoed validator invocation was reported as executed")
+	}
+	if !runsCommand("bash scripts/tests/test-isolated-chart-namespace-rules.sh",
+		isolatedChartNamespaceValidatorInvocation) {
+		t.Error("the real isolated-chart invocation was not recognised as executed")
+	}
+	if runsCommand("# bash scripts/tests/test-isolated-chart-namespace-rules.sh",
+		isolatedChartNamespaceValidatorInvocation) {
+		t.Error("a commented-out isolated-chart invocation was reported as executed")
+	}
 }

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -262,16 +262,101 @@ func errexitDisabledAt(script string, upto int) bool {
 		upto = len(script)
 	}
 	prefix := script[:upto]
-	disabled := false
+
+	// Every toggle is recorded with its position, because more than one scan
+	// contributes and only the LAST one before the gate is in force.
+	type toggle struct {
+		at  int
+		off bool
+	}
+	var seen []toggle
+
 	scanCommandRuns(prefix, "set", func(end int) bool {
 		if off, toggles := setTogglesErrexit(prefix[end:]); toggles {
-			disabled = off
+			seen = append(seen, toggle{at: end, off: off})
 		}
-		// Never accept: scanning must reach every `set` before the gate so the
-		// last one decides. Returning true here would stop at the first.
+		// Never accept: scanning must reach every candidate before the gate so
+		// the last one decides. Returning true here would stop at the first.
 		return false
 	})
+	// A transparent wrapper runs its operand as a builtin in THIS shell, so
+	// resolve through it to whatever it actually invokes.
+	for _, wrapper := range []string{"builtin", "command"} {
+		scanCommandRuns(prefix, wrapper, func(end int) bool {
+			if off, toggles := wrappedTogglesErrexit(prefix[end:]); toggles {
+				seen = append(seen, toggle{at: end, off: off})
+			}
+			return false
+		})
+	}
+	// An opaque construct can also run `set` in this shell, but what it runs
+	// cannot be read from the script text.
+	for _, opaque := range []string{"eval", "source", ".", "exec", "trap"} {
+		scanCommandRuns(prefix, opaque, func(end int) bool {
+			seen = append(seen, toggle{at: end, off: true})
+			return false
+		})
+	}
+
+	last, disabled := -1, false
+	for _, t := range seen {
+		if t.at > last {
+			last, disabled = t.at, t.off
+		}
+	}
 	return disabled
+}
+
+// wrappedTogglesErrexit reads the operands of a `builtin` or `command` word,
+// which begin at args, and reports the effect on errexit of whatever that
+// wrapper actually invokes.
+//
+// Both wrappers execute a builtin in the CURRENT shell, so `builtin set +e` and
+// `command set +e` disable errexit exactly as a bare `set +e` does — verified
+// under `bash -e`, where each prints `continued` and exits 0 with the gate
+// failing. They are resolved through rather than refused outright, because
+// `command -v ksail` is an ordinary lookup that cannot touch shell options and
+// refusing it would call sound gate steps UNCOVERED for no reason.
+//
+// A `-v` or `-V` option makes the word a query rather than an invocation. Any
+// other non-literal or unrecognised operand is treated as disabling, on the
+// same unreadable-means-unsafe rule applied to `set` itself.
+func wrappedTogglesErrexit(args string) (off bool, toggles bool) {
+	i := 0
+	for i < len(args) {
+		for i < len(args) && (args[i] == ' ' || args[i] == '\t') {
+			i++
+		}
+		if i >= len(args) || endsCommand(args[i]) {
+			return false, false
+		}
+		start := i
+		for i < len(args) && !endsWord(args[i]) {
+			i++
+		}
+		word := args[start:i]
+		if strings.ContainsAny(word, "'\"$`\\") {
+			// The invoked word cannot be read without a shell.
+			return true, true
+		}
+		switch {
+		case word == "-v", word == "-V":
+			// A lookup, not an invocation: it cannot change shell options.
+			return false, false
+		case strings.HasPrefix(word, "-"):
+			// Another wrapper option (`-p`); keep looking for the command word.
+			continue
+		case word == "set":
+			return setTogglesErrexit(args[i:])
+		case word == "builtin", word == "command":
+			// Wrappers nest: `builtin command set +e` reaches `set` too.
+			return wrappedTogglesErrexit(args[i:])
+		default:
+			// Any other builtin cannot disable errexit for the block.
+			return false, false
+		}
+	}
+	return false, false
 }
 
 // setTogglesErrexit reads the argument words of a `set` builtin, whose operands
@@ -1139,6 +1224,15 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		"set +x\n" + gate,
 		"set +o pipefail\n" + gate,
 		"set +e\ncurl -f probe || true\nset -e\n" + gate,
+		// The inversion must not swallow ordinary steps. `command -v` is a
+		// lookup rather than an invocation, `builtin echo` is a builtin that
+		// cannot touch shell options, and `./script.sh` is not the `.` builtin —
+		// without these controls the clause above would call sound gates
+		// UNCOVERED and this table would not notice.
+		"command -v ksail\n" + gate,
+		"builtin echo hello\n" + gate,
+		"./scripts/setup.sh\n" + gate,
+		"command ksail version\n" + gate,
 	}
 	for _, script := range enforcing {
 		if !runsGate(script, gate) {
@@ -1178,6 +1272,14 @@ func TestRunsGateRequiresFailurePropagation(t *testing.T) {
 		// Verified with `bash -e`: each prints `continued` and exits 0.
 		"set \"+e\"\n" + gate + "\necho continued",
 		"option=e\nset +${option}\n" + gate + "\necho continued",
+		// `builtin` and `command` run `set` in THIS shell, and `eval` can run
+		// anything at all. Verified under `bash -e`: each prints `continued` and
+		// exits 0 with the gate failing.
+		"builtin set +e\n" + gate + "\necho continued",
+		"command set +e\n" + gate + "\necho continued",
+		"eval 'set +e'\n" + gate + "\necho continued",
+		"builtin command set +e\n" + gate + "\necho continued",
+		". ./lib.sh\n" + gate + "\necho continued",
 	}
 	for _, script := range defused {
 		if !runsCommand(script, gate) {

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -18,6 +18,11 @@ const workflowsDir = "../../.github/workflows"
 // the gate by name.
 const validatorInvocation = "go run ./scripts/validate-eks-ci-role-policy"
 
+// isolatedChartNamespaceValidatorInvocation renders the reviewed staged-off
+// chart and checks every child namespace. It is a separate command because the
+// static Go validator runs before KSail is installed in each workflow.
+const isolatedChartNamespaceValidatorInvocation = "bash scripts/tests/test-isolated-chart-namespace-rules.sh"
+
 // workflow is the narrow slice of Actions schema this contract needs.
 //
 // It is parsed as YAML rather than string-matched on purpose: the workflow
@@ -38,9 +43,10 @@ type job struct {
 }
 
 type step struct {
-	Run  string     `yaml:"run"`
-	Uses string     `yaml:"uses"`
-	With stepInputs `yaml:"with"`
+	Run            string     `yaml:"run"`
+	Uses           string     `yaml:"uses"`
+	TimeoutMinutes int        `yaml:"timeout-minutes"`
+	With           stepInputs `yaml:"with"`
 }
 
 // stepInputs is the slice of an action's `with:` block these contracts read.
@@ -105,6 +111,24 @@ func (w workflow) runsValidator() bool {
 	for _, job := range w.Jobs {
 		for _, step := range job.Steps {
 			if strings.Contains(step.Run, validatorInvocation) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// runsIsolatedChartNamespaceValidator reports whether one job installs KSail
+// before executing the rendered-child namespace gate. Keeping both steps in
+// the same job matters: setup in another job does not share the runner.
+func (w workflow) runsIsolatedChartNamespaceValidator() bool {
+	for _, job := range w.Jobs {
+		ksailReady := false
+		for _, step := range job.Steps {
+			if strings.Contains(step.Run, ".github/scripts/setup-ksail.sh") {
+				ksailReady = true
+			}
+			if ksailReady && step.TimeoutMinutes == 10 && strings.Contains(step.Run, isolatedChartNamespaceValidatorInvocation) {
 				return true
 			}
 		}
@@ -228,6 +252,82 @@ func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 		}
 		if perturbed.coversPushToMain() {
 			t.Fatal("merely mentioning the validator must not count as running it")
+		}
+	})
+}
+
+// TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute prevents the
+// reviewed isolated-chart allowlist from outliving the rendered-child proof it
+// depends on. These three workflows cover pull requests and merge groups,
+// direct pushes to main, and the manual production deployment respectively.
+func TestIsolatedChartNamespaceGateCoversEveryDeploymentRoute(t *testing.T) {
+	workflows := loadWorkflows(t)
+	for _, name := range []string{"ci.yaml", "validate-main.yaml", "cd.yaml"} {
+		parsed, ok := workflows[name]
+		if !ok {
+			t.Errorf("required workflow %s is missing", name)
+			continue
+		}
+		if !parsed.runsIsolatedChartNamespaceValidator() {
+			t.Errorf("%s must install KSail and then run %q in the same job", name, isolatedChartNamespaceValidatorInvocation)
+		}
+	}
+}
+
+// TestIsolatedChartNamespaceGateCoverageIsNotVacuous ablates the ordering and
+// same-runner properties independently so the deployment-route guard above
+// cannot pass on an inert command or setup performed in another job.
+func TestIsolatedChartNamespaceGateCoverageIsNotVacuous(t *testing.T) {
+	covered := workflow{Jobs: map[string]job{
+		"gate": {Steps: []step{
+			{Run: ".github/scripts/setup-ksail.sh"},
+			{Run: isolatedChartNamespaceValidatorInvocation, TimeoutMinutes: 10},
+		}},
+	}}
+	if !covered.runsIsolatedChartNamespaceValidator() {
+		t.Fatal("positive control failed: setup followed by the namespace gate in one job must count")
+	}
+
+	t.Run("missing gate", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{{Run: ".github/scripts/setup-ksail.sh"}}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("KSail setup without the namespace gate must not count")
+		}
+	})
+
+	t.Run("gate before setup", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{
+				{Run: isolatedChartNamespaceValidatorInvocation},
+				{Run: ".github/scripts/setup-ksail.sh"},
+			}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("the namespace gate must not count before KSail is installed")
+		}
+	})
+
+	t.Run("setup in another job", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"setup": {Steps: []step{{Run: ".github/scripts/setup-ksail.sh"}}},
+			"gate":  {Steps: []step{{Run: isolatedChartNamespaceValidatorInvocation}}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("KSail setup in another runner job must not count")
+		}
+	})
+
+	t.Run("unbounded render", func(t *testing.T) {
+		ablated := workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{
+				{Run: ".github/scripts/setup-ksail.sh"},
+				{Run: isolatedChartNamespaceValidatorInvocation},
+			}},
+		}}
+		if ablated.runsIsolatedChartNamespaceValidator() {
+			t.Fatal("an unbounded chart render must not satisfy the namespace gate")
 		}
 	})
 }

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2140,7 +2140,10 @@ func authorizationIsolationRequested(document map[string]any) bool {
 }
 
 // reviewedIsolatedChartIdentities is the explicit allowlist of namespace/name
-// pairs whose isolated-chart declaration has been reviewed.
+// pairs whose isolated-chart declaration and exact rendered-child namespace
+// gate have both been reviewed. Each entry needs a path-scoped Helm render that
+// rejects every namespaced child outside the identity's namespace; the
+// data-product-controller gate is test-isolated-chart-namespace-rules.sh.
 //
 // A namespace denylist is not sufficient. Denying only "", "aws" and
 // "flux-system" leaves every other namespace able to exempt itself from the
@@ -2154,8 +2157,9 @@ var reviewedIsolatedChartIdentities = map[string]struct{}{
 
 // validateAuthorizationIsolation fails closed on every precondition behind an
 // isolated-chart declaration. It is intentionally limited to a namespace-local
-// HelmRelease and its immutable public OCIRepository; the rendered chart
-// children remain subject to the production CEL authorization rules.
+// HelmRelease and its immutable public OCIRepository. A separate path-scoped
+// KSail gate Helm-renders that exact artifact, constrains every child namespace,
+// and applies the production CEL authorization rules to its effective RBAC.
 func validateAuthorizationIsolation(document map[string]any, identity resourceIdentity) error {
 	if !authorizationIsolationRequested(document) {
 		return nil


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The reviewed `isolated-chart` authorization exemption proved that the HelmRelease and immutable OCIRepository were namespace-local, but it did not prove the same property for the chart children. A pinned chart could therefore render a workload into a foreign privileged namespace while the source-level guard and existing non-RBAC CEL paths stayed green.

### What

- Add a path-scoped CEL rule that accepts only the reviewed `data-product-controller` Namespace and cluster-scoped RBAC shapes, and requires every namespaced child to declare `data-product-controller`.
- Helm-render the exact staged-off OCI digest through KSail without adding the component to any deploy overlay.
- Gate pull requests, merge groups, direct pushes to `main`, and manual CD on the check, each with a 10-minute bound.
- Parse the workflows in Go so removing the command, moving it before KSail setup, splitting setup into another runner job, or dropping the timeout fails the contract.
- Refuse runtime value sources on the reviewed HelmRelease. The component sits outside every deploy overlay, so admission never re-checks it and this render is the only control standing over it; a value resolved in the cluster would mean Flux installs something the render never saw.
- Re-check the chart on the recovery path's own revision. The failure-path job that restores production republishes the current tip of `main`, which can differ from what was scanned, and the previous check was satisfied by any job in the workflow rather than the one doing the deploying.

Kyverno admission does not back this check. The final child object does not retain reliable HelmRelease provenance, so a cluster-wide admission rule could not safely distinguish this reviewed chart from unrelated workloads. The static gate keeps that provenance by validating only the exact component path and immutable chart digest; the existing production CEL suite continues to validate rendered RBAC.

### Proof

- RED: the permissive rule admitted the foreign-namespace Deployment and the focused test failed for that exact reason.
- GREEN: namespace-local control accepted; foreign Deployment, foreign Namespace, and namespace-omitted workload rejected by the named rule; exact chart digest `sha256:dd1bfb808253f9a52fdd383f95290215fdc14b6ecc959f7d507a03def8921bc7` rendered cleanly.
- Workflow RED/GREEN: the parsed contract failed independently for all three missing routes, then passed after wiring; removal, ordering, separate-job, and unbounded-render ablations remain covered.
- `go test ./scripts/validate-eks-ci-role-policy` passed.
- ShellCheck, Actionlint, and `git diff --check` passed.
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` passed: 117 kustomizations and 597 files in each mode.
- The standalone Go CLI reached its intentional renderer-version guard locally (`kubectl` v1.36.1 vs required v1.36.2); hosted workflows install the pinned v1.36.2 before invoking it.
- Commit `844787a080e537f3bb833369d85dcb3e0378b9a7` has a verified good signature.

Fixes #3497
