### PR TITLE
fix(security): supply C-0211's two universal fields at the controller object in opted-in namespaces

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -57,6 +57,9 @@ metadata:
     policies.kyverno.io/description: >-
       Mutates all pods to set security best-practice defaults using
       conditional anchors so explicit chart values are never overwritten.
+      In namespaces labelled baseline-context-controllers it also writes the
+      two inert C-0211 fields into the stored pod templates of Deployments,
+      StatefulSets, DaemonSets, Jobs and CronJobs.
 spec:
   rules:
     # User namespaces are default-off and enabled per namespace only after the

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -1,4 +1,6 @@
-# Mutates pods to apply security best-practices that kubescape checks:
+# Mutates pods — and, in namespaces opted in to the baseline-context rules, the
+# stored specs of their controllers — to apply security best-practices that
+# kubescape checks:
 # - seccompProfile: RuntimeDefault (C-0055 Linux hardening) — pod + container
 # - allowPrivilegeEscalation: false (C-0016)
 # - readOnlyRootFilesystem: true (C-0017)
@@ -405,3 +407,239 @@ spec:
                     securityContext:
                       seLinuxOptions:
                         +(level): s0
+    # CONTROLLER-KIND COUNTERPARTS of the three opt-in rules above. Those rules
+    # match `Pod` and this policy generates no autogen rules (its live
+    # `status.autogen` is empty), so they mutate only at pod admission and the
+    # STORED controller spec — the one Kubescape scores for C-0211 — is never
+    # touched. Measured 2026-09-03 against live prod after observability and
+    # longhorn-system were opted in: 0 of 15 and 0 of 12 stored specs carried
+    # either field, while the running pods created since the label did. The
+    # seven Coroot-operator workloads and Longhorn's CSI and manager workloads
+    # cannot take the template route the plain manifests took, because their
+    # specs are written by an operator whose CRD exposes no securityContext
+    # field (verified against the coroot-operator v1.9.5 CRD). These rules reach
+    # them where the pod rules cannot: at the controller object.
+    #
+    # CREATE and UPDATE, unlike the pod rules. A controller's pod template is
+    # mutable, so the 422 hazard that forced the pod rules to CREATE-only does
+    # not exist here — and UPDATE is the only way an already-stored spec that an
+    # operator rewrites on reconcile ever receives the fields. Both fields are
+    # written through conditional anchors, so a chart- or operator-set value is
+    # preserved and a second admission of the same object is a no-op.
+    #
+    # Same opt-in label, same two fields, same leaf-level SELinux anchors and the
+    # same wholesale-replace guards as the pod rules; only the path differs
+    # (`spec.template.spec`, and `spec.jobTemplate.spec.template.spec` for
+    # CronJobs). `tests/add-baseline-context` pins every state for the
+    # controller kinds too.
+    - name: add-baseline-context-optin-controllers
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                securityContext:
+                  +(fsGroupChangePolicy): OnRootMismatch
+    - name: add-baseline-context-optin-controllers-pod-selinux-level
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+            operator: NotEquals
+            value: ''
+          - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions.level || '' }}"
+            operator: Equals
+            value: ''
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                securityContext:
+                  seLinuxOptions:
+                    +(level): s0
+    - name: add-baseline-context-optin-controllers-containers
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      mutate:
+        foreach:
+          - list: "request.object.spec.template.spec.containers"
+            preconditions:
+              any:
+                - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+                  operator: Equals
+                  value: ''
+                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
+                  operator: NotEquals
+                  value: ''
+            patchStrategicMerge:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - (name): "{{element.name}}"
+                        securityContext:
+                          seLinuxOptions:
+                            +(level): s0
+          - list: "request.object.spec.template.spec.initContainers[]"
+            preconditions:
+              any:
+                - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+                  operator: Equals
+                  value: ''
+                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
+                  operator: NotEquals
+                  value: ''
+            patchStrategicMerge:
+              spec:
+                template:
+                  spec:
+                    initContainers:
+                      - (name): "{{element.name}}"
+                        securityContext:
+                          seLinuxOptions:
+                            +(level): s0
+    - name: add-baseline-context-optin-cronjobs
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      +(fsGroupChangePolicy): OnRootMismatch
+    - name: add-baseline-context-optin-cronjobs-pod-selinux-level
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+            operator: NotEquals
+            value: ''
+          - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.level || '' }}"
+            operator: Equals
+            value: ''
+      mutate:
+        patchStrategicMerge:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      seLinuxOptions:
+                        +(level): s0
+    - name: add-baseline-context-optin-cronjobs-containers
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+              operations:
+                - CREATE
+                - UPDATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context: enabled
+      mutate:
+        foreach:
+          - list: "request.object.spec.jobTemplate.spec.template.spec.containers"
+            preconditions:
+              any:
+                - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+                  operator: Equals
+                  value: ''
+                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
+                  operator: NotEquals
+                  value: ''
+            patchStrategicMerge:
+              spec:
+                jobTemplate:
+                  spec:
+                    template:
+                      spec:
+                        containers:
+                          - (name): "{{element.name}}"
+                            securityContext:
+                              seLinuxOptions:
+                                +(level): s0
+          - list: "request.object.spec.jobTemplate.spec.template.spec.initContainers[]"
+            preconditions:
+              any:
+                - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+                  operator: Equals
+                  value: ''
+                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
+                  operator: NotEquals
+                  value: ''
+            patchStrategicMerge:
+              spec:
+                jobTemplate:
+                  spec:
+                    template:
+                      spec:
+                        initContainers:
+                          - (name): "{{element.name}}"
+                            securityContext:
+                              seLinuxOptions:
+                                +(level): s0

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -52,7 +52,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Security Context Defaults
     policies.kyverno.io/category: Pod Security, Best Practices
