### PR TITLE
feat(security): require cosign verification on every devantler-tech OCIRepository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,19 @@ jobs:
           bash scripts/tests/test-publish-workflow-approved-revisions-guard.sh
           ./scripts/guard-publish-workflow-approved-revisions.sh
 
+      # Both subject guards above examine a file only when it already carries a
+      # shared-publish-workflow subject, so an OCIRepository pointed at a devantler-tech
+      # artifact with NO spec.verify at all is invisible to them — and refused by nothing
+      # else. This one discovers OCIRepositories by KIND and URL, at any nesting depth,
+      # and requires cosign with exactly one identity on every devantler-tech GHCR
+      # artifact (#3558). Unconditional, like the guards above.
+      - name: 🔐 Validate every devantler-tech OCIRepository verifies
+        run: |
+          shellcheck scripts/guard-oci-repository-verify.sh
+          shellcheck scripts/tests/test-guard-oci-repository-verify.sh
+          bash scripts/tests/test-guard-oci-repository-verify.sh
+          ./scripts/guard-oci-repository-verify.sh
+
       # Dropping a framework from the Kubescape gate REMOVES findings, so the
       # compliance score RISES and every check stays green — a coverage
       # regression that looks like an improvement. That is what un-gated 59
@@ -336,6 +349,9 @@ jobs:
               # inside the k8s-gated validation matrix alongside the manifests it judges.
               - 'scripts/guard-publish-workflow-approved-revisions.sh'
               - 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh'
+              # Both halves, for the same reason as the guards above.
+              - 'scripts/guard-oci-repository-verify.sh'
+              - 'scripts/tests/test-guard-oci-repository-verify.sh'
               # Both halves, for the same reason as the guard above.
               - 'scripts/validate-kubescape-frameworks/main.go'
               - 'scripts/validate-kubescape-frameworks/main_test.go'

