### PR TITLE
fix(security): verify proposed Crossplane package signatures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,13 @@ jobs:
           shellcheck -x scripts/tests/test-registry-auth-lib.sh
           bash scripts/tests/test-registry-auth-lib.sh
 
+      - name: 🔐 Validate proposed Crossplane package signature checks
+        run: |
+          go test ./scripts/collect-first-party-packages
+          shellcheck scripts/check-first-party-package-signatures.sh
+          shellcheck scripts/tests/test-check-first-party-package-signatures.sh
+          bash scripts/tests/test-check-first-party-package-signatures.sh
+
       # The guard above proves every matcher pins A revision. It cannot say WHICH, and
       # narrowing them to approved revisions (#2818) needs that fact for each consumer.
       # This runs the hermetic half of the report that computes it: the network resolver
@@ -611,6 +618,28 @@ jobs:
           fi
           echo "negative control refused a wrong subject, and the positive path still verifies"
           echo "=> the check above is not vacuous"
+
+      - name: ⚖️ Install Kyverno CLI for package admission checks
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
+        with:
+          release: v1.18.2
+
+      - name: 🔐 Verify proposed first-party Crossplane packages
+        # The package image becomes the provider controller's Pod image. Check
+        # both Talos's first-match pull rule and Kyverno's actual admission
+        # policy against the proposed reference, before a rollout can wedge it.
+        # This inherits the registry-read job's fork/merge-group boundary.
+        timeout-minutes: 10
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_CONFIG: ${{ runner.temp }}/package-signature-docker
+        run: |
+          set -euo pipefail
+          mkdir -p "$DOCKER_CONFIG"
+          trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+          printf '%s' "$REGISTRY_TOKEN" | cosign login ghcr.io -u "$REGISTRY_USER" --password-stdin
+          bash scripts/check-first-party-package-signatures.sh
 
   validate-eks-authorization:
     name: 🔐 Validate Production Authorization

--- a/docs/first-party-package-signatures.md
+++ b/docs/first-party-package-signatures.md
@@ -15,7 +15,11 @@ bash scripts/check-first-party-package-signatures.sh
 The script only renders files and reads the registry. It does not contact the
 cluster. For private packages, authenticate to GHCR through a Docker config that
 the credential can read; CI uses its package-read token and removes its temporary
-Docker config after the check.
+Docker config after the check. Kyverno 1.18.2's CLI has no Kubernetes Secret
+lister, so an ephemeral policy copy replaces its cluster pull-secret references
+with the default Docker credential provider. Image selection, signing identities,
+and validation expressions are preserved. This does not prove the live cluster's
+pull Secret has equivalent registry access.
 
 Each reference must pass both checks:
 

--- a/docs/first-party-package-signatures.md
+++ b/docs/first-party-package-signatures.md
@@ -1,0 +1,46 @@
+# First-party package signature checks
+
+The registry-reading CI job checks proposed first-party Crossplane packages on
+same-repository pull requests and merge-group revisions. It renders the five
+production Flux layers and reads `spec.package` from Crossplane `Provider`,
+`Function`, and `Configuration` resources. OCI source artifacts and third-party
+packages are outside this inventory.
+
+Run the same check locally with Go, kubectl, yq v4, jq, cosign, and Kyverno 1.18.2:
+
+```sh
+bash scripts/check-first-party-package-signatures.sh
+```
+
+The script only renders files and reads the registry. It does not contact the
+cluster. For private packages, authenticate to GHCR through a Docker config that
+the credential can read; CI uses its package-read token and removes its temporary
+Docker config after the check.
+
+Each reference must pass both checks:
+
+- The existing signature inventory applies the first matching Talos pull rule.
+- Kyverno evaluates `verify-app-images` against a synthetic Pod carrying the
+  package image, as a provider controller would. This exercises the policy's
+  actual image-to-attestor routing and identity, rather than a copied regex.
+
+Both verifiers must then reject a deliberately impossible identity, and both
+positive checks must still pass afterward. Empty inventories, unmatched packages,
+skipped policy evaluations, malformed reports, and unreadable registries fail the
+gate. An unreadable registry is `UNKNOWN`, not evidence that an image is unsigned.
+
+For a focused reproduction, pass a rendered manifest stream and optional verifier
+files:
+
+```sh
+bash scripts/check-first-party-package-signatures.sh \
+  --rendered /tmp/proposed-packages.yaml \
+  --rules /tmp/proposed-talos-rules.yaml \
+  --policy /tmp/proposed-image-policy.yaml
+```
+
+This is the package slice of #3425. It does not enumerate Helm-rendered containers,
+operator-generated child images, or tenant images arriving through remote OCI
+artifacts. Those still require the broader repository/fleet inventory. Checking a
+tag proves the registry's answer at check time; it does not make a mutable tag
+immutable or prove that the live cluster enforces the configured rules.

