### PR TITLE
feat(security): document every suppressed control's fail-open, and fail CI when one is not

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,10 @@ jobs:
               # Both halves, for the same reason as the guards above.
               - 'scripts/guard-pod-security-exception-scope.sh'
               - 'scripts/tests/test-guard-pod-security-exception-scope.sh'
+              # Both halves, for the same reason as the guards above. The guard also
+              # reads the exception manifest itself, covered by 'k8s/**'.
+              - 'scripts/guard-pod-security-exception-documented.sh'
+              - 'scripts/tests/test-guard-pod-security-exception-documented.sh'
               # Both halves, for the same reason as the guards above.
               - 'scripts/guard-crossplane-provider-name-parity.sh'
               - 'scripts/tests/test-guard-crossplane-provider-name-parity.sh'
@@ -1043,6 +1047,19 @@ jobs:
         run: |
           bash scripts/guard-pod-security-exception-scope.sh
           bash scripts/tests/test-guard-pod-security-exception-scope.sh
+
+      - name: 🔎 Validate every suppressed control is documented as failing open
+        if: needs.changes.outputs.k8s == 'true'
+        # A control added under spec.posture that the file's fail-open warning does
+        # not name. The exception makes each suppressed control report `passed` with
+        # subStatus "w/exceptions", so reading status alone yields a clean result over
+        # an unfixed population — 35 of 35 workloads when C-0211 was added (#3516).
+        # The check is scoped to the marked warning block, not the whole header: when
+        # C-0211 was added it WAS mentioned elsewhere in that header, so a file-wide
+        # match passes on the very tree that motivated the guard.
+        run: |
+          bash scripts/guard-pod-security-exception-documented.sh
+          bash scripts/tests/test-guard-pod-security-exception-documented.sh
 
       - name: 🧬 Validate Crossplane provider names match their derived names
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -22,6 +22,7 @@
 # setting a uid on a controller that is on its way out. #3223 tracks the narrowing
 # itself and is blocked on #3480.
 #
+# fail-open-warning:BEGIN — every spec.posture controlID must be named below.
 # 🔴 DO NOT RE-VERIFY ANY CONTROL IN THIS FILE ON workloadconfigurationscans ALONE —
 # THAT SURFACE FAILS OPEN FOR EVERY CONTROL THIS EXCEPTION SUPPRESSES. The hazard is a
 # property of the exception rather than of one control, so anything added under
@@ -47,6 +48,7 @@
 # either: it is a static hint from the rule definition and is populated identically on
 # workloads that genuinely pass. Verify against the live stored workload spec, which is
 # independent of both the scanner and this exception.
+# fail-open-warning:END
 #
 # C-0211 — CIS-5.7.3, and it is a twelve-rule control rather than the three-field
 # check its name suggests. The rules this exception suppresses include

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -22,16 +22,31 @@
 # setting a uid on a controller that is on its way out. #3223 tracks the narrowing
 # itself and is blocked on #3480.
 #
