### PR TITLE
feat(security): carry the two non-privilege C-0211 fields in velero's templates

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -55,6 +55,12 @@ spec:
         # readOnlyRootFilesystem is safe here (unlike the main server below).
         # UID 65532 matches this image's baked nonroot user.
         securityContext:
+          # SELinux level for the plugin-copy initContainer's stored template
+          # (#3522). The pod declares no seLinuxOptions, so this container-level
+          # object replaces no inherited struct -- the wholesale-replace hazard
+          # in #3469 is unreachable here.
+          seLinuxOptions:
+            level: s0
           runAsNonRoot: true
           runAsUser: 65532
           allowPrivilegeEscalation: false
@@ -84,6 +90,12 @@ spec:
     # pod-security-mutations ClusterSecurityException. (The plugin-copy
     # initContainer above CAN use readOnlyRootFilesystem:true.)
     podSecurityContext:
+      # C-0211 set-fsgroupchangepolicy-value. Kyverno's
+      # add-baseline-context-optin-* rules supply this at admission, but
+      # Kubescape scores the STORED spec, so the template must carry it
+      # itself (#3522). Inert at runtime here: it only governs ownership
+      # relabelling on volume mount, and fsGroup is already set above.
+      fsGroupChangePolicy: OnRootMismatch
       runAsNonRoot: true
       runAsUser: 65532
       runAsGroup: 65532
@@ -91,6 +103,10 @@ spec:
       seccompProfile:
         type: RuntimeDefault
     containerSecurityContext:
+      # SELinux level for the server container's stored template (#3522).
+      # The pod sets no seLinuxOptions, so this replaces no inherited struct.
+      seLinuxOptions:
+        level: s0
       runAsNonRoot: true
       runAsUser: 65532
       allowPrivilegeEscalation: false
@@ -210,6 +226,22 @@ spec:
     # PVCs. Defaults are sane; just confirm rolling update.
     deployNodeAgent: true
     nodeAgent:
+      # C-0211 non-privilege fields for the node-agent DaemonSet's STORED
+      # template (#3522). Kyverno's add-baseline-context-optin-* rules supply
+      # these at admission, but Kubescape scores the stored spec, so the
+      # template has to carry them itself.
+      #
+      # runAsUser: 0 is the chart default and is restated explicitly so this
+      # block cannot silently drop the root the node-agent needs for host
+      # path access. Nothing here touches user, group or privilege.
+      podSecurityContext:
+        runAsUser: 0
+        fsGroupChangePolicy: OnRootMismatch
+      # The DaemonSet declares no pod-level seLinuxOptions, so this
+      # container-level object replaces no inherited struct (#3469).
+      containerSecurityContext:
+        seLinuxOptions:
+          level: s0
       updateStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1552,7 +1552,31 @@ const (
 // The previous approved aggregate digest was:
 //
 //	5b298b96eba875cb5c05ba09c82eaf2833676930d1f76a3b7c4a954d104ceebd
-const expectedRenderedSurfaceSHA = "005c333f114ad4a2a5706ef9b0d4989623203eadc67657ffd15d2b4d9bb369dc"
+//
+// Re-approved for #3522: velero's Deployment and its node-agent DaemonSet now
+// carry fsGroupChangePolicy and seLinuxOptions.level in their own STORED
+// templates, instead of only receiving them from the admission-time mutation.
+// Kubescape scores the stored spec, so the scanned verdict never moved while the
+// fields existed only on the running pods. The only change since the value above
+// is 32 added lines in one file,
+// k8s/bases/infrastructure/controllers/velero/helm-release.yaml, so nothing else
+// moved the surface.
+//
+// The aggregate is the ONLY thing that moved, and the validator itself proves it:
+// the same run reported no per-identity "unapproved rendered ... fingerprint", no
+// "missing rendered authorization resource" and no "duplicate rendered
+// authorization resource", so every identity-keyed authorization resource is
+// unchanged. No grant-bearing field moved either -- node-agent keeps runAsUser: 0
+// (restated explicitly in the values so a later edit cannot silently drop the root
+// it needs for host path access) and the server keeps 65532, with fsGroup,
+// runAsGroup and runAsNonRoot untouched. Both added fields are non-privilege: one
+// governs ownership relabelling on volume mount, the other is an SELinux level
+// that is inert on this AppArmor cluster.
+//
+// The previous approved aggregate digest was:
+//
+//	005c333f114ad4a2a5706ef9b0d4989623203eadc67657ffd15d2b4d9bb369dc
+const expectedRenderedSurfaceSHA = "7a033c38847bf0ea7b052e783cbf1e68f317d8524c701243acb2d8b3c9972116"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

The cluster's security scanner grades the **stored workload definition**, not the running pod. A cluster rule already supplies two non-privilege settings to pods as they start, so velero's pods carry them — but its stored definitions do not, so the check still reads as failing and the blanket exemption covering it cannot be narrowed.

velero is the smallest place to fix that: two workloads, both already confirmed to show the gap.

### What this does

Sets those two settings directly in velero's Helm values, so both its workloads carry them in their own definitions rather than only picking them up at start-up.

Two things worth knowing before merging:

- **Nothing about privilege, user or group changes.** The node agent keeps running as root, which it needs for host access — that is written into the file explicitly so a later edit cannot drop it silently.
- **It changes nothing about how anything runs.** One setting only governs file-ownership handling on volume mount, and the other is inert on this cluster's security module. Velero's pods will restart once as the chart upgrade rolls through, well outside the 02:17 backup window.

This is the first of the affected namespaces; the rest follow the same pattern.

Part of #3522