--- a/scripts/guard-oci-repository-verify.sh
+++ b/scripts/guard-oci-repository-verify.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Require cosign verification on every devantler-tech OCIRepository, discovered by KIND
+# and URL rather than by the text of a cosign subject (#3558, under #3308).
+#
+# WHY THIS EXISTS
+# Both cosign-subject guards (scripts/guard-shared-publish-workflow-pin.sh and
+# scripts/guard-publish-workflow-approved-revisions.sh) examine a file only when it
+# already carries a shared-publish-workflow subject. An OCIRepository pointed at a
+# devantler-tech artifact with NO `spec.verify` at all therefore carries no subject, is
+# examined by neither guard, and is refused by nothing else: validate-flux-verify covers
+# the root source only, and the Kyverno cluster policies do not touch OCIRepositories.
+# Flux would apply an unsigned or foreign-signed artifact with every check green. This
+# guard closes that shape by asking the question the other way round: every
+# OCIRepository whose URL is a devantler-tech GHCR artifact must verify.
+#
+# WHAT IT REQUIRES, PER OCIRepository UNDER oci://ghcr.io/devantler-tech/
+#   - `spec.verify` present
+#   - `spec.verify.provider: cosign`
+#   - `spec.verify.matchOIDCIdentity` a sequence of EXACTLY ONE entry. Flux ORs the
+#     entries, so a second entry widens the trusted signer set while the first still
+#     reads as narrowed; alternation belongs inside the one subject regex, where the
+#     subject guards judge it.
+#   - that entry names a non-empty `issuer` and a non-empty `subject`.
+#
+# DISCOVERY IS BY KIND AT ANY DEPTH. A YAML document is walked with yq and every mapping
+# carrying `kind: OCIRepository` is examined — a top-level manifest, a later document in
+# a multi-document file, or a template nested inside a ResourceGraphDefinition. A
+# line-based scan would see none of the nested forms, and a top-level-only read would
+# miss the tenant template that every new tenant inherits.
+#
+# WHAT IT DOES NOT COVER, BY NAME
+#   - The ROOT source `flux-system/flux-system` is not a document in this tree: the
+#     FluxInstance creates it, and its `spec.verify` (a branch identity, legitimately)
+#     is supplied by a kustomize patch in flux-instance.yaml. That verification is
+#     asserted by scripts/validate-flux-verify against both halves of its config.
+#   - OCIRepositories outside oci://ghcr.io/devantler-tech/ are out of scope; this guard
+#     is about the suite's own artifacts.
+#
+# EXEMPTIONS ARE EXPLICIT, URL-KEYED, AND FAIL CLOSED. An OCIRepository that cannot verify
+# yet is admitted only by an entry in EXEMPTIONS below, carrying its reason and the
+# issue that retires it. Every exemption must still match an OCIRepository in the tree
+# (otherwise it is STALE and the run fails), and an exempt OCIRepository that gains
+# `spec.verify` fails too, so the list can only shrink as artifacts start signing.
+#
+# THE FLOOR. An empty result from a filtered read is a claim about the filter: if the
+# manifests move, the URL scheme changes, or yq stops matching, the scan returns nothing
+# and — without this — the guard would report a clean tree while checking nothing. The
+# in-scope count must reach EXPECTED_MIN_IN_SCOPE, raised when a consumer is genuinely
+# added and lowered only after verifying by hand that the scan still finds the rest.
+#
+# SEAMS (for scripts/tests/test-guard-oci-repository-verify.sh)
+#   OCI_VERIFY_SCAN_ROOT         directory to scan (default: <repo>/k8s)
+#   OCI_VERIFY_EXEMPTIONS_FILE   exemption rows `<url>\t<reason>` (default: the list below)
+#   OCI_VERIFY_EXPECTED_MIN      in-scope floor (default: EXPECTED_MIN_IN_SCOPE)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly SCAN_ROOT="${OCI_VERIFY_SCAN_ROOT:-$REPO_ROOT/k8s}"
+readonly REQUIRED_URL_PREFIX='oci://ghcr.io/devantler-tech/'
+
+# 6 on 2026-09-04: the aws, github-config, wedding-app and ascoachingogvaner manifests
+# consumers, the data-product-controller chart, and the tenant RGD template.
+readonly EXPECTED_MIN_IN_SCOPE=6
+readonly EXPECTED_MIN="${OCI_VERIFY_EXPECTED_MIN:-$EXPECTED_MIN_IN_SCOPE}"
+
+# <url><TAB><reason>, one per line. The reason names what retires the entry.
+DEFAULT_EXEMPTIONS="$(
+  cat <<'EOF'
+oci://ghcr.io/devantler-tech/charts/data-product-controller	the chart is published unsigned — a bare `helm push` with no cosign step (devantler-tech/data-product-controller#27 adds the signing); the OCIRepository is digest-pinned and the app is staged off (platform#3476). Remove this row when #27 ships and the manifest gains spec.verify.
+EOF
+)"
+readonly DEFAULT_EXEMPTIONS
+
+refuse() {
+  printf 'guard: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || refuse 'yq is required and was not found on PATH'
+[ -d "$SCAN_ROOT" ] || refuse "scan root $SCAN_ROOT is not a directory"
+
+case "$EXPECTED_MIN" in
+  '' | *[!0-9]*) refuse "OCI_VERIFY_EXPECTED_MIN must be a non-negative integer, got '$EXPECTED_MIN'" ;;
+esac
+
+exemptions="$DEFAULT_EXEMPTIONS"
+if [ -n "${OCI_VERIFY_EXEMPTIONS_FILE:-}" ]; then
+  [ -f "$OCI_VERIFY_EXEMPTIONS_FILE" ] || refuse "OCI_VERIFY_EXEMPTIONS_FILE $OCI_VERIFY_EXEMPTIONS_FILE does not exist"
+  exemptions="$(cat "$OCI_VERIFY_EXEMPTIONS_FILE")"
+fi
+
+# exempt_reason <url> — prints the reason and returns 0 when the URL is exempt.
+exempt_reason() {
+  local url="$1" row row_url
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    case "$row" in '#'*) continue ;; esac
+    row_url="${row%%	*}"
+    if [ "$row_url" = "$url" ]; then
+      case "$row" in
+        *"	"*) printf '%s' "${row#*	}" ;;
+        *) refuse "exemption for $url carries no reason; every exemption names what retires it" ;;
+      esac
+      return 0
+    fi
+  done <<EOF
+$exemptions
+EOF
+  return 1
+}
+
+# One row per OCIRepository mapping found anywhere in the file, tab-separated:
+#   url  name  has_verify  provider  identities_type  identities_count  incomplete_entries
+# `..` walks every node of every document, so a nested template counts exactly like a
+# top-level manifest. A mapping is examined only when its `kind` is OCIRepository.
+readonly YQ_ROWS='[.. | select(type == "!!map" and .kind == "OCIRepository")]
+  | .[]
+  | [
+      (.spec.url // ""),
+      (.metadata.name // ""),
+      ((.spec // {}) | has("verify")),
+      (.spec.verify.provider // ""),
+      (.spec.verify.matchOIDCIdentity | type),
+      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | length) // 0),
+      (([.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[]
+          | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length))
+    ]
+  | @tsv'
+
+status=0
+in_scope=0
+seen_exempt=""
+fail() {
+  printf '%s\n' "$*" >&2
+  status=1
+}
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  # FAIL CLOSED on a file yq cannot read: an unparseable manifest is not "no
+  # OCIRepository here", it is "unknown", and unknown must not read as clean.
+  if ! rows="$(yq -r "$YQ_ROWS" "$file" 2>&1)"; then
+    fail "$file: yq could not read this file, so its OCIRepositories are UNKNOWN: $rows"
+    continue
+  fi
+  while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete; do
+    [ -n "$url$name" ] || continue
+    case "$url" in
+      "$REQUIRED_URL_PREFIX"*) ;;
+      *) continue ;;
+    esac
+    in_scope=$((in_scope + 1))
+    if reason="$(exempt_reason "$url")"; then
+      seen_exempt="$seen_exempt$url
+"
+      if [ "$has_verify" = "true" ]; then
+        fail "$file: OCIRepository $name ($url) is exempt from verification but carries spec.verify; the exemption is stale — remove it ($reason)"
+      fi
+      continue
+    fi
+    if [ "$has_verify" != "true" ]; then
+      fail "$file: OCIRepository $name ($url) has NO spec.verify — Flux would apply an unsigned or foreign-signed artifact. Add provider: cosign with exactly one matchOIDCIdentity entry."
+      continue
+    fi
+    if [ "$provider" != "cosign" ]; then
+      fail "$file: OCIRepository $name ($url) verifies with provider '${provider:-<none>}', not cosign"
+      continue
+    fi
+    if [ "$ids_type" != "!!seq" ]; then
+      fail "$file: OCIRepository $name ($url) has no matchOIDCIdentity sequence (found ${ids_type:-nothing}); a verify block that names no identity admits no signer and pins none"
+      continue
+    fi
+    if [ "$ids_count" -eq 0 ]; then
+      fail "$file: OCIRepository $name ($url) has ZERO matchOIDCIdentity entries; verification with no identity is not a matcher"
+      continue
+    fi
+    if [ "$ids_count" -ne 1 ]; then
+      fail "$file: OCIRepository $name ($url) has $ids_count matchOIDCIdentity entries; Flux ORs them, so a second entry WIDENS the trusted signer set. Put any alternation inside the one subject regex."
+      continue
+    fi
+    if [ "$incomplete" -ne 0 ]; then
+      fail "$file: OCIRepository $name ($url) has a matchOIDCIdentity entry missing a non-empty issuer or subject"
+      continue
+    fi
+  done <<EOF
+$rows
+EOF
+done < <(find "$SCAN_ROOT" -type f \( -name '*.yaml' -o -name '*.yml' \) | LC_ALL=C sort)
+
+# Every exemption must still name an OCIRepository that exists, or it is a hole waiting
+# for a manifest to fall into it.
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  case "$row" in '#'*) continue ;; esac
+  row_url="${row%%	*}"
+  case "$seen_exempt" in
+    *"$row_url
+"*) ;;
+    *) fail "exemption for $row_url is STALE: no OCIRepository in $SCAN_ROOT carries that URL. Remove the row." ;;
+  esac
+done <<EOF
+$exemptions
+EOF
+
+if [ "$in_scope" -lt "$EXPECTED_MIN" ]; then
+  fail "found $in_scope in-scope OCIRepositor(y/ies) under $REQUIRED_URL_PREFIX, expected at least $EXPECTED_MIN. The scan, not the tree, is the likely cause: verify by hand, then fix the discovery or lower the floor with the reason."
+fi
+
+if [ "$status" -eq 0 ]; then
+  printf 'guard: %d devantler-tech OCIRepositor(y/ies) all verify with cosign and exactly one identity (exemptions honoured: %d).\n' \
+    "$in_scope" "$(printf '%s' "$seen_exempt" | grep -c . || true)"
+fi
+exit "$status"

--- a/scripts/guard-oci-repository-verify.sh
+++ b/scripts/guard-oci-repository-verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Require cosign verification on every devantler-tech OCIRepository, discovered by KIND
-# and URL rather than by the text of a cosign subject (#3558, under #3308).
+# and URL in what Flux actually applies (#3558, under #3308).
 #
 # WHY THIS EXISTS
 # Both cosign-subject guards (scripts/guard-shared-publish-workflow-pin.sh and
@@ -10,8 +10,8 @@
 # examined by neither guard, and is refused by nothing else: validate-flux-verify covers
 # the root source only, and the Kyverno cluster policies do not touch OCIRepositories.
 # Flux would apply an unsigned or foreign-signed artifact with every check green. This
-# guard closes that shape by asking the question the other way round: every
-# OCIRepository whose URL is a devantler-tech GHCR artifact must verify.
+# guard asks the question the other way round: every OCIRepository whose URL is a
+# devantler-tech GHCR artifact must verify.
 #
 # WHAT IT REQUIRES, PER OCIRepository UNDER oci://ghcr.io/devantler-tech/
 #   - `spec.verify` present
@@ -22,11 +22,24 @@
 #     subject guards judge it.
 #   - that entry names a non-empty `issuer` and a non-empty `subject`.
 #
-# DISCOVERY IS BY KIND AT ANY DEPTH. A YAML document is walked with yq and every mapping
-# carrying `kind: OCIRepository` is examined — a top-level manifest, a later document in
-# a multi-document file, or a template nested inside a ResourceGraphDefinition. A
-# line-based scan would see none of the nested forms, and a top-level-only read would
-# miss the tenant template that every new tenant inherits.
+# IT JUDGES THE KUSTOMIZE BUILD, NOT THE SOURCE FILES — MEASURED, NOT PREFERRED. A first
+# version scanned `k8s/**/*.yaml` with yq and was bypassed five ways in one review
+# session, each leaving the guard reporting "all verify" while `kubectl kustomize`
+# emitted an unverified OCIRepository: a `!!binary` tag or a YAML alias on `kind`
+# (yq compares the tagged/alias node, kustomize resolves it), a resource file named
+# `.json`, `.YAML` or with no extension (kustomize loads whatever `resources:` lists),
+# a symlink (`find -type f` skips it, kustomize follows it), and a kustomize patch that
+# removes `spec.verify` or appends an identity (patch text is a string, so no source
+# walk ever sees a map). Every one of those is resolved by the build, which is also the
+# only thing Flux sees. So the roots are RENDERED with `kubectl kustomize` and the
+# render is what is walked.
+#
+# WHICH ROOTS: exactly the ones Flux applies. Each cluster overlay under k8s/clusters/
+# renders the Flux Kustomization objects that point at the provider layers, and their
+# `spec.path` values are the roots — read from the render rather than listed here, so a
+# new layer is covered the day it is wired and an unwired one is not judged. Every
+# mapping in a rendered root carrying `kind: OCIRepository` is examined, at any depth: a
+# top-level manifest, a later document, or a template inside a ResourceGraphDefinition.
 #
 # WHAT IT DOES NOT COVER, BY NAME
 #   - The ROOT source `flux-system/flux-system` is not a document in this tree: the
@@ -34,22 +47,28 @@
 #     is supplied by a kustomize patch in flux-instance.yaml. That verification is
 #     asserted by scripts/validate-flux-verify against both halves of its config.
 #   - OCIRepositories outside oci://ghcr.io/devantler-tech/ are out of scope; this guard
-#     is about the suite's own artifacts.
+#     is about the suite's own artifacts. The host is compared case-insensitively
+#     (`GHCR.IO` is the same registry to DNS and TLS), and a URL that only decides its
+#     host at Flux substitution time (`${…}` before the org path) is refused as
+#     undecidable rather than waved through as foreign.
 #
 # EXEMPTIONS ARE EXPLICIT, URL-KEYED, AND FAIL CLOSED. An OCIRepository that cannot verify
 # yet is admitted only by an entry in EXEMPTIONS below, carrying its reason and the
-# issue that retires it. Every exemption must still match an OCIRepository in the tree
-# (otherwise it is STALE and the run fails), and an exempt OCIRepository that gains
-# `spec.verify` fails too, so the list can only shrink as artifacts start signing.
+# issue that retires it. Every exemption must still match an OCIRepository in some
+# rendered root (otherwise it is STALE and the run fails), and an exempt OCIRepository
+# that gains `spec.verify` fails too, so the list can only shrink as artifacts start
+# signing. An exemption counts toward the floor below — the floor guards discovery, not
+# the verified count, and the verified count is the floor minus the honoured exemptions.
 #
 # THE FLOOR. An empty result from a filtered read is a claim about the filter: if the
-# manifests move, the URL scheme changes, or yq stops matching, the scan returns nothing
-# and — without this — the guard would report a clean tree while checking nothing. The
+# roots move, the URL scheme changes, or yq stops matching, the walk returns nothing and
+# — without this — the guard would report a clean tree while checking nothing. The
 # in-scope count must reach EXPECTED_MIN_IN_SCOPE, raised when a consumer is genuinely
-# added and lowered only after verifying by hand that the scan still finds the rest.
+# added and lowered only after verifying by hand that the walk still finds the rest.
 #
 # SEAMS (for scripts/tests/test-guard-oci-repository-verify.sh)
-#   OCI_VERIFY_SCAN_ROOT         directory to scan (default: <repo>/k8s)
+#   OCI_VERIFY_ROOTS             kustomize roots to render, newline-separated (default:
+#                                derived from every cluster overlay under <repo>/k8s/clusters)
 #   OCI_VERIFY_EXEMPTIONS_FILE   exemption rows `<url>\t<reason>` (default: the list below)
 #   OCI_VERIFY_EXPECTED_MIN      in-scope floor (default: EXPECTED_MIN_IN_SCOPE)
 
@@ -57,18 +76,27 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly REPO_ROOT
-readonly SCAN_ROOT="${OCI_VERIFY_SCAN_ROOT:-$REPO_ROOT/k8s}"
 readonly REQUIRED_URL_PREFIX='oci://ghcr.io/devantler-tech/'
 
-# 6 on 2026-09-04: the aws, github-config, wedding-app and ascoachingogvaner manifests
-# consumers, the data-product-controller chart, and the tenant RGD template.
-readonly EXPECTED_MIN_IN_SCOPE=6
+# 5 on 2026-09-04, counted per rendered root: providers/hetzner/apps carries the aws,
+# github-config, wedding-app and ascoachingogvaner manifests consumers (4) and
+# providers/hetzner/infrastructure carries the tenant RGD template (1). The docker
+# provider opts into no apps and renders no tenant RGD, and the staged-off
+# data-product-controller chart is in no root at all. A consumer wired into both
+# providers would count twice.
+readonly EXPECTED_MIN_IN_SCOPE=5
 readonly EXPECTED_MIN="${OCI_VERIFY_EXPECTED_MIN:-$EXPECTED_MIN_IN_SCOPE}"
 
-# <url><TAB><reason>, one per line. The reason names what retires the entry.
+# <url><TAB><reason>, one per line; `#` lines are comments. The reason names what retires
+# the entry. Empty today: the one unsigned artifact in the tree — the
+# data-product-controller chart, published by a bare `helm push` with no cosign step
+# (devantler-tech/data-product-controller#27 adds the signing) — is staged off
+# (platform#3476), so no rendered root applies it and nothing needs admitting. Re-enabling
+# that app before #27 ships fails this guard by name, which is the intended order: sign
+# first, or add a reasoned row here deliberately.
 DEFAULT_EXEMPTIONS="$(
   cat <<'EOF'
-oci://ghcr.io/devantler-tech/charts/data-product-controller	the chart is published unsigned — a bare `helm push` with no cosign step (devantler-tech/data-product-controller#27 adds the signing); the OCIRepository is digest-pinned and the app is staged off (platform#3476). Remove this row when #27 ships and the manifest gains spec.verify.
+# oci://ghcr.io/devantler-tech/<artifact>	<why it cannot verify yet, and the issue that retires this row>
 EOF
 )"
 readonly DEFAULT_EXEMPTIONS
@@ -79,7 +107,7 @@ refuse() {
 }
 
 command -v yq >/dev/null 2>&1 || refuse 'yq is required and was not found on PATH'
-[ -d "$SCAN_ROOT" ] || refuse "scan root $SCAN_ROOT is not a directory"
+command -v kubectl >/dev/null 2>&1 || refuse 'kubectl is required to render the kustomize roots'
 
 case "$EXPECTED_MIN" in
   '' | *[!0-9]*) refuse "OCI_VERIFY_EXPECTED_MIN must be a non-negative integer, got '$EXPECTED_MIN'" ;;
@@ -91,6 +119,19 @@ if [ -n "${OCI_VERIFY_EXEMPTIONS_FILE:-}" ]; then
   exemptions="$(cat "$OCI_VERIFY_EXEMPTIONS_FILE")"
 fi
 
+# Every exemption row is validated up front, so a malformed row is one refusal with one
+# cause — not a cascade of wrong-reason messages later in the walk.
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  case "$row" in '#'*) continue ;; esac
+  case "$row" in
+    *"	"*) ;;
+    *) refuse "exemption row '$row' carries no reason; every exemption names what retires it" ;;
+  esac
+done <<EOF
+$exemptions
+EOF
+
 # exempt_reason <url> — prints the reason and returns 0 when the URL is exempt.
 exempt_reason() {
   local url="$1" row row_url
@@ -99,10 +140,7 @@ exempt_reason() {
     case "$row" in '#'*) continue ;; esac
     row_url="${row%%	*}"
     if [ "$row_url" = "$url" ]; then
-      case "$row" in
-        *"	"*) printf '%s' "${row#*	}" ;;
-        *) refuse "exemption for $url carries no reason; every exemption names what retires it" ;;
-      esac
+      printf '%s' "${row#*	}"
       return 0
     fi
   done <<EOF