-# 🔴 DO NOT RE-VERIFY THIS ON workloadconfigurationscans ALONE — IT NOW FAILS OPEN.
-# That surface was pre-exception when this gate was written, but today every one of
-# the six carries appliedIgnoreRules: [pod-security-mutations-unscoped/C-0013] and
-# reports status: passed with subStatus: "w/exceptions" — including tofu-controller,
-# which is genuinely broken. Reading .spec.controls["C-0013"].status.status
-# therefore says this gate is clearable when it is not. The discriminator is
-# subStatus plus a populated appliedIgnoreRules, never status. `fixPath` is NOT a
-# discriminator either: it is a static hint from the rule definition and is
-# populated identically on all six, including the five that pass. Verify against the
-# live Deployment spec, which is independent of the scanner and of this exception.
+# 🔴 DO NOT RE-VERIFY ANY CONTROL IN THIS FILE ON workloadconfigurationscans ALONE —
+# THAT SURFACE FAILS OPEN FOR EVERY CONTROL THIS EXCEPTION SUPPRESSES. The hazard is a
+# property of the exception rather than of one control, so anything added under
+# spec.posture below inherits it. Kubescape writes status: passed together with
+# subStatus: "w/exceptions" and a populated appliedIgnoreRules on each suppressed
+# control, so reading .spec.controls[<id>].status.status reports a gate as clearable
+# when nothing behind it has been fixed. Measured 2026-09-02 on both listed controls:
+#
+#   * C-0013 — five of the six flux-system workloads now pass genuinely, carrying an
+#     EMPTY subStatus; only tofu-controller, the single workload that is actually
+#     broken, reads passed with subStatus "w/exceptions". Status alone cannot tell the
+#     five apart from the one; subStatus isolates it exactly.
+#   * C-0211 — 35 of 35 scanned workloads read passed with subStatus "w/exceptions",
+#     each carrying appliedIgnoreRules: [pod-security-mutations-unscoped/C-0211],
+#     while all 35 are still missing both universal fields. Nothing here passes
+#     genuinely, so reading status alone yields exactly the "0 of 35 fail" that #3239
+#     states as its success signal, with no fix behind it.
+#
+# The discriminator is subStatus plus a populated appliedIgnoreRules, never status,
+# and it does discriminate: on one such workload the same scan carries 53 controls
+# passed with an EMPTY subStatus and 3 failed with appliedIgnoreRules null, so
+# "w/exceptions" is a real signal and not a constant. `fixPath` is NOT a discriminator
+# either: it is a static hint from the rule definition and is populated identically on
+# workloads that genuinely pass. Verify against the live stored workload spec, which is
+# independent of both the scanner and this exception.
 #
 # C-0211 — CIS-5.7.3, and it is a twelve-rule control rather than the three-field
 # check its name suggests. The rules this exception suppresses include
@@ -41,20 +56,29 @@
 # nor the name-scoped kubescape-privileged lists C-0211.
 #
 # Its residual population is every workload in the four excluded namespaces that are
-# actually scanned — flux-system, longhorn-system, observability and velero — all 33
-# of them: 17 Deployments, 7 DaemonSets, 6 CronJobs and 3 StatefulSets. (CronJobs are
+# actually scanned — flux-system, longhorn-system, observability and velero — all 35
+# of them: 17 Deployments, 8 DaemonSets, 7 CronJobs and 3 StatefulSets. (CronJobs are
 # scanned and carry a verdict; Jobs are not, so the ephemeral backup and heartbeat
-# Jobs in these namespaces are out of scope.) Measured 2026-08-19 against the live
-# PROD stored specs, which is the surface Kubescape reads. "Scanned" here means in the
-# scanner's configured scope: the config scan itself is not currently producing (#2933,
-# #3024), so this population is real but presently invisible to the posture score —
-# which is exactly the silent-suppression failure mode #2447 exists to prevent.
+# Jobs in these namespaces are out of scope.) Measured 2026-09-02 against the live
+# PROD stored specs, which is the surface Kubescape reads, and corroborated
+# independently by the count of Kubescape's own workload-kind scan objects in those
+# namespaces (flux-system 6, longhorn-system 12, observability 15, velero 2).
 #
-# Not one of the 33 passes, and two gaps are universal: the pod-level
-# `securityContext.fsGroupChangePolicy` is absent on 33 of 33 (read under
-# `jobTemplate` for the CronJobs), and `securityContext.seLinuxOptions` is absent on
-# every container of all 33. Pod-level `fsGroup` is absent on 20, `runAsGroup` on 18
-# and `runAsNonRoot` on 12 — each a strict subset of the two universal gaps.
+# "Scanned" here means in the scanner's configured scope. The population's absence
+# from the posture score is NOT reducible to the config scan's own producing gaps
+# (#2933, #3024): this exception suppresses C-0211 whatever the scanner's health, so
+# the score reads clean either way — which is exactly the silent-suppression failure
+# mode #2447 exists to prevent.
+#
+# Not one of the 35 passes, and two gaps are universal: the pod-level
+# `securityContext.fsGroupChangePolicy` is absent on 35 of 35 (read under
+# `jobTemplate` for the CronJobs), and no effective seLinux `level` reaches every
+# container on 35 of 35 — "effective" meaning the container's own seLinuxOptions where
+# it sets them and the pod-level object otherwise. That test is deliberately generous,
+# since a container-level object actually replaces the pod struct wholesale, so 35 of
+# 35 is a floor rather than an artifact of a strict rule. Pod-level `fsGroup` is absent
+# on 20, `runAsGroup` on 26 and `runAsNonRoot` on 19 — each a strict subset of the two
+# universal gaps. All re-measured 2026-09-02 against the live PROD stored specs.
 # Narrowing C-0211 today would surface the whole population with no fix behind it —
 # lowering the score to absorb a gap rather than closing it — so it stays
 # cluster-wide. The per-workload table and the remediation split are on #3217. These
