### PR TITLE
feat(security): fail CI when a suppressed control is undocumented as failing open

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,10 @@ jobs:
               # Both halves, for the same reason as the guards above.
               - 'scripts/guard-pod-security-exception-scope.sh'
               - 'scripts/tests/test-guard-pod-security-exception-scope.sh'
+              # Both halves, for the same reason as the guards above. The guard also
+              # reads the exception manifest itself, covered by 'k8s/**'.
+              - 'scripts/guard-pod-security-exception-documented.sh'
+              - 'scripts/tests/test-guard-pod-security-exception-documented.sh'
               # Both halves, for the same reason as the guards above.
               - 'scripts/guard-crossplane-provider-name-parity.sh'
               - 'scripts/tests/test-guard-crossplane-provider-name-parity.sh'
@@ -1043,6 +1047,19 @@ jobs:
         run: |
           bash scripts/guard-pod-security-exception-scope.sh
           bash scripts/tests/test-guard-pod-security-exception-scope.sh
+
+      - name: 🔎 Validate every suppressed control is documented as failing open
+        if: needs.changes.outputs.k8s == 'true'
+        # A control added under spec.posture that the file's fail-open warning does
+        # not name. The exception makes each suppressed control report `passed` with
+        # subStatus "w/exceptions", so reading status alone yields a clean result over
+        # an unfixed population — 35 of 35 workloads when C-0211 was added (#3516).
+        # The check is scoped to the marked warning block, not the whole header: when
+        # C-0211 was added it WAS mentioned elsewhere in that header, so a file-wide
+        # match passes on the very tree that motivated the guard.
+        run: |
+          bash scripts/guard-pod-security-exception-documented.sh
+          bash scripts/tests/test-guard-pod-security-exception-documented.sh
 
       - name: 🧬 Validate Crossplane provider names match their derived names
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -22,6 +22,7 @@
 # setting a uid on a controller that is on its way out. #3223 tracks the narrowing
 # itself and is blocked on #3480.
 #
+# fail-open-warning:BEGIN — every spec.posture controlID must be named below.
 # 🔴 DO NOT RE-VERIFY ANY CONTROL IN THIS FILE ON workloadconfigurationscans ALONE —
 # THAT SURFACE FAILS OPEN FOR EVERY CONTROL THIS EXCEPTION SUPPRESSES. The hazard is a
 # property of the exception rather than of one control, so anything added under
@@ -47,6 +48,7 @@
 # either: it is a static hint from the rule definition and is populated identically on
 # workloads that genuinely pass. Verify against the live stored workload spec, which is
 # independent of both the scanner and this exception.
+# fail-open-warning:END
 #
 # C-0211 — CIS-5.7.3, and it is a twelve-rule control rather than the three-field
 # check its name suggests. The rules this exception suppresses include