@@ -111,23 +149,68 @@ EOF
   return 1
 }
 
-# One row per OCIRepository mapping found anywhere in the file, tab-separated:
+# normalise_url <url> — lower-cases the scheme and host so the registry compares the
+# way DNS and TLS compare it; the path keeps its case (a GHCR path is case-sensitive).
+normalise_url() {
+  local url="$1" scheme_host rest
+  case "$url" in
+    */*/*/*)
+      scheme_host="${url%%//*}//"
+      rest="${url#*//}"
+      printf '%s%s/%s' "$(printf '%s' "$scheme_host" | tr '[:upper:]' '[:lower:]')" \
+        "$(printf '%s' "${rest%%/*}" | tr '[:upper:]' '[:lower:]')" "${rest#*/}"
+      ;;
+    *) printf '%s' "$url" ;;
+  esac
+}
+
+# The roots Flux applies: every `spec.path` of every Flux Kustomization each cluster
+# overlay renders. Read from the render, never listed by hand.
+roots=""
+if [ -n "${OCI_VERIFY_ROOTS:-}" ]; then
+  roots="$OCI_VERIFY_ROOTS"
+else
+  [ -d "$REPO_ROOT/k8s/clusters" ] || refuse "no k8s/clusters directory under $REPO_ROOT"
+  for overlay in "$REPO_ROOT"/k8s/clusters/*/; do
+    [ -f "$overlay/kustomization.yaml" ] || continue
+    # k8s/clusters/base is the wiring TEMPLATE the real overlays consume: its Flux paths
+    # are `__PROVIDER__`/`__CLUSTER__` placeholders that each cluster overlay replaces.
+    # No cluster applies it as-is, so it is not a root.
+    case "${overlay%/}" in */base) continue ;; esac
+    if ! paths="$(kubectl kustomize "$overlay" 2>/dev/null |
+      yq -N -r 'select(.kind == "Kustomization" and (.apiVersion | test("^kustomize\\.toolkit\\.fluxcd\\.io/"))) | .spec.path // ""')"; then
+      refuse "could not render the cluster overlay $overlay to discover its Flux roots"
+    fi
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      roots="$roots$REPO_ROOT/k8s/${p#./}
+"
+    done <<EOF
+$paths
+EOF
+  done
+fi
+[ -n "$roots" ] || refuse 'no Flux Kustomization roots were discovered; nothing would be judged'
+
+# One row per OCIRepository mapping found anywhere in the render. Fields are joined with
+# a tab, and an EMPTY field is spelled `-` so consecutive tabs never collapse under
+# `read`'s whitespace splitting (which shifted every column right of the first empty one
+# and produced wrong-reason messages). `-` is decoded back to empty below.
 #   url  name  has_verify  provider  identities_type  identities_count  incomplete_entries
-# `..` walks every node of every document, so a nested template counts exactly like a
-# top-level manifest. A mapping is examined only when its `kind` is OCIRepository.
 readonly YQ_ROWS='[.. | select(type == "!!map" and .kind == "OCIRepository")]
   | .[]
   | [
       (.spec.url // ""),
       (.metadata.name // ""),
-      ((.spec // {}) | has("verify")),
+      (((.spec // {}) | has("verify")) | tostring),
       (.spec.verify.provider // ""),
       (.spec.verify.matchOIDCIdentity | type),
-      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | length) // 0),
+      (((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | length) // 0) | tostring),
       (([.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[]
-          | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length))
+          | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length) | tostring)
     ]
-  | @tsv'
+  | map(sub("^$", "-"))
+  | join("	")'
 
 status=0
 in_scope=0
@@ -136,19 +219,42 @@ fail() {
   printf '%s\n' "$*" >&2
   status=1
 }
+decode() { [ "$1" = "-" ] && printf '' || printf '%s' "$1"; }
 
-while IFS= read -r file; do
-  [ -n "$file" ] || continue
-  # FAIL CLOSED on a file yq cannot read: an unparseable manifest is not "no
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+while IFS= read -r root; do
+  [ -n "$root" ] || continue
+  label="${root#"$REPO_ROOT"/}"
+  # FAIL CLOSED on a root that does not render: an unrenderable layer is not "no
   # OCIRepository here", it is "unknown", and unknown must not read as clean.
-  if ! rows="$(yq -r "$YQ_ROWS" "$file" 2>&1)"; then
-    fail "$file: yq could not read this file, so its OCIRepositories are UNKNOWN: $rows"
+  if ! kubectl kustomize "$root" >"$work/render.yaml" 2>"$work/render.err"; then
+    fail "$label: kubectl kustomize failed, so its OCIRepositories are UNKNOWN: $(tr '\n' ' ' <"$work/render.err")"
+    continue
+  fi
+  if ! yq -N -r "$YQ_ROWS" "$work/render.yaml" >"$work/rows" 2>"$work/rows.err"; then
+    fail "$label: yq could not read the render, so its OCIRepositories are UNKNOWN: $(tr '\n' ' ' <"$work/rows.err")"
     continue
   fi
   while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete; do
+    [ -n "$url" ] || continue
+    url="$(decode "$url")"; name="$(decode "$name")"; provider="$(decode "$provider")"
+    ids_type="$(decode "$ids_type")"
     [ -n "$url$name" ] || continue
+    url="$(normalise_url "$url")"
+    # The second pattern is the literal characters `${` — a Flux substitution marker,
+    # deliberately not expanded by the shell.
+    # shellcheck disable=SC2016
     case "$url" in
       "$REQUIRED_URL_PREFIX"*) ;;
+      *'${'*)
+        # The host or org is only decided at Flux substitution time; that is not
+        # provably foreign, so it is not out of scope.
+        in_scope=$((in_scope + 1))
+        fail "$label: OCIRepository $name ($url) decides its registry or organisation through a substitution variable, so this guard cannot tell whether it is a devantler-tech artifact. Spell the registry and organisation literally."
+        continue
+        ;;
       *) continue ;;
     esac
     in_scope=$((in_scope + 1))
@@ -156,60 +262,59 @@ while IFS= read -r file; do
       seen_exempt="$seen_exempt$url
 "
       if [ "$has_verify" = "true" ]; then
-        fail "$file: OCIRepository $name ($url) is exempt from verification but carries spec.verify; the exemption is stale — remove it ($reason)"
+        fail "$label: OCIRepository $name ($url) is exempt from verification but carries spec.verify; the exemption is stale — remove it ($reason)"
       fi
       continue
     fi
     if [ "$has_verify" != "true" ]; then
-      fail "$file: OCIRepository $name ($url) has NO spec.verify — Flux would apply an unsigned or foreign-signed artifact. Add provider: cosign with exactly one matchOIDCIdentity entry."
+      fail "$label: OCIRepository $name ($url) has NO spec.verify — Flux would apply an unsigned or foreign-signed artifact. Add provider: cosign with exactly one matchOIDCIdentity entry."
       continue
     fi
     if [ "$provider" != "cosign" ]; then
-      fail "$file: OCIRepository $name ($url) verifies with provider '${provider:-<none>}', not cosign"
+      fail "$label: OCIRepository $name ($url) verifies with provider '${provider:-<none>}', not cosign"
       continue
     fi
     if [ "$ids_type" != "!!seq" ]; then
-      fail "$file: OCIRepository $name ($url) has no matchOIDCIdentity sequence (found ${ids_type:-nothing}); a verify block that names no identity admits no signer and pins none"
+      fail "$label: OCIRepository $name ($url) has no matchOIDCIdentity sequence (found ${ids_type:-nothing}); a verify block that names no identity admits no signer and pins none"
       continue
     fi
     if [ "$ids_count" -eq 0 ]; then
-      fail "$file: OCIRepository $name ($url) has ZERO matchOIDCIdentity entries; verification with no identity is not a matcher"
+      fail "$label: OCIRepository $name ($url) has ZERO matchOIDCIdentity entries; verification with no identity is not a matcher"
       continue
     fi
     if [ "$ids_count" -ne 1 ]; then
-      fail "$file: OCIRepository $name ($url) has $ids_count matchOIDCIdentity entries; Flux ORs them, so a second entry WIDENS the trusted signer set. Put any alternation inside the one subject regex."
+      fail "$label: OCIRepository $name ($url) has $ids_count matchOIDCIdentity entries; Flux ORs them, so a second entry WIDENS the trusted signer set. Put any alternation inside the one subject regex."
       continue
     fi
     if [ "$incomplete" -ne 0 ]; then
-      fail "$file: OCIRepository $name ($url) has a matchOIDCIdentity entry missing a non-empty issuer or subject"
+      fail "$label: OCIRepository $name ($url) has a matchOIDCIdentity entry missing a non-empty issuer or subject"
       continue
     fi
-  done <<EOF
-$rows
+  done <"$work/rows"
+done <<EOF
+$roots
 EOF
-done < <(find "$SCAN_ROOT" -type f \( -name '*.yaml' -o -name '*.yml' \) | LC_ALL=C sort)
 
 # Every exemption must still name an OCIRepository that exists, or it is a hole waiting
-# for a manifest to fall into it.
+# for a manifest to fall into it. Exact match per line, never a substring.
 while IFS= read -r row; do
   [ -n "$row" ] || continue
   case "$row" in '#'*) continue ;; esac
   row_url="${row%%	*}"
-  case "$seen_exempt" in
-    *"$row_url
-"*) ;;
-    *) fail "exemption for $row_url is STALE: no OCIRepository in $SCAN_ROOT carries that URL. Remove the row." ;;
-  esac
+  if ! printf '%s' "$seen_exempt" | grep -qxF -- "$row_url"; then
+    fail "exemption for $row_url is STALE: no rendered OCIRepository carries that URL. Remove the row."
+  fi
 done <<EOF
 $exemptions
 EOF
 
 if [ "$in_scope" -lt "$EXPECTED_MIN" ]; then
-  fail "found $in_scope in-scope OCIRepositor(y/ies) under $REQUIRED_URL_PREFIX, expected at least $EXPECTED_MIN. The scan, not the tree, is the likely cause: verify by hand, then fix the discovery or lower the floor with the reason."
+  fail "found $in_scope in-scope OCIRepositor(y/ies) under $REQUIRED_URL_PREFIX across the rendered roots, expected at least $EXPECTED_MIN. The discovery, not the tree, is the likely cause: verify by hand, then fix it or lower the floor with the reason."
 fi
 
 if [ "$status" -eq 0 ]; then
-  printf 'guard: %d devantler-tech OCIRepositor(y/ies) all verify with cosign and exactly one identity (exemptions honoured: %d).\n' \
-    "$in_scope" "$(printf '%s' "$seen_exempt" | grep -c . || true)"
+  honoured="$(printf '%s' "$seen_exempt" | grep -c . || true)"
+  printf 'guard: %d devantler-tech OCIRepositor(y/ies) in the rendered Flux roots all verify with cosign and exactly one identity (exemptions honoured: %d).\n' \
+    "$in_scope" "$honoured"
 fi
 exit "$status"

--- a/scripts/guard-oci-repository-verify.sh
+++ b/scripts/guard-oci-repository-verify.sh
@@ -192,9 +192,10 @@ else
     # No cluster applies it as-is, so it is not a root.
     case "${overlay%/}" in */base) continue ;; esac
     # kustomize recognises all three descriptor names; an overlay using `.yml` or the
-    # bare name is a root exactly like one using `.yaml`, and skipping it would leave
-    # a whole cluster unjudged while the floor still passed on the others.
-    if [ ! -f "$overlay/kustomization.yaml" ] && [ ! -f "$overlay/kustomization.yml" ] && [ ! -f "$overlay/kustomization" ]; then
+    # extensionless, case-sensitive `Kustomization` name is a root exactly like one
+    # using `.yaml`, and skipping it would leave a whole cluster unjudged while the
+    # floor still passed on the others.
+    if [ ! -f "$overlay/kustomization.yaml" ] && [ ! -f "$overlay/kustomization.yml" ] && [ ! -f "$overlay/Kustomization" ]; then
       refuse "cluster overlay $overlay carries no kustomization descriptor; cannot discover its Flux roots"
     fi
     if ! paths="$(kubectl kustomize "$overlay" 2>/dev/null |

--- a/scripts/guard-oci-repository-verify.sh
+++ b/scripts/guard-oci-repository-verify.sh
@@ -77,6 +77,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly REPO_ROOT
 readonly REQUIRED_URL_PREFIX='oci://ghcr.io/devantler-tech/'
+# The identity every devantler-tech artifact is signed under: GitHub Actions keyless
+# signing, with a subject regex anchored on a devantler-tech GitHub path. Compared as
+# the literal regex text the manifests carry (the `.` escaped), not evaluated.
+readonly REQUIRED_ISSUER='^https://token\.actions\.githubusercontent\.com$'
+readonly REQUIRED_SUBJECT_PREFIX='^https://github\.com/devantler-tech/'
+# Where the cluster overlays and the Flux roots they name live (seam for the test's
+# discovery fixture; the roots are resolved relative to this directory).
+readonly K8S_DIR="${OCI_VERIFY_K8S_DIR:-$REPO_ROOT/k8s}"
 
 # 5 on 2026-09-04, counted per rendered root: providers/hetzner/apps carries the aws,
 # github-config, wedding-app and ascoachingogvaner manifests consumers (4) and
@@ -128,6 +136,13 @@ while IFS= read -r row; do
     *"	"*) ;;
     *) refuse "exemption row '$row' carries no reason; every exemption names what retires it" ;;
   esac
