### PR TITLE
docs(github-management): describe the deletion control that actually applies

### DIFF
--- a/docs/github-management.md
+++ b/docs/github-management.md
@@ -119,9 +119,20 @@ reconcile, then batch the rest.
 
 ## Safety rails
 
-- **Never `Delete`** — managed resources omit `Delete` from
-  `managementPolicies`, so neither CR deletion nor a Flux prune can ever delete
-  a real GitHub repository.
+- **Never `Delete`** — every managed resource omits `Delete` from
+  `managementPolicies`, so pruning a CR, or deleting it outright, detaches the
+  object from Crossplane and leaves the real GitHub repository, team or ruleset
+  in place.
+- **Removals are acknowledged in the open** — `deploy/` lives in
+  [`devantler-tech/.github`](https://github.com/devantler-tech/.github). Its CI
+  renders that tree before and after a pull request and compares the two. A
+  resource that leaves the render fails the check unless the pull-request body
+  names it in a `Deletion-Acknowledged: <Kind>.<group>/<name>` line, so a
+  removal cannot ride along unnoticed inside a larger diff. The comparison is
+  by resource identity rather than file path, so cutting one document out of a
+  multi-document file counts the same as deleting the file, and a line naming
+  a resource the diff does not remove fails too — the body stays an accurate
+  record.
 - **Observe-first adoption** — a new managed resource for an existing object
   always starts `managementPolicies: ["Observe"]` (read-only).
 - **Least privilege (RBAC)** — the app SA's authority is a namespaced `Role`


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The GitHub-management docs stated "Never `Delete`" as the whole of the deletion story. That rail is still accurate, but it is no longer the only thing standing between a merged diff and a removed GitHub team or ruleset — a CI acknowledgement check now guards manifest removals too, and the docs never caught up. A reader removing a manifest today would not learn that the check exists until it failed on them.

## What

Rewrites the safety rail to describe both controls: `Delete` stays omitted everywhere, so pruning a resource detaches it rather than destroying the real GitHub object; and a removal now fails a required CI check unless the pull-request body acknowledges that exact resource by name.

Part of #3376