--- a/scripts/guard-pod-security-exception-documented.sh
+++ b/scripts/guard-pod-security-exception-documented.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Fail when a control suppressed by a ClusterSecurityException is not named in that
+# file's fail-open warning block.
+#
+# #3516 exists because C-0211 was added to `pod-security-mutations-unscoped.yaml`
+# under `spec.posture` while the warning block above it still spoke only about
+# C-0013. That warning is the file's one record of a real hazard: the exception makes
+# every control it suppresses report `status: passed` with `subStatus: "w/exceptions"`
+# on `workloadconfigurationscans`, so reading `status` alone returns a clean result
+# over a wholly unfixed population. For C-0211 that was 35 of 35 workloads.
+#
+# Nothing detected the omission. It is silent in both directions — nothing fails when
+# the control is added undocumented, and the wrong reading it enables looks like a
+# passing security result rather than an error. It was found by hand.
+#
+# 🔴 THE WHOLE HEADER IS NOT THE ANSWER — SCOPE TO THE WARNING BLOCK.
+#
+# When C-0211 was added it WAS mentioned elsewhere in the same header, in a section
+# describing which rules it carries. A guard that accepts a mention anywhere in the
+# file therefore passes on exactly the tree that motivated it, and would have to be
+# rewritten the first time it was trusted. The block is delimited explicitly, by
+# `fail-open-warning:BEGIN` / `:END` markers, rather than inferred from comment
+# shape — an inferred boundary silently widens as the file is edited, which is the
+# same failure one level up.
+#
+# 🔴 FAIL CLOSED. Anything this guard cannot read is exit 2, never a quiet pass. An
+# empty control list compared against an empty block is the failure mode that makes a
+# guard look green forever, so both are required to be non-empty before any
+# comparison happens.
+#
+# Exit codes:
+#   0  every suppressed control is named in the warning block
+#   1  at least one is not — each is named on stderr
+#   2  cannot check: bad usage, a missing/unreadable/unparseable file, markers that
+#      are absent, duplicated or out of order, or either list coming back empty
+
+set -euo pipefail
+
+readonly BEGIN_MARK='fail-open-warning:BEGIN'
+readonly END_MARK='fail-open-warning:END'
+readonly DEFAULT_FILE='k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml'
+
+me="$(basename "$0")"
+die() {
+  printf '%s: cannot check: %s\n' "${me}" "$*" >&2
+  exit 2
+}
+fail() { printf '%s: %s\n' "${me}" "$*" >&2; }
+
+[ "$#" -le 1 ] || die "usage: ${me} [<exception-file>]"
+file="${1:-${DEFAULT_FILE}}"
+
+[ -f "${file}" ] || die "no such file: ${file}"
+[ -r "${file}" ] || die "unreadable: ${file}"
+command -v yq >/dev/null 2>&1 || die "yq is not installed"
+
+# --- the controls this exception suppresses -------------------------------------
+# Read as YAML rather than by grep: `controlID` is a structural field, and a grep
+# would also match the identifier wherever it appears in prose, including inside the
+# very warning block this guard checks against — which would make the check circular.
+kind="$(yq -r '.kind // ""' "${file}")" || die "yq failed to parse ${file}"
+[ "${kind}" = "ClusterSecurityException" ] ||
+  die "${file}: kind is '${kind}', expected ClusterSecurityException"
+
+controls="$(yq -r '.spec.posture[].controlID' "${file}")" ||
+  die "yq failed to read .spec.posture[].controlID from ${file}"
+[ -n "${controls}" ] ||
+  die "${file}: no controls under .spec.posture — refusing to vouch for an empty comparison"
+
+# --- the warning block ----------------------------------------------------------
+begin_n="$(grep -cF -- "${BEGIN_MARK}" "${file}")" || begin_n=0
+end_n="$(grep -cF -- "${END_MARK}" "${file}")" || end_n=0
+[ "${begin_n}" -eq 1 ] || die "${file}: expected exactly 1 '${BEGIN_MARK}' marker, found ${begin_n}"
+[ "${end_n}" -eq 1 ] || die "${file}: expected exactly 1 '${END_MARK}' marker, found ${end_n}"
+
+begin_line="$(grep -nF -- "${BEGIN_MARK}" "${file}" | cut -d: -f1)"
+end_line="$(grep -nF -- "${END_MARK}" "${file}" | cut -d: -f1)"
+[ "${begin_line}" -lt "${end_line}" ] ||
+  die "${file}: '${BEGIN_MARK}' (line ${begin_line}) must precede '${END_MARK}' (line ${end_line})"
+
+# Strictly between the markers: the marker lines themselves are structure, not prose,
+# and naming a control on one of them must not count as documenting it.
+block="$(awk -v a="${begin_line}" -v b="${end_line}" 'NR>a && NR<b' "${file}")" ||
+  die "${file}: could not extract the warning block"
+[ -n "${block}" ] ||
+  die "${file}: the warning block is empty — refusing to vouch for an empty comparison"
+
+# --- compare --------------------------------------------------------------------
+missing=0
+while IFS= read -r control; do
+  [ -n "${control}" ] || continue
+  case "${control}" in
+    C-[0-9]*) ;;
+    *) die "${file}: '${control}' is not a control id of the form C-<digits>" ;;
+  esac
+  # -w so C-0021 never satisfies a requirement to document C-0021x, and a bare
+  # substring of a longer id never counts.
+  # Capture grep's OWN status. `if cmd; then ...; fi` reports 0 when the condition is
+  # false and no else branch runs, so reading $? after the fi asks the `if` how it
+  # went, not the matcher — the same "status of the wrong thing" this guard's sibling
+  # fix (#3504) exists to close.
+  rc=0
+  grep -qwF -- "${control}" <<<"${block}" || rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    continue
+  fi
+  [ "${rc}" -eq 1 ] || die "${file}: grep failed (exit ${rc}) while looking for ${control}"
+  fail "${control} is suppressed under .spec.posture but is not named in the fail-open warning block (lines ${begin_line}-${end_line})"
+  missing=$((missing + 1))
+done <<EOF
+${controls}
+EOF
+
+if [ "${missing}" -gt 0 ]; then
+  fail "${missing} suppressed control(s) undocumented in ${file}"
+  fail "Add each to the block between '${BEGIN_MARK}' and '${END_MARK}', stating how that control fails open."
+  exit 1
+fi
+
+printf '%s: ok — %s suppressed control(s), each named in the fail-open warning block of %s\n' \
+  "${me}" "$(awk 'END { print NR }' <<<"${controls}")" "${file}"