+  # Both halves must be non-empty: `<url><TAB>` would waive verification with no
+  # recorded reason, and `<TAB><reason>` would key an exemption on the empty URL.
+  row_url="${row%%	*}"
+  row_reason="${row#*	}"
+  row_reason="${row_reason#"${row_reason%%[![:space:]]*}"}"
+  [ -n "$row_url" ] || refuse "exemption row '$row' names no URL"
+  [ -n "$row_reason" ] || refuse "exemption row '$row' carries an empty reason; every exemption names what retires it"
 done <<EOF
 $exemptions
 EOF
@@ -170,20 +185,25 @@ roots=""
 if [ -n "${OCI_VERIFY_ROOTS:-}" ]; then
   roots="$OCI_VERIFY_ROOTS"
 else
-  [ -d "$REPO_ROOT/k8s/clusters" ] || refuse "no k8s/clusters directory under $REPO_ROOT"
-  for overlay in "$REPO_ROOT"/k8s/clusters/*/; do
-    [ -f "$overlay/kustomization.yaml" ] || continue
+  [ -d "$K8S_DIR/clusters" ] || refuse "no clusters directory under $K8S_DIR"
+  for overlay in "$K8S_DIR"/clusters/*/; do
     # k8s/clusters/base is the wiring TEMPLATE the real overlays consume: its Flux paths
     # are `__PROVIDER__`/`__CLUSTER__` placeholders that each cluster overlay replaces.
     # No cluster applies it as-is, so it is not a root.
     case "${overlay%/}" in */base) continue ;; esac
+    # kustomize recognises all three descriptor names; an overlay using `.yml` or the
+    # bare name is a root exactly like one using `.yaml`, and skipping it would leave
+    # a whole cluster unjudged while the floor still passed on the others.
+    if [ ! -f "$overlay/kustomization.yaml" ] && [ ! -f "$overlay/kustomization.yml" ] && [ ! -f "$overlay/kustomization" ]; then
+      refuse "cluster overlay $overlay carries no kustomization descriptor; cannot discover its Flux roots"
+    fi
     if ! paths="$(kubectl kustomize "$overlay" 2>/dev/null |
       yq -N -r 'select(.kind == "Kustomization" and (.apiVersion | test("^kustomize\\.toolkit\\.fluxcd\\.io/"))) | .spec.path // ""')"; then
       refuse "could not render the cluster overlay $overlay to discover its Flux roots"
     fi
     while IFS= read -r p; do
       [ -n "$p" ] || continue
-      roots="$roots$REPO_ROOT/k8s/${p#./}
+      roots="$roots$K8S_DIR/${p#./}
 "
     done <<EOF
 $paths
@@ -207,7 +227,9 @@ readonly YQ_ROWS='[.. | select(type == "!!map" and .kind == "OCIRepository")]
       (.spec.verify.matchOIDCIdentity | type),
       (((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | length) // 0) | tostring),
       (([.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[]
-          | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length) | tostring)
+          | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length) | tostring),
+      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[0].issuer) // ""),
+      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[0].subject) // "")
     ]
   | map(sub("^$", "-"))
   | join("	")'
@@ -237,10 +259,10 @@ while IFS= read -r root; do
     fail "$label: yq could not read the render, so its OCIRepositories are UNKNOWN: $(tr '\n' ' ' <"$work/rows.err")"
     continue
   fi
-  while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete; do
+  while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete issuer subject; do
     [ -n "$url" ] || continue
     url="$(decode "$url")"; name="$(decode "$name")"; provider="$(decode "$provider")"
-    ids_type="$(decode "$ids_type")"
+    ids_type="$(decode "$ids_type")"; issuer="$(decode "$issuer")"; subject="$(decode "$subject")"
     [ -n "$url$name" ] || continue
     url="$(normalise_url "$url")"
     # The second pattern is the literal characters `${` — a Flux substitution marker,
@@ -290,6 +312,24 @@ while IFS= read -r root; do
       fail "$label: OCIRepository $name ($url) has a matchOIDCIdentity entry missing a non-empty issuer or subject"
       continue
     fi
+    # The one identity must be OURS. A single `issuer: '.*'` / `subject: '.*'` entry
+    # satisfies every shape check above and is invisible to both subject guards
+    # (they examine only subjects naming the shared publish workflows), so without
+    # this an OCIRepository could accept any signer with every check green. The
+    # issuer is exactly GitHub Actions' token issuer and the subject regex must
+    # anchor on a devantler-tech GitHub path; WHICH revision it pins is the
+    # subject guards' question, not this one's.
+    if [ "$issuer" != "$REQUIRED_ISSUER" ]; then
+      fail "$label: OCIRepository $name ($url) trusts issuer '$issuer'; the only accepted issuer is '$REQUIRED_ISSUER' (GitHub Actions keyless signing)"
+      continue
+    fi
+    case "$subject" in
+      "$REQUIRED_SUBJECT_PREFIX"*) ;;
+      *)
+        fail "$label: OCIRepository $name ($url) trusts subject '$subject', which does not anchor on '$REQUIRED_SUBJECT_PREFIX' — a signer outside devantler-tech would verify"
+        continue
+        ;;
+    esac
   done <"$work/rows"
 done <<EOF
 $roots

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -288,38 +288,47 @@ root="$(fresh_root broken)"
 add_resource "$root" missing.yaml
 expect_refused 'a root kustomize cannot build is refused as unknown' "$root" 'kubectl kustomize failed, so its OCIRepositories are UNKNOWN'
 
-# --- DISCOVERY: the default root discovery reads every cluster overlay, including one
-# whose descriptor is `kustomization.yml`, and judges the Flux roots it names ---
-k8s="$WORK/k8s"; rm -rf "$k8s"
-mkdir -p "$k8s/clusters/alpha" "$k8s/providers/alpha/apps"
-cat >"$k8s/clusters/alpha/kustomization.yml" <<'EOF'
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - flux-kustomization-apps.yaml
-EOF
-cat >"$k8s/clusters/alpha/flux-kustomization-apps.yaml" <<'EOF'
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: apps
-  namespace: flux-system
-spec:
-  interval: 10m
-  path: ./providers/alpha/apps
-  prune: true
-  sourceRef:
-    kind: OCIRepository
-    name: flux-system
-EOF
-printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - bare.yaml\n' >"$k8s/providers/alpha/apps/kustomization.yaml"
-repo_doc disc 'oci://ghcr.io/devantler-tech/disc/manifests' '' >"$k8s/providers/alpha/apps/bare.yaml"
+# --- DISCOVERY: every descriptor kustomize accepts makes an overlay discoverable, and
+# an overlay carrying none of them is UNKNOWN rather than silently skipped. ---
+write_discovery_overlay() {
+  local k8s="$1" cluster="$2" descriptor="$3" repo_name="$4" verify="$5"
+  local overlay="$k8s/clusters/$cluster" root="$k8s/providers/$cluster/apps"
+  mkdir -p "$overlay" "$root"
+  printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - flux-kustomization-apps.yaml\n' >"$overlay/$descriptor"
+  printf 'apiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\nmetadata:\n  name: apps\n  namespace: flux-system\nspec:\n  interval: 10m\n  path: ./providers/%s/apps\n  prune: true\n  sourceRef:\n    kind: OCIRepository\n    name: flux-system\n' "$cluster" >"$overlay/flux-kustomization-apps.yaml"
+  printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - repo.yaml\n' >"$root/kustomization.yaml"
+  repo_doc "$repo_name" "oci://ghcr.io/devantler-tech/$repo_name/manifests" "$verify" >"$root/repo.yaml"
+}
+
+expect_descriptor_discovered() {
+  local descriptor="$1" k8s="$WORK/k8s-$1"
+  rm -rf "$k8s"
+  write_discovery_overlay "$k8s" alpha "$descriptor" disc ''
+  if out="$(OCI_VERIFY_K8S_DIR="$k8s" OCI_VERIFY_EXEMPTIONS_FILE="$WORK/no-exemptions.tsv" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
+    fail "discovery: an overlay with $descriptor was not judged (guard passed): $out"
+    return
+  fi
+  case "$out" in
+    *'OCIRepository disc (oci://ghcr.io/devantler-tech/disc/manifests) has NO spec.verify'*) pass "a $descriptor cluster overlay is discovered and its Flux root judged" ;;
+    *) fail "discovery: $descriptor refused, but not for the right reason: $out" ;;
+  esac
+}
+
+expect_descriptor_discovered kustomization.yaml
+expect_descriptor_discovered kustomization.yml
+expect_descriptor_discovered kustomization
+
+# Keep one valid overlay in the fixture: if the guard regresses to `continue` for the
+# descriptor-less one, the good root satisfies the floor and the guard would pass.
+k8s="$WORK/k8s-missing-descriptor"; rm -rf "$k8s"
+write_discovery_overlay "$k8s" alpha kustomization.yml good "$(good_verify)"
+mkdir -p "$k8s/clusters/bravo"
 if out="$(OCI_VERIFY_K8S_DIR="$k8s" OCI_VERIFY_EXEMPTIONS_FILE="$WORK/no-exemptions.tsv" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
