### PR TITLE
feat(security): guard the per-consumer cosign matchers against the generated approved-revision set

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,12 +330,11 @@ jobs:
               # or a widened allow-list would ship with every check still green.
               - 'scripts/guard-shared-publish-workflow-pin.sh'
               - 'scripts/tests/test-shared-publish-workflow-pin-guard.sh'
-              # Both halves, plus the generated set the guard reads and the manifests it judges
-              # are already under k8s/**: a set regenerated without its guard's test would land
-              # with every check green.
+              # Both halves, for the same reason as the pin guard above: the guard step itself
+              # runs unconditionally, and listing the pair here is what keeps a guard edit
+              # inside the k8s-gated validation matrix alongside the manifests it judges.
               - 'scripts/guard-publish-workflow-approved-revisions.sh'
               - 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh'
-              - 'scripts/publish-workflow-approved-revisions.tsv'
               # Both halves, for the same reason as the guard above.
               - 'scripts/validate-kubescape-frameworks/main.go'
               - 'scripts/validate-kubescape-frameworks/main_test.go'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,20 @@ jobs:
           shellcheck -x scripts/tests/test-publish-workflow-approved-revisions.sh
           bash scripts/tests/test-publish-workflow-approved-revisions.sh
 
+      # The pin guard above proves each matcher pins a FIXED revision; this one proves each
+      # per-consumer matcher pins the revision PAIR the committed approved set names for that
+      # consumer, and refuses any revision outside it (#3551, AC4 of #3308). Unconditional for
+      # the same reason as the pin guard: the subjects live in four different trees. The switch
+      # (APPROVED_REVISIONS_ENFORCE) stays off here until the narrowing itself lands — with it
+      # off the pattern form is still accepted, so this checks the committed set against the
+      # live matchers without forcing the change.
+      - name: 🔐 Validate the approved-revisions guard
+        run: |
+          shellcheck -x scripts/guard-publish-workflow-approved-revisions.sh
+          shellcheck -x scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+          bash scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+          ./scripts/guard-publish-workflow-approved-revisions.sh
+
       # Dropping a framework from the Kubescape gate REMOVES findings, so the
       # compliance score RISES and every check stays green — a coverage
       # regression that looks like an improvement. That is what un-gated 59
@@ -316,6 +330,12 @@ jobs:
               # or a widened allow-list would ship with every check still green.
               - 'scripts/guard-shared-publish-workflow-pin.sh'
               - 'scripts/tests/test-shared-publish-workflow-pin-guard.sh'
+              # Both halves, plus the generated set the guard reads and the manifests it judges
+              # are already under k8s/**: a set regenerated without its guard's test would land
+              # with every check green.
+              - 'scripts/guard-publish-workflow-approved-revisions.sh'
+              - 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh'
+              - 'scripts/publish-workflow-approved-revisions.tsv'
               # Both halves, for the same reason as the guard above.
               - 'scripts/validate-kubescape-frameworks/main.go'
               - 'scripts/validate-kubescape-frameworks/main_test.go'

--- a/scripts/generate-publish-workflow-approved-revisions.sh
+++ b/scripts/generate-publish-workflow-approved-revisions.sh
@@ -9,7 +9,9 @@
 # revision the consumer pins on its default branch TODAY: the first keeps the deployed
 # artifact verifying, the second keeps the next artifact verifying. Hand-writing that set is
 # what #3308 rules out, so this script derives it from two observed inputs and writes one row
-# per consumer. It changes no matcher â the guard (#3551) and the switch come later.
+# per consumer. It changes no matcher: guard-publish-workflow-approved-revisions.sh (#3551)
+# holds each per-consumer matcher to the pair written here, and the switch that refuses the
+# pattern form (APPROVED_REVISIONS_ENFORCE) flips with the narrowing itself.
 #
 # THE TWO INPUTS
 #   applied  â the artifact revision Flux has verified and applied, read from the consumer's

--- a/scripts/guard-publish-workflow-approved-revisions.sh
+++ b/scripts/guard-publish-workflow-approved-revisions.sh
@@ -84,7 +84,9 @@ esac
 # cannot run where the matchers are edited is one that gets skipped there.
 # lookup <records> <key> → the record for <key> (fields after the key), or nothing.
 lookup() {
-  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 == k { sub(/^[^\t]*\t/, ""); print; exit }'
+  # `$1 "" == k ""` forces a STRING compare: awk compares two numeric-looking strings as
+  # numbers, so `100` would match a key of `1e2`.
+  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 "" == k "" { sub(/^[^\t]*\t/, ""); print; exit }'
 }
 
 # consumer → "workflow<TAB>signer<TAB>pin"
@@ -128,7 +130,11 @@ for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
   [ -f "$SCAN_ROOT/$generic" ] || refuse "generic subject file $generic is missing from the scan root; the scope boundary has moved — redraw GENERIC_SUBJECT_FILES deliberately"
 done
 
-subject_files="$(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$SCAN_ROOT" 2>/dev/null | sort -u || true)"
+# `.claude/` holds nested per-session worktrees on the maintainer's checkout — whole copies of
+# this tree — so descending into it reports every generic subject a second time from a path the
+# exclusion list does not name, and the guard refuses a correct repository. `.git` for the same
+# reason a packed ref or a stray object file must never be read as a manifest.
+subject_files="$(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' --exclude-dir=.git --exclude-dir=.claude "$SCAN_ROOT" 2>/dev/null | sort -u || true)"
 [ -n "$subject_files" ] || refuse "no shared-publish-workflow subject found under $SCAN_ROOT; the scan, not the tree, is the likely cause"
 
 # consumer → "file<TAB>workflow<TAB>ref"
@@ -145,23 +151,36 @@ while IFS= read -r file; do
   done
   [ "$is_generic" -eq 0 ] || continue
 
-  # One OCIRepository document per file, with exactly one subject naming a shared workflow —
-  # the same attribution the report makes, read the way Flux reads it. Fields: url, the number
-  # of shared-workflow subjects on the document, and the first of them.
-  # shellcheck disable=SC2016  # `$shared` is a yq variable, not a shell one
+  # One OCIRepository document per file, with exactly one identity entry, and that entry names a
+  # shared workflow — the same attribution the report makes, read the way Flux reads it. Fields:
+  # url, the total number of identity entries, the number naming a shared workflow, and the
+  # first of those.
+  #
+  # The TOTAL matters as much as the shared count: `matchOIDCIdentity` is an OR-list, so a second
+  # entry beside a correct pair (`subject: '.*'`, or a first-party branch identity) admits any
+  # signer while the pair reads as narrowed. Counting only the shared-workflow entries would
+  # report `form=set` over exactly that widening.
+  # shellcheck disable=SC2016  # `$ids`/`$shared` are yq variables, not shell ones
   docs="$(yq eval -r '
     select(.kind == "OCIRepository") |
