### PR TITLE
feat(security): opt longhorn-system into the baseline security-context mutation

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
@@ -8,3 +8,37 @@ metadata:
     # and CSI driver components.
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    # longhorn-system is excluded from add-pod-security-context /
+    # add-container-security-context because its workloads need elevated privilege
+    # by design. fsGroupChangePolicy and seLinuxOptions are not privilege fields —
+    # the first governs volume ownership relabelling, the second is a documented
+    # no-op on this AppArmor cluster kept for CIS-5.7.3 — so the blanket exclusion
+    # suppressed two C-0211 controls it never needed to. This label opts the
+    # namespace into add-baseline-context-optin-*, which supplies only those two
+    # through conditional anchors and touches no user, group or privilege field.
+    #
+    # Fourth namespace opted in, after velero, kubescape and observability.
+    # Measured against live prod 2026-09-02: 34 running pods, ALL 34 missing
+    # pod-level fsGroupChangePolicy, and all 47 containers/initContainers carrying
+    # no seLinuxOptions at all. As in observability, no pod carries a pod-level
+    # SELinux object, so add-baseline-context-optin-pod-selinux-level cannot fire
+    # here and none of the wholesale-replace hazards that rule exists for are
+    # reachable; only the two straightforward rules apply.
+    #
+    # fsGroupChangePolicy is inert in this namespace today, which is the point
+    # rather than a caveat: 0 of the 34 pods set fsGroup, and the kubelet runs its
+    # volume ownership pass only when one is set, so the field changes a declared
+    # posture without changing how anything runs. No pod mounts a
+    # PersistentVolumeClaim; the 137 volumes are hostPath (91), projected (34),
+    # secret (8) and emptyDir (4).
+    #
+    # Worth re-checking if that ever changes: hostPath dominates here and persists
+    # on the node, so a future workload in this namespace that DID set fsGroup
+    # would relabel only on a root mismatch instead of always. For host paths that
+    # is the safer direction — it avoids recursively chowning a host directory —
+    # but it is a real behavioural difference from the default, not a no-op, and
+    # this is the cluster storage system.
+    #
+    # The rules are CREATE-only, so running pods are unaffected until they are
+    # next recreated.
+    pod-security.devantler.tech/baseline-context: enabled

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -158,7 +158,7 @@ check coroot-node-agent-mutated.yaml '.spec.securityContext.seLinuxOptions' \
 #
 # Each namespace is opted in only after its live workloads are measured to still
 # start; see the rationale recorded on the namespace manifest itself.
-expected_optin="kubescape,observability,velero"
+expected_optin="kubescape,longhorn-system,observability,velero"
 
 # grep only prefilters candidate files; yq decides, so a mention in a comment or
 # in the policy that DEFINES the label cannot be counted as an opted-in namespace.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Twelve namespaces are excluded from the cluster's security-context mutation because their workloads genuinely need elevated privilege. That reason covers user, group and privilege settings — but it was also switching off two settings that have nothing to do with privilege, so those namespaces have been failing two CIS security checks they never needed to fail.

Three namespaces have already been opted back in (velero, kubescape, observability). This is the fourth, and it is the largest one still reachable: **34 pods, every one of them missing both settings.**

### What this does

Adds one label to the `longhorn-system` namespace, opting it into the narrow mutation that supplies only those two non-privilege settings. Nothing about user, group or privilege changes.

Two things worth knowing before merging:

- **It changes nothing that is running today.** The mutation only applies to newly created pods, so existing Longhorn pods are untouched until they are next restarted.
- **It is inert here, deliberately.** None of the 34 pods use the setting that would give the first field any runtime effect, and none mount a persistent volume. So this closes a compliance gap without changing how anything behaves. The one case that would need re-checking is written into the file itself, because this is the cluster's storage system and that deserves saying out loud rather than discovering later.

`kube-system` and `flux-system` still carry the same gap but cannot be opted in this way — their namespaces are not managed from this repo — so they need a different approach and are out of scope here.

Part of #3239
