### PR TITLE
fix(security): accept concrete approved revisions in the publish-pin guard

### DIFF
--- a/scripts/guard-shared-publish-workflow-pin.sh
+++ b/scripts/guard-shared-publish-workflow-pin.sh
@@ -38,18 +38,18 @@
 # says nothing about first-party platform workflows.
 #
 # WHAT IT DOES NOT CLAIM
-# Pinning a fixed revision is not the same as pinning an APPROVED one: a superseded
-# actions SHA still matches `[0-9a-f]{40}`. Restricting to approved revisions needs a
-# generated allow-list and is tracked separately on #2818. This guard keeps the
-# property #2816 established from silently regressing.
+# Pinning a fixed revision is not the same as pinning an APPROVED one. This guard
+# accepts either recognisable form — the pattern text `[0-9a-f]{40}`, which admits any
+# 40-hex commit, or a concrete 40-hex commit naming exactly one — so it proves the ref
+# SHAPE pins a revision. It does not decide WHICH revisions are approved, and it keeps
+# the property #2816 established from silently regressing.
 #
-# Note for whoever implements that allow-list: the check below matches the literal
-# PATTERN text `[0-9a-f]{40}`, because these subjects are regexes. A subject naming one
-# concrete commit — which is what a generated approved-revision list would emit — is
-# therefore REJECTED here today, despite being strictly narrower than what is accepted.
-# That is a limit of this check, not a judgement about the shape; extend the allow-list
-# deliberately when the generator lands, rather than reading the failure as a defect in
-# the generated output.
+# Which revisions must stay trusted is computed per consumer by
+# scripts/report-publish-workflow-signing-revisions.sh (#3048): it names both the
+# revision that signed the artifact currently deployed and the revision that consumer
+# pins today, and those routinely differ. A consumer narrowed to a set omitting its
+# signing revision would stop verifying an artifact that is running right now, so any
+# narrowing is derived from that report rather than from this guard or by hand (#3308).
 
 set -euo pipefail
 
@@ -367,7 +367,30 @@ EOF
       # prefix hazard of its own, but the whole-line anchor is what guarantees that —
       # `[0-9a-f]{40}` must be the entire alternative, so nothing can be appended to
       # it.
+      # TWO recognisable forms, both of which pin (#3308).
+      #
+      # 1. The literal PATTERN text `[0-9a-f]{40}`. These subjects are cosign identity
+      #    regexes, so this fragment accepts any 40-hex commit: a FIXED revision, but
+      #    not an APPROVED one.
+      # 2. A CONCRETE 40-hex commit, which is what a generated approved-revision
+      #    allow-list emits. It is strictly NARROWER than form 1 — it names one
+      #    revision rather than the whole 40-hex space.
+      #
+      # Form 2 was rejected until #3308, and the header of this file documented that as
+      # a known limit rather than a defect: "a subject naming one concrete commit is
+      # therefore REJECTED here today, despite being strictly narrower than what is
+      # accepted". This is the deliberate widening that note asked for.
+      #
+      # It is a WIDENING OF THE ALLOW-LIST, not a loosening of the property. Both forms
+      # keep the whole-line anchor (`-x`), so nothing may be appended to either: a short
+      # SHA, a tag, a branch, a bare ref and a partial group are all still rejected, and
+      # each keeps its own RED case in the test. Uppercase hex is deliberately NOT
+      # accepted — git emits lowercase, so an uppercase subject is an unreviewed shape
+      # rather than a spelling variant.
       if printf '%s' "$alternative" | grep -qxE '\[0-9a-f\]\{40\}'; then
+        continue
+      fi
+      if printf '%s' "$alternative" | grep -qxE '[0-9a-f]{40}'; then
         continue
       fi
       printf '%s: ref alternative %s does not pin a fixed revision (subject: %s)\n' \

--- a/scripts/guard-shared-publish-workflow-pin.sh
+++ b/scripts/guard-shared-publish-workflow-pin.sh
@@ -376,10 +376,9 @@ EOF
       #    allow-list emits. It is strictly NARROWER than form 1 — it names one
       #    revision rather than the whole 40-hex space.
       #
-      # Form 2 was rejected until #3308, and the header of this file documented that as
-      # a known limit rather than a defect: "a subject naming one concrete commit is
-      # therefore REJECTED here today, despite being strictly narrower than what is
-      # accepted". This is the deliberate widening that note asked for.
+      # Only form 1 is a regex fragment; form 2 is a literal identity. Both are judged
+      # by the same allow-list below, so adding a third recognisable shape is likewise a
+      # deliberate edit here rather than a silent widening (#3308).
       #
       # It is a WIDENING OF THE ALLOW-LIST, not a loosening of the property. Both forms
       # keep the whole-line anchor (`-x`), so nothing may be appended to either: a short

--- a/scripts/tests/test-shared-publish-workflow-pin-guard.sh
+++ b/scripts/tests/test-shared-publish-workflow-pin-guard.sh
@@ -22,11 +22,25 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly root_dir
 readonly guard="${root_dir}/scripts/guard-shared-publish-workflow-pin.sh"
 