-  fail "discovery: an overlay with kustomization.yml was not judged (guard passed): $out"
+  fail "discovery: a descriptor-less overlay was skipped (guard passed): $out"
 else
   case "$out" in
-    *'OCIRepository disc (oci://ghcr.io/devantler-tech/disc/manifests) has NO spec.verify'*) pass 'a kustomization.yml cluster overlay is discovered and its Flux root judged' ;;
-    *) fail "discovery: refused, but not for the right reason: $out" ;;
+    *'clusters/bravo/ carries no kustomization descriptor; cannot discover its Flux roots'*) pass 'a cluster overlay with no supported descriptor is refused' ;;
+    *) fail "discovery: a descriptor-less overlay was refused, but not for the right reason: $out" ;;
   esac
 fi
 

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -316,7 +316,7 @@ expect_descriptor_discovered() {
 
 expect_descriptor_discovered kustomization.yaml
 expect_descriptor_discovered kustomization.yml
-expect_descriptor_discovered kustomization
+expect_descriptor_discovered Kustomization
 
 # Keep one valid overlay in the fixture: if the guard regresses to `continue` for the
 # descriptor-less one, the good root satisfies the floor and the guard would pass.

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -7,14 +7,15 @@
 # Every RED case below isolates ONE conjunct and asserts the guard refuses it BY
 # NAME — the OCIRepository and the specific defect appear in the message — rather
 # than merely exiting non-zero for some other reason (a floor miss, a stale
-# exemption, an unreadable file). The floor, the exemption list and discovery
-# depth each get their own case, and the real tree is run last as the wiring
-# check.
+# exemption, an unrenderable root). Each case is a kustomize ROOT, because the guard
+# judges `kubectl kustomize` output: that is what closes the bypasses a source scan
+# had — a `!!binary` tag or alias on `kind`, a `.json` or extension-less resource, a
+# symlink, and a patch that strips or widens `verify` — and every one of those has a
+# case here that asserts the render is what gets judged.
 #
-# THE SEAMS: OCI_VERIFY_SCAN_ROOT points the guard at a synthetic tree built here,
-# OCI_VERIFY_EXEMPTIONS_FILE replaces the built-in exemption list, and
-# OCI_VERIFY_EXPECTED_MIN lowers the floor so a one-file fixture can be judged on
-# its own defect.
+# THE SEAMS: OCI_VERIFY_ROOTS lists the fixture roots, OCI_VERIFY_EXEMPTIONS_FILE
+# replaces the built-in exemption list, and OCI_VERIFY_EXPECTED_MIN lowers the floor
+# so a one-root fixture is judged on its own defect.
 
 set -euo pipefail
 
@@ -33,58 +34,62 @@ pass() { printf 'ok: %s\n' "$*"; }
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
+: >"$WORK/no-exemptions.tsv"
 
 readonly ISSUER="'^https://token\\.actions\\.githubusercontent\\.com\$'"
 readonly SUBJECT="'^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@[0-9a-f]{40}\$'"
-
-# write_repo <dir> <name> <url> <verify-block-or-empty> — one OCIRepository manifest.
-# The verify block is appended verbatim under spec:, so a case controls exactly it.
-write_repo() {
-  local dir="$1" name="$2" url="$3" verify="$4"
-  mkdir -p "$dir"
-  {
-    printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: %s\n  namespace: %s\nspec:\n  interval: 10m\n  url: %s\n  ref:\n    semver: ">=1.0.0"\n' "$name" "$name" "$url"
-    [ -z "$verify" ] || printf '%s\n' "$verify"
-  } >"$dir/oci-repository.yaml"
-}
 
 good_verify() {
   printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "$SUBJECT"
 }
 
-# fresh_tree — a new scan root holding one GOOD in-scope OCIRepository, so every case
-# starts from a tree the guard accepts and varies exactly one thing.
-fresh_tree() {
-  local root="$WORK/tree-$1"
+# repo_doc <name> <url> <verify-block-or-empty> — one OCIRepository document on stdout.
+repo_doc() {
+  printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: %s\n  namespace: %s\nspec:\n  interval: 10m\n  url: %s\n  ref:\n    semver: ">=1.0.0"\n' "$1" "$1" "$2"
+  [ -z "$3" ] || printf '%s\n' "$3"
+}
+
+# add_resource <root> <file> — appends a resource entry to the root's kustomization.
+add_resource() {
+  printf '  - %s\n' "$2" >>"$1/kustomization.yaml"
+}
+
+# fresh_root <case> — a kustomize root holding one GOOD in-scope OCIRepository, so every
+# case starts from a root the guard accepts and varies exactly one thing.
+fresh_root() {
+  local root="$WORK/root-$1"
   rm -rf "$root"
-  write_repo "$root/apps/good" good 'oci://ghcr.io/devantler-tech/good/manifests' "$(good_verify)"
+  mkdir -p "$root"
+  printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n' >"$root/kustomization.yaml"
+  repo_doc good 'oci://ghcr.io/devantler-tech/good/manifests' "$(good_verify)" >"$root/good.yaml"
+  add_resource "$root" good.yaml
   printf '%s' "$root"
 }
 
-# run_guard <root> [exemptions-file] — runs the guard with the floor lowered to 1 and an
-# EMPTY exemption list unless one is supplied; stdout+stderr captured in $out.
 out=""
+# run_guard <root> [exemptions-file]
 run_guard() {
   local root="$1" exemptions="${2:-$WORK/no-exemptions.tsv}"
-  : >"$WORK/no-exemptions.tsv"
-  if out="$(OCI_VERIFY_SCAN_ROOT="$root" OCI_VERIFY_EXEMPTIONS_FILE="$exemptions" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
+  if out="$(OCI_VERIFY_ROOTS="$root" OCI_VERIFY_EXEMPTIONS_FILE="$exemptions" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
     return 0
   fi
   return 1
 }
 
 # expect_refused <case> <root> <must-name> [exemptions-file]
+# The needle is matched with `case`, never a `printf | grep -q` pipe: under pipefail a
+# multi-line refusal makes grep exit early and printf take SIGPIPE, which reports a
+# correct refusal as the wrong reason.
 expect_refused() {
   local name="$1" root="$2" needle="$3" exemptions="${4:-}"
   if run_guard "$root" ${exemptions:+"$exemptions"}; then
     fail "$name: expected the guard to REFUSE, it passed: $out"
     return
   fi
-  if ! printf '%s' "$out" | grep -qF -- "$needle"; then
-    fail "$name: refused, but not for the right reason (wanted '$needle'): $out"
-    return
-  fi
-  pass "$name"
+  case "$out" in
+    *"$needle"*) pass "$name" ;;
+    *) fail "$name: refused, but not for the right reason (wanted '$needle'): $out" ;;
+  esac
 }
 
 expect_accepted() {
@@ -96,49 +101,53 @@ expect_accepted() {
   fi
 }
 
-# --- GREEN: the baseline fixture is accepted, so every RED below is attributable ---
-root="$(fresh_tree green)"
+# Confirms the fixture really renders an in-scope OCIRepository at the attack URL —
+# otherwise a "refused" could be a broken fixture rather than a caught bypass.
+assert_renders() {
+  local root="$1" url="$2"
+  if ! kubectl kustomize "$root" 2>/dev/null | grep -qF -- "url: $url"; then
+    fail "fixture $root does not render an OCIRepository at $url — the case would be vacuous"
+    return 1
+  fi
+}
+
+# --- GREEN: the baseline root is accepted, so every RED below is attributable ---
+root="$(fresh_root green)"
 expect_accepted 'a verified in-scope OCIRepository with one identity is accepted' "$root"
 
 # --- RED: no spec.verify at all (AC1) ---
-root="$(fresh_tree noverify)"
-write_repo "$root/apps/bare" bare 'oci://ghcr.io/devantler-tech/bare/manifests' ''
+root="$(fresh_root noverify)"
+repo_doc bare 'oci://ghcr.io/devantler-tech/bare/manifests' '' >"$root/bare.yaml"; add_resource "$root" bare.yaml
 expect_refused 'no spec.verify is refused by name' "$root" 'OCIRepository bare (oci://ghcr.io/devantler-tech/bare/manifests) has NO spec.verify'
 
 # --- RED: verify with zero identity entries (AC2) ---
-root="$(fresh_tree zero)"
-write_repo "$root/apps/zero" zero 'oci://ghcr.io/devantler-tech/zero/manifests' \
-  "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity: []')"
+root="$(fresh_root zero)"
+repo_doc zero 'oci://ghcr.io/devantler-tech/zero/manifests' "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity: []')" >"$root/zero.yaml"; add_resource "$root" zero.yaml
 expect_refused 'zero matchOIDCIdentity entries is refused' "$root" 'OCIRepository zero (oci://ghcr.io/devantler-tech/zero/manifests) has ZERO matchOIDCIdentity entries'
 
 # --- RED: verify with no matchOIDCIdentity key at all ---
-root="$(fresh_tree nokey)"
-write_repo "$root/apps/nokey" nokey 'oci://ghcr.io/devantler-tech/nokey/manifests' \
-  "$(printf '  verify:\n    provider: cosign')"
+root="$(fresh_root nokey)"
+repo_doc nokey 'oci://ghcr.io/devantler-tech/nokey/manifests' "$(printf '  verify:\n    provider: cosign')" >"$root/nokey.yaml"; add_resource "$root" nokey.yaml
 expect_refused 'a verify block without matchOIDCIdentity is refused' "$root" 'OCIRepository nokey (oci://ghcr.io/devantler-tech/nokey/manifests) has no matchOIDCIdentity sequence'
 
 # --- RED: two identity entries (Flux ORs them) ---
-root="$(fresh_tree two)"
-write_repo "$root/apps/two" two 'oci://ghcr.io/devantler-tech/two/manifests' \
-  "$(good_verify; printf '\n      - issuer: %s\n        subject: %s' "'.*'" "'.*'")"
+root="$(fresh_root two)"
+repo_doc two 'oci://ghcr.io/devantler-tech/two/manifests' "$(good_verify; printf '\n      - issuer: %s\n        subject: %s' "'.*'" "'.*'")" >"$root/two.yaml"; add_resource "$root" two.yaml
 expect_refused 'a second identity entry is refused as a widening' "$root" 'OCIRepository two (oci://ghcr.io/devantler-tech/two/manifests) has 2 matchOIDCIdentity entries'
 
 # --- RED: a provider other than cosign ---
-root="$(fresh_tree notation)"
-write_repo "$root/apps/notation" notation 'oci://ghcr.io/devantler-tech/notation/manifests' \
-  "$(printf '  verify:\n    provider: notation\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "$SUBJECT")"
+root="$(fresh_root notation)"
+repo_doc notation 'oci://ghcr.io/devantler-tech/notation/manifests' "$(printf '  verify:\n    provider: notation\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "$SUBJECT")" >"$root/notation.yaml"; add_resource "$root" notation.yaml
 expect_refused 'a non-cosign provider is refused' "$root" "OCIRepository notation (oci://ghcr.io/devantler-tech/notation/manifests) verifies with provider 'notation'"
 
 # --- RED: an entry with an empty subject ---
-root="$(fresh_tree nosubject)"
-write_repo "$root/apps/nosubject" nosubject 'oci://ghcr.io/devantler-tech/nosubject/manifests' \
-  "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s' "$ISSUER")"
+root="$(fresh_root nosubject)"
+repo_doc nosubject 'oci://ghcr.io/devantler-tech/nosubject/manifests' "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s' "$ISSUER")" >"$root/nosubject.yaml"; add_resource "$root" nosubject.yaml
 expect_refused 'an identity entry without a subject is refused' "$root" 'OCIRepository nosubject (oci://ghcr.io/devantler-tech/nosubject/manifests) has a matchOIDCIdentity entry missing a non-empty issuer or subject'
 
 # --- RED: discovery at depth — an unverified OCIRepository nested as a template ---
-root="$(fresh_tree nested)"
-mkdir -p "$root/rgd"
-cat >"$root/rgd/resource-graph-definition.yaml" <<'EOF'
+root="$(fresh_root nested)"
+cat >"$root/rgd.yaml" <<'EOF'
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
@@ -156,63 +165,105 @@ spec:
           ref:
             semver: ">=1.0.0"
 EOF
-# The `${schema.spec.name}` below is the kro template placeholder, quoted verbatim — it
-# must NOT expand, which is exactly what single quotes guarantee.
+add_resource "$root" rgd.yaml
+# The `${schema.spec.name}` below is the kro template placeholder, quoted verbatim.
 # shellcheck disable=SC2016
 expect_refused 'an unverified OCIRepository nested inside a template is discovered' "$root" 'OCIRepository ${schema.spec.name} (oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests) has NO spec.verify'
 
 # --- RED: discovery across documents — the second document of a multi-doc file ---
-root="$(fresh_tree multidoc)"
-{
-  printf -- '---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: second\n---\n'
-  printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: second\nspec:\n  url: oci://ghcr.io/devantler-tech/second/manifests\n'
-} >"$root/apps/second.yaml"
+root="$(fresh_root multidoc)"
+{ printf -- 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second\n---\n'; repo_doc second 'oci://ghcr.io/devantler-tech/second/manifests' ''; } >"$root/second.yaml"; add_resource "$root" second.yaml
 expect_refused 'an unverified OCIRepository in a later YAML document is discovered' "$root" 'OCIRepository second (oci://ghcr.io/devantler-tech/second/manifests) has NO spec.verify'
 
-# --- CONTROL: an OCIRepository outside the devantler-tech prefix is out of scope ---
-root="$(fresh_tree thirdparty)"
-write_repo "$root/apps/flux" flux 'oci://ghcr.io/fluxcd/flux-manifests' ''
+# --- RED: the render is judged, not the source — bypasses a source scan had ---
+root="$(fresh_root binarytag)"
+repo_doc bin 'oci://ghcr.io/devantler-tech/bin/manifests' '' | sed 's/^kind: OCIRepository$/kind: !!binary T0NJUmVwb3NpdG9yeQ==/' >"$root/bin.yaml"; add_resource "$root" bin.yaml
+assert_renders "$root" 'oci://ghcr.io/devantler-tech/bin/manifests' &&
+  expect_refused 'a !!binary-tagged kind is resolved by the render and refused' "$root" 'OCIRepository bin (oci://ghcr.io/devantler-tech/bin/manifests) has NO spec.verify'
+
+root="$(fresh_root alias)"
+{ printf 'apiVersion: source.toolkit.fluxcd.io/v1\nmetadata:\n  name: al\n  namespace: al\n  annotations:\n    note: &k OCIRepository\nkind: *k\nspec:\n  interval: 10m\n  url: oci://ghcr.io/devantler-tech/al/manifests\n  ref:\n    semver: ">=1.0.0"\n'; } >"$root/al.yaml"; add_resource "$root" al.yaml
+assert_renders "$root" 'oci://ghcr.io/devantler-tech/al/manifests' &&
+  expect_refused 'an aliased kind is resolved by the render and refused' "$root" 'OCIRepository al (oci://ghcr.io/devantler-tech/al/manifests) has NO spec.verify'
+
+root="$(fresh_root json)"
+printf '{"apiVersion":"source.toolkit.fluxcd.io/v1","kind":"OCIRepository","metadata":{"name":"js","namespace":"js"},"spec":{"interval":"10m","url":"oci://ghcr.io/devantler-tech/js/manifests","ref":{"semver":">=1.0.0"}}}\n' >"$root/js.json"; add_resource "$root" js.json
+assert_renders "$root" 'oci://ghcr.io/devantler-tech/js/manifests' &&
+  expect_refused 'a .json resource is rendered and refused' "$root" 'OCIRepository js (oci://ghcr.io/devantler-tech/js/manifests) has NO spec.verify'
+
+root="$(fresh_root noext)"
+repo_doc noext 'oci://ghcr.io/devantler-tech/noext/manifests' '' >"$root/ocirepo"; add_resource "$root" ocirepo
+assert_renders "$root" 'oci://ghcr.io/devantler-tech/noext/manifests' &&
+  expect_refused 'an extension-less resource is rendered and refused' "$root" 'OCIRepository noext (oci://ghcr.io/devantler-tech/noext/manifests) has NO spec.verify'
+
+root="$(fresh_root symlink)"
+repo_doc sym 'oci://ghcr.io/devantler-tech/sym/manifests' '' >"$root/real.txt"; ln -s real.txt "$root/sym.yaml"; add_resource "$root" sym.yaml
+assert_renders "$root" 'oci://ghcr.io/devantler-tech/sym/manifests' &&
+  expect_refused 'a symlinked resource is rendered and refused' "$root" 'OCIRepository sym (oci://ghcr.io/devantler-tech/sym/manifests) has NO spec.verify'
+
+root="$(fresh_root patchremove)"
+repo_doc pr 'oci://ghcr.io/devantler-tech/pr/manifests' "$(good_verify)" >"$root/pr.yaml"; add_resource "$root" pr.yaml
+printf 'patches:\n  - target:\n      kind: OCIRepository\n      name: pr\n    patch: |\n      - op: remove\n        path: /spec/verify\n' >>"$root/kustomization.yaml"
+expect_refused 'a patch that removes spec.verify is judged on the render' "$root" 'OCIRepository pr (oci://ghcr.io/devantler-tech/pr/manifests) has NO spec.verify'
+
+root="$(fresh_root patchappend)"
+repo_doc pa 'oci://ghcr.io/devantler-tech/pa/manifests' "$(good_verify)" >"$root/pa.yaml"; add_resource "$root" pa.yaml
+printf 'patches:\n  - target:\n      kind: OCIRepository\n      name: pa\n    patch: |\n      - op: add\n        path: /spec/verify/matchOIDCIdentity/-\n        value:\n          issuer: ".*"\n          subject: ".*"\n' >>"$root/kustomization.yaml"
+expect_refused 'a patch that appends an identity is judged on the render' "$root" 'OCIRepository pa (oci://ghcr.io/devantler-tech/pa/manifests) has 2 matchOIDCIdentity entries'
+
+# --- RED: host case and substituted hosts ---
+root="$(fresh_root upper)"
+repo_doc up 'oci://GHCR.IO/devantler-tech/up/manifests' '' >"$root/up.yaml"; add_resource "$root" up.yaml
+expect_refused 'an upper-cased registry host is still in scope' "$root" 'OCIRepository up (oci://ghcr.io/devantler-tech/up/manifests) has NO spec.verify'
+
+root="$(fresh_root subst)"
+# The `${REGISTRY}` below is a Flux substitution placeholder, quoted verbatim.
+# shellcheck disable=SC2016
+repo_doc sub 'oci://${REGISTRY}/devantler-tech/sub/manifests' '' >"$root/sub.yaml"; add_resource "$root" sub.yaml
+expect_refused 'a host decided by a substitution variable is refused as undecidable' "$root" 'decides its registry or organisation through a substitution variable'
+
+# --- CONTROLS ---
+root="$(fresh_root thirdparty)"
+repo_doc flux 'oci://ghcr.io/fluxcd/flux-manifests' '' >"$root/flux.yaml"; add_resource "$root" flux.yaml
 expect_accepted 'a third-party OCIRepository without verify is out of scope' "$root"
 
-# --- CONTROL: the scan root is honoured — the same defect outside it is not seen ---
-root="$(fresh_tree outside)"
-write_repo "$WORK/elsewhere-outside" outside 'oci://ghcr.io/devantler-tech/outside/manifests' ''
-expect_accepted 'a defect outside the scan root is not attributed to the tree' "$root"
+root="$(fresh_root outside)"
+mkdir -p "$WORK/elsewhere"; repo_doc outside 'oci://ghcr.io/devantler-tech/outside/manifests' '' >"$WORK/elsewhere/outside.yaml"
+expect_accepted 'a defect in a root that is not listed is not attributed to the tree' "$root"
 
-# --- EXEMPTIONS: an exempt URL without verify passes; the row must be reasoned ---
-root="$(fresh_tree exempt)"
-write_repo "$root/apps/unsigned" unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' ''
+# --- EXEMPTIONS ---
+root="$(fresh_root exempt)"
+repo_doc unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' '' >"$root/unsigned.yaml"; add_resource "$root" unsigned.yaml
 printf 'oci://ghcr.io/devantler-tech/charts/unsigned\tpublished unsigned; tracked by example#1\n' >"$WORK/exempt.tsv"
 expect_accepted 'an exempt unverified OCIRepository is admitted' "$root" "$WORK/exempt.tsv"
-
-# --- RED: the exemption must be LOAD-BEARING — the same tree without the row is refused ---
-expect_refused 'the same tree with no exemption row is refused' "$root" 'OCIRepository unsigned (oci://ghcr.io/devantler-tech/charts/unsigned) has NO spec.verify'
-
-# --- RED: an exemption row with no reason is refused ---
+expect_refused 'the same root with no exemption row is refused' "$root" 'OCIRepository unsigned (oci://ghcr.io/devantler-tech/charts/unsigned) has NO spec.verify'
 printf 'oci://ghcr.io/devantler-tech/charts/unsigned\n' >"$WORK/exempt-noreason.tsv"
-expect_refused 'an exemption row without a reason is refused' "$root" 'carries no reason' "$WORK/exempt-noreason.tsv"
+expect_refused 'an exemption row without a reason is refused, once' "$root" 'carries no reason' "$WORK/exempt-noreason.tsv"
+case "$out" in *"has NO spec.verify"*|*"STALE"*) fail 'a reason-less row produced cascading wrong-reason messages';; esac
 
-# --- RED: a STALE exemption (no OCIRepository carries the URL) is refused ---
-root="$(fresh_tree stale)"
+root="$(fresh_root stale)"
 printf 'oci://ghcr.io/devantler-tech/charts/gone\tretired long ago\n' >"$WORK/stale.tsv"
-expect_refused 'an exemption naming no OCIRepository in the tree is STALE' "$root" 'exemption for oci://ghcr.io/devantler-tech/charts/gone is STALE' "$WORK/stale.tsv"
+expect_refused 'an exemption naming no rendered OCIRepository is STALE' "$root" 'exemption for oci://ghcr.io/devantler-tech/charts/gone is STALE' "$WORK/stale.tsv"
 
-# --- RED: an exempt OCIRepository that GAINED verify makes the row stale ---
-root="$(fresh_tree gained)"
-write_repo "$root/apps/unsigned" unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' "$(good_verify)"
+root="$(fresh_root stalesuffix)"
+repo_doc unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' '' >"$root/unsigned.yaml"; add_resource "$root" unsigned.yaml
+printf 'oci://ghcr.io/devantler-tech/charts/unsigned\treal\ntech/charts/unsigned\tdead\n' >"$WORK/stale-suffix.tsv"
+expect_refused 'a row that is only a suffix of a rendered URL is STALE (exact match)' "$root" 'exemption for tech/charts/unsigned is STALE' "$WORK/stale-suffix.tsv"
+
+root="$(fresh_root gained)"
+repo_doc unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' "$(good_verify)" >"$root/unsigned.yaml"; add_resource "$root" unsigned.yaml
 expect_refused 'an exempt OCIRepository that now verifies reports its exemption as stale' "$root" 'is exempt from verification but carries spec.verify' "$WORK/exempt.tsv"
 
-# --- RED: the floor — an empty in-scope result is a claim about the scan ---
-root="$WORK/tree-floor"
-rm -rf "$root"
-mkdir -p "$root"
-write_repo "$root/apps/flux" flux 'oci://ghcr.io/fluxcd/flux-manifests' "$(good_verify)"
+# --- RED: the floor — an empty in-scope result is a claim about the discovery ---
+root="$WORK/root-floor"; rm -rf "$root"; mkdir -p "$root"
+printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n' >"$root/kustomization.yaml"
+repo_doc flux 'oci://ghcr.io/fluxcd/flux-manifests' "$(good_verify)" >"$root/flux.yaml"; add_resource "$root" flux.yaml
 expect_refused 'zero in-scope OCIRepositories fails the floor' "$root" 'found 0 in-scope OCIRepositor(y/ies)'
 
-# --- RED: an unreadable file is UNKNOWN, never clean ---
-root="$(fresh_tree unreadable)"
-printf 'kind: OCIRepository\nspec: [unterminated\n' >"$root/apps/broken.yaml"
-expect_refused 'a file yq cannot parse is refused as unknown' "$root" 'yq could not read this file'
+# --- RED: a root that does not render is UNKNOWN, never clean ---
+root="$(fresh_root broken)"
+add_resource "$root" missing.yaml
+expect_refused 'a root kustomize cannot build is refused as unknown' "$root" 'kubectl kustomize failed, so its OCIRepositories are UNKNOWN'
 
 # --- WIRING: the real tree passes with the built-in exemptions and floor ---
 if out="$("$GUARD" 2>&1)"; then

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# RED/GREEN coverage for scripts/guard-oci-repository-verify.sh (#3558).
+#
+# WHAT IS ACTUALLY BEING PROVED
+# The guard's one harmful failure mode is passing: an OCIRepository with no
+# `spec.verify` still reconciles, so no schema, kubeconform pass or deploy notices.
+# Every RED case below isolates ONE conjunct and asserts the guard refuses it BY
+# NAME — the OCIRepository and the specific defect appear in the message — rather
+# than merely exiting non-zero for some other reason (a floor miss, a stale
+# exemption, an unreadable file). The floor, the exemption list and discovery
+# depth each get their own case, and the real tree is run last as the wiring
+# check.
+#
+# THE SEAMS: OCI_VERIFY_SCAN_ROOT points the guard at a synthetic tree built here,
+# OCI_VERIFY_EXEMPTIONS_FILE replaces the built-in exemption list, and
+# OCI_VERIFY_EXPECTED_MIN lowers the floor so a one-file fixture can be judged on
+# its own defect.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly REPO_ROOT
+readonly GUARD="$REPO_ROOT/scripts/guard-oci-repository-verify.sh"
+
+failures=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+pass() { printf 'ok: %s\n' "$*"; }
+
+[ -x "$GUARD" ] || { fail "guard not executable at $GUARD"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+readonly ISSUER="'^https://token\\.actions\\.githubusercontent\\.com\$'"
+readonly SUBJECT="'^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@[0-9a-f]{40}\$'"
+
+# write_repo <dir> <name> <url> <verify-block-or-empty> — one OCIRepository manifest.
+# The verify block is appended verbatim under spec:, so a case controls exactly it.
+write_repo() {
+  local dir="$1" name="$2" url="$3" verify="$4"
+  mkdir -p "$dir"
+  {
+    printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: %s\n  namespace: %s\nspec:\n  interval: 10m\n  url: %s\n  ref:\n    semver: ">=1.0.0"\n' "$name" "$name" "$url"
+    [ -z "$verify" ] || printf '%s\n' "$verify"
+  } >"$dir/oci-repository.yaml"
+}
+
+good_verify() {
+  printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "$SUBJECT"
+}
+
+# fresh_tree — a new scan root holding one GOOD in-scope OCIRepository, so every case
+# starts from a tree the guard accepts and varies exactly one thing.
+fresh_tree() {
+  local root="$WORK/tree-$1"
+  rm -rf "$root"
+  write_repo "$root/apps/good" good 'oci://ghcr.io/devantler-tech/good/manifests' "$(good_verify)"
+  printf '%s' "$root"
+}
+
+# run_guard <root> [exemptions-file] — runs the guard with the floor lowered to 1 and an
+# EMPTY exemption list unless one is supplied; stdout+stderr captured in $out.
+out=""
+run_guard() {
+  local root="$1" exemptions="${2:-$WORK/no-exemptions.tsv}"
+  : >"$WORK/no-exemptions.tsv"
+  if out="$(OCI_VERIFY_SCAN_ROOT="$root" OCI_VERIFY_EXEMPTIONS_FILE="$exemptions" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
+    return 0
+  fi
+  return 1
+}
+
+# expect_refused <case> <root> <must-name> [exemptions-file]
+expect_refused() {
+  local name="$1" root="$2" needle="$3" exemptions="${4:-}"
+  if run_guard "$root" ${exemptions:+"$exemptions"}; then
+    fail "$name: expected the guard to REFUSE, it passed: $out"
+    return
+  fi
+  if ! printf '%s' "$out" | grep -qF -- "$needle"; then
+    fail "$name: refused, but not for the right reason (wanted '$needle'): $out"
+    return
+  fi
+  pass "$name"
+}
+
+expect_accepted() {
+  local name="$1" root="$2" exemptions="${3:-}"
+  if run_guard "$root" ${exemptions:+"$exemptions"}; then
+    pass "$name"
+  else
+    fail "$name: expected the guard to ACCEPT, it refused: $out"
+  fi
+}
+
+# --- GREEN: the baseline fixture is accepted, so every RED below is attributable ---
+root="$(fresh_tree green)"
+expect_accepted 'a verified in-scope OCIRepository with one identity is accepted' "$root"
+
+# --- RED: no spec.verify at all (AC1) ---
+root="$(fresh_tree noverify)"
+write_repo "$root/apps/bare" bare 'oci://ghcr.io/devantler-tech/bare/manifests' ''
+expect_refused 'no spec.verify is refused by name' "$root" 'OCIRepository bare (oci://ghcr.io/devantler-tech/bare/manifests) has NO spec.verify'
+
+# --- RED: verify with zero identity entries (AC2) ---
+root="$(fresh_tree zero)"
+write_repo "$root/apps/zero" zero 'oci://ghcr.io/devantler-tech/zero/manifests' \
+  "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity: []')"
+expect_refused 'zero matchOIDCIdentity entries is refused' "$root" 'OCIRepository zero (oci://ghcr.io/devantler-tech/zero/manifests) has ZERO matchOIDCIdentity entries'
+
+# --- RED: verify with no matchOIDCIdentity key at all ---
+root="$(fresh_tree nokey)"
+write_repo "$root/apps/nokey" nokey 'oci://ghcr.io/devantler-tech/nokey/manifests' \
+  "$(printf '  verify:\n    provider: cosign')"
+expect_refused 'a verify block without matchOIDCIdentity is refused' "$root" 'OCIRepository nokey (oci://ghcr.io/devantler-tech/nokey/manifests) has no matchOIDCIdentity sequence'
+
+# --- RED: two identity entries (Flux ORs them) ---
+root="$(fresh_tree two)"
+write_repo "$root/apps/two" two 'oci://ghcr.io/devantler-tech/two/manifests' \
+  "$(good_verify; printf '\n      - issuer: %s\n        subject: %s' "'.*'" "'.*'")"
+expect_refused 'a second identity entry is refused as a widening' "$root" 'OCIRepository two (oci://ghcr.io/devantler-tech/two/manifests) has 2 matchOIDCIdentity entries'
+
+# --- RED: a provider other than cosign ---
+root="$(fresh_tree notation)"
+write_repo "$root/apps/notation" notation 'oci://ghcr.io/devantler-tech/notation/manifests' \
+  "$(printf '  verify:\n    provider: notation\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "$SUBJECT")"
+expect_refused 'a non-cosign provider is refused' "$root" "OCIRepository notation (oci://ghcr.io/devantler-tech/notation/manifests) verifies with provider 'notation'"
+
+# --- RED: an entry with an empty subject ---
+root="$(fresh_tree nosubject)"
+write_repo "$root/apps/nosubject" nosubject 'oci://ghcr.io/devantler-tech/nosubject/manifests' \
+  "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s' "$ISSUER")"
+expect_refused 'an identity entry without a subject is refused' "$root" 'OCIRepository nosubject (oci://ghcr.io/devantler-tech/nosubject/manifests) has a matchOIDCIdentity entry missing a non-empty issuer or subject'
+
+# --- RED: discovery at depth — an unverified OCIRepository nested as a template ---
+root="$(fresh_tree nested)"
+mkdir -p "$root/rgd"
+cat >"$root/rgd/resource-graph-definition.yaml" <<'EOF'
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: tenant
+spec:
+  resources:
+    - id: ociRepository
+      template:
+        apiVersion: source.toolkit.fluxcd.io/v1
+        kind: OCIRepository
+        metadata:
+          name: ${schema.spec.name}
+        spec:
+          url: oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests
+          ref:
+            semver: ">=1.0.0"
+EOF
+# The `${schema.spec.name}` below is the kro template placeholder, quoted verbatim — it
+# must NOT expand, which is exactly what single quotes guarantee.
+# shellcheck disable=SC2016
+expect_refused 'an unverified OCIRepository nested inside a template is discovered' "$root" 'OCIRepository ${schema.spec.name} (oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests) has NO spec.verify'
+
+# --- RED: discovery across documents — the second document of a multi-doc file ---
+root="$(fresh_tree multidoc)"
+{
+  printf -- '---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: second\n---\n'
+  printf 'apiVersion: source.toolkit.fluxcd.io/v1\nkind: OCIRepository\nmetadata:\n  name: second\nspec:\n  url: oci://ghcr.io/devantler-tech/second/manifests\n'
+} >"$root/apps/second.yaml"
+expect_refused 'an unverified OCIRepository in a later YAML document is discovered' "$root" 'OCIRepository second (oci://ghcr.io/devantler-tech/second/manifests) has NO spec.verify'
+
+# --- CONTROL: an OCIRepository outside the devantler-tech prefix is out of scope ---
+root="$(fresh_tree thirdparty)"
+write_repo "$root/apps/flux" flux 'oci://ghcr.io/fluxcd/flux-manifests' ''
+expect_accepted 'a third-party OCIRepository without verify is out of scope' "$root"
+
+# --- CONTROL: the scan root is honoured — the same defect outside it is not seen ---
+root="$(fresh_tree outside)"
+write_repo "$WORK/elsewhere-outside" outside 'oci://ghcr.io/devantler-tech/outside/manifests' ''
+expect_accepted 'a defect outside the scan root is not attributed to the tree' "$root"
+
+# --- EXEMPTIONS: an exempt URL without verify passes; the row must be reasoned ---
+root="$(fresh_tree exempt)"
+write_repo "$root/apps/unsigned" unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' ''
+printf 'oci://ghcr.io/devantler-tech/charts/unsigned\tpublished unsigned; tracked by example#1\n' >"$WORK/exempt.tsv"
+expect_accepted 'an exempt unverified OCIRepository is admitted' "$root" "$WORK/exempt.tsv"
+
+# --- RED: the exemption must be LOAD-BEARING — the same tree without the row is refused ---
+expect_refused 'the same tree with no exemption row is refused' "$root" 'OCIRepository unsigned (oci://ghcr.io/devantler-tech/charts/unsigned) has NO spec.verify'
+
+# --- RED: an exemption row with no reason is refused ---
+printf 'oci://ghcr.io/devantler-tech/charts/unsigned\n' >"$WORK/exempt-noreason.tsv"
+expect_refused 'an exemption row without a reason is refused' "$root" 'carries no reason' "$WORK/exempt-noreason.tsv"
+
+# --- RED: a STALE exemption (no OCIRepository carries the URL) is refused ---
+root="$(fresh_tree stale)"
+printf 'oci://ghcr.io/devantler-tech/charts/gone\tretired long ago\n' >"$WORK/stale.tsv"
+expect_refused 'an exemption naming no OCIRepository in the tree is STALE' "$root" 'exemption for oci://ghcr.io/devantler-tech/charts/gone is STALE' "$WORK/stale.tsv"
+
+# --- RED: an exempt OCIRepository that GAINED verify makes the row stale ---
+root="$(fresh_tree gained)"
+write_repo "$root/apps/unsigned" unsigned 'oci://ghcr.io/devantler-tech/charts/unsigned' "$(good_verify)"
+expect_refused 'an exempt OCIRepository that now verifies reports its exemption as stale' "$root" 'is exempt from verification but carries spec.verify' "$WORK/exempt.tsv"
+
+# --- RED: the floor — an empty in-scope result is a claim about the scan ---
+root="$WORK/tree-floor"
+rm -rf "$root"
+mkdir -p "$root"
+write_repo "$root/apps/flux" flux 'oci://ghcr.io/fluxcd/flux-manifests' "$(good_verify)"
+expect_refused 'zero in-scope OCIRepositories fails the floor' "$root" 'found 0 in-scope OCIRepositor(y/ies)'
+
+# --- RED: an unreadable file is UNKNOWN, never clean ---
+root="$(fresh_tree unreadable)"
+printf 'kind: OCIRepository\nspec: [unterminated\n' >"$root/apps/broken.yaml"
+expect_refused 'a file yq cannot parse is refused as unknown' "$root" 'yq could not read this file'
+
+# --- WIRING: the real tree passes with the built-in exemptions and floor ---
+if out="$("$GUARD" 2>&1)"; then
+  pass "the real tree passes: $out"
+else
+  fail "the real tree is refused: $out"
+fi
+
+# --- WIRING: ci.yaml runs the guard unconditionally in the validate job ---
+if grep -qF './scripts/guard-oci-repository-verify.sh' "$REPO_ROOT/.github/workflows/ci.yaml"; then
+  pass 'ci.yaml invokes the guard'
+else
+  fail 'ci.yaml does not invoke scripts/guard-oci-repository-verify.sh'
+fi
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d failure(s)\n' "$failures" >&2
+  exit 1
+fi
+printf '\nall cases passed\n'

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -104,11 +104,15 @@ expect_accepted() {
 # Confirms the fixture really renders an in-scope OCIRepository at the attack URL —
 # otherwise a "refused" could be a broken fixture rather than a caught bypass.
 assert_renders() {
-  local root="$1" url="$2"
-  if ! kubectl kustomize "$root" 2>/dev/null | grep -qF -- "url: $url"; then
-    fail "fixture $root does not render an OCIRepository at $url — the case would be vacuous"
-    return 1
-  fi
+  local root="$1" url="$2" render
+  # Capture the whole render first: under pipefail a `grep -q` that closes the
+  # pipe early would hand kubectl a SIGPIPE and reject a perfectly valid render.
+  render="$(kubectl kustomize "$root" 2>/dev/null)" || render=""
+  case "$render" in
+    *"url: $url"*) return 0 ;;
+  esac
+  fail "fixture $root does not render an OCIRepository at $url — the case would be vacuous"
+  return 1
 }
 
 # --- GREEN: the baseline root is accepted, so every RED below is attributable ---
@@ -211,6 +215,20 @@ repo_doc pa 'oci://ghcr.io/devantler-tech/pa/manifests' "$(good_verify)" >"$root
 printf 'patches:\n  - target:\n      kind: OCIRepository\n      name: pa\n    patch: |\n      - op: add\n        path: /spec/verify/matchOIDCIdentity/-\n        value:\n          issuer: ".*"\n          subject: ".*"\n' >>"$root/kustomization.yaml"
 expect_refused 'a patch that appends an identity is judged on the render' "$root" 'OCIRepository pa (oci://ghcr.io/devantler-tech/pa/manifests) has 2 matchOIDCIdentity entries'
 
+# --- RED: the one identity must be OURS — a foreign issuer or subject passes every
+# shape check and is invisible to both subject guards ---
+root="$(fresh_root foreignissuer)"
+repo_doc fiss 'oci://ghcr.io/devantler-tech/fiss/manifests' "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "'^https://accounts\\.google\\.com\$'" "$SUBJECT")" >"$root/fiss.yaml"; add_resource "$root" fiss.yaml
+expect_refused 'a foreign issuer is refused' "$root" "OCIRepository fiss (oci://ghcr.io/devantler-tech/fiss/manifests) trusts issuer '^https://accounts\\.google\\.com\$'"
+
+root="$(fresh_root wildcard)"
+repo_doc wc 'oci://ghcr.io/devantler-tech/wc/manifests' "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "'.*'")" >"$root/wc.yaml"; add_resource "$root" wc.yaml
+expect_refused 'a wildcard subject is refused' "$root" "OCIRepository wc (oci://ghcr.io/devantler-tech/wc/manifests) trusts subject '.*'"
+
+root="$(fresh_root foreignorg)"
+repo_doc fo 'oci://ghcr.io/devantler-tech/fo/manifests' "$(printf '  verify:\n    provider: cosign\n    matchOIDCIdentity:\n      - issuer: %s\n        subject: %s' "$ISSUER" "'^https://github\\.com/evil-org/actions/\\.github/workflows/publish-app\\.yaml@[0-9a-f]{40}\$'")" >"$root/fo.yaml"; add_resource "$root" fo.yaml
+expect_refused 'a subject anchored on another organisation is refused' "$root" 'does not anchor on'
+
 # --- RED: host case and substituted hosts ---
 root="$(fresh_root upper)"
 repo_doc up 'oci://GHCR.IO/devantler-tech/up/manifests' '' >"$root/up.yaml"; add_resource "$root" up.yaml
@@ -241,6 +259,11 @@ printf 'oci://ghcr.io/devantler-tech/charts/unsigned\n' >"$WORK/exempt-noreason.
 expect_refused 'an exemption row without a reason is refused, once' "$root" 'carries no reason' "$WORK/exempt-noreason.tsv"
 case "$out" in *"has NO spec.verify"*|*"STALE"*) fail 'a reason-less row produced cascading wrong-reason messages';; esac
 
+printf 'oci://ghcr.io/devantler-tech/charts/unsigned\t \n' >"$WORK/exempt-emptyreason.tsv"
+expect_refused 'an exemption row with an empty reason is refused' "$root" 'carries an empty reason' "$WORK/exempt-emptyreason.tsv"
+printf '\tsome reason\n' >"$WORK/exempt-emptyurl.tsv"
+expect_refused 'an exemption row with an empty URL is refused' "$root" 'names no URL' "$WORK/exempt-emptyurl.tsv"
+
 root="$(fresh_root stale)"
 printf 'oci://ghcr.io/devantler-tech/charts/gone\tretired long ago\n' >"$WORK/stale.tsv"
 expect_refused 'an exemption naming no rendered OCIRepository is STALE' "$root" 'exemption for oci://ghcr.io/devantler-tech/charts/gone is STALE' "$WORK/stale.tsv"
@@ -264,6 +287,41 @@ expect_refused 'zero in-scope OCIRepositories fails the floor' "$root" 'found 0 
 root="$(fresh_root broken)"
 add_resource "$root" missing.yaml
 expect_refused 'a root kustomize cannot build is refused as unknown' "$root" 'kubectl kustomize failed, so its OCIRepositories are UNKNOWN'
+
+# --- DISCOVERY: the default root discovery reads every cluster overlay, including one
+# whose descriptor is `kustomization.yml`, and judges the Flux roots it names ---
+k8s="$WORK/k8s"; rm -rf "$k8s"
+mkdir -p "$k8s/clusters/alpha" "$k8s/providers/alpha/apps"
+cat >"$k8s/clusters/alpha/kustomization.yml" <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization-apps.yaml
+EOF
+cat >"$k8s/clusters/alpha/flux-kustomization-apps.yaml" <<'EOF'
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./providers/alpha/apps
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+EOF
+printf 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - bare.yaml\n' >"$k8s/providers/alpha/apps/kustomization.yaml"
+repo_doc disc 'oci://ghcr.io/devantler-tech/disc/manifests' '' >"$k8s/providers/alpha/apps/bare.yaml"
+if out="$(OCI_VERIFY_K8S_DIR="$k8s" OCI_VERIFY_EXEMPTIONS_FILE="$WORK/no-exemptions.tsv" OCI_VERIFY_EXPECTED_MIN=1 "$GUARD" 2>&1)"; then
+  fail "discovery: an overlay with kustomization.yml was not judged (guard passed): $out"
+else
+  case "$out" in
+    *'OCIRepository disc (oci://ghcr.io/devantler-tech/disc/manifests) has NO spec.verify'*) pass 'a kustomization.yml cluster overlay is discovered and its Flux root judged' ;;
+    *) fail "discovery: refused, but not for the right reason: $out" ;;
+  esac
+fi
 
 # --- WIRING: the real tree passes with the built-in exemptions and floor ---
 if out="$("$GUARD" 2>&1)"; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The two cosign-subject guards only look at a file that already carries a shared-publish-workflow subject, so an OCIRepository pointed at one of our own artifacts with no verification block at all is checked by neither of them and refused by nothing else. Flux would apply an unsigned or foreign-signed artifact with every check green — the cheapest bypass of the supply-chain floor.

## What

A new CI guard finds every OCIRepository by kind and URL, wherever it sits in a manifest, and requires cosign verification with exactly one signer identity on every devantler-tech artifact. The one artifact we publish unsigned today (the staged-off data-product-controller chart) is admitted by an explicit, reasoned exemption that fails the build as stale the moment the chart is signed or the manifest goes away.

Fixes #3558
Part of #3308