-    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/subject: Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/description: >-
       Mutates all pods to set security best-practice defaults using
@@ -420,15 +420,28 @@ spec:
     # field (verified against the coroot-operator v1.9.5 CRD). These rules reach
     # them where the pod rules cannot: at the controller object.
     #
-    # CREATE and UPDATE, unlike the pod rules. A controller's pod template is
-    # mutable, so the 422 hazard that forced the pod rules to CREATE-only does
-    # not exist here — and UPDATE is the only way an already-stored spec that an
-    # operator rewrites on reconcile ever receives the fields. Both fields are
-    # written through conditional anchors, so a chart- or operator-set value is
-    # preserved and a second admission of the same object is a no-op.
+    # DEFAULT-OFF behind ITS OWN label, `baseline-context-controllers`, distinct
+    # from the pod rules' `baseline-context`. The two fields are inert, but
+    # writing them into a stored pod template changes the template hash, so the
+    # first admission of a pre-existing workload ROLLS it — a Longhorn manager
+    # DaemonSet or a Coroot ClickHouse StatefulSet restarts at whatever moment
+    # its owner next writes it. That is a rollout, not a posture edit, and it is
+    # opted into one namespace at a time with the live workloads read back
+    # afterwards; a namespace carrying only the pod-rule label is untouched.
     #
-    # Same opt-in label, same two fields, same leaf-level SELinux anchors and the
-    # same wholesale-replace guards as the pod rules; only the path differs
+    # CREATE and UPDATE for Deployment, StatefulSet and DaemonSet, whose pod
+    # template is mutable — UPDATE is the only way an already-stored spec that an
+    # operator rewrites on reconcile ever receives the fields, and the `+()`
+    # anchors make every later admission a no-op, so an operator that rewrites
+    # its template wholesale pays one no-op write per reconcile, never a loop.
+    # Job is CREATE-only: a Job's template is immutable once created, so an
+    # UPDATE-time mutation would turn any later edit (a label, `suspend`) into a
+    # rejected template change — the same 422 hazard that keeps the pod rules
+    # CREATE-only. A Job spawned from a mutated CronJob already carries the
+    # fields; a standalone Job gets them at creation.
+    #
+    # Same two fields, same leaf-level SELinux anchors and the same
+    # wholesale-replace guards as the pod rules; only the path differs
     # (`spec.template.spec`, and `spec.jobTemplate.spec.template.spec` for
     # CronJobs). `tests/add-baseline-context` pins every state for the
     # controller kinds too.
@@ -440,13 +453,20 @@ spec:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
-                - Job
               operations:
                 - CREATE
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
+          - resources:
+              kinds:
+                - Job
+              operations:
+                - CREATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       mutate:
         patchStrategicMerge:
           spec:
@@ -462,13 +482,20 @@ spec:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
-                - Job
               operations:
                 - CREATE
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
+          - resources:
+              kinds:
+                - Job
+              operations:
+                - CREATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       preconditions:
         all:
           - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
@@ -493,13 +520,20 @@ spec:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
-                - Job
               operations:
                 - CREATE
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
+          - resources:
+              kinds:
+                - Job
+              operations:
+                - CREATE
+              namespaceSelector:
+                matchLabels:
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       mutate:
         foreach:
           - list: "request.object.spec.template.spec.containers"
@@ -549,7 +583,7 @@ spec:
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       mutate:
         patchStrategicMerge:
           spec:
@@ -570,7 +604,7 @@ spec:
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       preconditions:
         all:
           - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
@@ -600,7 +634,7 @@ spec:
                 - UPDATE
               namespaceSelector:
                 matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
+                  pod-security.devantler.tech/baseline-context-controllers: enabled
       mutate:
         foreach:
           - list: "request.object.spec.jobTemplate.spec.template.spec.containers"

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -372,14 +372,18 @@ spec:
             # `{user: system_u, level: s9}` came back with the container on `{level: s0}`,
             # losing both the operator's level and its user. Inject only when the pod sets
             # no SELinux options at all, or when the container already overrides them.
+            # "Overrides" is tested by KEY PRESENCE, not truthiness: a container that sets
+            # `seLinuxOptions: {}` is an override Kubernetes honours (the pod-level object no
+            # longer applies to it), yet the empty mapping is falsy to JMESPath, so an
+            # `|| ''` test read it as absent and left that container with no level at all.
             preconditions:
               any:
                 - key: "{{ request.object.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 containers:
@@ -395,14 +399,18 @@ spec:
             # `{user: system_u, level: s9}` came back with the container on `{level: s0}`,
             # losing both the operator's level and its user. Inject only when the pod sets
             # no SELinux options at all, or when the container already overrides them.
+            # "Overrides" is tested by KEY PRESENCE, not truthiness: a container that sets
+            # `seLinuxOptions: {}` is an override Kubernetes honours (the pod-level object no
+            # longer applies to it), yet the empty mapping is falsy to JMESPath, so an
+            # `|| ''` test read it as absent and left that container with no level at all.
             preconditions:
               any:
                 - key: "{{ request.object.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 initContainers:
@@ -545,9 +553,9 @@ spec:
                 - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 template:
@@ -563,9 +571,9 @@ spec:
                 - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 template:
@@ -646,9 +654,9 @@ spec:
                 - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 jobTemplate:
@@ -666,9 +674,9 @@ spec:
                 - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
                   operator: Equals
                   value: ''