-# These subjects are cosign identity REGEXES, so the accepted ref is the pattern
-# `[0-9a-f]{40}` as literal text — not a concrete commit. A hand-written literal
-# SHA is a different thing (an approved-revision allow-list, #2818's option 2) and
-# the guard does not recognise it today.
+# These subjects are cosign identity REGEXES, so TWO ref forms pin a revision and the
+# guard accepts both (#3308): the pattern text `[0-9a-f]{40}`, which admits any 40-hex
+# commit, and a CONCRETE 40-hex commit naming exactly one. The second is what a
+# generated approved-revision allow-list emits, and it is strictly narrower.
+#
+# The two forms are DISJOINT — neither string can match the other's check — so the
+# cases below can attribute an acceptance to one form or the other rather than to
+# "something matched".
 readonly SHA_PATTERN='[0-9a-f]{40}'
+
+# A real 40-hex commit: the revision that signed the deployed github-config artifact,
+# as reported by report-publish-workflow-signing-revisions.sh. Using a revision the
+# report actually names keeps this test anchored to the shape the generator emits
+# rather than to an invented string.
+readonly CONCRETE_SHA='b3783a5148b844b3f1f4011cdc84871ad66348c1'
+# A second, different real revision — the one every consumer pins today. A diverged
+# consumer's generated set is the alternation of these two, which is the shape that
+# must be accepted for a currently deployed artifact to keep verifying.
+readonly CONCRETE_SHA_2='3ee6cb9bbd616c2a38779be41a5e41f3e77282d0'
 
 pass_count=0
 
@@ -82,6 +96,34 @@ else
   fail "eight SHA-only subjects should pass, guard rejected them"
 fi
 
+# --- GREEN: the generated approved-revision shapes are accepted (#3308) ------
+#
+# A concrete commit is what an approved-revision allow-list emits, and it is strictly
+# NARROWER than the pattern form: one revision instead of the whole 40-hex space. It
+# was rejected before #3308, so correct generated output read as a guard failure.
+# These cases are what stop that widening being reverted silently.
+
+tree="${work_dir}/green-concrete"
+build_tree "${tree}" "${CONCRETE_SHA}"
+if run_tree "${tree}"; then
+  ok "a concrete 40-hex commit passes"
+else
+  printf '%s\n' "$(cat "${tree}/stderr")" >&2
+  fail "a concrete 40-hex commit should pass, guard rejected it"
+fi
+
+# The shape a DIVERGED consumer needs: the revision that signed the artifact currently
+# deployed AND the revision pinned today. The #3048 report names both, and a set
+# carrying only one of them stops verifying an artifact that is running right now.
+tree="${work_dir}/green-concrete-pair"
+build_tree "${tree}" "(${CONCRETE_SHA}|${CONCRETE_SHA_2})"
+if run_tree "${tree}"; then
+  ok "an alternation of two concrete commits passes"
+else
+  printf '%s\n' "$(cat "${tree}/stderr")" >&2
+  fail "a two-revision approved set should pass, guard rejected it"
+fi
+
 # --- RED: every widening must fire -------------------------------------------
 #
 # `([0-9a-f]{40}|refs/tags/v.+)` is the shape this change removed (#3022). It is
@@ -108,6 +150,18 @@ assert_rejected "a branch ref" 'refs/heads/main' branchref
 assert_rejected "a bare moving ref" 'main' bareref
 assert_rejected "a short commit" '0123456' shortsha
 assert_rejected "a partially grouped alternation" '([0-9a-f]{40})?refs/heads/.+' partialgroup
+
+# --- RED: the #3308 widening must not have opened a hole ---------------------
+#
+# The concrete form is accepted only as a WHOLE 40-hex alternative. Each case below is
+# one character, one case-fold or one alternative away from that, so any of them
+# passing would mean the new check matches by prefix, ignores case, or is applied
+# per-substring rather than per-alternative.
+assert_rejected "a 39-hex near-commit" "${CONCRETE_SHA%?}" sha39
+assert_rejected "a 41-hex near-commit" "${CONCRETE_SHA}a" sha41
+assert_rejected "an uppercase commit" "$(printf '%s' "${CONCRETE_SHA}" | tr 'a-f' 'A-F')" shaupper
+assert_rejected "a concrete commit with a wildcard appended" "${CONCRETE_SHA}.+" shasuffix
+assert_rejected "an approved set widened back with a branch" "(${CONCRETE_SHA}|refs/heads/main)" shabranch
 
 # --- RED: the floor fails closed on a shrunken match set ---------------------
 #


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Our cosign matchers currently accept *any* fixed revision of the shared publish workflows, so a superseded one still passes every check we have. Narrowing them to an approved set is the fix, and the tooling that computes that set already shipped — but the guard protecting these matchers rejected the very output that tooling produces, so the narrowing could not be built. This removes that blocker.

### What

The guard now recognises a subject naming one specific approved revision, alongside the existing "any fixed revision" form. This is a narrowing being made possible, not a relaxation: everything the guard rejected before is still rejected, and the change is pinned by tests that fail if someone reverts it or implements it sloppily.

No matchers change here. Actually switching the live ones over is the remaining half of #3308 and is deliberately separate, because it can stop a deployed app verifying if the revision set is wrong.

Fixes #3531
Part of #3308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