@@ -78,7 +102,7 @@ metadata:
     # Cluster-wide, and knowingly wider than its own rationale: in the twelve
     # namespaces "add-security-context" excludes, nothing injects these fields.
     # Both controls are retained rather than narrowed on an unmeasured guess —
-    # C-0013 pending #3480 (via #3223); C-0211 sized 2026-08-19 and pending #3217.
+    # C-0013 pending #3480 (via #3223); C-0211 sized 2026-09-02 and pending #3217.
     platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
@@ -89,7 +113,7 @@ spec:
     rather than on expressiveness: C-0013 has a measured one-workload gap in
     flux-system (tofu-controller, pending its removal in #3480), and C-0211's
     residual population is every scanned workload the mutation does not reach,
-    sized at 33 (#3217).
+    sized at 35 (#3217).
   posture:
     - controlID: C-0013
       action: ignore

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -712,7 +712,7 @@ data:
             "controlID": "^C-0211$"
           }
         ],
-        "reason": "Kyverno mutate policy \"add-security-context\" injects runAsNonRoot, runAsUser, runAsGroup and fsGroupChangePolicy at pod admission. The Deployment spec does not contain them and Kubescape scans the stored spec, not the live pod. These two controls remain cluster-wide because narrowing them is blocked on evidence rather than on expressiveness: C-0013 has a measured one-workload gap in flux-system (tofu-controller, pending its removal in #3480), and C-0211's residual population is every scanned workload the mutation does not reach, sized at 33 (#3217)."
+        "reason": "Kyverno mutate policy \"add-security-context\" injects runAsNonRoot, runAsUser, runAsGroup and fsGroupChangePolicy at pod admission. The Deployment spec does not contain them and Kubescape scans the stored spec, not the live pod. These two controls remain cluster-wide because narrowing them is blocked on evidence rather than on expressiveness: C-0013 has a measured one-workload gap in flux-system (tofu-controller, pending its removal in #3480), and C-0211's residual population is every scanned workload the mutation does not reach, sized at 35 (#3217)."
       },
       {
         "name": "readonly-rootfs-pending",

--- a/scripts/guard-pod-security-exception-documented.sh
+++ b/scripts/guard-pod-security-exception-documented.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Fail when a control suppressed by a ClusterSecurityException is not named in that
+# file's fail-open warning block.
+#
+# #3516 exists because C-0211 was added to `pod-security-mutations-unscoped.yaml`
+# under `spec.posture` while the warning block above it still spoke only about
+# C-0013. That warning is the file's one record of a real hazard: the exception makes
+# every control it suppresses report `status: passed` with `subStatus: "w/exceptions"`
+# on `workloadconfigurationscans`, so reading `status` alone returns a clean result
+# over a wholly unfixed population. For C-0211 that was 35 of 35 workloads.
+#
+# Nothing detected the omission. It is silent in both directions — nothing fails when
+# the control is added undocumented, and the wrong reading it enables looks like a
+# passing security result rather than an error. It was found by hand.
+#
+# 🔴 THE WHOLE HEADER IS NOT THE ANSWER — SCOPE TO THE WARNING BLOCK.
+#
+# When C-0211 was added it WAS mentioned elsewhere in the same header, in a section
+# describing which rules it carries. A guard that accepts a mention anywhere in the
+# file therefore passes on exactly the tree that motivated it, and would have to be
+# rewritten the first time it was trusted. The block is delimited explicitly, by
+# `fail-open-warning:BEGIN` / `:END` markers, rather than inferred from comment
+# shape — an inferred boundary silently widens as the file is edited, which is the
+# same failure one level up.
+#
+# 🔴 FAIL CLOSED. Anything this guard cannot read is exit 2, never a quiet pass. An
+# empty control list compared against an empty block is the failure mode that makes a
+# guard look green forever, so both are required to be non-empty before any
+# comparison happens.
+#
+# Exit codes:
+#   0  every suppressed control is named in the warning block
+#   1  at least one is not — each is named on stderr
+#   2  cannot check: bad usage, a missing/unreadable/unparseable file, markers that
+#      are absent, duplicated or out of order, or either list coming back empty
+
+set -euo pipefail
+
+readonly BEGIN_MARK='fail-open-warning:BEGIN'
+readonly END_MARK='fail-open-warning:END'
+readonly DEFAULT_FILE='k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml'
+
+me="$(basename "$0")"
+die() {
+  printf '%s: cannot check: %s\n' "${me}" "$*" >&2
+  exit 2
+}
+fail() { printf '%s: %s\n' "${me}" "$*" >&2; }
+
+[ "$#" -le 1 ] || die "usage: ${me} [<exception-file>]"
+file="${1:-${DEFAULT_FILE}}"
+
+[ -f "${file}" ] || die "no such file: ${file}"
+[ -r "${file}" ] || die "unreadable: ${file}"
+command -v yq >/dev/null 2>&1 || die "yq is not installed"
+
+# --- the controls this exception suppresses -------------------------------------
+# Read as YAML rather than by grep: `controlID` is a structural field, and a grep
+# would also match the identifier wherever it appears in prose, including inside the
+# very warning block this guard checks against — which would make the check circular.
+kind="$(yq -r '.kind // ""' "${file}")" || die "yq failed to parse ${file}"
+[ "${kind}" = "ClusterSecurityException" ] ||
+  die "${file}: kind is '${kind}', expected ClusterSecurityException"
+
+controls="$(yq -r '.spec.posture[].controlID' "${file}")" ||
+  die "yq failed to read .spec.posture[].controlID from ${file}"
+[ -n "${controls}" ] ||
+  die "${file}: no controls under .spec.posture — refusing to vouch for an empty comparison"
+
+# --- the warning block ----------------------------------------------------------
+begin_n="$(grep -cF -- "${BEGIN_MARK}" "${file}")" || begin_n=0
+end_n="$(grep -cF -- "${END_MARK}" "${file}")" || end_n=0
+[ "${begin_n}" -eq 1 ] || die "${file}: expected exactly 1 '${BEGIN_MARK}' marker, found ${begin_n}"
+[ "${end_n}" -eq 1 ] || die "${file}: expected exactly 1 '${END_MARK}' marker, found ${end_n}"
+
+begin_line="$(grep -nF -- "${BEGIN_MARK}" "${file}" | cut -d: -f1)"
+end_line="$(grep -nF -- "${END_MARK}" "${file}" | cut -d: -f1)"
+[ "${begin_line}" -lt "${end_line}" ] ||
+  die "${file}: '${BEGIN_MARK}' (line ${begin_line}) must precede '${END_MARK}' (line ${end_line})"
+
+# Strictly between the markers: the marker lines themselves are structure, not prose,
+# and naming a control on one of them must not count as documenting it.
+block="$(awk -v a="${begin_line}" -v b="${end_line}" 'NR>a && NR<b' "${file}")" ||
+  die "${file}: could not extract the warning block"
+[ -n "${block}" ] ||
+  die "${file}: the warning block is empty — refusing to vouch for an empty comparison"
+
+# --- compare --------------------------------------------------------------------
+missing=0
+while IFS= read -r control; do
+  [ -n "${control}" ] || continue
+  case "${control}" in
+    C-[0-9]*) ;;
+    *) die "${file}: '${control}' is not a control id of the form C-<digits>" ;;
+  esac
+  # -w so C-0021 never satisfies a requirement to document C-0021x, and a bare
+  # substring of a longer id never counts.
+  # Capture grep's OWN status. `if cmd; then ...; fi` reports 0 when the condition is
+  # false and no else branch runs, so reading $? after the fi asks the `if` how it
+  # went, not the matcher — the same "status of the wrong thing" this guard's sibling
+  # fix (#3504) exists to close.
+  rc=0
+  grep -qwF -- "${control}" <<<"${block}" || rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    continue
+  fi
+  [ "${rc}" -eq 1 ] || die "${file}: grep failed (exit ${rc}) while looking for ${control}"
+  fail "${control} is suppressed under .spec.posture but is not named in the fail-open warning block (lines ${begin_line}-${end_line})"
+  missing=$((missing + 1))
+done <<EOF
+${controls}
+EOF
+
+if [ "${missing}" -gt 0 ]; then
+  fail "${missing} suppressed control(s) undocumented in ${file}"
+  fail "Add each to the block between '${BEGIN_MARK}' and '${END_MARK}', stating how that control fails open."
+  exit 1
+fi
+
+printf '%s: ok — %s suppressed control(s), each named in the fail-open warning block of %s\n' \
+  "${me}" "$(awk 'END { print NR }' <<<"${controls}")" "${file}"