--- a/scripts/tests/test-guard-pod-security-exception-documented.sh
+++ b/scripts/tests/test-guard-pod-security-exception-documented.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Cover guard-pod-security-exception-documented.sh.
+#
+# The load-bearing case is "documented elsewhere in the file, but not in the warning
+# block" — the exact shape the tree had when C-0211 was added (#3516). A guard that
+# accepts a mention anywhere passes on that tree, so it is asserted directly rather
+# than left implied by the happy path.
+#
+# Every fail-closed claim is proven by ablation: each bad input is built from the
+# REAL file and mutated one way, so a case cannot pass because the fixture failed to
+# build.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+readonly GUARD='scripts/guard-pod-security-exception-documented.sh'
+readonly REAL='k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml'
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+failures=0
+ok() { printf 'ok: %s\n' "$1"; }
+bad() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+# Run the guard on a file, reporting its exit status without tripping `set -e`.
+run() {
+  local f="$1" rc=0
+  bash "${GUARD}" "${f}" >/dev/null 2>&1 || rc=$?
+  printf '%s\n' "${rc}"
+}
+expect() { # <label> <expected-rc> <file>
+  local label="$1" want="$2" f="$3" got
+  got="$(run "${f}")"
+  if [ "${got}" = "${want}" ]; then ok "${label} — exit ${got}"; else
+    bad "${label} — expected exit ${want}, got ${got}"
+  fi
+}
+
+[ -f "${REAL}" ] || {
+  printf 'FAIL: fixture source %s is missing; every case below would be vacuous\n' "${REAL}" >&2
+  exit 1
+}
+
+# --- the tree as it stands ------------------------------------------------------
+expect 'current tree passes' 0 "${REAL}"
+
+# --- AC1: a suppressed control absent from the block ----------------------------
+f="${tmp}/undocumented.yaml"
+sed 's/^      action: ignore$/      action: ignore/' "${REAL}" >"${f}"
+# Append a third control that is named nowhere in the file.
+printf '    - controlID: C-0999\n      action: ignore\n' >>"${f}"
+grep -q 'C-0999' "${f}" || bad 'fixture build: C-0999 was not added'
+expect 'a control absent from the block fails' 1 "${f}"
+# Capture, then match. Under `pipefail` a `guard | grep` pipeline reports the GUARD's
+# non-zero status even when grep matched, so the assertion would fail on a correct
+# guard — the same status-through-a-pipe trap the guard itself guards against.
+guard_out="$(bash "${GUARD}" "${f}" 2>&1 || true)"
+if grep -q 'C-0999' <<<"${guard_out}"; then
+  ok 'the failure names the undocumented control'
+else
+  bad 'the failure did not name C-0999'
+fi
+
+# --- THE HISTORICAL DEFECT: documented, but outside the block -------------------
+# Move every mention of C-0211 out of the warning block, leaving it mentioned later
+# in the same header. This reproduces the tree that motivated #3516.
+f="${tmp}/outside-block.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { inblock = 1 }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock && /C-0211/       { next }          # drop it from the block only
+  { print }
+' "${REAL}" >"${f}"
+grep -q 'C-0211' "${f}" || bad 'fixture build: C-0211 vanished from the whole file, not just the block'
+awk '/fail-open-warning:BEGIN/{i=1} /fail-open-warning:END/{i=0} i && /C-0211/{found=1} END{exit !found}' "${f}" &&
+  bad 'fixture build: C-0211 is still inside the block' || true
+expect 'named outside the block but not inside it fails' 1 "${f}"
+
+# --- the marker lines are structure, not documentation --------------------------
+f="${tmp}/on-marker.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { inblock = 1 }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock && /C-0211/       { next }
+  { print }
+' "${REAL}" |
+  sed 's/^# fail-open-warning:BEGIN.*$/# fail-open-warning:BEGIN — covers C-0211/' >"${f}"
+expect 'a control named only on the BEGIN marker line does not count' 1 "${f}"
+
+# --- word-boundary: a longer id must not satisfy a shorter one ------------------
+f="${tmp}/superstring.yaml"
+sed 's/C-0211/C-02110/g' "${REAL}" |
+  sed 's/^    - controlID: C-02110$/    - controlID: C-0211/' >"${f}"
+expect 'C-02110 in the block does not document C-0211' 1 "${f}"
+
+# --- fail-closed inputs ---------------------------------------------------------
+expect 'a missing file is exit 2' 2 "${tmp}/does-not-exist.yaml"
+
+f="${tmp}/unreadable.yaml"
+cp "${REAL}" "${f}"
+chmod 000 "${f}"
+if [ "$(id -u)" -eq 0 ]; then
+  ok 'unreadable-file case skipped (running as root, which can read anyway)'
+else
+  expect 'an unreadable file is exit 2' 2 "${f}"
+fi
+chmod 644 "${f}"
+
+f="${tmp}/no-posture.yaml"
+yq 'del(.spec.posture)' "${REAL}" >"${f}"
+expect 'no .spec.posture is exit 2' 2 "${f}"
+
+f="${tmp}/empty-posture.yaml"
+yq '.spec.posture = []' "${REAL}" >"${f}"
+expect 'an empty .spec.posture is exit 2' 2 "${f}"
+
+f="${tmp}/no-begin.yaml"
+grep -v 'fail-open-warning:BEGIN' "${REAL}" >"${f}"
+expect 'a missing BEGIN marker is exit 2' 2 "${f}"
+
+f="${tmp}/no-end.yaml"
+grep -v 'fail-open-warning:END' "${REAL}" >"${f}"
+expect 'a missing END marker is exit 2' 2 "${f}"
+
+f="${tmp}/dup-begin.yaml"
+sed 's|^# fail-open-warning:END$|# fail-open-warning:BEGIN dup\n# fail-open-warning:END|' "${REAL}" >"${f}"
+expect 'a duplicated BEGIN marker is exit 2' 2 "${f}"
+
+f="${tmp}/swapped.yaml"
+sed -e 's|^# fail-open-warning:BEGIN.*$|# fail-open-warning:TMPEND|' \
+  -e 's|^# fail-open-warning:END$|# fail-open-warning:BEGIN swapped|' "${REAL}" |
+  sed 's|^# fail-open-warning:TMPEND$|# fail-open-warning:END|' >"${f}"
+expect 'markers out of order is exit 2' 2 "${f}"
+
+f="${tmp}/empty-block.yaml"
+awk '
+  /fail-open-warning:BEGIN/ { print; inblock = 1; next }
+  /fail-open-warning:END/   { inblock = 0 }
+  inblock                   { next }
+  { print }
+' "${REAL}" >"${f}"
+expect 'an empty warning block is exit 2' 2 "${f}"
+
+f="${tmp}/wrong-kind.yaml"
+yq '.kind = "ConfigMap"' "${REAL}" >"${f}"
+expect 'a non-ClusterSecurityException is exit 2' 2 "${f}"
+
+f="${tmp}/not-yaml.yaml"
+printf 'this: is: not: valid: yaml: [\n' >"${f}"
+expect 'an unparseable file is exit 2' 2 "${f}"
+
+f="${tmp}/bad-id.yaml"
+yq '.spec.posture[0].controlID = "not-a-control"' "${REAL}" >"${f}"
+expect 'a malformed control id is exit 2' 2 "${f}"
+
+if [ "${failures}" -gt 0 ]; then
+  printf 'FAILED: %s case(s)\n' "${failures}" >&2
+  exit 1
+fi
+printf 'PASS: the documented-control guard holds, and fails closed on every unreadable input\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A security exception silently makes the controls it suppresses *look* fixed. Everything it covers reports a passing result, so anyone checking the obvious signal sees a clean cluster over a population where nothing has been fixed.

The file carries a prominent warning about exactly that — but nothing kept the warning in step with the list of controls. One control was added suppressed and undocumented, and the passing reading it enabled was the very number another issue names as its success criterion. Nobody noticed; it was found by hand.

### What

Adds a CI guard that fails when a control this exception suppresses is not documented as failing open, naming the control and how to fix it. It needs no cluster access, so it runs in ordinary CI.

The guard checks the marked warning block specifically, not the whole file — the control that motivated this *was* mentioned elsewhere in the same file, so a looser check would pass on the exact tree that produced the problem.

⚠️ **Merge order: land #3517 first.** This is stacked on it and targets its branch. #3517 corrects the warning text; without it this guard correctly fails. Retarget to `main` once #3517 merges.

Fixes #3516
Part of #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
