### PR TITLE
feat(security): opt observability into the baseline-context mutation

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
@@ -8,3 +8,26 @@ metadata:
     # privileged PSS, exactly like the prometheus node-exporter it replaces.
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    # observability is excluded from add-pod-security-context /
+    # add-container-security-context because its workloads need elevated privilege
+    # by design. fsGroupChangePolicy and seLinuxOptions are not privilege fields —
+    # the first governs volume ownership relabelling, the second is a documented
+    # no-op on this AppArmor cluster kept for CIS-5.7.3 — so the blanket exclusion
+    # suppressed two C-0211 controls it never needed to. This label opts the
+    # namespace into add-baseline-context-optin-*, which supplies only those two
+    # through conditional anchors and touches no user, group or privilege field.
+    #
+    # Third namespace opted in, after velero and kubescape. Measured against live
+    # prod 2026-09-02: 31 running pods, ALL 31 missing pod-level
+    # fsGroupChangePolicy, and all 44 containers/initContainers carrying no
+    # seLinuxOptions at all. That last shape matters — with no pod-level SELinux
+    # object anywhere, only the two straightforward rules apply
+    # (add-baseline-context-optin-namespaces supplies fsGroupChangePolicy,
+    # add-baseline-context-optin-containers supplies level: s0 per container).
+    # add-baseline-context-optin-pod-selinux-level requires a pre-existing
+    # pod-level object, so it cannot fire here; none of the wholesale-replace
+    # hazards that rule exists for are reachable in this namespace.
+    #
+    # The rules are CREATE-only, so running pods are unaffected until they are
+    # next recreated.
+    pod-security.devantler.tech/baseline-context: enabled

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -130,6 +130,25 @@ check podlevel-partial-mutated.yaml '.spec.initContainers[0].securityContext.seL
   null "initContainer-level injection replaced the partial pod-level SELinux object"
 check podlevel-partial-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "pod-level rule did not fire on the podlevel-partial fixture"
+
+# The shape the observability namespace actually presents, measured against live
+# prod 2026-09-02 before it was opted in: no pod-level securityContext SELinux
+# object anywhere, and no container carrying seLinuxOptions of its own. That is
+# the plain shape, so both straightforward rules must fire and the pod-scope fill
+# must NOT — it requires a pre-existing pod-level object, and creating one here
+# would move ownership between rules and change what the `plain` case proves.
+#
+# Asserted on its own fixture rather than inherited from velero/plain because the
+# rollout guardrail is explicit that each namespace is proven, not assumed.
+check coroot-node-agent-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "observability pod did not receive fsGroupChangePolicy"
+check coroot-node-agent-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "observability container did not receive seLinuxOptions"
+check coroot-node-agent-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s0 "observability initContainer did not receive seLinuxOptions"
+check coroot-node-agent-mutated.yaml '.spec.securityContext.seLinuxOptions' \
+  null "pod-scope SELinux fill created an object where the author set none"
+
 # ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
 # in the cluster is decided entirely by which namespaces carry the opt-in label —
 # a fact no mutation fixture can see. Without this gate, widening the rollout from
@@ -139,7 +158,7 @@ check podlevel-partial-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' 
 #
 # Each namespace is opted in only after its live workloads are measured to still
 # start; see the rationale recorded on the namespace manifest itself.
-expected_optin="kubescape,velero"
+expected_optin="kubescape,observability,velero"
 
 # grep only prefilters candidate files; yq decides, so a mention in a comment or
 # in the policy that DEFINES the label cannot be counted as an opted-in namespace.

--- a/tests/add-baseline-context/kyverno-test.yaml
+++ b/tests/add-baseline-context/kyverno-test.yaml
@@ -23,6 +23,7 @@ results:
       - velero/partial
       - velero/podlevel
       - velero/podlevel-partial
+      - observability/coroot-node-agent
     kind: Pod
     result: pass
     patchedResources: patched-resources.yaml
@@ -32,6 +33,7 @@ results:
       - velero/plain
       - velero/no-init
       - velero/partial
+      - observability/coroot-node-agent
     kind: Pod
     result: pass
     patchedResources: patched-resources.yaml
@@ -77,5 +79,8 @@ results:
       - velero/partial
       - velero/preset
       - velero/podlevel
+      # The observability fixture sets no pod-level SELinux object, so this rule
+      # must not fire there either — that shape belongs to the container rule.
+      - observability/coroot-node-agent
     kind: Pod
     result: skip