--- a/scripts/guard-pod-security-exception-documented.sh
+++ b/scripts/guard-pod-security-exception-documented.sh
@@ -90,10 +90,13 @@ block="$(awk -v a="${begin_line}" -v b="${end_line}" 'NR>a && NR<b' "${file}")" 
 missing=0
 while IFS= read -r control; do
   [ -n "${control}" ] || continue
-  case "${control}" in
-    C-[0-9]*) ;;
-    *) die "${file}: '${control}' is not a control id of the form C-<digits>" ;;
-  esac
+  # Anchored at BOTH ends. A `case` glob `C-[0-9]*` anchors only the head, so its
+  # trailing `*` admits any suffix — `C-0211x`, `C-0211-extra`, and `C-0211 ` all pass
+  # a check whose own message promises C-<digits>. The trailing-space shape is the
+  # one that fails OPEN: `grep -wF` then matches the id inside the block's prose and
+  # the guard exits 0 over a control it never really verified.
+  [[ "${control}" =~ ^C-[0-9]+$ ]] ||
+    die "${file}: '${control}' is not a control id of the form C-<digits>"
   # -w so C-0021 never satisfies a requirement to document C-0021x, and a bare
   # substring of a longer id never counts.
   # Capture grep's OWN status. `if cmd; then ...; fi` reports 0 when the condition is

