### PR TITLE
fix(kyverno): restore GitHub team policy reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,6 +244,7 @@ jobs:
               # either side changing alone is the drift this test exists to catch.
               - 'scripts/tests/test-restrict-homepage-service-groups.sh'
               - 'scripts/tests/test-kyverno-umami-mutation-rbac.sh'
+              - 'scripts/tests/test-kyverno-github-team-report-rbac.sh'
               - 'scripts/tests/test-tenant-route-hostname-boundary.sh'
               - 'scripts/tests/test-umami-provisioning-bootstrap.sh'
               # The snapshot manifests and this test are one contract: the
@@ -949,6 +950,8 @@ jobs:
           bash scripts/tests/test-restrict-homepage-service-groups.sh
           shellcheck scripts/tests/test-kyverno-umami-mutation-rbac.sh
           bash scripts/tests/test-kyverno-umami-mutation-rbac.sh
+          shellcheck scripts/tests/test-kyverno-github-team-report-rbac.sh
+          bash scripts/tests/test-kyverno-github-team-report-rbac.sh
           shellcheck scripts/tests/test-tenant-route-hostname-boundary.sh
           bash scripts/tests/test-tenant-route-hostname-boundary.sh
           shellcheck scripts/tests/test-actual-budget-auth-route.sh

--- a/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-github-teams.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-github-teams.yaml
@@ -1,0 +1,23 @@
+---
+# Background scans of restrict-github-team-management need read access to the
+# managed team resources. Both controllers aggregate this read-only grant; it
+# does not authorize either controller to change GitHub configuration.
+# The controllers layer applies the grant before the policy layer reconciles.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:read-github-teams
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups:
+      - team.github.m.upbound.io
+    resources:
+      - teams
+      - teammemberships
+      - teamrepositories
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-github-teams.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-github-teams.yaml
@@ -1,14 +1,13 @@
 ---
-# Background scans of restrict-github-team-management need read access to the
-# managed team resources. Both controllers aggregate this read-only grant; it
-# does not authorize either controller to change GitHub configuration.
+# The reports controller scans the managed team resources for this validate-only
+# policy. The background controller handles generate and mutateExisting rules,
+# so it does not need this read access.
 # The controllers layer applies the grant before the policy layer reconciles.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kyverno:read-github-teams
   labels:
-    rbac.kyverno.io/aggregate-to-background-controller: "true"
     rbac.kyverno.io/aggregate-to-reports-controller: "true"
 rules:
   - apiGroups:

--- a/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - role.yaml
   - role-binding.yaml
   - cluster-role-reports-controller-read-keda.yaml
+  - cluster-role-read-github-teams.yaml