-                - key: "{{ element.securityContext.seLinuxOptions || '' }}"
-                  operator: NotEquals
-                  value: ''
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "true"
             patchStrategicMerge:
               spec:
                 jobTemplate:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -442,9 +442,37 @@ spec:
     #
     # CREATE and UPDATE for Deployment, StatefulSet and DaemonSet, whose pod
     # template is mutable — UPDATE is the only way an already-stored spec that an
-    # operator rewrites on reconcile ever receives the fields, and the `+()`
-    # anchors make every later admission a no-op, so an operator that rewrites
-    # its template wholesale pays one no-op write per reconcile, never a loop.
+    # operator rewrites on reconcile ever receives the fields. The `+()` anchors
+    # inspect the INCOMING request, not the stored object, so they make an
+    # admission a no-op only when the writer already carries the fields: an
+    # owner that reads the stored object back and preserves unknown fields
+    # (controller-runtime CreateOrUpdate on the fetched object) converges after
+    # one write, but an owner that REBUILDS its template from its own desired
+    # state omits the fields on every write, Kyverno re-adds them before
+    # persistence, and the live object never equals what that owner wanted —
+    # each write still advances resourceVersion, which can requeue the owner
+    # into a continuous reconcile loop. Coroot is a known candidate: it already
+    # fights external ownership of its generated Deployment
+    # (docs/progressive-delivery.md). The label therefore makes NO claim that a
+    # namespace's owners converge; that is what the per-namespace flip proves.
+    #
+    # Labelling a namespace also does not by itself touch anything already
+    # stored: helm-controller reapplies a rendered resource only on a chart or
+    # values change and excludes `/spec/template` from drift correction, so a
+    # Helm-rendered controller (Longhorn's manager, CSI and UI) keeps its old
+    # template indefinitely until some writer issues an UPDATE. The flip is
+    # therefore a procedure, not a label edit. For each namespace it:
+    #   1. adds the label and, per existing controller, issues a
+    #      `kubectl rollout restart`-style template-annotation UPDATE — the
+    #      admission of that write is what backfills the fields (and it is the
+    #      one rollout per workload the paragraph above warns about);
+    #   2. reads the stored specs back and confirms both fields landed;
+    #   3. watches every owner's write rate on those objects for the loop above
+    #      (resourceVersion advancing with no spec change) and, on a loop,
+    #      reverts the label or excludes that owner's objects by ownerReference
+    #      before the label is kept;
+    #   4. records the read-back on the namespace manifest, which is what the
+    #      inventory gate in tests/add-baseline-context expects.
     # Job is CREATE-only: a Job's template is immutable once created, so an
     # UPDATE-time mutation would turn any later edit (a label, `suspend`) into a
     # rejected template change — the same 422 hazard that keeps the pod rules

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -462,11 +462,18 @@ spec:
     # Helm-rendered controller (Longhorn's manager, CSI and UI) keeps its old
     # template indefinitely until some writer issues an UPDATE. The flip is
     # therefore a procedure, not a label edit. For each namespace it:
-    #   1. adds the label and, per existing controller, issues a
-    #      `kubectl rollout restart`-style template-annotation UPDATE — the
-    #      admission of that write is what backfills the fields (and it is the
-    #      one rollout per workload the paragraph above warns about);
-    #   2. reads the stored specs back and confirms both fields landed;
+    #   1. adds the label and, per existing Deployment, StatefulSet, DaemonSet
+    #      and CronJob, issues a `kubectl rollout restart`-style
+    #      template-annotation UPDATE — the admission of that write is what
+    #      backfills the fields (and it is the one rollout per workload the
+    #      paragraph above warns about). A pre-existing Job is OUT of that
+    #      backfill: its template is immutable, so no UPDATE can carry the
+    #      fields into it. A CronJob-spawned Job is replaced with the fields at
+    #      its next schedule (a fresh CREATE); a standalone Job keeps its stored
+    #      template until it is deleted and recreated, and the read-back lists
+    #      it as such rather than counting it as backfilled;
+    #   2. reads the stored specs back and confirms both fields landed on every
+    #      restarted kind, and names any pre-existing Job left as-is;
     #   3. watches every owner's write rate on those objects for the loop above
     #      (resourceVersion advancing with no spec change) and, on a loop,
     #      reverts the label or excludes that owner's objects by ownerReference

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -227,6 +227,41 @@ check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.securityContext.
 check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
   null "container-level injection replaced the partial Deployment pod-level SELinux object"
 
+# A standalone Job (CREATE-only kind) takes the template path like the others.
+check oneshot-job-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "opted-in Job template did not receive fsGroupChangePolicy"
+check oneshot-job-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in Job container did not receive seLinuxOptions"
+
+# The jobTemplate pod-scope fill: a CronJob whose pod-level SELinux object has no
+# `level` receives it there, keeps its `user`, and its containers stay untouched.
+# Measured on this fixture with the rule deleted: the fixture reads Excluded and
+# `kyverno test` still passes, so this is the only gate that sees the rule.
+check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.level' \
+  s0 "partial CronJob pod-level seLinuxOptions did not receive the missing level"
+check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.user' \
+  system_u "partial CronJob pod-level seLinuxOptions lost its pre-existing user"
+check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "container-level injection replaced the partial CronJob pod-level SELinux object"
+check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "initContainer-level injection replaced the partial CronJob pod-level SELinux object"
+check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "CronJob rule did not fire on the podlevel-partial-cronjob fixture"
+
+# A complete pod-level object on a CronJob: preserved, containers untouched.
+check podlevel-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.level' \
+  s9 "CronJob pod-level seLinuxOptions.level was not preserved"
+check podlevel-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "CronJob pod-level SELinux options were overridden by a container-level injection"
+
+# The controller rules are gated by their OWN label. A namespace carrying only
+# the pod-rule label (kubescape in values.yaml) must see no controller mutation,
+# or the separate rollout gate is not a gate.
+check podlabel-only-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  null "pod-rule label alone mutated a controller template"
+check podlabel-only-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "pod-rule label alone injected seLinuxOptions into a controller"
+
 # ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
 # in the cluster is decided entirely by which namespaces carry the opt-in label —
 # a fact no mutation fixture can see. Without this gate, widening the rollout from