--- a/scripts/tests/test-guard-pod-security-exception-documented.sh
+++ b/scripts/tests/test-guard-pod-security-exception-documented.sh
@@ -158,6 +158,27 @@ f="${tmp}/bad-id.yaml"
 yq '.spec.posture[0].controlID = "not-a-control"' "${REAL}" >"${f}"
 expect 'a malformed control id is exit 2' 2 "${f}"
 
+# --- the id form is checked WHOLE, not just at its start ------------------------
+# `C-[0-9]*` as a case glob anchors only the head: the trailing `*` accepts any
+# suffix, so it admits every id below while the die message claims to require
+# C-<digits>. One fixture per shape, so a pass cannot be carried by a sibling.
+f="${tmp}/id-trailing-alpha.yaml"
+yq '.spec.posture[0].controlID = "C-0211x"' "${REAL}" >"${f}"
+expect 'a control id with a trailing non-digit is exit 2' 2 "${f}"
+
+f="${tmp}/id-trailing-space.yaml"
+yq '.spec.posture[0].controlID = "C-0211 "' "${REAL}" >"${f}"
+expect 'a control id with a trailing space is exit 2' 2 "${f}"
+
+f="${tmp}/id-embedded-punct.yaml"
+yq '.spec.posture[0].controlID = "C-0211-extra"' "${REAL}" >"${f}"
+expect 'a control id with a trailing segment is exit 2' 2 "${f}"
+
+# The negative control: the fix must not start rejecting well-formed ids.
+f="${tmp}/id-well-formed.yaml"
+yq '.spec.posture[0].controlID = "C-0013"' "${REAL}" >"${f}"
+expect 'a well-formed control id is still accepted' 0 "${f}"
+
 if [ "${failures}" -gt 0 ]; then
   printf 'FAILED: %s case(s)\n' "${failures}" >&2
   exit 1