--- a/scripts/check-first-party-package-signatures.sh
+++ b/scripts/check-first-party-package-signatures.sh
@@ -10,12 +10,18 @@ rendered=""
 rules=talos/cluster/verify-first-party-images.yaml
 policy=k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
 while [[ $# -gt 0 ]]; do
-  [[ $# -ge 2 ]] || { echo 'expected --rendered PATH, --rules PATH or --policy PATH' >&2; exit 2; }
+  [[ $# -ge 2 ]] || {
+    echo 'expected --rendered PATH, --rules PATH or --policy PATH' >&2
+    exit 2
+  }
   case "$1" in
     --rendered) rendered="$2" ;;
     --rules) rules="$2" ;;
     --policy) policy="$2" ;;
-    *) echo "unknown argument: $1" >&2; exit 2 ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
   esac
   shift 2
 done
@@ -29,32 +35,34 @@ if [[ -z "$rendered" ]]; then
   for layer in k8s/clusters/prod k8s/clusters/prod/bootstrap \
     k8s/providers/hetzner/infrastructure/controllers \
     k8s/providers/hetzner/infrastructure k8s/providers/hetzner/apps; do
-    if ! kubectl kustomize "$layer" >> "$rendered"; then
+    if ! kubectl kustomize "$layer" >>"$rendered"; then
       echo "UNKNOWN: could not render $layer" >&2
       exit 1
     fi
-    printf '\n---\n' >> "$rendered"
+    printf '\n---\n' >>"$rendered"
   done
 fi
-go run ./scripts/collect-first-party-packages < "$rendered" > "$scratch/packages.json"
-jq -er '.images[]' "$scratch/packages.json" > "$scratch/images.txt"
+go run ./scripts/collect-first-party-packages <"$rendered" >"$scratch/packages.json"
+jq -er '.images[]' "$scratch/packages.json" >"$scratch/images.txt"
 # Kyverno's CLI needs separate resources; a Kubernetes List panics in its
 # fake-client setup. JSON objects are valid YAML documents, with no re-encoding
 # of image references or regexes needed.
-jq -r '.pods[] | "---\n" + tojson' "$scratch/packages.json" > "$scratch/pods.yaml"
+jq -r '.pods[] | "---\n" + tojson' "$scratch/packages.json" >"$scratch/pods.yaml"
 count="$(jq -er '.images | length' "$scratch/packages.json")"
 policy_name="$(yq -er '.metadata.name' "$policy")"
 # The pinned Kyverno CLI has no Kubernetes Secret lister. Replace only its
 # registry-credential transport with the default Docker provider; leave image
 # selection, identities and validation expressions exactly as deployed.
 yq 'del(.spec.credentials.secrets) | .spec.credentials.providers = ["default"]' \
-  "$policy" > "$scratch/offline-policy.yaml"
+  "$policy" >"$scratch/offline-policy.yaml"
 policy="$scratch/offline-policy.yaml"
 
+# Check every proposed package against the supplied Talos rules and expected
+# PASS/FAIL verdict. Return nonzero for missing verdicts or inconsistent status.
 inventory() {
   local rule_file="$1" verdict="$2" status=0
   bash scripts/inventory-first-party-image-signatures.sh --rules "$rule_file" \
-    --images "$scratch/images.txt" > "$scratch/inventory.tsv" || status=$?
+    --images "$scratch/images.txt" >"$scratch/inventory.tsv" || status=$?
   cat "$scratch/inventory.tsv"
   # The inventory skips unmatched references. Its success alone is therefore
   # insufficient: every proposed package must have an explicit verdict.
@@ -70,11 +78,13 @@ inventory() {
   fi
 }
 
+# Check every synthetic Pod against the supplied Kyverno policy and expected
+# pass/fail verdict. Return nonzero for incomplete reports or inconsistent status.
 admission() {
   local policy_file="$1" verdict="$2" status=0
   kyverno apply "$policy_file" --resource "$scratch/pods.yaml" --registry \
     --warn-no-pass --warn-exit-code 1 --policy-report --output-format json \
-    > "$scratch/report.json" 2> "$scratch/kyverno.log" || status=$?
+    >"$scratch/report.json" 2>"$scratch/kyverno.log" || status=$?
   # A skipped policy or empty report can exit successfully. Require precisely
   # one verdict for each synthetic Pod, from this ImageValidatingPolicy. JSON
   # parsing/registry/engine errors remain UNKNOWN, never an apparent refusal.
@@ -87,7 +97,7 @@ admission() {
         .resources[0].kind == "Pod" and .resources[0].apiVersion == "v1") and
       ([.results[].resources[] | .namespace + "/" + .name] | sort) ==
       ([$packages[0].pods[].metadata | .namespace + "/" + .name] | sort)
-    ' "$scratch/report.json" > /dev/null; then
+    ' "$scratch/report.json" >/dev/null; then
     echo "UNKNOWN: Kyverno did not produce $count explicit $verdict verdicts (exit $status)" >&2
     # Preserve the engine's reason on failure; otherwise a registry/CLI error
     # is indistinguishable from a report format change on another runner.
@@ -109,9 +119,9 @@ admission "$policy" pass
 # Both engines must refuse a well-formed but impossible signing identity.
 # Read rules from the proposed manifests; never copy production regexes here.
 export PACKAGE_WRONG_SUBJECT='^https://github\.com/devantler-tech/NOT-A-REAL-REPO/.*$'
-yq '.rules[].keyless.subjectRegex = strenv(PACKAGE_WRONG_SUBJECT)' "$rules" > "$scratch/wrong-rules.yaml"
+yq '.rules[].keyless.subjectRegex = strenv(PACKAGE_WRONG_SUBJECT)' "$rules" >"$scratch/wrong-rules.yaml"
 yq '.spec.attestors[].cosign.keyless.identities[].subjectRegExp = strenv(PACKAGE_WRONG_SUBJECT)' \
-  "$policy" > "$scratch/wrong-policy.yaml"
+  "$policy" >"$scratch/wrong-policy.yaml"
 if ! inventory "$scratch/wrong-rules.yaml" FAIL; then
   echo 'UNKNOWN: Talos negative control did not prove a mismatch' >&2
   exit 1

--- a/scripts/check-first-party-package-signatures.sh
+++ b/scripts/check-first-party-package-signatures.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Check proposed Crossplane package images before merge (#3425). These are
+# rendered from this revision, not obtained from already-running Pods. The
+# broader Helm/container inventory remains a separate part of that issue.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+rendered=""
+rules=talos/cluster/verify-first-party-images.yaml
+policy=k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+while [[ $# -gt 0 ]]; do
+  [[ $# -ge 2 ]] || { echo 'expected --rendered PATH, --rules PATH or --policy PATH' >&2; exit 2; }
+  case "$1" in
+    --rendered) rendered="$2" ;;
+    --rules) rules="$2" ;;
+    --policy) policy="$2" ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift 2
+done
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+if [[ -z "$rendered" ]]; then
+  rendered="$scratch/rendered.yaml"
+  # Flux reconciles these layers separately; building clusters/prod alone
+  # produces Flux Kustomizations rather than the Provider objects they apply.
+  for layer in k8s/clusters/prod k8s/clusters/prod/bootstrap \
+    k8s/providers/hetzner/infrastructure/controllers \
+    k8s/providers/hetzner/infrastructure k8s/providers/hetzner/apps; do
+    if ! kubectl kustomize "$layer" >> "$rendered"; then
+      echo "UNKNOWN: could not render $layer" >&2
+      exit 1
+    fi
+    printf '\n---\n' >> "$rendered"
+  done
+fi
+go run ./scripts/collect-first-party-packages < "$rendered" > "$scratch/packages.json"
+jq -er '.images[]' "$scratch/packages.json" > "$scratch/images.txt"
+# Kyverno's CLI needs separate resources; a Kubernetes List panics in its
+# fake-client setup. JSON objects are valid YAML documents, with no re-encoding
+# of image references or regexes needed.
+jq -r '.pods[] | "---\n" + tojson' "$scratch/packages.json" > "$scratch/pods.yaml"
+count="$(jq -er '.images | length' "$scratch/packages.json")"
+policy_name="$(yq -er '.metadata.name' "$policy")"
+
+inventory() {
+  local rule_file="$1" verdict="$2" status=0
+  bash scripts/inventory-first-party-image-signatures.sh --rules "$rule_file" \
+    --images "$scratch/images.txt" > "$scratch/inventory.tsv" || status=$?
+  cat "$scratch/inventory.tsv"
+  # The inventory skips unmatched references. Its success alone is therefore
+  # insufficient: every proposed package must have an explicit verdict.
+  if ! awk -F '\t' -v expected="$count" -v verdict="$verdict" \
+    '$1 == verdict { n++ } END { exit n != expected }' "$scratch/inventory.tsv"; then
+    echo "UNKNOWN: expected $count Talos $verdict verdicts; missing or unproven verification" >&2
+    return 1
+  fi
+  if [[ "$verdict" == PASS ]]; then
+    [[ "$status" -eq 0 ]]
+  else
+    [[ "$status" -eq 1 ]]
+  fi
+}
+
+admission() {
+  local policy_file="$1" verdict="$2" status=0
+  kyverno apply "$policy_file" --resource "$scratch/pods.yaml" --registry \
+    --warn-no-pass --warn-exit-code 1 --policy-report --output-format json \
+    > "$scratch/report.json" 2> "$scratch/kyverno.log" || status=$?
+  # A skipped policy or empty report can exit successfully. Require precisely
+  # one verdict for each synthetic Pod, from this ImageValidatingPolicy. JSON
+  # parsing/registry/engine errors remain UNKNOWN, never an apparent refusal.
+  if ! jq -e --arg verdict "$verdict" --arg policy "$policy_name" \
+    --slurpfile packages "$scratch/packages.json" '
+      (.results | length) == ($packages[0].pods | length) and
+      all(.results[]; .source == "KyvernoImageValidatingPolicy" and
+        .policy == $policy and .result == $verdict and
+        (.resources | length) == 1 and
+        .resources[0].kind == "Pod" and .resources[0].apiVersion == "v1") and
+      ([.results[].resources[] | .namespace + "/" + .name] | sort) ==
+      ([$packages[0].pods[].metadata | .namespace + "/" + .name] | sort)
+    ' "$scratch/report.json" > /dev/null; then
+    echo "UNKNOWN: Kyverno did not produce $count explicit $verdict verdicts" >&2
+    return 1
+  fi
+  if [[ "$verdict" == pass ]]; then
+    [[ "$status" -eq 0 ]]
+  else
+    [[ "$status" -ne 0 ]]
+  fi
+}
+
+inventory "$rules" PASS
+admission "$policy" pass
+
+# Both engines must refuse a well-formed but impossible signing identity.
+# Read rules from the proposed manifests; never copy production regexes here.
+export PACKAGE_WRONG_SUBJECT='^https://github\.com/devantler-tech/NOT-A-REAL-REPO/.*$'
+yq '.rules[].keyless.subjectRegex = strenv(PACKAGE_WRONG_SUBJECT)' "$rules" > "$scratch/wrong-rules.yaml"
+yq '.spec.attestors[].cosign.keyless.identities[].subjectRegExp = strenv(PACKAGE_WRONG_SUBJECT)' \
+  "$policy" > "$scratch/wrong-policy.yaml"
+if ! inventory "$scratch/wrong-rules.yaml" FAIL; then
+  echo 'UNKNOWN: Talos negative control did not prove a mismatch' >&2
+  exit 1
+fi
+if ! admission "$scratch/wrong-policy.yaml" fail; then
+  echo 'UNKNOWN: Kyverno negative control did not prove a mismatch' >&2
+  exit 1
+fi
+
+# Refusal during an outage proves nothing. Recheck both positive paths after
+# the negative controls, using the same references and registry credentials.
+inventory "$rules" PASS
+admission "$policy" pass
+echo "$count package signatures and both negative controls passed"

--- a/scripts/check-first-party-package-signatures.sh
+++ b/scripts/check-first-party-package-signatures.sh
@@ -44,6 +44,12 @@ jq -er '.images[]' "$scratch/packages.json" > "$scratch/images.txt"
 jq -r '.pods[] | "---\n" + tojson' "$scratch/packages.json" > "$scratch/pods.yaml"
 count="$(jq -er '.images | length' "$scratch/packages.json")"
 policy_name="$(yq -er '.metadata.name' "$policy")"
+# The pinned Kyverno CLI has no Kubernetes Secret lister. Replace only its
+# registry-credential transport with the default Docker provider; leave image
+# selection, identities and validation expressions exactly as deployed.
+yq 'del(.spec.credentials.secrets) | .spec.credentials.providers = ["default"]' \
+  "$policy" > "$scratch/offline-policy.yaml"
+policy="$scratch/offline-policy.yaml"
 
 inventory() {
   local rule_file="$1" verdict="$2" status=0
@@ -82,7 +88,12 @@ admission() {
       ([.results[].resources[] | .namespace + "/" + .name] | sort) ==
       ([$packages[0].pods[].metadata | .namespace + "/" + .name] | sort)
     ' "$scratch/report.json" > /dev/null; then
-    echo "UNKNOWN: Kyverno did not produce $count explicit $verdict verdicts" >&2
+    echo "UNKNOWN: Kyverno did not produce $count explicit $verdict verdicts (exit $status)" >&2
+    # Preserve the engine's reason on failure; otherwise a registry/CLI error
+    # is indistinguishable from a report format change on another runner.
+    jq '{summary, results: [.results[] | {source, policy, result, message}]}' \
+      "$scratch/report.json" >&2 || true
+    head -n 40 "$scratch/kyverno.log" >&2
     return 1
   fi
   if [[ "$verdict" == pass ]]; then

--- a/scripts/collect-first-party-packages/main.go
+++ b/scripts/collect-first-party-packages/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,12 +24,12 @@ func collect(input io.Reader) ([]string, error) {
 		if object["apiVersion"] == "v1" && object["kind"] == "List" {
 			items, ok := object["items"].([]any)
 			if !ok {
-				return fmt.Errorf("List has no valid items")
+				return fmt.Errorf("list has no valid items")
 			}
 			for _, item := range items {
 				child, ok := item.(map[string]any)
 				if !ok {
-					return fmt.Errorf("List contains a non-object item")
+					return fmt.Errorf("list contains a non-object item")
 				}
 				if err := visit(child); err != nil {
 					return err
@@ -58,7 +59,7 @@ func collect(input io.Reader) ([]string, error) {
 	decoder := yaml.NewDecoder(input)
 	for {
 		var object map[string]any
-		if err := decoder.Decode(&object); err == io.EOF {
+		if err := decoder.Decode(&object); errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, fmt.Errorf("read rendered manifests: %w", err)

--- a/scripts/collect-first-party-packages/main.go
+++ b/scripts/collect-first-party-packages/main.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// collect returns sorted, distinct first-party Crossplane package references from
+// rendered YAML, including Lists. It rejects malformed or empty inventories.
 func collect(input io.Reader) ([]string, error) {
 	images := map[string]bool{}
 	var visit func(map[string]any) error
@@ -76,6 +78,8 @@ func collect(input io.Reader) ([]string, error) {
 	return refs, nil
 }
 
+// main reads rendered YAML from stdin and writes package references and synthetic
+// verification Pods as JSON. Invalid input or output failures exit unsuccessfully.
 func main() {
 	if len(os.Args) != 1 {
 		fmt.Fprintln(os.Stderr, "usage: collect-first-party-packages < rendered.yaml")

--- a/scripts/collect-first-party-packages/main.go
+++ b/scripts/collect-first-party-packages/main.go
@@ -1,0 +1,104 @@
+// collect-first-party-packages inventories proposed Crossplane package images
+// from a rendered YAML stream, without reading the cluster or a registry.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+func collect(input io.Reader) ([]string, error) {
+	images := map[string]bool{}
+	var visit func(map[string]any) error
+	visit = func(object map[string]any) error {
+		if object["apiVersion"] == "v1" && object["kind"] == "List" {
+			items, ok := object["items"].([]any)
+			if !ok {
+				return fmt.Errorf("List has no valid items")
+			}
+			for _, item := range items {
+				child, ok := item.(map[string]any)
+				if !ok {
+					return fmt.Errorf("List contains a non-object item")
+				}
+				if err := visit(child); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		api, _ := object["apiVersion"].(string)
+		if !strings.HasPrefix(api, "pkg.crossplane.io/") {
+			return nil
+		}
+		switch object["kind"] {
+		case "Provider", "Function", "Configuration":
+		default:
+			return nil
+		}
+		spec, _ := object["spec"].(map[string]any)
+		ref, ok := spec["package"].(string)
+		if !ok || ref == "" || strings.ContainsAny(ref, "$\"'{}") || strings.IndexFunc(ref, unicode.IsSpace) >= 0 {
+			return fmt.Errorf("%v has a missing, malformed or unresolved spec.package", object["kind"])
+		}
+		if strings.HasPrefix(ref, "ghcr.io/devantler-tech/") {
+			images[ref] = true
+		}
+		return nil
+	}
+	decoder := yaml.NewDecoder(input)
+	for {
+		var object map[string]any
+		if err := decoder.Decode(&object); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("read rendered manifests: %w", err)
+		}
+		if err := visit(object); err != nil {
+			return nil, err
+		}
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("no first-party Crossplane packages found; inventory is unproven")
+	}
+	refs := make([]string, 0, len(images))
+	for ref := range images {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs, nil
+}
+
+func main() {
+	if len(os.Args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: collect-first-party-packages < rendered.yaml")
+		os.Exit(2)
+	}
+	refs, err := collect(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "UNKNOWN:", err)
+		os.Exit(1)
+	}
+	// Crossplane providers run the package image as their controller. Synthetic
+	// Pods let Kyverno evaluate the actual deployed admission expressions, not a
+	// second implementation of their image-to-attestor routing.
+	pods := make([]map[string]any, 0, len(refs))
+	for i, ref := range refs {
+		pods = append(pods, map[string]any{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": map[string]any{"name": fmt.Sprintf("package-signature-%d", i), "namespace": "crossplane"},
+			"spec":     map[string]any{"containers": []map[string]string{{"name": "package", "image": ref}}},
+		})
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(map[string]any{"images": refs, "pods": pods}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/scripts/collect-first-party-packages/main_test.go
+++ b/scripts/collect-first-party-packages/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollectProposedPackagesIncludingListsAndAllPackageKinds(t *testing.T) {
+	input := `apiVersion: pkg.crossplane.io/v1
+kind: Provider
+spec:
+  package: ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: pkg.crossplane.io/v1beta1
+    kind: Function
+    spec:
+      package: ghcr.io/devantler-tech/function-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  - apiVersion: pkg.crossplane.io/v1
+    kind: Configuration
+    spec:
+      package: ghcr.io/devantler-tech/config-test:v2
+  - apiVersion: pkg.crossplane.io/v1
+    kind: Provider
+    spec:
+      package: ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+spec:
+  package: xpkg.upbound.io/crossplane/provider-example:v1
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+spec:
+  url: oci://ghcr.io/devantler-tech/platform/manifests
+---
+apiVersion: example.io/v1
+kind: Provider
+spec:
+  package: ghcr.io/devantler-tech/not-crossplane:v1
+`
+	got, err := collect(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ghcr.io/devantler-tech/config-test:v2\nghcr.io/devantler-tech/function-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0"
+	if strings.Join(got, "\n") != want {
+		t.Fatalf("package inventory = %q, want %q", got, want)
+	}
+}
+
+func TestCollectRefusesUnmeasurablePackageInventory(t *testing.T) {
+	for name, input := range map[string]string{
+		"empty render":            "",
+		"invalid YAML":            "spec: [",
+		"no first-party packages": "apiVersion: v1\nkind: ConfigMap\n",
+		"missing package":         "apiVersion: pkg.crossplane.io/v1\nkind: Provider\nspec: {}\n",
+		"unresolved substitution": "apiVersion: pkg.crossplane.io/v1\nkind: Provider\nspec:\n  package: ghcr.io/devantler-tech/provider:${version}\n",
+		"non-string package":      "apiVersion: pkg.crossplane.io/v1\nkind: Provider\nspec:\n  package: [bad]\n",
+		"whitespace in reference": "apiVersion: pkg.crossplane.io/v1\nkind: Provider\nspec:\n  package: 'ghcr.io/devantler-tech/provider:bad tag'\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := collect(strings.NewReader(input)); err == nil {
+				t.Fatal("unmeasurable inventory accepted")
+			}
+		})
+	}
+}

--- a/scripts/collect-first-party-packages/main_test.go
+++ b/scripts/collect-first-party-packages/main_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// TestCollectProposedPackagesIncludingListsAndAllPackageKinds checks supported
+// package kinds, nested Lists, deduplication, ordering, and unrelated-object exclusion.
 func TestCollectProposedPackagesIncludingListsAndAllPackageKinds(t *testing.T) {
 	input := `apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -52,6 +54,8 @@ spec:
 	}
 }
 
+// TestCollectRefusesUnmeasurablePackageInventory rejects missing, malformed, or
+// unresolved references and inputs that cannot prove a first-party inventory.
 func TestCollectRefusesUnmeasurablePackageInventory(t *testing.T) {
 	for name, input := range map[string]string{
 		"empty render":            "",

--- a/scripts/tests/test-check-first-party-package-signatures.sh
+++ b/scripts/tests/test-check-first-party-package-signatures.sh
@@ -32,6 +32,9 @@ cat > "$scratch/bin/kyverno" <<'SH'
 set -euo pipefail
 # The real CLI requires individual documents, and panics on a Kubernetes List.
 yq -o=json -I=0 '.' "$4" | jq -se 'all(.[]; .kind == "Pod")' > /dev/null
+# Kyverno 1.18.2 cannot resolve Kubernetes pull Secrets in its CLI; the
+# standalone check must use the Docker credential provider for registry reads.
+yq -o=json '.' "$2" | jq -e '(.spec.credentials.secrets // [] | length) == 0 and .spec.credentials.providers == ["default"]' > /dev/null
 verdict=pass
 status=0
 if [[ ${KYVERNO_MODE:-normal} != inert ]] &&
@@ -52,7 +55,13 @@ export PATH="$scratch/bin:$PATH"
 rules=talos/cluster/verify-first-party-images.yaml
 policy=k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
 check() {
-  bash scripts/check-first-party-package-signatures.sh --rendered "$scratch/packages.yaml" --rules "${1:-$rules}" --policy "$policy"
+  bash scripts/check-first-party-package-signatures.sh --rendered "$scratch/packages.yaml" --rules "$1" --policy "$policy"
+}
+accept() {
+  if ! check "$rules" > "$scratch/output" 2>&1; then
+    cat "$scratch/output" >&2
+    exit 1
+  fi
 }
 reject() {
   local name="$1" expected="$2"
@@ -70,11 +79,11 @@ reject() {
 # #3422's bump alone: tag-signed package plus the old main-only verifier.
 yq '.rules[] |= (.keyless.subjectRegex = "^https://github\\.com/devantler-tech/provider-upjet-unifi/\\.github/workflows/publish-provider-package\\.yml@refs/heads/main$")' "$rules" > "$scratch/main-only.yaml"
 reject 'tag bump with old verifier' 'FAIL' check "$scratch/main-only.yaml"
-check > "$scratch/output" 2>&1
+accept
 grep -qF 'package signatures and both negative controls passed' "$scratch/output"
-SIGNATURE_UNREADABLE=true reject 'unauthenticated registry' 'UNKNOWN' check
-KYVERNO_MODE=empty reject 'skipped admission check' 'UNKNOWN' check
-KYVERNO_MODE=inert reject 'inert admission verifier' 'negative control' check
+SIGNATURE_UNREADABLE=true reject 'unauthenticated registry' 'UNKNOWN' check "$rules"
+KYVERNO_MODE=empty reject 'skipped admission check' 'UNKNOWN' check "$rules"
+KYVERNO_MODE=inert reject 'inert admission verifier' 'negative control' check "$rules"
 cat >> "$scratch/packages.yaml" <<'YAML'
 ---
 apiVersion: pkg.crossplane.io/v1
@@ -82,7 +91,7 @@ kind: Provider
 spec:
   package: ghcr.io/devantler-tech/provider-upjet-extra:v1.0.0
 YAML
-check > "$scratch/output" 2>&1
+accept
 grep -qF '2 package signatures and both negative controls passed' "$scratch/output"
 yq '.rules = [.rules[1]] | .rules[0].image = "ghcr.io/devantler-tech/provider-upjet-unifi"' "$rules" > "$scratch/unmatched.yaml"
 reject 'one package silently unmatched by Talos' 'UNKNOWN' check "$scratch/unmatched.yaml"

--- a/scripts/tests/test-check-first-party-package-signatures.sh
+++ b/scripts/tests/test-check-first-party-package-signatures.sh
@@ -5,7 +5,7 @@ cd "$root"
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 mkdir "$scratch/bin"
-cat > "$scratch/packages.yaml" <<'YAML'
+cat >"$scratch/packages.yaml" <<'YAML'
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
@@ -13,7 +13,7 @@ metadata:
 spec:
   package: ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0
 YAML
-cat > "$scratch/verify" <<'SH'
+cat >"$scratch/verify" <<'SH'
 #!/usr/bin/env bash
 [[ "$1" == ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0 || "$1" == ghcr.io/devantler-tech/provider-upjet-extra:v1.0.0 ]] || exit 1
 [[ "$2" == https://token.actions.githubusercontent.com ]] || exit 1
@@ -21,13 +21,13 @@ cat > "$scratch/verify" <<'SH'
 identity='https://github.com/devantler-tech/provider-upjet-unifi/.github/workflows/publish-provider-package.yml@refs/tags/v1.0.0'
 [[ "$identity" =~ $3 ]]
 SH
-cat > "$scratch/probe" <<'SH'
+cat >"$scratch/probe" <<'SH'
 #!/usr/bin/env bash
 if [[ ${SIGNATURE_UNREADABLE:-false} == true ]]; then echo 401; else echo 200; fi
 SH
 # Only the external engine is substituted in this hermetic suite. The real
 # Kyverno engine and cosign are exercised by the required registry job.
-cat > "$scratch/bin/kyverno" <<'SH'
+cat >"$scratch/bin/kyverno" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 # The real CLI requires individual documents, and panics on a Kubernetes List.
@@ -54,19 +54,25 @@ export INVENTORY_VERIFY_CMD="$scratch/verify" INVENTORY_PROBE_CMD="$scratch/prob
 export PATH="$scratch/bin:$PATH"
 rules=talos/cluster/verify-first-party-images.yaml
 policy=k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+# Run the real checker with the supplied Talos rules and this suite's fixture
+# inventory and admission policy; preserve its output and exit status.
 check() {
   bash scripts/check-first-party-package-signatures.sh --rendered "$scratch/packages.yaml" --rules "$1" --policy "$policy"
 }
+# Require the fixture to pass both real checker paths and their negative controls,
+# printing the captured diagnostic and stopping the suite on failure.
 accept() {
-  if ! check "$rules" > "$scratch/output" 2>&1; then
+  if ! check "$rules" >"$scratch/output" 2>&1; then
     cat "$scratch/output" >&2
     exit 1
   fi
 }
+# Require the named command to fail with the expected literal diagnostic. Reject
+# accidental success and unrelated failures so each negative control proves its cause.
 reject() {
   local name="$1" expected="$2"
   shift 2
-  if "$@" > "$scratch/output" 2>&1; then
+  if "$@" >"$scratch/output" 2>&1; then
     echo "FAIL: $name passed" >&2
     exit 1
   fi
@@ -77,14 +83,14 @@ reject() {
   fi
 }
 # #3422's bump alone: tag-signed package plus the old main-only verifier.
-yq '.rules[] |= (.keyless.subjectRegex = "^https://github\\.com/devantler-tech/provider-upjet-unifi/\\.github/workflows/publish-provider-package\\.yml@refs/heads/main$")' "$rules" > "$scratch/main-only.yaml"
+yq '.rules[] |= (.keyless.subjectRegex = "^https://github\\.com/devantler-tech/provider-upjet-unifi/\\.github/workflows/publish-provider-package\\.yml@refs/heads/main$")' "$rules" >"$scratch/main-only.yaml"
 reject 'tag bump with old verifier' 'FAIL' check "$scratch/main-only.yaml"
 accept
 grep -qF 'package signatures and both negative controls passed' "$scratch/output"
 SIGNATURE_UNREADABLE=true reject 'unauthenticated registry' 'UNKNOWN' check "$rules"
 KYVERNO_MODE=empty reject 'skipped admission check' 'UNKNOWN' check "$rules"
 KYVERNO_MODE=inert reject 'inert admission verifier' 'negative control' check "$rules"
-cat >> "$scratch/packages.yaml" <<'YAML'
+cat >>"$scratch/packages.yaml" <<'YAML'
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -93,6 +99,6 @@ spec:
 YAML
 accept
 grep -qF '2 package signatures and both negative controls passed' "$scratch/output"
-yq '.rules = [.rules[1]] | .rules[0].image = "ghcr.io/devantler-tech/provider-upjet-unifi"' "$rules" > "$scratch/unmatched.yaml"
+yq '.rules = [.rules[1]] | .rules[0].image = "ghcr.io/devantler-tech/provider-upjet-unifi"' "$rules" >"$scratch/unmatched.yaml"
 reject 'one package silently unmatched by Talos' 'UNKNOWN' check "$scratch/unmatched.yaml"
 printf 'first-party package signature guard tests passed\n'

--- a/scripts/tests/test-check-first-party-package-signatures.sh
+++ b/scripts/tests/test-check-first-party-package-signatures.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+mkdir "$scratch/bin"
+cat > "$scratch/packages.yaml" <<'YAML'
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: unifi
+spec:
+  package: ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0
+YAML
+cat > "$scratch/verify" <<'SH'
+#!/usr/bin/env bash
+[[ "$1" == ghcr.io/devantler-tech/provider-upjet-unifi:v1.0.0 || "$1" == ghcr.io/devantler-tech/provider-upjet-extra:v1.0.0 ]] || exit 1
+[[ "$2" == https://token.actions.githubusercontent.com ]] || exit 1
+[[ ${SIGNATURE_UNREADABLE:-false} != true ]] || exit 1
+identity='https://github.com/devantler-tech/provider-upjet-unifi/.github/workflows/publish-provider-package.yml@refs/tags/v1.0.0'
+[[ "$identity" =~ $3 ]]
+SH
+cat > "$scratch/probe" <<'SH'
+#!/usr/bin/env bash
+if [[ ${SIGNATURE_UNREADABLE:-false} == true ]]; then echo 401; else echo 200; fi
+SH
+# Only the external engine is substituted in this hermetic suite. The real
+# Kyverno engine and cosign are exercised by the required registry job.
+cat > "$scratch/bin/kyverno" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+# The real CLI requires individual documents, and panics on a Kubernetes List.
+yq -o=json -I=0 '.' "$4" | jq -se 'all(.[]; .kind == "Pod")' > /dev/null
+verdict=pass
+status=0
+if [[ ${KYVERNO_MODE:-normal} != inert ]] &&
+  yq -e '.spec.attestors[].cosign.keyless.identities[].subjectRegExp | contains("NOT-A-REAL-REPO")' "$2" >/dev/null; then
+  verdict=fail
+  status=1
+fi
+if [[ ${KYVERNO_MODE:-normal} == empty ]]; then
+  echo '{"results":[],"summary":{"pass":0,"skip":1}}'
+else
+  yq -o=json -I=0 '.' "$4" | jq -s --arg verdict "$verdict" '{results:map({source:"KyvernoImageValidatingPolicy",policy:"verify-app-images",result:$verdict,resources:[{apiVersion:.apiVersion,kind:.kind,namespace:.metadata.namespace,name:.metadata.name}]})}'
+fi
+exit "$status"
+SH
+chmod +x "$scratch/verify" "$scratch/probe" "$scratch/bin/kyverno"
+export INVENTORY_VERIFY_CMD="$scratch/verify" INVENTORY_PROBE_CMD="$scratch/probe"
+export PATH="$scratch/bin:$PATH"
+rules=talos/cluster/verify-first-party-images.yaml
+policy=k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+check() {
+  bash scripts/check-first-party-package-signatures.sh --rendered "$scratch/packages.yaml" --rules "${1:-$rules}" --policy "$policy"
+}
+reject() {
+  local name="$1" expected="$2"
+  shift 2
+  if "$@" > "$scratch/output" 2>&1; then
+    echo "FAIL: $name passed" >&2
+    exit 1
+  fi
+  if ! grep -qF "$expected" "$scratch/output"; then
+    echo "FAIL: $name failed for the wrong reason" >&2
+    cat "$scratch/output" >&2
+    exit 1
+  fi
+}
+# #3422's bump alone: tag-signed package plus the old main-only verifier.
+yq '.rules[] |= (.keyless.subjectRegex = "^https://github\\.com/devantler-tech/provider-upjet-unifi/\\.github/workflows/publish-provider-package\\.yml@refs/heads/main$")' "$rules" > "$scratch/main-only.yaml"
+reject 'tag bump with old verifier' 'FAIL' check "$scratch/main-only.yaml"
+check > "$scratch/output" 2>&1
+grep -qF 'package signatures and both negative controls passed' "$scratch/output"
+SIGNATURE_UNREADABLE=true reject 'unauthenticated registry' 'UNKNOWN' check
+KYVERNO_MODE=empty reject 'skipped admission check' 'UNKNOWN' check
+KYVERNO_MODE=inert reject 'inert admission verifier' 'negative control' check
+cat >> "$scratch/packages.yaml" <<'YAML'
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+spec:
+  package: ghcr.io/devantler-tech/provider-upjet-extra:v1.0.0
+YAML
+check > "$scratch/output" 2>&1
+grep -qF '2 package signatures and both negative controls passed' "$scratch/output"
+yq '.rules = [.rules[1]] | .rules[0].image = "ghcr.io/devantler-tech/provider-upjet-unifi"' "$rules" > "$scratch/unmatched.yaml"
+reject 'one package silently unmatched by Talos' 'UNKNOWN' check "$scratch/unmatched.yaml"
+printf 'first-party package signature guard tests passed\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

A tag-signed Crossplane package could pass CI while its configured verifiers still accepted only a main-branch signature, leaving the provider unable to start after rollout. CI now checks proposed first-party package references against both the Talos pull rule and the actual Kyverno admission policy, including negative controls and explicit coverage checks.

Part of #3425. This delivers the production Crossplane package slice; the issue remains open for Helm-rendered containers and other image sources.

Validated with Go and shell regression tests, ShellCheck, actionlint, and real registry RED/GREEN checks: the obsolete main-only rule rejects `provider-upjet-unifi:v1.0.0`, while the current rules pass both verifiers and both negative controls.