--- a/scripts/tests/test-kyverno-github-team-report-rbac.sh
+++ b/scripts/tests/test-kyverno-github-team-report-rbac.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+rendered_dir="$(mktemp -d)"
+trap 'rm -rf "${rendered_dir}"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# Inspect the rules selected by each controller's aggregation label, rather
+# than a source filename: an unreferenced or wrongly labelled grant gives the
+# controller no access even when the grant's own rules look correct.
+assert_team_reads() {
+  local rendered="$1" controller="$2" scope="$3"
+
+  if ! jq -e --arg label "rbac.kyverno.io/aggregate-to-${controller}-controller" '
+    [ .[]
+      | select(.kind == "ClusterRole" and .metadata.labels[$label] == "true")
+      | select(any(.rules[]?.apiGroups[]?;
+          . == "team.github.m.upbound.io" or . == "*"))
+    ] as $roles
+    | ($roles | length) > 0
+      and all($roles[];
+        .aggregationRule == null
+        and all(.rules[];
+          .apiGroups == ["team.github.m.upbound.io"]
+          and ((.resources // []) - ["teams", "teammemberships", "teamrepositories"] | length) == 0
+          and ((.verbs // []) - ["get", "list", "watch"] | length) == 0
+          and ((.resourceNames // []) | length) == 0
+          and ((.nonResourceURLs // []) | length) == 0))
+      and ([ $roles[].rules[]
+             | .resources[] as $resource
+             | .verbs[]
+             | [$resource, .]
+           ] | unique | sort) ==
+          ([ ["teams", "get"], ["teams", "list"], ["teams", "watch"],
+             ["teammemberships", "get"], ["teammemberships", "list"], ["teammemberships", "watch"],
+             ["teamrepositories", "get"], ["teamrepositories", "list"], ["teamrepositories", "watch"]
+           ] | sort)
+  ' "${rendered}" >/dev/null; then
+    fail "${scope}: ${controller} controller must aggregate unrestricted get/list/watch on exactly the three GitHub team resources, with no additional authority"
+  fi
+}
+
+for scope in base prod; do
+  case "${scope}" in
+    base) render_path="k8s/bases/infrastructure/controllers/kyverno" ;;
+    prod) render_path="k8s/providers/hetzner/infrastructure/controllers" ;;
+  esac
+  kubectl kustomize "${root_dir}/${render_path}" >"${rendered_dir}/${scope}.yaml" ||
+    fail "${scope}: the controller manifests must render"
+  yq -o=json '.' "${rendered_dir}/${scope}.yaml" | jq -s '.' >"${rendered_dir}/${scope}.json"
+  for controller in background reports; do
+    assert_team_reads "${rendered_dir}/${scope}.json" "${controller}" "${scope}"
+  done
+done
+
+echo 'Both Kyverno controllers can read GitHub team resources without receiving write or wildcard access.'

--- a/scripts/tests/test-kyverno-github-team-report-rbac.sh
+++ b/scripts/tests/test-kyverno-github-team-report-rbac.sh
@@ -12,7 +12,7 @@ fail() {
   exit 1
 }
 
-# Inspect the rules selected by each controller's aggregation label, rather
+# Inspect the rules selected by the reports controller's aggregation label, rather
 # than a source filename: an unreferenced or wrongly labelled grant gives the
 # controller no access even when the grant's own rules look correct.
 assert_team_reads() {
@@ -27,6 +27,11 @@ assert_team_reads() {
     | ($roles | length) > 0
       and all($roles[];
         .aggregationRule == null
+        and all(.metadata.labels | to_entries[];
+          if (.key | startswith("rbac.kyverno.io/aggregate-to-")
+                     or startswith("rbac.authorization.k8s.io/aggregate-to-"))
+          then .key == $label or .value != "true"
+          else true end)
         and all(.rules[];
           .apiGroups == ["team.github.m.upbound.io"]
           and ((.resources // []) - ["teams", "teammemberships", "teamrepositories"] | length) == 0
@@ -55,9 +60,7 @@ for scope in base prod; do
   kubectl kustomize "${root_dir}/${render_path}" >"${rendered_dir}/${scope}.yaml" ||
     fail "${scope}: the controller manifests must render"
   yq -o=json '.' "${rendered_dir}/${scope}.yaml" | jq -s '.' >"${rendered_dir}/${scope}.json"
-  for controller in background reports; do
-    assert_team_reads "${rendered_dir}/${scope}.json" "${controller}" "${scope}"
-  done
+  assert_team_reads "${rendered_dir}/${scope}.json" reports "${scope}"
 done
 
-echo 'Both Kyverno controllers can read GitHub team resources without receiving write or wildcard access.'
+echo 'The Kyverno reports controller can read GitHub team resources without write, wildcard, or unrelated-controller access.'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

GitHub team policy violations are enforced but missing from background reports because Kyverno cannot read the resources being evaluated. Give the reports controller read-only access to the three team resource types so the policy can surface existing configuration in reports.

The security gain is visible policy results plus a regression check that rejects missing access, write permissions, and broader resource grants. Day-to-day GitHub configuration requires no extra steps.

Fixes #3447