@@ -257,8 +292,31 @@ if [ "${actual_optin}" != "${expected_optin}" ]; then
   fail=1
 fi
 
+# The controller-kind rules carry their OWN opt-in label, because writing the
+# fields into a stored pod template rolls the workload. Nothing is opted in yet:
+# this pins the default-off state, and each namespace is added here only with the
+# post-rollout read-back of its workloads recorded on the namespace manifest.
+expected_controllers_optin=""
+
+actual_controllers_optin="$(
+  grep -rl 'pod-security.devantler.tech/baseline-context-controllers' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null |
+    while IFS= read -r f; do
+      yq -N '
+        select(.kind == "Namespace" and
+               .metadata.labels."pod-security.devantler.tech/baseline-context-controllers" == "enabled") |
+        .metadata.name
+      ' "${f}" 2>/dev/null
+    done | awk 'NF' | LC_ALL=C sort -u | paste -sd, -
+)"
+
+if [ "${actual_controllers_optin}" != "${expected_controllers_optin}" ]; then
+  echo "::error::baseline-context-controllers opt-in inventory changed: expected '${expected_controllers_optin}', got '${actual_controllers_optin}'"
+  echo "::error::a namespace joins the controller rollout only together with its measured post-rollout read-back"
+  fail=1
+fi
+
 if [ "${fail}" -ne 0 ]; then
   exit 1
 fi
 
-echo "Baseline-context opt-in mutation: injected when labelled, preserved when preset, inert when not."
+echo "Baseline-context opt-in mutation: injected when labelled, preserved when preset, inert when not — at the pod and, behind its own label, at the controller."

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -149,6 +149,84 @@ check coroot-node-agent-mutated.yaml '.spec.initContainers[0].securityContext.se
 check coroot-node-agent-mutated.yaml '.spec.securityContext.seLinuxOptions' \
   null "pod-scope SELinux fill created an object where the author set none"
 
+# CONTROLLER KINDS. Kubescape scores the STORED controller spec, and the pod
+# rules never reach it (this policy has no autogen rules; measured 2026-09-03
+# against live prod: 0 of 15 observability and 0 of 12 longhorn-system stored
+# specs carried either field after the namespaces were opted in). The
+# controller-kind rules close that at the object Kubescape reads. Every state
+# the pod fixtures pin is asserted again here, on the kinds the residual
+# population consists of. Pod-level assertions on the templates use a different
+# path per kind: `spec.template.spec` and, for CronJobs, `spec.jobTemplate`.
+
+# ON state — the plain operator-written shape receives both fields, on the
+# template and on every container and initContainer.
+check operator-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "opted-in Deployment template did not receive fsGroupChangePolicy"
+check operator-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in Deployment container did not receive seLinuxOptions"
+check operator-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in Deployment initContainer did not receive seLinuxOptions"
+check operator-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions' \
+  null "controller pod-scope SELinux fill created an object where the author set none"
+
+# A StatefulSet without initContainers: the foreach must tolerate the absent
+# field rather than dropping the container mutation with it.
+check server-sts-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "opted-in StatefulSet template did not receive fsGroupChangePolicy"
+check server-sts-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in StatefulSet container did not receive seLinuxOptions"
+
+# A privileged DaemonSet, the shape Longhorn actually runs: privilege is
+# untouched and the two fields are supplied beside it.
+check manager-ds-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "opted-in DaemonSet template did not receive fsGroupChangePolicy"
+check manager-ds-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in DaemonSet container did not receive seLinuxOptions"
+check manager-ds-mutated.yaml '.spec.template.spec.containers[0].securityContext.privileged' \
+  true "controller rule changed a privilege field it must not touch"
+
+# The jobTemplate path.
+check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "opted-in CronJob template did not receive fsGroupChangePolicy"
+check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in CronJob container did not receive seLinuxOptions"
+check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s0 "opted-in CronJob initContainer did not receive seLinuxOptions"
+
+# OFF state — an unlabelled namespace's controllers are untouched.
+check unlabelled-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  null "unlabelled namespace Deployment was mutated at the template level"
+check unlabelled-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "unlabelled namespace Deployment had seLinuxOptions injected"
+
+# Conditional anchors — a controller that sets its own values keeps them.
+check preset-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  Always "preset Deployment fsGroupChangePolicy was overwritten"
+check preset-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s9 "preset Deployment container seLinuxOptions was overwritten"
+check preset-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s9 "preset Deployment initContainer seLinuxOptions was overwritten"
+
+# The wholesale-replace guard at controller scope: a complete pod-level SELinux
+# object stays the only one, and fsGroupChangePolicy still lands.
+check podlevel-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "Deployment pod-level SELinux options were overridden by a container-level injection"
+check podlevel-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "Deployment pod-level SELinux options were overridden by an initContainer-level injection"
+check podlevel-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.level' \
+  s9 "Deployment pod-level seLinuxOptions.level was not preserved"
+check podlevel-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
+  OnRootMismatch "controller rule did not fire on the podlevel-deploy fixture"
+
+# The pod-level-object-without-level shape at controller scope: only the
+# pod-scope fill may supply the level, preserving the sibling user.
+check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.level' \
+  s0 "partial Deployment pod-level seLinuxOptions did not receive the missing level"
+check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.user' \
+  system_u "partial Deployment pod-level seLinuxOptions lost its pre-existing user"
+check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "container-level injection replaced the partial Deployment pod-level SELinux object"
+
 # ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
 # in the cluster is decided entirely by which namespaces carry the opt-in label —
 # a fact no mutation fixture can see. Without this gate, widening the rollout from

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -319,7 +319,11 @@ fi
 # The controller-kind rules carry their OWN opt-in label, because writing the
 # fields into a stored pod template rolls the workload. Nothing is opted in yet:
 # this pins the default-off state, and each namespace is added here only with the
