### PR TITLE
security(flux): supply the two non-privilege C-0211 fields to flux-system

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -185,6 +185,53 @@ spec:
           - op: add
             path: /spec/template/spec/containers/0/securityContext/runAsGroup
             value: 65534
+      # Supply the two NON-PRIVILEGE C-0211 fields that the cluster-wide
+      # add-security-context mutation cannot reach here. That policy excludes
+      # flux-system, and correctly so — the exclusion protects privilege, user
+      # and group fields on a namespace whose controllers need elevated access.
+      # fsGroupChangePolicy and seLinuxOptions are neither: the first only
+      # governs ownership-relabel behaviour on volume mount, and the second is a
+      # documented no-op on this AppArmor cluster (runc ignores SELinux labels
+      # when SELinux is not the active LSM), retained as CIS-5.7.3
+      # defence-in-depth. The values are kept identical to
+      # add-security-context.yaml so a workload does not read differently
+      # depending on which surface supplied the field.
+      #
+      # 🔴 PATCHED HERE RATHER THAN BY NAMESPACE OPT-IN, and that is the whole
+      # point. The mutation runs on Pod CREATE, so it only ever reaches the
+      # running pod; Kubescape scores the STORED WORKLOAD SPEC, which no pod
+      # mutation ever touches. Measured on velero (#3239): it is opted in, all
+      # 56 of its pods carry both fields, and its Deployment template carries
+      # neither. A kustomize patch writes the template itself, so it moves both
+      # surfaces at once — the only route here that does.
+      #
+      # Same app.kubernetes.io/part-of=flux selector as the three patches above,
+      # which resolves to exactly the four installed controllers (measured live
+      # 2026-09-03: helm-, kustomize-, notification- and source-controller, each
+      # with one container and zero initContainers). flux-operator and
+      # tofu-controller do NOT carry that label and are deliberately untouched —
+      # the first is patched at its own HelmRelease, and the second is the
+      # documented tf-runner exemption in add-security-context.yaml.
+      #
+      # Pod-level securityContext already exists on all four (fsGroup: 1337,
+      # read live 2026-09-03), so `add` writes into an existing object rather
+      # than failing on a missing parent. The `op: test` guard matches the
+      # runAsUser/runAsGroup patch above: if a future chart reorders containers,
+      # this fails loudly instead of writing onto the wrong one.
+      - target:
+          kind: Deployment
+          labelSelector: app.kubernetes.io/part-of=flux
+        patch: |
+          - op: test
+            path: /spec/template/spec/containers/0/name
+            value: manager
+          - op: add
+            path: /spec/template/spec/securityContext/fsGroupChangePolicy
+            value: OnRootMismatch
+          - op: add
+            path: /spec/template/spec/containers/0/securityContext/seLinuxOptions
+            value:
+              level: s0
       # Enforce cosign signature verification on the ROOT source — the
       # flux-system OCIRepository every controller, tenant binding and policy
       # arrives through. Without this the root artifact is pulled from a mutable


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Two security-posture fields are missing from every workload in `flux-system`. They are missing for a
reason that no longer applies to them: the cluster-wide hardening policy skips that namespace to avoid
touching privilege settings on controllers that genuinely need elevated access — but the two fields in
question are not privilege settings. One only affects file-ownership behaviour when a volume is
mounted; the other is inert on this cluster and is kept purely as a defence-in-depth box-tick.

So the exclusion has been suppressing two harmless controls in order to protect a different concern.

### What this changes

Supplies those two fields to the four Flux controllers directly, reusing the same targeting the
existing hardening patch already uses for that namespace. Values match the cluster-wide policy exactly,
so a workload does not read differently depending on which surface supplied the field.

It applies them to the workload definition rather than switching the namespace into the existing
policy, and that distinction is the substance of the change: the policy only rewrites pods as they
start, while the security scanner reads the stored workload definition. Measured on the one namespace
already switched in, every running pod carries both fields and its stored definition carries neither —
so switching more namespaces in could never have moved the scored result. Patching the definition moves
both.

Scope is deliberately the four Flux controllers only. The two other workloads in that namespace are
covered elsewhere or are a documented exemption, and are untouched.

Part of #3239

### Operational note

Changing the pod template rolls the four Flux controllers once on deploy. That restart is the mechanism
by which the fields take effect, and it is the same routine roll any chart bump causes — but it does
briefly cycle the controllers a revert would travel back through, so it is worth knowing it happens.