--- a/scripts/tests/test-guard-pod-security-exception-documented.sh
+++ b/scripts/tests/test-guard-pod-security-exception-documented.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Cover guard-pod-security-exception-documented.sh.
+#
+# The load-bearing case is "documented elsewhere in the file, but not in the warning
+# block" — the exact shape the tree had when C-0211 was added (#3516). A guard that
+# accepts a mention anywhere passes on that tree, so it is asserted directly rather
+# than left implied by the happy path.
+#
+# Every fail-closed claim is proven by ablation: each bad input is built from the
+# REAL file and mutated one way, so a case cannot pass because the fixture failed to
+# build.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+readonly GUARD='scripts/guard-pod-security-exception-documented.sh'
+readonly REAL='k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml'
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+failures=0
+ok() { printf 'ok: %s\n' "$1"; }
+bad() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+# Run the guard on a file, reporting its exit status without tripping `set -e`.
+run() {
+  local f="$1" rc=0
+  bash "${GUARD}" "${f}" >/dev/null 2>&1 || rc=$?
+  printf '%s\n' "${rc}"
+}
+expect() { # <label> <expected-rc> <file>
+  local label="$1" want="$2" f="$3" got
+  got="$(run "${f}")"
+  if [ "${got}" = "${want}" ]; then ok "${label} — exit ${got}"; else
+    bad "${label} — expected exit ${want}, got ${got}"
+  fi
+}
+
+[ -f "${REAL}" ] || {
+  printf 'FAIL: fixture source %s is missing; every case below would be vacuous\n' "${REAL}" >&2
+  exit 1
+}
+
+# --- the tree as it stands ------------------------------------------------------
+expect 'current tree passes' 0 "${REAL}"
+
+# --- AC1: a suppressed control absent from the block ----------------------------
+f="${tmp}/undocumented.yaml"
+sed 's/^      action: ignore$/      action: ignore/' "${REAL}" >"${f}"
+# Append a third control that is named nowhere in the file.
+printf '    - controlID: C-0999\n      action: ignore\n' >>"${f}"
+grep -q 'C-0999' "${f}" || bad 'fixture build: C-0999 was not added'
+expect 'a control absent from the block fails' 1 "${f}"
+# Capture, then match. Under `pipefail` a `guard | grep` pipeline reports the GUARD's
+# non-zero status even when grep matched, so the assertion would fail on a correct
+# guard — the same status-through-a-pipe trap the guard itself guards against.
+guard_out="$(bash "${GUARD}" "${f}" 2>&1 || true)"
+if grep -q 'C-0999' <<<"${guard_out}"; then
+  ok 'the failure names the undocumented control'
+else
+  bad 'the failure did not name C-0999'
+fi
+
+# --- THE HISTORICAL DEFECT: documented, but outside the block -------------------
+# Move every mention of C-0211 out of the warning block, leaving it mentioned later
+# in the same header. This reproduces the tree that motivated #3516.
+f="${tmp}/outside-block.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { inblock = 1 }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock && /C-0211/       { next }          # drop it from the block only
+  { print }
+' "${REAL}" >"${f}"
+grep -q 'C-0211' "${f}" || bad 'fixture build: C-0211 vanished from the whole file, not just the block'
+awk '/fail-open-warning:BEGIN/{i=1} /fail-open-warning:END/{i=0} i && /C-0211/{found=1} END{exit !found}' "${f}" &&
+  bad 'fixture build: C-0211 is still inside the block' || true
+expect 'named outside the block but not inside it fails' 1 "${f}"
+
+# --- the marker lines are structure, not documentation --------------------------
+f="${tmp}/on-marker.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { inblock = 1 }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock && /C-0211/       { next }
+  { print }
+' "${REAL}" |
+  sed 's/^# fail-open-warning:BEGIN.*$/# fail-open-warning:BEGIN — covers C-0211/' >"${f}"
+expect 'a control named only on the BEGIN marker line does not count' 1 "${f}"
+
+# --- word-boundary: a longer id must not satisfy a shorter one ------------------
+f="${tmp}/superstring.yaml"
+sed 's/C-0211/C-02110/g' "${REAL}" |
+  sed 's/^    - controlID: C-02110$/    - controlID: C-0211/' >"${f}"
+expect 'C-02110 in the block does not document C-0211' 1 "${f}"
+
+# --- fail-closed inputs ---------------------------------------------------------
+expect 'a missing file is exit 2' 2 "${tmp}/does-not-exist.yaml"
+
+f="${tmp}/unreadable.yaml"
+cp "${REAL}" "${f}"
+chmod 000 "${f}"
+if [ "$(id -u)" -eq 0 ]; then
+  ok 'unreadable-file case skipped (running as root, which can read anyway)'
+else
+  expect 'an unreadable file is exit 2' 2 "${f}"
+fi
+chmod 644 "${f}"
+
+f="${tmp}/no-posture.yaml"
+yq 'del(.spec.posture)' "${REAL}" >"${f}"
+expect 'no .spec.posture is exit 2' 2 "${f}"
+
+f="${tmp}/empty-posture.yaml"
+yq '.spec.posture = []' "${REAL}" >"${f}"
+expect 'an empty .spec.posture is exit 2' 2 "${f}"
+
+f="${tmp}/no-begin.yaml"
+grep -v 'fail-open-warning:BEGIN' "${REAL}" >"${f}"
+expect 'a missing BEGIN marker is exit 2' 2 "${f}"
+
+f="${tmp}/no-end.yaml"
+grep -v 'fail-open-warning:END' "${REAL}" >"${f}"
+expect 'a missing END marker is exit 2' 2 "${f}"
+
+f="${tmp}/dup-begin.yaml"
+sed 's|^# fail-open-warning:END$|# fail-open-warning:BEGIN dup\n# fail-open-warning:END|' "${REAL}" >"${f}"
+expect 'a duplicated BEGIN marker is exit 2' 2 "${f}"
+
+f="${tmp}/swapped.yaml"
+sed -e 's|^# fail-open-warning:BEGIN.*$|# fail-open-warning:TMPEND|' \
+  -e 's|^# fail-open-warning:END$|# fail-open-warning:BEGIN swapped|' "${REAL}" |
+  sed 's|^# fail-open-warning:TMPEND$|# fail-open-warning:END|' >"${f}"
+expect 'markers out of order is exit 2' 2 "${f}"
+
+f="${tmp}/empty-block.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { print; inblock = 1; next }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock                   { next }
+  { print }
+' "${REAL}" >"${f}"
+expect 'an empty warning block is exit 2' 2 "${f}"
+
+f="${tmp}/wrong-kind.yaml"
+yq '.kind = "ConfigMap"' "${REAL}" >"${f}"
+expect 'a non-ClusterSecurityException is exit 2' 2 "${f}"
+
+f="${tmp}/not-yaml.yaml"
+printf 'this: is: not: valid: yaml: [\n' >"${f}"
+expect 'an unparseable file is exit 2' 2 "${f}"
+
+f="${tmp}/bad-id.yaml"
+yq '.spec.posture[0].controlID = "not-a-control"' "${REAL}" >"${f}"
+expect 'a malformed control id is exit 2' 2 "${f}"
+
+if [ "${failures}" -gt 0 ]; then
+  printf 'FAILED: %s case(s)\n' "${failures}" >&2
+  exit 1
+fi
+printf 'PASS: the documented-control guard holds, and fails closed on every unreadable input\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A security exception silently makes every control it suppresses *look* fixed. Everything it covers reports a passing result, so anyone checking the obvious signal sees a clean cluster over a population where nothing has actually been fixed.

This file carried a prominent warning about exactly that hazard — but the warning had been written for one control, and a second was added later without it. Reading the obvious signal for that second control returned "nothing failing" across every workload it covers, which is precisely the number another issue names as its success criterion. Nothing detected the gap; it was found by hand.

### What

Two halves of one concern — the warning is made correct, and then kept correct:

1. **Corrects the documentation** so it covers every control the exception suppresses rather than just the first, with both controls re-measured against live production, and corrects the affected population size.
2. **Adds a CI guard** that fails when a suppressed control is not documented as failing open, naming the control. It needs no cluster access, so it runs in ordinary CI.

The guard checks the marked warning block specifically, not the whole file — the control that motivated this *was* mentioned elsewhere in the same file, so a looser check would pass on the exact tree that produced the problem. That case is asserted directly in the tests rather than left implied. Every "fails closed" claim is proven by ablation.

Fixes #3516
Part of #3239
