### PR TITLE
docs(security): correct what actually blocks the C-0211 controller-scope opt-in

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -104,12 +104,12 @@
 # untouched — which is why the opt-in alone moves none of those 27. The
 # controller-scope rules that DO reach the stored spec are
 # add-baseline-context-optin-controllers* (Deployment/StatefulSet/DaemonSet on
-# CREATE and UPDATE), and they gate on a SECOND label,
-# `baseline-context-controllers`, which was applied in no namespace at all until
-# longhorn-system opted in — re-measure this split once that has reconciled.
-# Template-level changes are what moved
-# velero and flux-system. flux-system's remaining two are flux-operator and
-# tofu-controller, the latter retired and pending removal in #3480.
+# CREATE and UPDATE), gated on a SECOND label, `baseline-context-controllers`,
+# which is deliberately applied in NO namespace — tests/add-baseline-context pins
+# that empty inventory, and a namespace joins only together with the measured
+# post-rollout read-back its documented flip procedure produces. So the 27 are
+# waiting on that per-namespace rollout, not on a mechanism that cannot reach
+# them. Template-level changes are what moved
 #
 # The per-workload table and the remediation split are on #3217. These counts are
 # prod-only and the local overlay opts in to a different namespace set, so re-measure

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -104,7 +104,7 @@
 # untouched — which is why the opt-in alone moves none of those 27. The rules that
 # DO reach the stored spec are TWO families, both gated on a SECOND label,
 # `baseline-context-controllers`: add-baseline-context-optin-controllers*
-# (Deployment/StatefulSet/DaemonSet on CREATE and UPDATE) and
+# (Deployment/StatefulSet/DaemonSet on CREATE and UPDATE, Job on CREATE) and
 # add-baseline-context-optin-cronjobs* (CronJob on CREATE and UPDATE). Both are
 # load-bearing for this rollout — seven of the residual workloads are CronJobs, so
 # planning only the controller family would silently leave those out along with

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -99,9 +99,15 @@
 #
 # The remaining 29 split observability 15, longhorn-system 12, flux-system 2.
 # observability and longhorn-system are already labelled into
-# add-baseline-context-optin-*, but all three of those rules match `kinds: Pod`, so
-# they mutate at admission and leave the stored spec Kubescape reads untouched — which
-# is why the opt-in alone moves none of those 27. Template-level changes are what moved
+# add-baseline-context-optin-*, but that label gates only the three `kinds: Pod`
+# rules, so they mutate at admission and leave the stored spec Kubescape reads
+# untouched — which is why the opt-in alone moves none of those 27. The
+# controller-scope rules that DO reach the stored spec are
+# add-baseline-context-optin-controllers* (Deployment/StatefulSet/DaemonSet on
+# CREATE and UPDATE), and they gate on a SECOND label,
+# `baseline-context-controllers`, which was applied in no namespace at all until
+# longhorn-system opted in — re-measure this split once that has reconciled.
+# Template-level changes are what moved
 # velero and flux-system. flux-system's remaining two are flux-operator and
 # tofu-controller, the latter retired and pending removal in #3480.
 #

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -109,7 +109,9 @@
 # that empty inventory, and a namespace joins only together with the measured
 # post-rollout read-back its documented flip procedure produces. So the 27 are
 # waiting on that per-namespace rollout, not on a mechanism that cannot reach
-# them. Template-level changes are what moved
+# them. Template-level changes are what moved velero and flux-system. flux-system's
+# remaining two are flux-operator and tofu-controller, the latter retired and pending
+# removal in #3480.
 #
 # The per-workload table and the remediation split are on #3217. These counts are
 # prod-only and the local overlay opts in to a different namespace set, so re-measure

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations-unscoped.yaml
@@ -101,11 +101,15 @@
 # observability and longhorn-system are already labelled into
 # add-baseline-context-optin-*, but that label gates only the three `kinds: Pod`
 # rules, so they mutate at admission and leave the stored spec Kubescape reads
-# untouched — which is why the opt-in alone moves none of those 27. The
-# controller-scope rules that DO reach the stored spec are
-# add-baseline-context-optin-controllers* (Deployment/StatefulSet/DaemonSet on
-# CREATE and UPDATE), gated on a SECOND label, `baseline-context-controllers`,
-# which is deliberately applied in NO namespace — tests/add-baseline-context pins
+# untouched — which is why the opt-in alone moves none of those 27. The rules that
+# DO reach the stored spec are TWO families, both gated on a SECOND label,
+# `baseline-context-controllers`: add-baseline-context-optin-controllers*
+# (Deployment/StatefulSet/DaemonSet on CREATE and UPDATE) and
+# add-baseline-context-optin-cronjobs* (CronJob on CREATE and UPDATE). Both are
+# load-bearing for this rollout — seven of the residual workloads are CronJobs, so
+# planning only the controller family would silently leave those out along with
+# their read-back checks. That label is deliberately applied in NO namespace —
+# tests/add-baseline-context pins
 # that empty inventory, and a namespace joins only together with the measured
 # post-rollout read-back its documented flip procedure produces. So the 27 are
 # waiting on that per-namespace rollout, not on a mechanism that cannot reach

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
@@ -42,30 +42,3 @@ metadata:
     # The rules are CREATE-only, so running pods are unaffected until they are
     # next recreated.
     pod-security.devantler.tech/baseline-context: enabled
