### PR TITLE
feat(security): supply fsGroupChangePolicy and seLinuxOptions to the observability plain-manifest workloads

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -105,6 +105,13 @@ spec:
             # volume to root:65532, which the group-readable mode below then
             # opens to this container and nothing else.
             fsGroup: 65532
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -238,6 +245,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
@@ -94,6 +94,13 @@ spec:
             # owner-only mode would be unreadable by this container's own
             # non-root user. Same rationale as cnpg-degraded-alert.
             fsGroup: 65532
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -283,6 +290,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
@@ -70,6 +70,13 @@ spec:
             # which the group-readable mode then opens to this container and nothing
             # else.
             fsGroup: 65532
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
             seccompProfile:
               type: RuntimeDefault
           containers:
@@ -119,6 +126,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -50,6 +50,13 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         fsGroup: 65534
+        # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+        # fields the cluster-wide add-security-context mutation cannot supply
+        # here: observability is excluded from it, and the namespace opt-in
+        # mutates the running POD, while Kubescape scores the STORED workload
+        # spec (#3239). Writing them into the template is the only route that
+        # moves both surfaces. Values match add-security-context.yaml.
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -76,6 +83,9 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+            seLinuxOptions:
+              level: s0
           resources:
             requests:
               cpu: 10m
@@ -104,6 +114,9 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+            seLinuxOptions:
+              level: s0
           resources:
             requests:
               cpu: 20m

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
@@ -82,6 +82,13 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: autosuppressor
               # curl + jq, digest-pinned (same image as custom-cloud-pricing).
@@ -93,6 +100,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -76,6 +76,13 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: alerter
               # curl + jq, digest-pinned (same image as the autosuppressor).
@@ -87,6 +94,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-custom-cloud-pricing.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-custom-cloud-pricing.yaml
@@ -73,6 +73,13 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+            # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+            # fields the cluster-wide add-security-context mutation cannot supply
+            # here: observability is excluded from it, and the namespace opt-in
+            # mutates the running POD, while Kubescape scores the STORED workload
+            # spec (#3239). Writing them into the template is the only route that
+            # moves both surfaces. Values match add-security-context.yaml.
+            fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: set-pricing
               # curl + jq, pinned by digest. jq replaces the former grep/sed/awk
@@ -89,6 +96,9 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65532
                 runAsGroup: 65532
+                # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
+                seLinuxOptions:
+                  level: s0
                 capabilities:
                   drop:
                     - ALL


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Kubescape's C-0211 control still fails on 29 workloads in the four namespaces the cluster-wide security-context mutation excludes, and the observability namespace holds 15 of them. The namespace opt-in shipped earlier cannot move that number, because it mutates running pods while the scanner scores the stored workload spec. Only writing the fields into the templates closes the gap, as the velero and flux-system slices proved.

### What

Adds the two non-privilege fields, `fsGroupChangePolicy` and `seLinuxOptions`, to the seven observability workloads this repository authors directly: the six alerting and heartbeat CronJobs and the crossplane-sync-exporter Deployment. No privilege, user or group field changes. The eight remaining observability workloads are owned by the Coroot operator and the audit-log-forwarder chart and are a separate slice; the residual re-measurement and the sizing note follow after this deploys.

Mechanical two-field addition, so no feature flag: the rendered manifests with and without the change are the two states, and both render and validate.

Part of #3239