-    ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | map(select(test("devantler-tech/actions/.{1,2}github/workflows/publish-(app|manifests)")))) as $shared |
-    [(.spec.url // "-"), ($shared | length), ($shared[0] // "-")] | @tsv
+    (.spec.verify.matchOIDCIdentity // []) as $ids |
+    ($ids | map(.subject // "") | map(select(test("devantler-tech/actions/.{1,2}github/workflows/publish-(app|manifests)")))) as $shared |
+    [(.spec.url // "-"), ($ids | length), ($shared | length), ($shared[0] // "-")] | @tsv
   ' "$file" 2>/dev/null)" || refuse "$rel could not be read as YAML"
   [ -n "$docs" ] || refuse "$rel carries a shared-publish-workflow subject but no OCIRepository document owns it; attribute it to a consumer or add it to GENERIC_SUBJECT_FILES"
   [ "$(printf '%s\n' "$docs" | grep -c .)" -eq 1 ] || refuse "$rel carries more than one OCIRepository document; the attribution is ambiguous"
-  IFS=$'\t' read -r url subject_count subject <<<"$docs"
+  IFS=$'\t' read -r url identity_count subject_count subject <<<"$docs"
   case "$url" in
     oci://ghcr.io/devantler-tech/*) ;;
     *) refuse "$rel: OCIRepository url '$url' is not a devantler-tech GHCR artifact" ;;
   esac
   [ "$subject_count" = "1" ] || refuse "$rel: expected exactly one shared-publish-workflow subject on the OCIRepository, found $subject_count"
+  [ "$identity_count" = "1" ] || refuse "$rel: the OCIRepository carries $identity_count matchOIDCIdentity entries; a second entry beside the pair admits any signer it names, so exactly one is allowed"
+  # The line scan that discovered this file and the document read above must agree: a shared-
+  # workflow subject in a SECOND document (a policy appended after `---`) is invisible to the
+  # OCIRepository selection, and would otherwise pass unjudged.
+  line_count="$(grep -cE "$SUBJECT_PATTERN" "$file" || true)"
+  [ "$line_count" = "1" ] || refuse "$rel: $line_count shared-publish-workflow subject lines found but exactly one OCIRepository entry was read; a subject outside the OCIRepository document is unjudged"
   repo="${url#oci://ghcr.io/devantler-tech/}"; repo="${repo%%/*}"
   repo="$(oci_name_to_repo "$repo")"
   plausible_repo "$repo" || refuse "$rel: consumer name '$repo' derived from $url is implausible"

--- a/scripts/guard-publish-workflow-approved-revisions.sh
+++ b/scripts/guard-publish-workflow-approved-revisions.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# guard-publish-workflow-approved-revisions.sh — assert that each per-consumer cosign matcher
+# for the shared devantler-tech/actions publish workflows pins EXACTLY the revision pair the
+# generated approved set names for that consumer (#3551, second child of #3308).
+#
+# WHY A SECOND GUARD
+# guard-shared-publish-workflow-pin.sh proves every matcher pins a FIXED revision — the pattern
+# text `[0-9a-f]{40}`, one concrete commit, or an alternation of two. It judges ref SHAPE and
+# says nothing about set MEMBERSHIP: a matcher narrowed to a revision nobody approved, or a
+# regeneration that moved the set while a matcher stayed behind, passes it. This guard reads
+# scripts/publish-workflow-approved-revisions.tsv (written by
+# generate-publish-workflow-approved-revisions.sh, #3550) and checks that each consumer's
+# matcher names that consumer's pair and nothing else. An out-of-set revision is refused in
+# every mode — that is #3308's AC4.
+#
+# THE SWITCH (feature-flag-first, default OFF)
+# Today every per-consumer matcher carries the pattern form, and the narrowing to
+# `(<applied-signer>|<main-pin>)` is a separate, reversible step. While
+# APPROVED_REVISIONS_ENFORCE is unset or `0`, the pattern form is still ACCEPTED for a
+# per-consumer subject, so this guard is live on main without forcing the switch; a matcher
+# that has already been narrowed is judged against the set either way. With
+# APPROVED_REVISIONS_ENFORCE=1 the pattern form is REFUSED for a per-consumer subject, which is
+# what keeps the narrowing from quietly reverting once it has happened. Flipping the switch is
+# the same change that narrows the matchers, so the two cannot drift.
+#
+# SCOPE — GENERIC SUBJECTS ARE EXCLUDED BY NAME
+# Three subjects name the shared workflows without belonging to one consumer: the Kyverno
+# app-image policy, the tenant ResourceGraphDefinition template, and the Talos first-party
+# image-verification rule. Each verifies artifacts from MANY consumers, so no single generated
+# pair could be correct for it; they stay on the pattern form and are listed in
+# GENERIC_SUBJECT_FILES below so that the boundary is recorded beside the check. A shared-
+# workflow subject that is neither attributed to a registered consumer nor on that list fails
+# the run: an unattributed subject is one whose revision nobody is checking.
+#
+# FAIL CLOSED. A missing, malformed, or incomplete approved set, a consumer whose manifest
+# cannot be found or read the way Flux reads it, or a subject this guard cannot attribute all
+# exit 1 — a guard that skips what it cannot read reports a clean tree while checking nothing.
+#
+# SEAMS (tests substitute these; production leaves them unset)
+#   APPROVED_REVISIONS_FILE      the generated set (default scripts/publish-workflow-approved-revisions.tsv)
+#   PUBLISH_CONSUMER_ROOT        scan root for consumer manifests (default: the repository root)
+#   APPROVED_REVISIONS_ENFORCE   `1` refuses the pattern form on per-consumer subjects (default: off)
+set -euo pipefail
+
+GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly GUARD_DIR
+readonly REPORT="$GUARD_DIR/report-publish-workflow-signing-revisions.sh"
+# shellcheck source=scripts/report-publish-workflow-signing-revisions.sh
+source "$REPORT"
+
+readonly APPROVED_SET="${APPROVED_REVISIONS_FILE:-$REPO_ROOT/scripts/publish-workflow-approved-revisions.tsv}"
+readonly SCAN_ROOT="${PUBLISH_CONSUMER_ROOT:-$REPO_ROOT}"
+readonly ENFORCE="${APPROVED_REVISIONS_ENFORCE:-0}"
+readonly HEADER=$'consumer\tworkflow\tapplied_tag\tapplied_digest\tapplied_signer_sha\tmain_pin_sha\tobserved_on'
+
+# Relative to the scan root. Every entry must exist: a generic subject that moves or is
+# renamed would otherwise become an unattributed subject with no home, and this list is
+# where its absence should be noticed and the boundary redrawn on purpose.
+readonly GENERIC_SUBJECT_FILES=(
+  'k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml'
+  'k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml'
+  'talos/cluster/verify-first-party-images.yaml'
+)
+
+readonly SUBJECT_PREFIX='^https://github\.com/devantler-tech/actions/\.github/workflows/publish-'
+readonly PATTERN_REF='[0-9a-f]{40}'
+
+refuse() {
+  printf 'guard-publish-workflow-approved-revisions: %s\n' "$*" >&2
+  exit 1
+}
+
+case "$ENFORCE" in
+  0 | 1) ;;
+  *) refuse "APPROVED_REVISIONS_ENFORCE must be 0 or 1, got '$ENFORCE'" ;;
+esac
+
+# ── 1. The approved set, read strictly ──────────────────────────────────────────────────
+[ -f "$APPROVED_SET" ] || refuse "approved set not found at $APPROVED_SET; run scripts/generate-publish-workflow-approved-revisions.sh"
+[ "$(head -n1 "$APPROVED_SET")" = "$HEADER" ] || refuse "approved set header is not the generator's; refusing to read it"
+
+# Records are newline-delimited "<key><TAB>…" strings rather than associative arrays: the
+# maintainer's macOS ships bash 3.2, where `declare -A` is a hard error, and a guard that
+# cannot run where the matchers are edited is one that gets skipped there.
+# lookup <records> <key> → the record for <key> (fields after the key), or nothing.
+lookup() {
+  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 == k { sub(/^[^\t]*\t/, ""); print; exit }'
+}
+
+# consumer → "workflow<TAB>signer<TAB>pin"
+approved=""
+line_no=1
+while IFS=$'\t' read -r consumer workflow applied_tag applied_digest signer pin observed_on extra; do
+  line_no=$((line_no + 1))
+  [ -n "$consumer" ] || continue
+  [ "$line_no" -gt 2 ] || [ "$consumer" != 'consumer' ] || continue  # the header
+  [ -z "${extra:-}" ] || refuse "approved set line $line_no has more than seven fields"
+  [ -n "$observed_on" ] || refuse "approved set line $line_no has fewer than seven fields"
+  plausible_repo "$consumer" || refuse "approved set line $line_no names an implausible consumer '$consumer'"
+  case "$workflow" in
+    publish-app | publish-manifests) ;;
+    *) refuse "approved set line $line_no: '$workflow' is not a shared publish workflow" ;;
+  esac
+  is_sha "$signer" || refuse "approved set line $line_no ($consumer): applied_signer_sha '$signer' is not a 40-hex commit"
+  is_sha "$pin" || refuse "approved set line $line_no ($consumer): main_pin_sha '$pin' is not a 40-hex commit"
+  [ -z "$(lookup "$approved" "$consumer")" ] || refuse "approved set names $consumer twice"
+  : "$applied_tag" "$applied_digest"
+  approved="${approved}${consumer}"$'\t'"${workflow}"$'\t'"${signer}"$'\t'"${pin}"$'\n'
+done <"$APPROVED_SET"
+
+# Exactly the registered consumers, both directions: a missing row is a consumer nobody
+# narrowed, an extra row is a set nothing consumes.
+for expected in "${EXPECTED_CONSUMERS[@]}"; do
+  [ -n "$(lookup "$approved" "$expected")" ] || refuse "approved set has no row for registered consumer $expected"
+done
+while IFS=$'\t' read -r consumer _rest; do
+  [ -n "$consumer" ] || continue
+  known=0
+  for expected in "${EXPECTED_CONSUMERS[@]}"; do
+    [ "$expected" = "$consumer" ] && known=1 && break
+  done
+  [ "$known" -eq 1 ] || refuse "approved set names $consumer, which is not a registered consumer"
+done <<<"$approved"
+
+# ── 2. Every shared-workflow subject in the tree, attributed or excluded ─────────────────
+[ -d "$SCAN_ROOT" ] || refuse "scan root $SCAN_ROOT is not a directory"
+for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
+  [ -f "$SCAN_ROOT/$generic" ] || refuse "generic subject file $generic is missing from the scan root; the scope boundary has moved — redraw GENERIC_SUBJECT_FILES deliberately"
+done
+
+subject_files="$(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' "$SCAN_ROOT" 2>/dev/null | sort -u || true)"
+[ -n "$subject_files" ] || refuse "no shared-publish-workflow subject found under $SCAN_ROOT; the scan, not the tree, is the likely cause"
+
+# consumer → "file<TAB>workflow<TAB>ref"
+observed=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  rel="${file#"$SCAN_ROOT"/}"
+  case "$rel" in
+    scripts/*) continue ;;  # test fixtures under scripts/ carry subjects that verify nothing
+  esac
+  is_generic=0
+  for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
+    [ "$rel" = "$generic" ] && is_generic=1 && break
+  done
+  [ "$is_generic" -eq 0 ] || continue
+
+  # One OCIRepository document per file, with exactly one subject naming a shared workflow —
+  # the same attribution the report makes, read the way Flux reads it. Fields: url, the number
+  # of shared-workflow subjects on the document, and the first of them.
+  # shellcheck disable=SC2016  # `$shared` is a yq variable, not a shell one
+  docs="$(yq eval -r '
+    select(.kind == "OCIRepository") |
+    ((.spec.verify.matchOIDCIdentity // []) | map(.subject // "") | map(select(test("devantler-tech/actions/.{1,2}github/workflows/publish-(app|manifests)")))) as $shared |
+    [(.spec.url // "-"), ($shared | length), ($shared[0] // "-")] | @tsv
+  ' "$file" 2>/dev/null)" || refuse "$rel could not be read as YAML"
+  [ -n "$docs" ] || refuse "$rel carries a shared-publish-workflow subject but no OCIRepository document owns it; attribute it to a consumer or add it to GENERIC_SUBJECT_FILES"
+  [ "$(printf '%s\n' "$docs" | grep -c .)" -eq 1 ] || refuse "$rel carries more than one OCIRepository document; the attribution is ambiguous"
+  IFS=$'\t' read -r url subject_count subject <<<"$docs"
+  case "$url" in
+    oci://ghcr.io/devantler-tech/*) ;;
+    *) refuse "$rel: OCIRepository url '$url' is not a devantler-tech GHCR artifact" ;;
+  esac
+  [ "$subject_count" = "1" ] || refuse "$rel: expected exactly one shared-publish-workflow subject on the OCIRepository, found $subject_count"
+  repo="${url#oci://ghcr.io/devantler-tech/}"; repo="${repo%%/*}"
+  repo="$(oci_name_to_repo "$repo")"
+  plausible_repo "$repo" || refuse "$rel: consumer name '$repo' derived from $url is implausible"
+  [ -n "$(lookup "$approved" "$repo")" ] || refuse "$rel is a shared-workflow consumer ($repo) with no row in the approved set and no entry in GENERIC_SUBJECT_FILES"
+  prior="$(lookup "$observed" "$repo")"
+  [ -z "$prior" ] || refuse "consumer $repo has an OCIRepository in both $rel and ${prior%%$'\t'*}"
+
+  case "$subject" in
+    "$SUBJECT_PREFIX"*) ;;
+    *) refuse "$rel: subject does not start with the shared-workflow identity prefix: $subject" ;;
+  esac
+  rest="${subject#"$SUBJECT_PREFIX"}"          # <workflow>\.yaml@<ref>$
+  case "$rest" in
+    *'\.yaml@'*) ;;
+    *) refuse "$rel: subject has no '\\.yaml@' boundary: $subject" ;;
+  esac
+  workflow="publish-${rest%%\\.yaml@*}"
+  ref="${rest#*\\.yaml@}"
+  case "$ref" in
+    *'$') ref="${ref%\$}" ;;
+    *) refuse "$rel: subject is not anchored with a trailing \$: $subject" ;;
+  esac
+  observed="${observed}${repo}"$'\t'"${rel}"$'\t'"${workflow}"$'\t'"${ref}"$'\n'
+done <<<"$subject_files"
+
+# ── 3. Each registered consumer: its matcher equals its generated pair ───────────────────
+for consumer in "${EXPECTED_CONSUMERS[@]}"; do
+  record="$(lookup "$observed" "$consumer")"
+  [ -n "$record" ] || refuse "no OCIRepository under $SCAN_ROOT is attributed to registered consumer $consumer; the scan, not the tree, is the likely cause"
+  IFS=$'\t' read -r file workflow ref <<<"$record"
+  IFS=$'\t' read -r set_workflow signer pin <<<"$(lookup "$approved" "$consumer")"
+  [ "$workflow" = "$set_workflow" ] || refuse "$consumer: $file names $workflow but the approved set names $set_workflow"
+
+  if [ "$signer" = "$pin" ]; then
+    accepted="$signer or ($signer)"
+  else
+    accepted="($signer|$pin) or ($pin|$signer)"
+  fi
+
+  form=""
+  if [ "$ref" = "$PATTERN_REF" ]; then
+    if [ "$ENFORCE" = "1" ]; then
+      refuse "$consumer: $file still carries the pattern form '@$PATTERN_REF' while APPROVED_REVISIONS_ENFORCE=1; narrow it to @$accepted"
+    fi
+    form="pattern (accepted while the switch is off)"
+  elif [ "$signer" = "$pin" ] && { [ "$ref" = "$signer" ] || [ "$ref" = "($signer)" ]; }; then
+    form="set"
+  elif [ "$signer" != "$pin" ] && { [ "$ref" = "($signer|$pin)" ] || [ "$ref" = "($pin|$signer)" ]; }; then
+    form="set"
+  else
+    refuse "$consumer: $file pins '@$ref', which is not the generated pair — expected @$accepted (or the pattern form while the switch is off)"
+  fi
+  printf 'ok %s %s %s form=%s\n' "$consumer" "$workflow" "$file" "$form"
+done
+
+printf 'guard-publish-workflow-approved-revisions: %d consumer matcher(s) agree with %s (enforce=%s)\n' \
+  "${#EXPECTED_CONSUMERS[@]}" "${APPROVED_SET#"$REPO_ROOT"/}" "$ENFORCE"

--- a/scripts/guard-shared-publish-workflow-pin.sh
+++ b/scripts/guard-shared-publish-workflow-pin.sh
@@ -50,6 +50,8 @@
 # pins today, and those routinely differ. A consumer narrowed to a set omitting its
 # signing revision would stop verifying an artifact that is running right now, so any
 # narrowing is derived from that report rather than from this guard or by hand (#3308).
+# Set MEMBERSHIP — that each per-consumer matcher names exactly the generated pair and no
+# revision outside it — is guard-publish-workflow-approved-revisions.sh's question (#3551).
 
 set -euo pipefail
 

--- a/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+++ b/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
@@ -98,6 +98,35 @@ spec:
 EOF
 }
 
+# append_identity <root> <repo> <subject-regex> — a SECOND matchOIDCIdentity entry on the
+# consumer's OCIRepository. Flux ORs the entries, so this is the shape that widens a matcher
+# while its shared-workflow entry still reads as narrowed.
+append_identity() {
+  local root="$1" repo="$2" subject="$3"
+  printf "      - issuer: '.*'\n        subject: '%s'\n" "$subject" \
+    >>"$root/k8s/bases/apps/$(package_for "$repo")/oci-repository.yaml"
+}
+
+# append_document <root> <repo> <ref> — a second YAML document after the consumer's
+# OCIRepository, carrying a shared-workflow subject the OCIRepository selection cannot see.
+append_document() {
+  local root="$1" repo="$2" ref="$3"
+  cat >>"$root/k8s/bases/apps/$(package_for "$repo")/oci-repository.yaml" <<EOF
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: stray
+spec:
+  rules:
+    - verifyImages:
+        - attestors:
+            - entries:
+                - keyless:
+                    subjectRegExp: ^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@$ref\$
+EOF
+}
+
 # write_generics <root> <ref> — the three generic subject files, on the given ref form.
 write_generics() {
   local root="$1" ref="$2"
@@ -249,6 +278,49 @@ root="$(build_tree off-tag pair)"
 write_consumer "$root" "$first_consumer" "$first_workflow" 'refs/tags/v.+'
 expect_refusal 'switch off: a tag ref is refused' "$root" 0 "$first_consumer" 'refs/tags/v.+'
 
+# `matchOIDCIdentity` is an OR-list: a wildcard sibling beside a correct pair admits any signer.
+root="$(build_tree off-wildcard-sibling pair)"
+append_identity "$root" "$first_consumer" '.*'
+expect_refusal 'a second matchOIDCIdentity entry beside the pair is refused (an OR-list widens the matcher)' \
+  "$root" 0 "$(first_path "$first_consumer")" 'matchOIDCIdentity entries'
+root="$(build_tree on-branch-sibling pair)"
+append_identity "$root" "$first_consumer" '^https://github\.com/devantler-tech/platform/\.github/workflows/cd\.yaml@refs/heads/.+$'
+expect_refusal 'switch on: a first-party branch identity beside the pair is refused' \
+  "$root" 1 "$(first_path "$first_consumer")" 'matchOIDCIdentity entries'
+root="$(build_tree off-two-shared pair)"
+append_identity "$root" "$first_consumer" "^https://github\\.com/devantler-tech/actions/\\.github/workflows/$first_workflow\\.yaml@$SHA_D\$"
+expect_refusal 'two shared-workflow subjects on one OCIRepository are refused' \
+  "$root" 0 "$(first_path "$first_consumer")" 'found 2'
+
+# A subject in a second document of the consumer's file is invisible to the OCIRepository read.
+root="$(build_tree off-second-document pair)"
+append_document "$root" "$first_consumer" "$SHA_D"
+expect_refusal 'a shared-workflow subject in a second document of a consumer file is refused as unjudged' \
+  "$root" 0 "$(first_path "$first_consumer")" 'unjudged'
+
+# signer == pin: the steady state after a consumer re-releases on the revision it pins.
+same_set() { # <root> — rewrite the first consumer's row with signer == pin == SHA_B
+  local root="$1"
+  { head -n1 "$root/scripts/approved.tsv"
+    tail -n +2 "$root/scripts/approved.tsv" | awk -F'\t' -v c="$first_consumer" -v s="$SHA_B" 'BEGIN{OFS="\t"} $1 "" == c "" {$5=s} {print}'
+  } >"$root/scripts/approved.tmp"
+  mv "$root/scripts/approved.tmp" "$root/scripts/approved.tsv"
+}
+root="$(build_tree same-single pair)"; same_set "$root"
+write_consumer "$root" "$first_consumer" "$first_workflow" "$SHA_B"
+expect_pass 'signer == pin: the single concrete revision is the set and passes' "$root" 1
+root="$(build_tree same-group pair)"; same_set "$root"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($SHA_B)"
+expect_pass 'signer == pin: the single revision in a group passes' "$root" 1
+root="$(build_tree same-doubled pair)"; same_set "$root"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($SHA_B|$SHA_B)"
+expect_refusal 'signer == pin: a doubled alternation is not the canonical set and is refused' \
+  "$root" 0 "$first_consumer" 'not the generated pair'
+root="$(build_tree same-foreign pair)"; same_set "$root"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($SHA_B|$SHA_D)"
+expect_refusal 'signer == pin: an alternation adding a foreign revision is refused' \
+  "$root" 1 "$first_consumer" "$SHA_D"
+
 # ── switch ON: the pattern form is refused for a per-consumer subject ────────────────────────
 root="$(build_tree on-pair pair)"
 expect_pass 'switch on: every consumer on its generated pair passes' "$root" 1
@@ -278,7 +350,15 @@ expect_pass 'switch on: the three generic subjects stay on the pattern form and 
 root="$(build_tree generics-missing pattern)"
 rm -f "$root/$GENERIC_TALOS"
 expect_refusal 'a generic subject file missing from the tree is refused: the scope boundary moved' \
-  "$root" 0 "$GENERIC_TALOS"
+  "$root" 0 "$GENERIC_TALOS" 'missing from the scan root'
+
+# The maintainer's checkout carries nested per-session worktrees under .claude/ — whole copies
+# of the tree. Those must not be read as a second, unlisted set of generic subjects.
+root="$(build_tree nested-worktree pattern)"
+mkdir -p "$root/.claude/worktrees/session/$(dirname "$GENERIC_TALOS")" "$root/.git/objects"
+cp "$root/$GENERIC_TALOS" "$root/.claude/worktrees/session/$GENERIC_TALOS"
+cp "$root/$GENERIC_TALOS" "$root/.git/objects/stray.yaml"
+expect_pass 'copies under .claude/ (nested worktrees) and .git/ are not scanned' "$root" 0
 
 # A fourth kind of file naming the shared workflow that is neither a consumer nor listed.
 root="$(build_tree unattributed pattern)"
@@ -325,6 +405,21 @@ write_set "$root/scripts/approved.tsv" "$first_consumer" "$(printf '%s\t%s\t1.0.
 expect_refusal 'an approved set with a malformed signer sha is refused' \
   "$root" 0 "$first_consumer" 'not a 40-hex commit'
 
+root="$(build_tree set-bad-pin pattern)"
+write_set "$root/scripts/approved.tsv" "$first_consumer" "$(printf '%s\t%s\t1.0.0\t%s\t%s\tdeadbeef\t2026-09-03' "$first_consumer" "$first_workflow" "$DIGEST" "$SHA_A")"
+expect_refusal 'an approved set with a malformed main_pin_sha is refused' \
+  "$root" 0 "$first_consumer" 'main_pin_sha'
+
+root="$(build_tree set-duplicate pattern)"
+write_set "$root/scripts/approved.tsv" '' "$(printf '%s\t%s\t1.0.0\t%s\t%s\t%s\t2026-09-03' "$first_consumer" "$first_workflow" "$DIGEST" "$SHA_A" "$SHA_B")"
+expect_refusal 'an approved set naming a consumer twice is refused' \
+  "$root" 0 "$first_consumer" 'twice'
+
+root="$(build_tree set-extra-field pattern)"
+write_set "$root/scripts/approved.tsv" "$first_consumer" "$(printf '%s\t%s\t1.0.0\t%s\t%s\t%s\t2026-09-03\textra' "$first_consumer" "$first_workflow" "$DIGEST" "$SHA_A" "$SHA_B")"
+expect_refusal 'an approved set row with an eighth field is refused' \
+  "$root" 0 'more than seven fields'
+
 root="$(build_tree set-bad-header pattern)"
 { printf 'consumer\tworkflow\n'; tail -n +2 "$root/scripts/approved.tsv"; } >"$root/scripts/approved.tmp"
 mv "$root/scripts/approved.tmp" "$root/scripts/approved.tsv"
@@ -340,7 +435,7 @@ expect_refusal 'a consumer whose manifest names a different workflow than its ro
 root="$(build_tree consumer-missing pattern)"
 rm -f "$root/$(first_path "$first_consumer")"
 expect_refusal 'a registered consumer with no OCIRepository in the tree is refused' \
-  "$root" 0 "$first_consumer"
+  "$root" 0 "$first_consumer" 'no OCIRepository under'
 
 # ── wiring: CI reaches the guard and this test ──────────────────────────────────────────────
 ci="$REPO_ROOT/.github/workflows/ci.yaml"
@@ -349,7 +444,7 @@ grep -Fq 'scripts/guard-publish-workflow-approved-revisions.sh' "$ci" ||
 grep -Fq 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh' "$ci" ||
   fail 'ci.yaml does not run test-publish-workflow-approved-revisions-guard.sh'
 # The switch must stay OFF in CI until the narrowing lands in the same change (#3308).
-if grep -Eq 'APPROVED_REVISIONS_ENFORCE:[[:space:]]*["'"'"']?1' "$ci"; then
+if grep -Eq 'APPROVED_REVISIONS_ENFORCE(:[[:space:]]*|=)["'"'"']?1' "$ci"; then
   fail 'ci.yaml turns APPROVED_REVISIONS_ENFORCE on; the switch flips only with the matcher narrowing'
 fi
 [ "$failures" -eq 0 ] && pass 'wiring: ci.yaml runs the guard and its test with the switch off'

--- a/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+++ b/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# RED/GREEN coverage for `guard-publish-workflow-approved-revisions.sh` (#3551).
+#
+# WHAT IS ACTUALLY BEING PROVED
+# The guard's one harmful failure mode is passing: a per-consumer matcher that names a revision
+# outside that consumer's generated pair still verifies SOMETHING, so no schema, kubeconform
+# pass or deploy notices. Every case below therefore isolates one conjunct and asserts the
+# guard refuses it BY NAME — the consumer and the offending ref appear in the message — rather
+# than merely exiting non-zero for some other reason. The switch is proved in both states.
+#
+# THE SEAMS
+# The guard reads the approved set from APPROVED_REVISIONS_FILE and scans PUBLISH_CONSUMER_ROOT;
+# both are pointed at a synthetic tree built here. Discovery, attribution and the registered
+# consumer list are REAL (sourced from the report), so the fixture carries exactly the four
+# registered consumers plus the three generic subject files the guard excludes by name.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly GUARD="$REPO_ROOT/scripts/guard-publish-workflow-approved-revisions.sh"
+readonly REPORT="$REPO_ROOT/scripts/report-publish-workflow-signing-revisions.sh"
+
+readonly PATTERN='[0-9a-f]{40}'
+readonly SHA_A='1111111111111111111111111111111111111111'
+readonly SHA_B='2222222222222222222222222222222222222222'
+readonly SHA_C='3333333333333333333333333333333333333333'
+readonly SHA_D='4444444444444444444444444444444444444444'
+readonly DIGEST='sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+readonly GENERIC_KYVERNO='k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml'
+readonly GENERIC_RGD='k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml'
+readonly GENERIC_TALOS='talos/cluster/verify-first-party-images.yaml'
+
+failures=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+pass() { printf 'ok: %s\n' "$*"; }
+
+[ -x "$GUARD" ] || { fail "guard not executable at $GUARD"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The registered consumers, from the report itself, so this test cannot drift from the list
+# the guard enforces. Each row: <repo>\t<workflow>.
+consumers="$("$REPORT" --list-consumers 2>/dev/null | cut -f1,2 || true)"
+if [ -z "$consumers" ]; then
+  fail '--list-consumers produced nothing; every case below would pass vacuously'
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+consumer_count="$(printf '%s\n' "$consumers" | grep -c .)"
+[ "$consumer_count" -ge 2 ] || { fail "need at least two registered consumers to cross pairs, found $consumer_count"; exit 1; }
+first_consumer="$(printf '%s\n' "$consumers" | sed -n 1p | cut -f1)"
+first_workflow="$(printf '%s\n' "$consumers" | sed -n 1p | cut -f2)"
+second_consumer="$(printf '%s\n' "$consumers" | sed -n 2p | cut -f1)"
+
+# The artifact name is the repository name except for `.github`, which publishes as
+# `github-config` — the same table the report uses.
+package_for() {
+  case "$1" in
+    .github) printf '%s\n' 'github-config' ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+# Per-consumer pair: consumer N signs with SHA_A+N-ish spelled as distinct SHAs. Keep it simple:
+# every consumer's signer is SHA_A except the second, whose signer is SHA_C; every pin is SHA_B.
+signer_for() {
+  if [ "$1" = "$second_consumer" ]; then printf '%s\n' "$SHA_C"; else printf '%s\n' "$SHA_A"; fi
+}
+
+subject_for() { # <workflow> <ref>
+  printf "'^https://github\\\\.com/devantler-tech/actions/\\\\.github/workflows/%s\\\\.yaml@%s\$'" "$1" "$2"
+}
+
+# write_consumer <root> <repo> <workflow> <ref> — one OCIRepository manifest at the path the
+# real tree uses for that consumer (the guard attributes by URL, not path, so the path is free).
+write_consumer() {
+  local root="$1" repo="$2" workflow="$3" ref="$4" dir
+  dir="$root/k8s/bases/apps/$(package_for "$repo")"
+  mkdir -p "$dir"
+  cat >"$dir/oci-repository.yaml" <<EOF
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: $(package_for "$repo")
+spec:
+  url: oci://ghcr.io/devantler-tech/$(package_for "$repo")/manifests
+  ref:
+    semver: '>=1.0.0'
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\\.actions\\.githubusercontent\\.com\$'
+        subject: $(subject_for "$workflow" "$ref")
+EOF
+}
+
+# write_generics <root> <ref> — the three generic subject files, on the given ref form.
+write_generics() {
+  local root="$1" ref="$2"
+  mkdir -p "$root/$(dirname "$GENERIC_KYVERNO")" "$root/$(dirname "$GENERIC_RGD")" "$root/$(dirname "$GENERIC_TALOS")"
+  cat >"$root/$GENERIC_KYVERNO" <<EOF
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-app-images
+spec:
+  rules:
+    - name: x
+      verifyImages:
+        - attestors:
+            - entries:
+                - keyless:
+                    subjectRegExp: ^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@$ref\$
+EOF
+  cat >"$root/$GENERIC_RGD" <<EOF
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: tenant
+spec:
+  resources:
+    - id: oci
+      template:
+        apiVersion: source.toolkit.fluxcd.io/v1
+        kind: OCIRepository
+        spec:
+          verify:
+            matchOIDCIdentity:
+              - issuer: x
+                subject: $(subject_for publish-app "$ref")
+EOF
+  cat >"$root/$GENERIC_TALOS" <<EOF
+apiVersion: v1alpha1
+kind: ImageVerificationConfig
+rules:
+  - subjectRegex: ^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@$ref\$
+EOF
+}
+
+# write_set <path> [<omit-repo>] [<extra-row>] — the approved set for every registered consumer.
+write_set() {
+  local path="$1" omit="${2:-}" extra="${3:-}" repo workflow
+  printf 'consumer\tworkflow\tapplied_tag\tapplied_digest\tapplied_signer_sha\tmain_pin_sha\tobserved_on\n' >"$path"
+  while IFS=$'\t' read -r repo workflow; do
+    [ -n "$repo" ] || continue
+    [ "$repo" = "$omit" ] && continue
+    printf '%s\t%s\t1.0.0\t%s\t%s\t%s\t2026-09-03\n' "$repo" "$workflow" "$DIGEST" "$(signer_for "$repo")" "$SHA_B" >>"$path"
+  done <<<"$consumers"
+  [ -z "$extra" ] || printf '%s\n' "$extra" >>"$path"
+}
+
+# build_tree <name> <ref-form-for-all-consumers|pair> — a complete fixture: every consumer on the
+# pattern form (`pattern`) or on its own generated pair (`pair`), generics on the pattern form.
+build_tree() {
+  local name="$1" form="$2" root repo workflow ref
+  root="$WORK/$name"
+  rm -rf "$root"
+  mkdir -p "$root/scripts"
+  while IFS=$'\t' read -r repo workflow; do
+    [ -n "$repo" ] || continue
+    case "$form" in
+      pattern) ref="$PATTERN" ;;
+      pair) ref="($(signer_for "$repo")|$SHA_B)" ;;
+      *) printf 'build_tree: unknown form %s\n' "$form" >&2; exit 1 ;;
+    esac
+    write_consumer "$root" "$repo" "$workflow" "$ref"
+  done <<<"$consumers"
+  write_generics "$root" "$PATTERN"
+  write_set "$root/scripts/approved.tsv"
+  printf '%s\n' "$root"
+}
+
+# run_guard <root> <enforce> — runs the guard against the fixture; prints combined output, returns its status.
+run_guard() {
+  local root="$1" enforce="$2"
+  APPROVED_REVISIONS_FILE="$root/scripts/approved.tsv" PUBLISH_CONSUMER_ROOT="$root" \
+    APPROVED_REVISIONS_ENFORCE="$enforce" bash "$GUARD" 2>&1
+}
+
+expect_pass() { # <case> <root> <enforce>
+  local out
+  if out="$(run_guard "$2" "$3")"; then
+    pass "$1"
+  else
+    fail "$1 — expected exit 0, got a refusal:"; printf '%s\n' "$out" >&2
+  fi
+}
+expect_refusal() { # <case> <root> <enforce> <must-mention>...
+  local case_name="$1" root="$2" enforce="$3" out needle
+  shift 3
+  if out="$(run_guard "$root" "$enforce")"; then
+    fail "$case_name — expected a refusal, guard exited 0:"; printf '%s\n' "$out" >&2
+    return
+  fi
+  for needle in "$@"; do
+    case "$out" in
+      *"$needle"*) ;;
+      *) fail "$case_name — refusal does not name '$needle':"; printf '%s\n' "$out" >&2; return ;;
+    esac
+  done
+  pass "$case_name"
+}
+
+first_path() { printf 'k8s/bases/apps/%s/oci-repository.yaml\n' "$(package_for "$1")"; }
+
+# ── switch OFF: pattern form accepted, set form accepted, anything else refused ─────────────
+root="$(build_tree off-pattern pattern)"
+expect_pass 'switch off: every consumer on the pattern form passes' "$root" 0
+
+root="$(build_tree off-pair pair)"
+expect_pass 'switch off: every consumer on its generated pair passes' "$root" 0
+
+root="$(build_tree off-pair-reversed pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($SHA_B|$(signer_for "$first_consumer"))"
+expect_pass 'switch off: the pair in the other order is the same set and passes' "$root" 0
+
+# AC4 of #3308: an out-of-set revision is refused whatever the switch says.
+root="$(build_tree off-foreign pattern)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($(signer_for "$first_consumer")|$SHA_D)"
+expect_refusal 'switch off: an alternation carrying a revision outside the pair is refused by consumer and ref' \
+  "$root" 0 "$first_consumer" "$SHA_D" 'not the generated pair'
+
+root="$(build_tree off-single-foreign pattern)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "$SHA_D"
+expect_refusal 'switch off: a single concrete revision outside the pair is refused' \
+  "$root" 0 "$first_consumer" "$SHA_D"
+
+root="$(build_tree off-half pattern)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "$(signer_for "$first_consumer")"
+expect_refusal 'switch off: one revision where the pair needs two is refused' \
+  "$root" 0 "$first_consumer" 'not the generated pair'
+
+root="$(build_tree off-three pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($(signer_for "$first_consumer")|$SHA_B|$SHA_D)"
+expect_refusal 'switch off: a third alternative widens the set and is refused' \
+  "$root" 0 "$first_consumer" "$SHA_D"
+
+# Membership is PER CONSUMER: the second consumer's valid pair is not the first's.
+root="$(build_tree off-crossed pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($(signer_for "$second_consumer")|$SHA_B)"
+expect_refusal "switch off: another consumer's pair on $first_consumer is refused" \
+  "$root" 0 "$first_consumer" "$(signer_for "$second_consumer")"
+
+root="$(build_tree off-tag pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" 'refs/tags/v.+'
+expect_refusal 'switch off: a tag ref is refused' "$root" 0 "$first_consumer" 'refs/tags/v.+'
+
+# ── switch ON: the pattern form is refused for a per-consumer subject ────────────────────────
+root="$(build_tree on-pair pair)"
+expect_pass 'switch on: every consumer on its generated pair passes' "$root" 1
+
+root="$(build_tree on-pattern pattern)"
+expect_refusal 'switch on: the pattern form is refused and the fix names the pair' \
+  "$root" 1 'pattern form' "($(signer_for "$first_consumer")|$SHA_B)"
+
+root="$(build_tree on-one-left pair)"
+write_consumer "$root" "$second_consumer" "$(printf '%s\n' "$consumers" | sed -n 2p | cut -f2)" "$PATTERN"
+expect_refusal 'switch on: a single consumer left on the pattern form is refused by name' \
+  "$root" 1 "$second_consumer" 'pattern form'
+
+root="$(build_tree on-foreign pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "($(signer_for "$first_consumer")|$SHA_D)"
+expect_refusal 'switch on: an out-of-set revision is refused just as it is with the switch off' \
+  "$root" 1 "$first_consumer" "$SHA_D"
+
+root="$(build_tree on-bad-switch pair)"
+expect_refusal 'a switch value other than 0 or 1 is refused rather than read as off' \
+  "$root" yes 'APPROVED_REVISIONS_ENFORCE'
+
+# ── generic subjects: excluded by name, in both states ──────────────────────────────────────
+root="$(build_tree generics-on pair)"
+expect_pass 'switch on: the three generic subjects stay on the pattern form and are not judged' "$root" 1
+
+root="$(build_tree generics-missing pattern)"
+rm -f "$root/$GENERIC_TALOS"
+expect_refusal 'a generic subject file missing from the tree is refused: the scope boundary moved' \
+  "$root" 0 "$GENERIC_TALOS"
+
+# A fourth kind of file naming the shared workflow that is neither a consumer nor listed.
+root="$(build_tree unattributed pattern)"
+mkdir -p "$root/k8s/extra"
+cat >"$root/k8s/extra/policy.yaml" <<EOF
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: extra
+spec:
+  rules:
+    - verifyImages:
+        - attestors:
+            - entries:
+                - keyless:
+                    subjectRegExp: ^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@$PATTERN\$
+EOF
+expect_refusal 'an unlisted non-OCIRepository subject is refused rather than skipped' \
+  "$root" 0 'k8s/extra/policy.yaml' 'GENERIC_SUBJECT_FILES'
+
+# An OCIRepository for a consumer the approved set does not know.
+root="$(build_tree unregistered pattern)"
+write_consumer "$root" 'stranger' 'publish-app' "$PATTERN"
+expect_refusal 'an OCIRepository for a consumer with no approved row is refused' \
+  "$root" 0 'stranger' 'no row in the approved set'
+
+# ── the approved set itself, read strictly ──────────────────────────────────────────────────
+root="$(build_tree set-missing pattern)"
+rm -f "$root/scripts/approved.tsv"
+expect_refusal 'a missing approved set is refused' "$root" 0 'approved set not found'
+
+root="$(build_tree set-no-row pattern)"
+write_set "$root/scripts/approved.tsv" "$first_consumer"
+expect_refusal 'an approved set missing a registered consumer is refused by name' \
+  "$root" 0 "$first_consumer" 'no row'
+
+root="$(build_tree set-extra pattern)"
+write_set "$root/scripts/approved.tsv" '' "$(printf 'stranger\tpublish-app\t1.0.0\t%s\t%s\t%s\t2026-09-03' "$DIGEST" "$SHA_A" "$SHA_B")"
+expect_refusal 'an approved set naming an unregistered consumer is refused' \
+  "$root" 0 'stranger' 'not a registered consumer'
+
+root="$(build_tree set-bad-sha pattern)"
+write_set "$root/scripts/approved.tsv" "$first_consumer" "$(printf '%s\t%s\t1.0.0\t%s\tdeadbeef\t%s\t2026-09-03' "$first_consumer" "$first_workflow" "$DIGEST" "$SHA_B")"
+expect_refusal 'an approved set with a malformed signer sha is refused' \
+  "$root" 0 "$first_consumer" 'not a 40-hex commit'
+
+root="$(build_tree set-bad-header pattern)"
+{ printf 'consumer\tworkflow\n'; tail -n +2 "$root/scripts/approved.tsv"; } >"$root/scripts/approved.tmp"
+mv "$root/scripts/approved.tmp" "$root/scripts/approved.tsv"
+expect_refusal "an approved set whose header is not the generator's is refused" "$root" 0 'header'
+
+root="$(build_tree set-workflow-mismatch pair)"
+other_workflow='publish-manifests'; [ "$first_workflow" = 'publish-manifests' ] && other_workflow='publish-app'
+write_consumer "$root" "$first_consumer" "$other_workflow" "($(signer_for "$first_consumer")|$SHA_B)"
+expect_refusal 'a consumer whose manifest names a different workflow than its row is refused' \
+  "$root" 0 "$first_consumer" "$other_workflow"
+
+# A consumer manifest that vanished: the registered list says it must exist.
+root="$(build_tree consumer-missing pattern)"
+rm -f "$root/$(first_path "$first_consumer")"
+expect_refusal 'a registered consumer with no OCIRepository in the tree is refused' \
+  "$root" 0 "$first_consumer"
+
+# ── wiring: CI reaches the guard and this test ──────────────────────────────────────────────
+ci="$REPO_ROOT/.github/workflows/ci.yaml"
+grep -Fq 'scripts/guard-publish-workflow-approved-revisions.sh' "$ci" ||
+  fail 'ci.yaml does not run guard-publish-workflow-approved-revisions.sh'
+grep -Fq 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh' "$ci" ||
+  fail 'ci.yaml does not run test-publish-workflow-approved-revisions-guard.sh'
+# The switch must stay OFF in CI until the narrowing lands in the same change (#3308).
+if grep -Eq 'APPROVED_REVISIONS_ENFORCE:[[:space:]]*["'"'"']?1' "$ci"; then
+  fail 'ci.yaml turns APPROVED_REVISIONS_ENFORCE on; the switch flips only with the matcher narrowing'
+fi
+[ "$failures" -eq 0 ] && pass 'wiring: ci.yaml runs the guard and its test with the switch off'
+
+# ── the real tree, switch off: the committed set and the live matchers agree ────────────────
+if out="$(bash "$GUARD" 2>&1)"; then
+  pass 'real tree: the committed approved set agrees with the live per-consumer matchers (switch off)'
+else
+  fail 'real tree: guard refuses the committed state:'; printf '%s\n' "$out" >&2
+fi
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall approved-revisions guard cases passed\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why
The shared publish workflows' cosign matchers are about to be narrowed from "any commit" to each consumer's approved revision pair, and nothing today checks that a narrowed matcher names the pair the generated set actually holds. A hand edit or a stale regeneration could quietly widen a matcher back, or point it at a revision nobody approved, with every existing check still green.

### What
Adds a CI guard that reads the committed approved-revision set and asserts each of the four per-consumer matchers pins exactly that consumer's pair, refusing any revision outside it. It ships behind a switch that is off by default: while off, today's pattern-form matchers still pass, so the guard is live now without forcing the narrowing; once on, a matcher left on the pattern form fails. The three generic subjects are excluded by name and stay as they are. Both switch states and every refusal are covered by the accompanying test.

Fixes #3551
Part of #3308