-    #
-    # 🔴 The label above is NOT sufficient to move C-0211, and that is why this
-    # second one exists. add-baseline-context-optin-namespaces / -pod-selinux-level /
-    # -containers all match `kinds: Pod`, so they mutate pods at ADMISSION while
-    # Kubescape scans the STORED SPEC of the controller. Measured on prod 2026-09-04:
-    # kubescape's pods pick both fields up as they are recreated — 7 of 15, then 8 of 16
-    # eleven minutes later, the same pods carrying both — while 0 of its 6 Deployments
-    # and DaemonSets ever do. Here all 11 workloads still carry neither, despite this
-    # namespace having been opted in since 2026-09-02. The pod figures are volatile by
-    # construction and only their direction is the evidence; the controller figures are
-    # the stable ones, and they are the surface the scanner reads. velero reads 2/2 only
-    # because its HelmRelease supplies the fields at the source, not because a mutation
-    # reached it — so velero could not have revealed this gap.
-    #
-    # add-baseline-context-optin-controllers* match Deployment/StatefulSet/DaemonSet on
-    # CREATE *and* UPDATE, so Flux's next reconcile rewrites the stored spec without
-    # anything needing to be deleted. They inject the same two fields through the same
-    # +(key) anchors and touch no user, group or privilege field.
-    #
-    # First namespace opted in at controller scope. longhorn-system is the right place
-    # to start: its 11 workloads are genuinely scanned (the namespace holds Deployment:6
-    # and DaemonSet:5 workloadconfigurationscan objects), all 11 miss both fields, and
-    # none sets fsGroup — so the change is inert at runtime here, exactly as the pod
-    # rules already are. kubescape is deliberately NOT next: the operator's own
-    # excludeNamespaces drops its workloads, which hold no workload-kind scan objects at
-    # all, so mutating them cannot move the control.
-    pod-security.devantler.tech/baseline-context-controllers: enabled

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
@@ -42,3 +42,30 @@ metadata:
     # The rules are CREATE-only, so running pods are unaffected until they are
     # next recreated.
     pod-security.devantler.tech/baseline-context: enabled
+    #
+    # 🔴 The label above is NOT sufficient to move C-0211, and that is why this
+    # second one exists. add-baseline-context-optin-namespaces / -pod-selinux-level /
+    # -containers all match `kinds: Pod`, so they mutate pods at ADMISSION while
+    # Kubescape scans the STORED SPEC of the controller. Measured on prod 2026-09-04:
+    # kubescape's pods pick both fields up as they are recreated — 7 of 15, then 8 of 16
+    # eleven minutes later, the same pods carrying both — while 0 of its 6 Deployments
+    # and DaemonSets ever do. Here all 11 workloads still carry neither, despite this
+    # namespace having been opted in since 2026-09-02. The pod figures are volatile by
+    # construction and only their direction is the evidence; the controller figures are
+    # the stable ones, and they are the surface the scanner reads. velero reads 2/2 only
+    # because its HelmRelease supplies the fields at the source, not because a mutation
+    # reached it — so velero could not have revealed this gap.
+    #
+    # add-baseline-context-optin-controllers* match Deployment/StatefulSet/DaemonSet on
+    # CREATE *and* UPDATE, so Flux's next reconcile rewrites the stored spec without
+    # anything needing to be deleted. They inject the same two fields through the same
+    # +(key) anchors and touch no user, group or privilege field.
+    #
+    # First namespace opted in at controller scope. longhorn-system is the right place
+    # to start: its 11 workloads are genuinely scanned (the namespace holds Deployment:6
+    # and DaemonSet:5 workloadconfigurationscan objects), all 11 miss both fields, and
+    # none sets fsGroup — so the change is inert at runtime here, exactly as the pod
+    # rules already are. kubescape is deliberately NOT next: the operator's own
+    # excludeNamespaces drops its workloads, which hold no workload-kind scan objects at
+    # all, so mutating them cannot move the control.
+    pod-security.devantler.tech/baseline-context-controllers: enabled


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A comment in our security-exception notes told the next reader that the mutation we rely on to close two Kubescape checks **structurally cannot** reach the thing the scanner grades. That was true when written and is no longer true — the capability was added later. Left as it stood, it reads as "this route is a dead end", which would send whoever picks this up next looking for a different solution that isn't needed.

The accurate position is narrower and more useful: the capability exists, it is deliberately switched off everywhere, and each namespace turns it on only alongside evidence that it worked there. Those are very different situations — one says the approach is broken, the other says there is a queue of per-namespace rollouts waiting.

### What

Corrects that comment. Comment-only — the rendered output is byte-identical before and after, so nothing about the cluster changes.

### Note on scope

This PR originally also opted one namespace into that rollout. A repository guard correctly rejected it: turning it on is a documented procedure — the switch, a restart of every workload in the namespace, a read-back proving the fields landed, and a watch for a specific failure mode — not a one-line change. For the namespace I picked that means restarting the cluster's storage components on production, which is not an unattended change. That commit is reverted here; the measurement behind it is recorded on #3239 so the rollout can be picked up deliberately.

Part of #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