-# post-rollout read-back of its workloads recorded on the namespace manifest.
+# post-rollout read-back of its workloads recorded on the namespace manifest. The
+# label alone updates nothing already stored (helm-controller does not reapply an
+# unchanged template), so a flip also restarts each existing controller to backfill
+# the fields and watches its owner for a reconcile loop — the procedure is spelled
+# out beside the rules in add-security-context.yaml.
 expected_controllers_optin=""
 
 # `grep -rl` exits 1 when nothing matches; under pipefail that would abort the assignment

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -276,7 +276,7 @@ expected_optin="kubescape,longhorn-system,observability,velero"
 # grep only prefilters candidate files; yq decides, so a mention in a comment or
 # in the policy that DEFINES the label cannot be counted as an opted-in namespace.
 actual_optin="$(
-  grep -rl 'pod-security.devantler.tech/baseline-context' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null |
+  { grep -rl 'pod-security.devantler.tech/baseline-context' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null || true; } |
     while IFS= read -r f; do
       yq -N '
         select(.kind == "Namespace" and
@@ -298,8 +298,11 @@ fi
 # post-rollout read-back of its workloads recorded on the namespace manifest.
 expected_controllers_optin=""
 
+# `grep -rl` exits 1 when nothing matches; under pipefail that would abort the assignment
+# and the gate would die before comparing against the (legitimately empty) inventory,
+# so the no-match case is folded into an empty list rather than an errexit.
 actual_controllers_optin="$(
-  grep -rl 'pod-security.devantler.tech/baseline-context-controllers' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null |
+  { grep -rl 'pod-security.devantler.tech/baseline-context-controllers' --include='*.yaml' "${repo_root}/k8s" 2>/dev/null || true; } |
     while IFS= read -r f; do
       yq -N '
         select(.kind == "Namespace" and

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -262,6 +262,30 @@ check podlabel-only-deploy-mutated.yaml '.spec.template.spec.securityContext.fsG
 check podlabel-only-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
   null "pod-rule label alone injected seLinuxOptions into a controller"
 
+# An EXPLICITLY EMPTY container-level SELinux object under a complete pod-level object.
+# Kubernetes treats the non-null empty object as an override (DetermineEffectiveSecurityContext),
+# so the effective container context has NO level — and to JMESPath the empty mapping is
+# falsy, so an `|| ''` presence test read it as absent and left it that way. Measured on
+# the previous head: `{}` came back unchanged at pod and controller scope. The key-presence
+# test fills the level; the sibling container that sets nothing stays untouched because the
+# pod-level object still governs it.
+check empty-override-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "empty container-level SELinux override did not receive the missing level (pod)"
+check empty-override-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s0 "empty initContainer-level SELinux override did not receive the missing level (pod)"
+check empty-override-mutated.yaml '.spec.containers[1].securityContext.seLinuxOptions' \
+  null "a container with no override was injected beside an empty-override sibling (pod)"
+check empty-override-mutated.yaml '.spec.securityContext.seLinuxOptions.level' \
+  s9 "pod-level level was not preserved beside an empty container override (pod)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
+  s0 "empty container-level SELinux override did not receive the missing level (Deployment)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
+  s0 "empty initContainer-level SELinux override did not receive the missing level (Deployment)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.containers[1].securityContext.seLinuxOptions' \
+  null "a container with no override was injected beside an empty-override sibling (Deployment)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.level' \
+  s9 "pod-level level was not preserved beside an empty container override (Deployment)"
+
 # ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
 # in the cluster is decided entirely by which namespaces carry the opt-in label —
 # a fact no mutation fixture can see. Without this gate, widening the rollout from

--- a/tests/add-baseline-context/kyverno-test.yaml
+++ b/tests/add-baseline-context/kyverno-test.yaml
@@ -253,3 +253,27 @@ results:
       - kubescape/podlabel-only-deploy
     kind: Deployment
     result: skip
+  # An explicitly EMPTY container-level SELinux object under a complete pod-level
+  # object is an override Kubernetes honours, so the container rule must fill its
+  # level (and leave the sibling container that sets nothing alone).
+  - policy: add-security-context
+    rule: add-baseline-context-optin-containers
+    resources:
+      - velero/empty-override
+    kind: Pod
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - velero/empty-override-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - velero/empty-override-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml

--- a/tests/add-baseline-context/kyverno-test.yaml
+++ b/tests/add-baseline-context/kyverno-test.yaml
@@ -84,3 +84,113 @@ results:
       - observability/coroot-node-agent
     kind: Pod
     result: skip
+  # --- Controller kinds ---------------------------------------------------
+  # The stored controller spec is what Kubescape scores and the pod rules never
+  # reach it, so every state above is pinned again at the controller object.
+  # ON state, template path.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - observability/operator-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - observability/server-sts
+    kind: StatefulSet
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - longhorn-system/manager-ds
+    kind: DaemonSet
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - observability/operator-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - observability/server-sts
+    kind: StatefulSet
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - longhorn-system/manager-ds
+    kind: DaemonSet
+    result: pass
+    patchedResources: patched-resources.yaml
+  # ON state, jobTemplate path.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs
+    resources:
+      - observability/nightly-cronjob
+    kind: CronJob
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs-containers
+    resources:
+      - observability/nightly-cronjob
+    kind: CronJob
+    result: pass
+    patchedResources: patched-resources.yaml
+  # The pod-scope SELinux fill at controller scope: fires only on the
+  # pod-level-object-without-level shape.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-pod-selinux-level
+    resources:
+      - velero/podlevel-partial-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - velero/podlevel-deploy
+      - velero/podlevel-partial-deploy
+    kind: Deployment
+    result: pass
+    patchedResources: patched-resources.yaml
+  # OFF state and anchor preservation at controller scope.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - chaos-mesh/unlabelled-deploy
+      - velero/preset-deploy
+    kind: Deployment
+    result: skip
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - chaos-mesh/unlabelled-deploy
+      - velero/preset-deploy
+      - velero/podlevel-deploy
+      - velero/podlevel-partial-deploy
+    kind: Deployment
+    result: skip
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-pod-selinux-level
+    resources:
+      - chaos-mesh/unlabelled-deploy
+      - velero/preset-deploy
+      - velero/podlevel-deploy
+      - observability/operator-deploy
+    kind: Deployment
+    result: skip
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
+    resources:
+      - observability/nightly-cronjob
+    kind: CronJob
+    result: skip

--- a/tests/add-baseline-context/kyverno-test.yaml
+++ b/tests/add-baseline-context/kyverno-test.yaml
@@ -194,3 +194,62 @@ results:
       - observability/nightly-cronjob
     kind: CronJob
     result: skip
+  # A standalone Job (CREATE-only kind) takes the template path.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - observability/oneshot-job
+    kind: Job
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - observability/oneshot-job
+    kind: Job
+    result: pass
+    patchedResources: patched-resources.yaml
+  # The jobTemplate pod-scope fill fires on exactly the partial pod-level shape
+  # and nowhere else; the CronJob rules still land fsGroupChangePolicy on the
+  # pod-level fixtures and keep the container foreach out.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
+    resources:
+      - velero/podlevel-partial-cronjob
+    kind: CronJob
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs
+    resources:
+      - velero/podlevel-partial-cronjob
+      - velero/podlevel-cronjob
+    kind: CronJob
+    result: pass
+    patchedResources: patched-resources.yaml
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
+    resources:
+      - velero/podlevel-cronjob
+    kind: CronJob
+    result: skip
+  - policy: add-security-context
+    rule: add-baseline-context-optin-cronjobs-containers
+    resources:
+      - velero/podlevel-partial-cronjob
+      - velero/podlevel-cronjob
+    kind: CronJob
+    result: skip
+  # The pod-rule label alone reaches no controller.
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers
+    resources:
+      - kubescape/podlabel-only-deploy
+    kind: Deployment
+    result: skip
+  - policy: add-security-context
+    rule: add-baseline-context-optin-controllers-containers
+    resources:
+      - kubescape/podlabel-only-deploy
+    kind: Deployment
+    result: skip

--- a/tests/add-baseline-context/patched-resources.yaml
+++ b/tests/add-baseline-context/patched-resources.yaml
@@ -338,3 +338,63 @@ spec:
           containers:
             - name: velero
               image: velero/velero:v1.16.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: empty-override
+  namespace: velero
+spec:
+  securityContext:
+    seLinuxOptions:
+      user: system_u
+      level: s9
+    fsGroupChangePolicy: OnRootMismatch
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          level: s0
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          level: s0
+    - name: plain
+      image: velero/velero:v1.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-override-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: empty-override-deploy
+  template:
+    metadata:
+      labels:
+        app: empty-override-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+          level: s9
+        fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions:
+              level: s0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions:
+              level: s0
+        - name: plain
+          image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/patched-resources.yaml
+++ b/tests/add-baseline-context/patched-resources.yaml
@@ -275,3 +275,66 @@ spec:
       containers:
         - name: velero
           image: velero/velero:v1.16.0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: oneshot-job
+  namespace: observability
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: job
+          image: ghcr.io/coroot/coroot:1.22.2
+          securityContext:
+            seLinuxOptions:
+              level: s0
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: podlevel-partial-cronjob
+  namespace: velero
+spec:
+  schedule: "0 4 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+              level: s0
+            fsGroupChangePolicy: OnRootMismatch
+          initContainers:
+            - name: init
+              image: velero/velero:v1.16.0
+          containers:
+            - name: velero
+              image: velero/velero:v1.16.0
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: podlevel-cronjob
+  namespace: velero
+spec:
+  schedule: "0 5 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+              level: s9
+            fsGroupChangePolicy: OnRootMismatch
+          containers:
+            - name: velero
+              image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/patched-resources.yaml
+++ b/tests/add-baseline-context/patched-resources.yaml
@@ -119,3 +119,159 @@ spec:
           level: s0
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator-deploy
+  namespace: observability
+spec:
+  selector:
+    matchLabels:
+      app: operator-deploy
+  template:
+    metadata:
+      labels:
+        app: operator-deploy
+    spec:
+      initContainers:
+        - name: init
+          image: ghcr.io/coroot/coroot-operator:1.9.5
+          securityContext:
+            seLinuxOptions:
+              level: s0
+      containers:
+        - name: operator
+          image: ghcr.io/coroot/coroot-operator:1.9.5
+          securityContext:
+            seLinuxOptions:
+              level: s0
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-sts
+  namespace: observability
+spec:
+  serviceName: server-sts
+  selector:
+    matchLabels:
+      app: server-sts
+  template:
+    metadata:
+      labels:
+        app: server-sts
+    spec:
+      containers:
+        - name: server
+          image: ghcr.io/coroot/coroot:1.22.2
+          securityContext:
+            seLinuxOptions:
+              level: s0
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: manager-ds
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: manager-ds
+  template:
+    metadata:
+      labels:
+        app: manager-ds
+    spec:
+      containers:
+        - name: manager
+          image: longhornio/longhorn-manager:v1.9.0
+          securityContext:
+            privileged: true
+            seLinuxOptions:
+              level: s0
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightly-cronjob
+  namespace: observability
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          initContainers:
+            - name: init
+              image: ghcr.io/coroot/coroot:1.22.2
+              securityContext:
+                seLinuxOptions:
+                  level: s0
+          containers:
+            - name: job
+              image: ghcr.io/coroot/coroot:1.22.2
+              securityContext:
+                seLinuxOptions:
+                  level: s0
+          securityContext:
+            fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podlevel-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: podlevel-deploy
+  template:
+    metadata:
+      labels:
+        app: podlevel-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+          level: s9
+        fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podlevel-partial-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: podlevel-partial-deploy
+  template:
+    metadata:
+      labels:
+        app: podlevel-partial-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+          level: s0
+        fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/resources.yaml
+++ b/tests/add-baseline-context/resources.yaml
@@ -365,3 +365,84 @@ spec:
       containers:
         - name: velero
           image: velero/velero:v1.16.0
+---
+# A standalone Job without initContainers (CREATE-only kind).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: oneshot-job
+  namespace: observability
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: job
+          image: ghcr.io/coroot/coroot:1.22.2
+---
+# A CronJob whose pod-level SELinux object exists but has no `level`: only the
+# jobTemplate pod-scope fill may supply it, preserving the sibling `user`.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: podlevel-partial-cronjob
+  namespace: velero
+spec:
+  schedule: "0 4 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+          initContainers:
+            - name: init
+              image: velero/velero:v1.16.0
+          containers:
+            - name: velero
+              image: velero/velero:v1.16.0
+---
+# A CronJob with a complete pod-level SELinux object: the container foreach and
+# the pod-scope fill both stay out; fsGroupChangePolicy still lands.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: podlevel-cronjob
+  namespace: velero
+spec:
+  schedule: "0 5 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            seLinuxOptions:
+              user: system_u
+              level: s9
+          containers:
+            - name: velero
+              image: velero/velero:v1.16.0
+---
+# The pod-rule label ALONE (kubescape carries `baseline-context` but not
+# `baseline-context-controllers`): no controller rule may touch this, or the
+# separate rollout gate is not a gate.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podlabel-only-deploy
+  namespace: kubescape
+spec:
+  selector:
+    matchLabels:
+      app: podlabel-only-deploy
+  template:
+    metadata:
+      labels:
+        app: podlabel-only-deploy
+    spec:
+      containers:
+        - name: app
+          image: quay.io/kubescape/operator:v0.2.0

--- a/tests/add-baseline-context/resources.yaml
+++ b/tests/add-baseline-context/resources.yaml
@@ -168,3 +168,200 @@ spec:
   containers:
     - name: node-agent
       image: ghcr.io/coroot/coroot-node-agent:v1.0.0
+# --- Controller kinds ---------------------------------------------------------
+# The stored controller spec is what Kubescape scores, and the pod rules above
+# never reach it (this policy has no autogen rules). Each shape the pod fixtures
+# pin is pinned again at the controller object, on the kinds the residual
+# population actually consists of: operator-written Deployments, StatefulSets
+# and DaemonSets, plus a CronJob for the jobTemplate path.
+---
+# The plain shape an operator writes: no securityContext anywhere. Both fields
+# must land in the pod template.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator-deploy
+  namespace: observability
+spec:
+  selector:
+    matchLabels:
+      app: operator-deploy
+  template:
+    metadata:
+      labels:
+        app: operator-deploy
+    spec:
+      initContainers:
+        - name: init
+          image: ghcr.io/coroot/coroot-operator:1.9.5
+      containers:
+        - name: operator
+          image: ghcr.io/coroot/coroot-operator:1.9.5
+---
+# A StatefulSet with no initContainers — the foreach over
+# `spec.template.spec.initContainers[]` must tolerate the absent field.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-sts
+  namespace: observability
+spec:
+  serviceName: server-sts
+  selector:
+    matchLabels:
+      app: server-sts
+  template:
+    metadata:
+      labels:
+        app: server-sts
+    spec:
+      containers:
+        - name: server
+          image: ghcr.io/coroot/coroot:1.22.2
+---
+# A privileged DaemonSet, the shape Longhorn's manager and CSI plugin run.
+# Privilege is untouched; only the two fields are supplied.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: manager-ds
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: manager-ds
+  template:
+    metadata:
+      labels:
+        app: manager-ds
+    spec:
+      containers:
+        - name: manager
+          image: longhornio/longhorn-manager:v1.9.0
+          securityContext:
+            privileged: true
+---
+# The jobTemplate path.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightly-cronjob
+  namespace: observability
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          initContainers:
+            - name: init
+              image: ghcr.io/coroot/coroot:1.22.2
+          containers:
+            - name: job
+              image: ghcr.io/coroot/coroot:1.22.2
+---
+# OFF state: no opt-in label, so no controller rule may touch it.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unlabelled-deploy
+  namespace: chaos-mesh
+spec:
+  selector:
+    matchLabels:
+      app: unlabelled-deploy
+  template:
+    metadata:
+      labels:
+        app: unlabelled-deploy
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/chaos-mesh/chaos-mesh:v2.7.0
+---
+# Anchor preservation: a controller that already sets both fields to
+# non-default values keeps them.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: preset-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: preset-deploy
+  template:
+    metadata:
+      labels:
+        app: preset-deploy
+    spec:
+      securityContext:
+        fsGroupChangePolicy: Always
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions:
+              level: s9
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions:
+              level: s9
+---
+# A complete pod-level SELinux object with containers carrying none: the
+# container foreach must stay out (a container-level object would replace the
+# pod struct wholesale), the pod-scope fill must not fire (level present), and
+# fsGroupChangePolicy still lands.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podlevel-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: podlevel-deploy
+  template:
+    metadata:
+      labels:
+        app: podlevel-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+          level: s9
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+---
+# A pod-level SELinux object that EXISTS but has no `level`: only the pod-scope
+# fill may supply it, preserving the sibling `user`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podlevel-partial-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: podlevel-partial-deploy
+  template:
+    metadata:
+      labels:
+        app: podlevel-partial-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/resources.yaml
+++ b/tests/add-baseline-context/resources.yaml
@@ -446,3 +446,63 @@ spec:
       containers:
         - name: app
           image: quay.io/kubescape/operator:v0.2.0
+---
+# A container that EXPLICITLY sets `seLinuxOptions: {}` under a complete pod-level
+# object. Kubernetes treats that non-null empty object as an override, so the
+# effective container context has no level unless the rule fills it — but the
+# empty mapping is falsy to JMESPath, so an `|| ''` presence test reads it as
+# absent and the container is left without a level. The key-presence test
+# distinguishes the two shapes. Pinned at pod scope (this) and controller scope.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: empty-override
+  namespace: velero
+spec:
+  securityContext:
+    seLinuxOptions:
+      user: system_u
+      level: s9
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+      securityContext:
+        seLinuxOptions: {}
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+      securityContext:
+        seLinuxOptions: {}
+    - name: plain
+      image: velero/velero:v1.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-override-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: empty-override-deploy
+  template:
+    metadata:
+      labels:
+        app: empty-override-deploy
+    spec:
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+          level: s9
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions: {}
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+          securityContext:
+            seLinuxOptions: {}
+        - name: plain
+          image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/values.yaml
+++ b/tests/add-baseline-context/values.yaml
@@ -19,3 +19,9 @@ namespaceSelector:
   - name: observability
     labels:
       pod-security.devantler.tech/baseline-context: enabled
+  # longhorn-system, opted in via #3540. Declared so the controller-kind
+  # DaemonSet fixture (a privileged manager, the shape Longhorn actually runs)
+  # is evaluated rather than reported "Excluded".
+  - name: longhorn-system
+    labels:
+      pod-security.devantler.tech/baseline-context: enabled

--- a/tests/add-baseline-context/values.yaml
+++ b/tests/add-baseline-context/values.yaml
@@ -3,6 +3,13 @@
 # resources.yaml — a rule matched by namespaceSelector is reported "Excluded"
 # for every resource unless the labels are declared here, and the whole fixture
 # then passes vacuously including the default-off control.
+#
+# Two labels are declared per namespace because the pod rules and the
+# controller-kind rules are gated separately: `baseline-context` opts a
+# namespace into the Pod rules, `baseline-context-controllers` into the rules
+# that write the stored controller spec (a rollout). kubescape carries only the
+# first, so its controller fixture proves the pod-rule label alone reaches no
+# controller.
 apiVersion: cli.kyverno.io/v1alpha1
 kind: Values
 metadata:
@@ -11,6 +18,7 @@ namespaceSelector:
   - name: velero
     labels:
       pod-security.devantler.tech/baseline-context: enabled
+      pod-security.devantler.tech/baseline-context-controllers: enabled
   - name: chaos-mesh
     labels: {}
   # observability, opted in alongside velero. Declared here so the ON-state
@@ -19,9 +27,15 @@ namespaceSelector:
   - name: observability
     labels:
       pod-security.devantler.tech/baseline-context: enabled
+      pod-security.devantler.tech/baseline-context-controllers: enabled
   # longhorn-system, opted in via #3540. Declared so the controller-kind
   # DaemonSet fixture (a privileged manager, the shape Longhorn actually runs)
   # is evaluated rather than reported "Excluded".
   - name: longhorn-system
+    labels:
+      pod-security.devantler.tech/baseline-context: enabled
+      pod-security.devantler.tech/baseline-context-controllers: enabled
+  # Pod-rule label only: the controller fixture here must stay untouched.
+  - name: kubescape
     labels:
       pod-security.devantler.tech/baseline-context: enabled


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Opting `observability` and `longhorn-system` into the baseline-context rules added the two harmless C-0211 fields to newly created pods, but not to the stored controller specs Kubescape actually scores — measured on prod, none of the 27 remaining workloads in those namespaces moved. The Coroot-operator and Longhorn workloads have no template we can edit, so the residual could not shrink further by the route the earlier slices used.

## What

The same two fields, with the same value-preserving anchors and guards, can now land on Deployments, StatefulSets, DaemonSets, Jobs and CronJobs — on create and, for the mutable kinds, on every later update, so an operator rewriting its workload picks them up. No privilege, user or group field is touched.

**Ships latent.** Writing the fields into a stored pod template restarts that workload at its owner's next write, so the controller rules sit behind their own namespace label, distinct from the pod-rule label, and nothing carries it yet. This merge changes no running workload. Each namespace is flipped in its own follow-up, which restarts its existing controllers to backfill the fields (a label alone updates nothing already stored), watches each owner for a reconcile loop, and records the read-back — Longhorn first, then observability with the Coroot loop watch. The fixture and the positive shell gate pin every state on the new kinds in both label states, and the gate pins the empty rollout inventory.

Part of #3239