--- a/tests/add-baseline-context/patched-resources.yaml
+++ b/tests/add-baseline-context/patched-resources.yaml
@@ -93,3 +93,29 @@ spec:
     seLinuxOptions:
       level: s0
       user: system_u
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: coroot-node-agent
+  namespace: observability
+spec:
+  hostPID: true
+  volumes:
+    - name: host-sys
+      hostPath:
+        path: /sys
+  initContainers:
+    - name: init
+      image: ghcr.io/coroot/coroot-node-agent:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          level: s0
+  containers:
+    - name: node-agent
+      image: ghcr.io/coroot/coroot-node-agent:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          level: s0
+  securityContext:
+    fsGroupChangePolicy: OnRootMismatch

--- a/tests/add-baseline-context/resources.yaml
+++ b/tests/add-baseline-context/resources.yaml
@@ -134,3 +134,37 @@ spec:
   containers:
     - name: app
       image: velero/velero:v1.0.0
+---
+# The shape the observability namespace actually presents, measured against live
+# prod on 2026-09-02 before opting it in: 31 running pods, ALL 31 with no
+# pod-level securityContext.fsGroupChangePolicy, and all 44 containers and
+# initContainers carrying no seLinuxOptions at all — no pod-level SELinux object
+# anywhere in the namespace.
+#
+# That is the plain shape, so the two straightforward rules do all the work and
+# add-baseline-context-optin-pod-selinux-level cannot fire (it requires a
+# pre-existing pod-level object). Pinned as its own case rather than leaning on
+# velero/plain because the issue's guardrail is explicit that a rollout proves
+# each namespace rather than assuming the previous one generalises — and because
+# this fixture records WHICH shape was onboarded, so a future namespace
+# presenting a different one is not silently assumed covered.
+#
+# hostPID and the hostPath volume are coroot's node-agent (eBPF collection); no
+# rule reads them, they are here so the fixture is recognisably the real workload.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: coroot-node-agent
+  namespace: observability
+spec:
+  hostPID: true
+  volumes:
+    - name: host-sys
+      hostPath:
+        path: /sys
+  initContainers:
+    - name: init
+      image: ghcr.io/coroot/coroot-node-agent:v1.0.0
+  containers:
+    - name: node-agent
+      image: ghcr.io/coroot/coroot-node-agent:v1.0.0

--- a/tests/add-baseline-context/values.yaml
+++ b/tests/add-baseline-context/values.yaml
@@ -13,3 +13,9 @@ namespaceSelector:
       pod-security.devantler.tech/baseline-context: enabled
   - name: chaos-mesh
     labels: {}
+  # observability, opted in alongside velero. Declared here so the ON-state
+  # assertions for the coroot-node-agent fixture are evaluated rather than
+  # reported "Excluded" — an omission here would make that case pass vacuously.
+  - name: observability
+    labels:
+      pod-security.devantler.tech/baseline-context: enabled


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Twelve namespaces are excluded from the cluster's security-context mutation because their workloads genuinely need elevated privilege. That exclusion also withheld two settings that have nothing to do with privilege — one governs how volume ownership is relabelled, the other is a compliance field that does nothing at all on this cluster — so those namespaces were losing two security checks they never needed to lose.

The fix for that already shipped, switched off, and is being turned on one namespace at a time so each is proven rather than assumed. `velero` and `kubescape` went first. This turns it on for `observability`, where all 31 running pods were measured today as missing both settings.

### Changes

- Opts `observability` into the mutation, with the measured before-state recorded on the namespace itself.
- Pins the shape that namespace actually presents as its own test case, and asserts it positively in the existing shell gate — the gate is what carries the proof here, because the policy fixture alone can pass without the rules ever firing.
- Updates the rollout inventory the gate pins, so the namespace could not be added without review.

No privilege, user or group setting is touched, and nothing changes for pods already running — they pick it up when next recreated.

Part of #3239

### One thing to know before merging

This widens the reach of a latent gap already tracked in #3477: the SELinux value the mutation writes is a plain one, which on a future SELinux-enforcing node would replace the per-container isolation label the runtime assigns rather than add to it. It is inert on every node we run today (they use AppArmor, and no pod in this namespace declares the setting at all — measured today), and #3477 deliberately judged fixing it out of scope for the rollout, because doing so there would block a check that is currently unmet. A third namespace does not change the nature of that risk, but it does widen it, so it belongs in front of you rather than in a comment thread.
