### PR TITLE
fix(security): enforce generated consumer signer pairs

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -45,6 +45,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # The action and policy come from the same checkout. Recovery therefore
+    # restores the policy of main even during the first narrowing rollout.
+    - name: 🔐 Enforce approved publication signers
+      shell: bash
+      env:
+        APPROVED_REVISIONS_ENFORCE: '1'
+      run: ./scripts/guard-publish-workflow-approved-revisions.sh
+
     - name: ⚙️ Setup KSail
       # Install the KSail CLI from the release tarball and verify the
       # downloaded asset against GitHub's published release checksum before

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -129,6 +129,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🔐 Enforce approved publication signers
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
+        run: ./scripts/guard-publish-workflow-approved-revisions.sh
+
       - name: ⚙️ Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,11 @@ jobs:
           shellcheck scripts/tests/test-write-publish-workflow-matchers.sh
           bash scripts/tests/test-publish-workflow-approved-revisions-guard.sh
           bash scripts/tests/test-write-publish-workflow-matchers.sh
-          ./scripts/guard-publish-workflow-approved-revisions.sh
+
+      - name: 🔐 Enforce approved publication signers
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
+        run: ./scripts/guard-publish-workflow-approved-revisions.sh
 
       # The scheduled regeneration (#3552, third child of #3308) runs the generator and
       # writer and guard above against prod and turns a moved set into ONE draft pull request.
@@ -1906,6 +1910,11 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+
+      - name: 🔐 Enforce approved publication signers
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
+        run: ./scripts/guard-publish-workflow-approved-revisions.sh
 
       - name: ⚙️ Setup Go for version compatibility validation
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,21 +114,25 @@ jobs:
       # The pin guard above proves each matcher pins a FIXED revision; this one proves each
       # per-consumer matcher pins the revision PAIR the committed approved set names for that
       # consumer, and refuses any revision outside it (#3551, AC4 of #3308). Unconditional for
-      # the same reason as the pin guard: the subjects live in four different trees. The switch
-      # (APPROVED_REVISIONS_ENFORCE) stays off here until the narrowing itself lands — with it
-      # off the pattern form is still accepted, so this checks the committed set against the
-      # live matchers without forcing the change.
+      # the same reason as the pin guard: the subjects live in four different trees.
+      # Enforcement rejects broad SHA patterns and revisions outside each approved pair.
       - name: 🔐 Validate the approved-revisions guard
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
         run: |
+          shellcheck -x scripts/publish-workflow-approved-revisions.lib.sh
           shellcheck -x scripts/guard-publish-workflow-approved-revisions.sh
+          shellcheck -x scripts/write-publish-workflow-matchers.sh
           shellcheck -x scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+          shellcheck scripts/tests/test-write-publish-workflow-matchers.sh
           bash scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+          bash scripts/tests/test-write-publish-workflow-matchers.sh
           ./scripts/guard-publish-workflow-approved-revisions.sh
 
       # The scheduled regeneration (#3552, third child of #3308) runs the generator and
-      # the guard above against prod and turns a moved set into ONE draft pull request.
+      # writer and guard above against prod and turns a moved set into ONE draft pull request.
       # Its safety is the WORKFLOW's shape — a fixed branch, a draft, an App-signed
-      # commit, least-privilege token grants, and generator → guard → pull request with
+      # commit, least-privilege token grants, and generator → writer → guard → pull request with
       # no continue-on-error — none of which any script it calls can enforce, so the
       # test below pins each with an ablation. Unconditional for the same reason as
       # the two steps above: the workflow lives outside the k8s paths.
@@ -363,6 +367,9 @@ jobs:
               # runs unconditionally, and listing the pair here is what keeps a guard edit
               # inside the k8s-gated validation matrix alongside the manifests it judges.
               - 'scripts/guard-publish-workflow-approved-revisions.sh'
+              - 'scripts/publish-workflow-approved-revisions.lib.sh'
+              - 'scripts/write-publish-workflow-matchers.sh'
+              - 'scripts/tests/test-write-publish-workflow-matchers.sh'
               - 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh'
               # The generator that writes the set the guard above reads, and its test — both
               # halves, so editing either alone still runs the fail-closed proof (an unresolved

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1911,11 +1911,8 @@ jobs:
           ref: main
           persist-credentials: false
 
-      - name: 🔐 Enforce approved publication signers
-        env:
-          APPROVED_REVISIONS_ENFORCE: '1'
-        run: ./scripts/guard-publish-workflow-approved-revisions.sh
-
+      # Signer approval is enforced first by the deploy action from this main
+      # checkout, so recovery uses the policy version of the revision it restores.
       - name: ⚙️ Setup Go for version compatibility validation
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -109,6 +109,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🔐 Enforce approved publication signers
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
+        run: ./scripts/guard-publish-workflow-approved-revisions.sh
+
       - name: 🛡️ Protect the nested RGD deployment gate
         run: |
           shellcheck scripts/tests/test-rgd-template-static-scan-wiring.sh

--- a/.github/workflows/regenerate-publish-workflow-approved-revisions.yaml
+++ b/.github/workflows/regenerate-publish-workflow-approved-revisions.yaml
@@ -1,39 +1,10 @@
 name: Regenerate Approved Publish Revisions
 
-# Keep scripts/publish-workflow-approved-revisions.tsv current without a hand-run
-# (#3552, third child of #3308).
-#
-# WHY A SCHEDULE. Every consumer's `uses:` pin on a shared devantler-tech/actions
-# publish workflow moves with each actions bump — several times a month, by
-# dependency automation. The approved set the per-consumer cosign matchers are
-# narrowed from (#3550, #3551) is stale the moment such a bump merges: the next
-# artifact is signed by a revision the platform no longer accepts and that
-# consumer's OCIRepository stops reconciling while every check in CI stays
-# green. Regenerating by hand turns every dependency bump into a two-repository
-# ordered rollout, which is the DevEx tax the hardening rule forbids. So the
-# generator runs here daily and on demand, and a moved set becomes a draft pull
-# request on the ordinary review path.
-#
-# FAIL RED, NEVER A PR THAT DROPPED A CONSUMER. The generator refuses to write
-# when any consumer cannot be resolved on either half (cluster or pin), so a
-# failed resolution is a red run with nothing to commit. The approved-revisions
-# guard then re-reads the moved set against the live matchers BEFORE the pull
-# request step, so a narrowed matcher the new set no longer names is also a red
-# run rather than a pull request whose own CI fails later. Neither step carries
-# `continue-on-error`, and the pull-request step is not `if: always()` — the
-# contract test (scripts/tests/test-regenerate-publish-workflow-approved-
-# revisions.sh) pins both.
-#
-# ONE OPEN PULL REQUEST AT A TIME. The pull request is opened from a FIXED
-# branch, so a later run with a further-moved set updates the same pull request
-# instead of opening a second one; `queue: single` keeps two runs from racing
-# each other for it.
-#
-# WHAT THIS DOES NOT DO. It regenerates the DATA file only. Rewriting the four
-# per-consumer matchers to the generated pair is the narrowing switch
-# (APPROVED_REVISIONS_ENFORCE), which #3308's remaining child flips only after
-# this workflow has run green at least once — feature-flag-first: generated
-# file first, switch second.
+# Regenerate the approved set and its four consumer matchers together. Every
+# consumer must resolve before generation succeeds; the writer validates all
+# inputs and stages the complete update before changing any manifest. The guard
+# then enforces each exact signer/current-pin pair before the draft PR is opened.
+# A fixed branch and serialized runs keep one regeneration PR open at a time.
 #
 # WHY `environment: prod`. The applied half of every row is a cluster
 # observation (the OCIRepository's `status.artifact.revision`), and KUBE_CONFIG
@@ -174,35 +145,50 @@ jobs:
           PUBLISH_KUBE_CONTEXT: admin@prod
         run: ./scripts/generate-publish-workflow-approved-revisions.sh
 
-      # The generator writes ONE file. Anything else in the tree is not this
-      # workflow's to commit — it would ride into the pull request under a title
-      # that does not describe it — so refuse rather than narrow the commit.
+      - name: 🔐 Update the consumer matchers
+        shell: bash
+        run: ./scripts/write-publish-workflow-matchers.sh
+
+      # The set and its four consumer manifests are the complete write boundary.
+      # Refuse unrelated changes before the PR action can stage anything.
       - name: 🔍 Detect a moved set
         id: moved
         shell: bash
         run: |
           set -euo pipefail
-          other="$(git status --porcelain | grep -v ' scripts/publish-workflow-approved-revisions.tsv$' || true)"
+          paths=(
+            scripts/publish-workflow-approved-revisions.tsv
+            k8s/bases/apps/github-config/oci-repository.yaml
+            k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+            k8s/providers/hetzner/apps/aws/oci-repository.yaml
+            k8s/bases/apps/wedding-app/oci-repository.yaml
+          )
+          other=''
+          while IFS= read -r change; do
+            allowed=false
+            for path in "${paths[@]}"; do
+              if [ "${change:3}" = "$path" ]; then allowed=true; break; fi
+            done
+            if [ "$allowed" = false ]; then other+="${change}"$'\n'; fi
+          done < <(git status --porcelain --untracked-files=all)
           if [ -n "${other}" ]; then
-            printf 'refusing: the generator left changes outside its data file:\n%s\n' "${other}" >&2
+            printf 'refusing: regeneration left changes outside the approved set and matchers:\n%s\n' "${other}" >&2
             exit 1
           fi
-          if git diff --quiet -- scripts/publish-workflow-approved-revisions.tsv; then
+          if git diff HEAD --quiet -- "${paths[@]}"; then
             echo "moved=false" >> "${GITHUB_OUTPUT}"
-            echo 'approved set unchanged; nothing to open'
+            echo 'approved set and matchers unchanged; nothing to open'
           else
             echo "moved=true" >> "${GITHUB_OUTPUT}"
-            git --no-pager diff -- scripts/publish-workflow-approved-revisions.tsv
+            git --no-pager diff HEAD -- "${paths[@]}"
           fi
 
-      # Re-read the MOVED set against the live matchers before anything is
-      # pushed. With the switch off this passes while every per-consumer matcher
-      # still carries the pattern form; once a matcher is narrowed, a set that no
-      # longer names its pair is refused HERE — a red run that names the matcher,
-      # never a pull request whose own CI discovers it later.
+      # Validate the updated matchers against the same generated set before pushing.
       - name: 🔐 Guard the moved set against the live matchers
         if: steps.moved.outputs.moved == 'true'
         shell: bash
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
         run: ./scripts/guard-publish-workflow-approved-revisions.sh
 
       - name: 📦 Open or update the regeneration pull request
@@ -219,22 +205,24 @@ jobs:
       # red guard means this step never runs, which the contract test pins.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          # Exactly the generator's output. `add-paths` is the second fence behind
+          # Exactly the set and matcher outputs. `add-paths` is the second fence behind
           # the refusal above: even a change that slipped past it cannot be committed.
-          add-paths: scripts/publish-workflow-approved-revisions.tsv
+          add-paths: |
+            scripts/publish-workflow-approved-revisions.tsv
+            k8s/bases/apps/github-config/oci-repository.yaml
+            k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+            k8s/providers/hetzner/apps/aws/oci-repository.yaml
+            k8s/bases/apps/wedding-app/oci-repository.yaml
           commit-message: "chore(security): regenerate the approved publish-workflow revisions"
           title: "chore(security): regenerate the approved publish-workflow revisions"
           body: |
             > 🤖 Generated by the Agentic Engineer
 
-            The per-consumer approved-revision set moved: a consumer's default-branch pin
-            on a shared publish workflow, or the artifact revision Flux has applied,
-            differs from what `scripts/publish-workflow-approved-revisions.tsv` recorded.
-            Regenerated by `scripts/generate-publish-workflow-approved-revisions.sh`
-            against the prod cluster; every consumer resolved on both halves, or this
-            run would have failed instead of opening this.
+            Refresh the approved publish revisions and their consumer matchers from
+            the deployed artifacts and current publish-workflow pins. Every consumer
+            resolved on both halves, and each matcher accepts exactly its approved pair.
 
-            Part of #3308 (the regeneration path of #3552).
+            Part of #3308.
           # PINNED base. A manual dispatch checks out the ref it was dispatched
           # from, and without this the pull request would target THAT ref rather
           # than the default branch — so a regeneration run from a topic branch

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -45,6 +45,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🔐 Enforce approved publication signers
+        env:
+          APPROVED_REVISIONS_ENFORCE: '1'
+        run: ./scripts/guard-publish-workflow-approved-revisions.sh
+
       - name: ⚙️ Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,15 +16,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-app workflow this app's cd.yaml
-      # calls. The ref part accepts only a 40-hex commit SHA, so an artifact
-      # signed from any other ref — a floating @main, or a release tag — does
-      # not verify. Every caller of the shared publish workflows pins them by
-      # commit across its whole history, which is what makes the commit form
-      # sufficient on its own (#3022).
-      # cosign's keyless attestation verification rejects MULTIPLE identity
-      # entries outright ("unsupported: multiple identities are not supported at
-      # this time"), so any future alternation must stay inside one subject
-      # regex.
+      # Generated from scripts/publish-workflow-approved-revisions.tsv by
+      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
+      # signer and this consumer's current publish-workflow pin in one identity.
+      # Regeneration updates the pair and the approved set in the same PR.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(625b7c0cd5ad4a04f9eb7494298c6d0fa44521ef|4f4e07a3ebf3e1161756a292966e36c91a65ee04)$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -24,19 +24,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-manifests workflow that .github's
-      # cd.yaml calls. Signing runs INSIDE that workflow, so the cosign OIDC
-      # subject is that workflow's path, NOT .github's own cd.yaml — same
-      # convention as the publish-app.yaml-signed app artifacts.
-      #
-      # The ref part accepts only a 40-hex commit SHA, so an artifact signed
-      # from any other ref — a floating @main, or a release tag — does not
-      # verify. Every caller of the shared publish workflows pins them by
-      # commit across its whole history, which is what makes the commit form
-      # sufficient on its own (#3022).
-      # cosign's keyless attestation verification rejects MULTIPLE identity
-      # entries outright ("unsupported: multiple identities are not supported at
-      # this time"), so any future alternation must stay inside one subject
-      # regex.
+      # Generated from scripts/publish-workflow-approved-revisions.tsv by
+      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
+      # signer and this consumer's current publish-workflow pin in one identity.
+      # Regeneration updates the pair and the approved set in the same PR.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@[0-9a-f]{40}$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@(b3783a5148b844b3f1f4011cdc84871ad66348c1|3ee6cb9bbd616c2a38779be41a5e41f3e77282d0)$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,15 +16,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-app workflow this app's cd.yaml
-      # calls. The ref part accepts only a 40-hex commit SHA, so an artifact
-      # signed from any other ref — a floating @main, or a release tag — does
-      # not verify. Every caller of the shared publish workflows pins them by
-      # commit across its whole history, which is what makes the commit form
-      # sufficient on its own (#3022).
-      # cosign's keyless attestation verification rejects MULTIPLE identity
-      # entries outright ("unsupported: multiple identities are not supported at
-      # this time"), so any future alternation must stay inside one subject
-      # regex.
+      # Generated from scripts/publish-workflow-approved-revisions.tsv by
+      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
+      # signer and this consumer's current publish-workflow pin in one identity.
+      # Regeneration updates the pair and the approved set in the same PR.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(6ae5d87b342984cdaf34740e60366b9d570d8fc5|3ee6cb9bbd616c2a38779be41a5e41f3e77282d0)$'

--- a/k8s/providers/hetzner/apps/aws/oci-repository.yaml
+++ b/k8s/providers/hetzner/apps/aws/oci-repository.yaml
@@ -21,14 +21,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-manifests workflow that aws's
-      # cd.yaml calls. Signing runs INSIDE that workflow, so the cosign OIDC
-      # subject is that workflow's path, NOT aws's own cd.yaml.
-      #
-      # The ref part accepts only a 40-hex commit SHA, so an artifact signed
-      # from any other ref — a floating @main, or a release tag — does not
-      # verify. Every caller of the shared publish workflows pins them by
-      # commit across its whole history, which is what makes the commit form
-      # sufficient on its own (#3022).
+      # Generated from scripts/publish-workflow-approved-revisions.tsv by
+      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
+      # signer and this consumer's current publish-workflow pin in one identity.
+      # Regeneration updates the pair and the approved set in the same PR.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@[0-9a-f]{40}$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@(b089a1b041cb86af22cdc57de58a4d7d258dcc32|4f4e07a3ebf3e1161756a292966e36c91a65ee04)$'

--- a/scripts/guard-publish-workflow-approved-revisions.sh
+++ b/scripts/guard-publish-workflow-approved-revisions.sh
@@ -13,22 +13,18 @@
 # matcher names that consumer's pair and nothing else. An out-of-set revision is refused in
 # every mode — that is #3308's AC4.
 #
-# THE SWITCH (feature-flag-first, default OFF)
-# Today every per-consumer matcher carries the pattern form, and the narrowing to
-# `(<applied-signer>|<main-pin>)` is a separate, reversible step. While
-# APPROVED_REVISIONS_ENFORCE is unset or `0`, the pattern form is still ACCEPTED for a
-# per-consumer subject, so this guard is live on main without forcing the switch; a matcher
-# that has already been narrowed is judged against the set either way. With
-# APPROVED_REVISIONS_ENFORCE=1 the pattern form is REFUSED for a per-consumer subject, which is
-# what keeps the narrowing from quietly reverting once it has happened. Flipping the switch is
-# the same change that narrows the matchers, so the two cannot drift.
+# ENFORCEMENT
+# CI and scheduled regeneration set APPROVED_REVISIONS_ENFORCE=1, which refuses
+# the broad pattern form. Unset or 0 retains compatibility for inspection and
+# fixtures; already narrowed matchers must equal the approved pair in either mode.
+# write-publish-workflow-matchers.sh derives the four subjects from the set.
 #
 # SCOPE — GENERIC SUBJECTS ARE EXCLUDED BY NAME
 # Three subjects name the shared workflows without belonging to one consumer: the Kyverno
 # app-image policy, the tenant ResourceGraphDefinition template, and the Talos first-party
 # image-verification rule. Each verifies artifacts from MANY consumers, so no single generated
 # pair could be correct for it; they stay on the pattern form and are listed in
-# GENERIC_SUBJECT_FILES below so that the boundary is recorded beside the check. A shared-
+# GENERIC_SUBJECT_FILES in the shared library so that the boundary is recorded beside the check. A shared-
 # workflow subject that is neither attributed to a registered consumer nor on that list fails
 # the run: an unattributed subject is one whose revision nobody is checking.
 #
@@ -43,168 +39,8 @@
 set -euo pipefail
 
 GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly GUARD_DIR
-readonly REPORT="$GUARD_DIR/report-publish-workflow-signing-revisions.sh"
-# shellcheck source=scripts/report-publish-workflow-signing-revisions.sh
-source "$REPORT"
-
-readonly APPROVED_SET="${APPROVED_REVISIONS_FILE:-$REPO_ROOT/scripts/publish-workflow-approved-revisions.tsv}"
-readonly SCAN_ROOT="${PUBLISH_CONSUMER_ROOT:-$REPO_ROOT}"
-readonly ENFORCE="${APPROVED_REVISIONS_ENFORCE:-0}"
-readonly HEADER=$'consumer\tworkflow\tapplied_tag\tapplied_digest\tapplied_signer_sha\tmain_pin_sha\tobserved_on'
-
-# Relative to the scan root. Every entry must exist: a generic subject that moves or is
-# renamed would otherwise become an unattributed subject with no home, and this list is
-# where its absence should be noticed and the boundary redrawn on purpose.
-readonly GENERIC_SUBJECT_FILES=(
-  'k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml'
-  'k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml'
-  'talos/cluster/verify-first-party-images.yaml'
-)
-
-readonly SUBJECT_PREFIX='^https://github\.com/devantler-tech/actions/\.github/workflows/publish-'
-readonly PATTERN_REF='[0-9a-f]{40}'
-
-refuse() {
-  printf 'guard-publish-workflow-approved-revisions: %s\n' "$*" >&2
-  exit 1
-}
-
-case "$ENFORCE" in
-  0 | 1) ;;
-  *) refuse "APPROVED_REVISIONS_ENFORCE must be 0 or 1, got '$ENFORCE'" ;;
-esac
-
-# ── 1. The approved set, read strictly ──────────────────────────────────────────────────
-[ -f "$APPROVED_SET" ] || refuse "approved set not found at $APPROVED_SET; run scripts/generate-publish-workflow-approved-revisions.sh"
-[ "$(head -n1 "$APPROVED_SET")" = "$HEADER" ] || refuse "approved set header is not the generator's; refusing to read it"
-
-# Records are newline-delimited "<key><TAB>…" strings rather than associative arrays: the
-# maintainer's macOS ships bash 3.2, where `declare -A` is a hard error, and a guard that
-# cannot run where the matchers are edited is one that gets skipped there.
-# lookup <records> <key> → the record for <key> (fields after the key), or nothing.
-lookup() {
-  # `$1 "" == k ""` forces a STRING compare: awk compares two numeric-looking strings as
-  # numbers, so `100` would match a key of `1e2`.
-  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 "" == k "" { sub(/^[^\t]*\t/, ""); print; exit }'
-}
-
-# consumer → "workflow<TAB>signer<TAB>pin"
-approved=""
-line_no=1
-while IFS=$'\t' read -r consumer workflow applied_tag applied_digest signer pin observed_on extra; do
-  line_no=$((line_no + 1))
-  [ -n "$consumer" ] || continue
-  [ "$line_no" -gt 2 ] || [ "$consumer" != 'consumer' ] || continue  # the header
-  [ -z "${extra:-}" ] || refuse "approved set line $line_no has more than seven fields"
-  [ -n "$observed_on" ] || refuse "approved set line $line_no has fewer than seven fields"
-  plausible_repo "$consumer" || refuse "approved set line $line_no names an implausible consumer '$consumer'"
-  case "$workflow" in
-    publish-app | publish-manifests) ;;
-    *) refuse "approved set line $line_no: '$workflow' is not a shared publish workflow" ;;
-  esac
-  is_sha "$signer" || refuse "approved set line $line_no ($consumer): applied_signer_sha '$signer' is not a 40-hex commit"
-  is_sha "$pin" || refuse "approved set line $line_no ($consumer): main_pin_sha '$pin' is not a 40-hex commit"
-  [ -z "$(lookup "$approved" "$consumer")" ] || refuse "approved set names $consumer twice"
-  : "$applied_tag" "$applied_digest"
-  approved="${approved}${consumer}"$'\t'"${workflow}"$'\t'"${signer}"$'\t'"${pin}"$'\n'
-done <"$APPROVED_SET"
-
-# Exactly the registered consumers, both directions: a missing row is a consumer nobody
-# narrowed, an extra row is a set nothing consumes.
-for expected in "${EXPECTED_CONSUMERS[@]}"; do
-  [ -n "$(lookup "$approved" "$expected")" ] || refuse "approved set has no row for registered consumer $expected"
-done
-while IFS=$'\t' read -r consumer _rest; do
-  [ -n "$consumer" ] || continue
-  known=0
-  for expected in "${EXPECTED_CONSUMERS[@]}"; do
-    [ "$expected" = "$consumer" ] && known=1 && break
-  done
-  [ "$known" -eq 1 ] || refuse "approved set names $consumer, which is not a registered consumer"
-done <<<"$approved"
-
-# ── 2. Every shared-workflow subject in the tree, attributed or excluded ─────────────────
-[ -d "$SCAN_ROOT" ] || refuse "scan root $SCAN_ROOT is not a directory"
-for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
-  [ -f "$SCAN_ROOT/$generic" ] || refuse "generic subject file $generic is missing from the scan root; the scope boundary has moved — redraw GENERIC_SUBJECT_FILES deliberately"
-done
-
-# `.claude/` holds nested per-session worktrees on the maintainer's checkout — whole copies of
-# this tree — so descending into it reports every generic subject a second time from a path the
-# exclusion list does not name, and the guard refuses a correct repository. `.git` for the same
-# reason a packed ref or a stray object file must never be read as a manifest.
-subject_files="$(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' --exclude-dir=.git --exclude-dir=.claude "$SCAN_ROOT" 2>/dev/null | sort -u || true)"
-[ -n "$subject_files" ] || refuse "no shared-publish-workflow subject found under $SCAN_ROOT; the scan, not the tree, is the likely cause"
-
-# consumer → "file<TAB>workflow<TAB>ref"
-observed=""
-while IFS= read -r file; do
-  [ -n "$file" ] || continue
-  rel="${file#"$SCAN_ROOT"/}"
-  case "$rel" in
-    scripts/*) continue ;;  # test fixtures under scripts/ carry subjects that verify nothing
-  esac
-  is_generic=0
-  for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
-    [ "$rel" = "$generic" ] && is_generic=1 && break
-  done
-  [ "$is_generic" -eq 0 ] || continue
-
-  # One OCIRepository document per file, with exactly one identity entry, and that entry names a
-  # shared workflow — the same attribution the report makes, read the way Flux reads it. Fields:
-  # url, the total number of identity entries, the number naming a shared workflow, and the
-  # first of those.
-  #
-  # The TOTAL matters as much as the shared count: `matchOIDCIdentity` is an OR-list, so a second
-  # entry beside a correct pair (`subject: '.*'`, or a first-party branch identity) admits any
-  # signer while the pair reads as narrowed. Counting only the shared-workflow entries would
-  # report `form=set` over exactly that widening.
-  # shellcheck disable=SC2016  # `$ids`/`$shared` are yq variables, not shell ones
-  docs="$(yq eval -r '
-    select(.kind == "OCIRepository") |
-    (.spec.verify.matchOIDCIdentity // []) as $ids |
-    ($ids | map(.subject // "") | map(select(test("devantler-tech/actions/.{1,2}github/workflows/publish-(app|manifests)")))) as $shared |
-    [(.spec.url // "-"), ($ids | length), ($shared | length), ($shared[0] // "-")] | @tsv
-  ' "$file" 2>/dev/null)" || refuse "$rel could not be read as YAML"
-  [ -n "$docs" ] || refuse "$rel carries a shared-publish-workflow subject but no OCIRepository document owns it; attribute it to a consumer or add it to GENERIC_SUBJECT_FILES"
-  [ "$(printf '%s\n' "$docs" | grep -c .)" -eq 1 ] || refuse "$rel carries more than one OCIRepository document; the attribution is ambiguous"
-  IFS=$'\t' read -r url identity_count subject_count subject <<<"$docs"
-  case "$url" in
-    oci://ghcr.io/devantler-tech/*) ;;
-    *) refuse "$rel: OCIRepository url '$url' is not a devantler-tech GHCR artifact" ;;
-  esac
-  [ "$subject_count" = "1" ] || refuse "$rel: expected exactly one shared-publish-workflow subject on the OCIRepository, found $subject_count"
-  [ "$identity_count" = "1" ] || refuse "$rel: the OCIRepository carries $identity_count matchOIDCIdentity entries; a second entry beside the pair admits any signer it names, so exactly one is allowed"
-  # The line scan that discovered this file and the document read above must agree: a shared-
-  # workflow subject in a SECOND document (a policy appended after `---`) is invisible to the
-  # OCIRepository selection, and would otherwise pass unjudged.
-  line_count="$(grep -cE "$SUBJECT_PATTERN" "$file" || true)"
-  [ "$line_count" = "1" ] || refuse "$rel: $line_count shared-publish-workflow subject lines found but exactly one OCIRepository entry was read; a subject outside the OCIRepository document is unjudged"
-  repo="${url#oci://ghcr.io/devantler-tech/}"; repo="${repo%%/*}"
-  repo="$(oci_name_to_repo "$repo")"
-  plausible_repo "$repo" || refuse "$rel: consumer name '$repo' derived from $url is implausible"
-  [ -n "$(lookup "$approved" "$repo")" ] || refuse "$rel is a shared-workflow consumer ($repo) with no row in the approved set and no entry in GENERIC_SUBJECT_FILES"
-  prior="$(lookup "$observed" "$repo")"
-  [ -z "$prior" ] || refuse "consumer $repo has an OCIRepository in both $rel and ${prior%%$'\t'*}"
-
-  case "$subject" in
-    "$SUBJECT_PREFIX"*) ;;
-    *) refuse "$rel: subject does not start with the shared-workflow identity prefix: $subject" ;;
-  esac
-  rest="${subject#"$SUBJECT_PREFIX"}"          # <workflow>\.yaml@<ref>$
-  case "$rest" in
-    *'\.yaml@'*) ;;
-    *) refuse "$rel: subject has no '\\.yaml@' boundary: $subject" ;;
-  esac
-  workflow="publish-${rest%%\\.yaml@*}"
-  ref="${rest#*\\.yaml@}"
-  case "$ref" in
-    *'$') ref="${ref%\$}" ;;
-    *) refuse "$rel: subject is not anchored with a trailing \$: $subject" ;;
-  esac
-  observed="${observed}${repo}"$'\t'"${rel}"$'\t'"${workflow}"$'\t'"${ref}"$'\n'
-done <<<"$subject_files"
+# shellcheck source=scripts/publish-workflow-approved-revisions.lib.sh
+source "$GUARD_DIR/publish-workflow-approved-revisions.lib.sh"
 
 # ── 3. Each registered consumer: its matcher equals its generated pair ───────────────────
 for consumer in "${EXPECTED_CONSUMERS[@]}"; do

--- a/scripts/publish-workflow-approved-revisions.lib.sh
+++ b/scripts/publish-workflow-approved-revisions.lib.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Shared, read-only validation and consumer attribution for the matcher guard and writer.
+# Sourcing validates the complete approved set and source tree before either caller acts.
+
+set -euo pipefail
+
+GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly GUARD_DIR
+readonly REPORT="$GUARD_DIR/report-publish-workflow-signing-revisions.sh"
+# shellcheck source=scripts/report-publish-workflow-signing-revisions.sh
+source "$REPORT"
+
+readonly APPROVED_SET="${APPROVED_REVISIONS_FILE:-$REPO_ROOT/scripts/publish-workflow-approved-revisions.tsv}"
+readonly SCAN_ROOT="${PUBLISH_CONSUMER_ROOT:-$REPO_ROOT}"
+readonly ENFORCE="${APPROVED_REVISIONS_ENFORCE:-0}"
+readonly HEADER=$'consumer\tworkflow\tapplied_tag\tapplied_digest\tapplied_signer_sha\tmain_pin_sha\tobserved_on'
+
+# Relative to the scan root. Every entry must exist: a generic subject that moves or is
+# renamed would otherwise become an unattributed subject with no home, and this list is
+# where its absence should be noticed and the boundary redrawn on purpose.
+readonly GENERIC_SUBJECT_FILES=(
+  'k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml'
+  'k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml'
+  'talos/cluster/verify-first-party-images.yaml'
+)
+
+readonly SUBJECT_PREFIX='^https://github\.com/devantler-tech/actions/\.github/workflows/publish-'
+# Used by both callers after the shared discovery completes.
+# shellcheck disable=SC2034
+readonly PATTERN_REF='[0-9a-f]{40}'
+
+refuse() {
+  printf 'guard-publish-workflow-approved-revisions: %s\n' "$*" >&2
+  exit 1
+}
+
+case "$ENFORCE" in
+  0 | 1) ;;
+  *) refuse "APPROVED_REVISIONS_ENFORCE must be 0 or 1, got '$ENFORCE'" ;;
+esac
+
+# ── 1. The approved set, read strictly ──────────────────────────────────────────────────
+[ -f "$APPROVED_SET" ] || refuse "approved set not found at $APPROVED_SET; run scripts/generate-publish-workflow-approved-revisions.sh"
+[ "$(head -n1 "$APPROVED_SET")" = "$HEADER" ] || refuse "approved set header is not the generator's; refusing to read it"
+
+# Records are newline-delimited "<key><TAB>…" strings rather than associative arrays: the
+# maintainer's macOS ships bash 3.2, where `declare -A` is a hard error, and a guard that
+# cannot run where the matchers are edited is one that gets skipped there.
+# lookup <records> <key> → the record for <key> (fields after the key), or nothing.
+lookup() {
+  # `$1 "" == k ""` forces a STRING compare: awk compares two numeric-looking strings as
+  # numbers, so `100` would match a key of `1e2`.
+  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 "" == k "" { sub(/^[^\t]*\t/, ""); print; exit }'
+}
+
+# consumer → "workflow<TAB>signer<TAB>pin"
+approved=""
+line_no=1
+while IFS=$'\t' read -r consumer workflow applied_tag applied_digest signer pin observed_on extra; do
+  line_no=$((line_no + 1))
+  [ -n "$consumer" ] || continue
+  [ "$line_no" -gt 2 ] || [ "$consumer" != 'consumer' ] || continue  # the header
+  [ -z "${extra:-}" ] || refuse "approved set line $line_no has more than seven fields"
+  [ -n "$observed_on" ] || refuse "approved set line $line_no has fewer than seven fields"
+  plausible_repo "$consumer" || refuse "approved set line $line_no names an implausible consumer '$consumer'"
+  case "$workflow" in
+    publish-app | publish-manifests) ;;
+    *) refuse "approved set line $line_no: '$workflow' is not a shared publish workflow" ;;
+  esac
+  is_sha "$signer" || refuse "approved set line $line_no ($consumer): applied_signer_sha '$signer' is not a 40-hex commit"
+  is_sha "$pin" || refuse "approved set line $line_no ($consumer): main_pin_sha '$pin' is not a 40-hex commit"
+  [ -z "$(lookup "$approved" "$consumer")" ] || refuse "approved set names $consumer twice"
+  : "$applied_tag" "$applied_digest"
+  approved="${approved}${consumer}"$'\t'"${workflow}"$'\t'"${signer}"$'\t'"${pin}"$'\n'
+done <"$APPROVED_SET"
+
+# Exactly the registered consumers, both directions: a missing row is a consumer nobody
+# narrowed, an extra row is a set nothing consumes.
+for expected in "${EXPECTED_CONSUMERS[@]}"; do
+  [ -n "$(lookup "$approved" "$expected")" ] || refuse "approved set has no row for registered consumer $expected"
+done
+while IFS=$'\t' read -r consumer _rest; do
+  [ -n "$consumer" ] || continue
+  known=0
+  for expected in "${EXPECTED_CONSUMERS[@]}"; do
+    [ "$expected" = "$consumer" ] && known=1 && break
+  done
+  [ "$known" -eq 1 ] || refuse "approved set names $consumer, which is not a registered consumer"
+done <<<"$approved"
+
+# ── 2. Every shared-workflow subject in the tree, attributed or excluded ─────────────────
+[ -d "$SCAN_ROOT" ] || refuse "scan root $SCAN_ROOT is not a directory"
+for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
+  [ -f "$SCAN_ROOT/$generic" ] || refuse "generic subject file $generic is missing from the scan root; the scope boundary has moved — redraw GENERIC_SUBJECT_FILES deliberately"
+done
+
+# `.claude/` holds nested per-session worktrees on the maintainer's checkout — whole copies of
+# this tree — so descending into it reports every generic subject a second time from a path the
+# exclusion list does not name, and the guard refuses a correct repository. `.git` for the same
+# reason a packed ref or a stray object file must never be read as a manifest.
+subject_files="$(grep -rlE "$SUBJECT_PATTERN" --include='*.yaml' --exclude-dir=.git --exclude-dir=.claude "$SCAN_ROOT" 2>/dev/null | sort -u || true)"
+[ -n "$subject_files" ] || refuse "no shared-publish-workflow subject found under $SCAN_ROOT; the scan, not the tree, is the likely cause"
+
+# consumer → "file<TAB>workflow<TAB>ref"
+observed=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  rel="${file#"$SCAN_ROOT"/}"
+  case "$rel" in
+    scripts/*) continue ;;  # test fixtures under scripts/ carry subjects that verify nothing
+  esac
+  is_generic=0
+  for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
+    [ "$rel" = "$generic" ] && is_generic=1 && break
+  done
+  [ "$is_generic" -eq 0 ] || continue
+
+  # One OCIRepository document per file, with exactly one identity entry, and that entry names a
+  # shared workflow — the same attribution the report makes, read the way Flux reads it. Fields:
+  # url, the total number of identity entries, the number naming a shared workflow, and the
+  # first of those.
+  #
+  # The TOTAL matters as much as the shared count: `matchOIDCIdentity` is an OR-list, so a second
+  # entry beside a correct pair (`subject: '.*'`, or a first-party branch identity) admits any
+  # signer while the pair reads as narrowed. Counting only the shared-workflow entries would
+  # report `form=set` over exactly that widening.
+  # shellcheck disable=SC2016  # `$ids`/`$shared` are yq variables, not shell ones
+  docs="$(yq eval -r '
+    select(.kind == "OCIRepository") |
+    (.spec.verify.matchOIDCIdentity // []) as $ids |
+    ($ids | map(.subject // "") | map(select(test("devantler-tech/actions/.{1,2}github/workflows/publish-(app|manifests)")))) as $shared |
+    [(.spec.url // "-"), ($ids | length), ($shared | length), ($shared[0] // "-")] | @tsv
+  ' "$file" 2>/dev/null)" || refuse "$rel could not be read as YAML"
+  [ -n "$docs" ] || refuse "$rel carries a shared-publish-workflow subject but no OCIRepository document owns it; attribute it to a consumer or add it to GENERIC_SUBJECT_FILES"
+  [ "$(printf '%s\n' "$docs" | grep -c .)" -eq 1 ] || refuse "$rel carries more than one OCIRepository document; the attribution is ambiguous"
+  IFS=$'\t' read -r url identity_count subject_count subject <<<"$docs"
+  case "$url" in
+    oci://ghcr.io/devantler-tech/*) ;;
+    *) refuse "$rel: OCIRepository url '$url' is not a devantler-tech GHCR artifact" ;;
+  esac
+  [ "$subject_count" = "1" ] || refuse "$rel: expected exactly one shared-publish-workflow subject on the OCIRepository, found $subject_count"
+  [ "$identity_count" = "1" ] || refuse "$rel: the OCIRepository carries $identity_count matchOIDCIdentity entries; a second entry beside the pair admits any signer it names, so exactly one is allowed"
+  # The line scan that discovered this file and the document read above must agree: a shared-
+  # workflow subject in a SECOND document (a policy appended after `---`) is invisible to the
+  # OCIRepository selection, and would otherwise pass unjudged.
+  line_count="$(grep -cE "$SUBJECT_PATTERN" "$file" || true)"
+  [ "$line_count" = "1" ] || refuse "$rel: $line_count shared-publish-workflow subject lines found but exactly one OCIRepository entry was read; a subject outside the OCIRepository document is unjudged"
+  repo="${url#oci://ghcr.io/devantler-tech/}"; repo="${repo%%/*}"
+  repo="$(oci_name_to_repo "$repo")"
+  plausible_repo "$repo" || refuse "$rel: consumer name '$repo' derived from $url is implausible"
+  [ -n "$(lookup "$approved" "$repo")" ] || refuse "$rel is a shared-workflow consumer ($repo) with no row in the approved set and no entry in GENERIC_SUBJECT_FILES"
+  prior="$(lookup "$observed" "$repo")"
+  [ -z "$prior" ] || refuse "consumer $repo has an OCIRepository in both $rel and ${prior%%$'\t'*}"
+
+  case "$subject" in
+    "$SUBJECT_PREFIX"*) ;;
+    *) refuse "$rel: subject does not start with the shared-workflow identity prefix: $subject" ;;
+  esac
+  rest="${subject#"$SUBJECT_PREFIX"}"          # <workflow>\.yaml@<ref>$
+  case "$rest" in
+    *'\.yaml@'*) ;;
+    *) refuse "$rel: subject has no '\\.yaml@' boundary: $subject" ;;
+  esac
+  workflow="publish-${rest%%\\.yaml@*}"
+  ref="${rest#*\\.yaml@}"
+  case "$ref" in
+    *'$') ref="${ref%\$}" ;;
+    *) refuse "$rel: subject is not anchored with a trailing \$: $subject" ;;
+  esac
+  observed="${observed}${repo}"$'\t'"${rel}"$'\t'"${workflow}"$'\t'"${ref}"$'\n'
+done <<<"$subject_files"

--- a/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+++ b/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
@@ -445,7 +445,9 @@ grep -Fq 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh' "$ci"
   fail 'ci.yaml does not run test-publish-workflow-approved-revisions-guard.sh'
 # CI must apply enforcement to the step that executes the guard, not an unrelated job.
 enforce="$(yq -r '.jobs[].steps[] | select(.run // "" | contains("./scripts/guard-publish-workflow-approved-revisions.sh")) | .env.APPROVED_REVISIONS_ENFORCE' "$ci")"
-[ "$enforce" = '1' ] || fail 'ci.yaml must enforce the approved set in the guard step'
+if [ -z "$enforce" ] || printf '%s\n' "$enforce" | grep -qv '^1$'; then
+  fail 'ci.yaml must enforce the approved set in every guard step'
+fi
 [ "$failures" -eq 0 ] && pass 'wiring: ci.yaml enforces the approved set'
 
 # ── the real tree: every committed consumer uses exactly its approved pair ────────────────

--- a/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+++ b/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
@@ -443,15 +443,14 @@ grep -Fq 'scripts/guard-publish-workflow-approved-revisions.sh' "$ci" ||
   fail 'ci.yaml does not run guard-publish-workflow-approved-revisions.sh'
 grep -Fq 'scripts/tests/test-publish-workflow-approved-revisions-guard.sh' "$ci" ||
   fail 'ci.yaml does not run test-publish-workflow-approved-revisions-guard.sh'
-# The switch must stay OFF in CI until the narrowing lands in the same change (#3308).
-if grep -Eq 'APPROVED_REVISIONS_ENFORCE(:[[:space:]]*|=)["'"'"']?1' "$ci"; then
-  fail 'ci.yaml turns APPROVED_REVISIONS_ENFORCE on; the switch flips only with the matcher narrowing'
-fi
-[ "$failures" -eq 0 ] && pass 'wiring: ci.yaml runs the guard and its test with the switch off'
+# CI must apply enforcement to the step that executes the guard, not an unrelated job.
+enforce="$(yq -r '.jobs[].steps[] | select(.run // "" | contains("./scripts/guard-publish-workflow-approved-revisions.sh")) | .env.APPROVED_REVISIONS_ENFORCE' "$ci")"
+[ "$enforce" = '1' ] || fail 'ci.yaml must enforce the approved set in the guard step'
+[ "$failures" -eq 0 ] && pass 'wiring: ci.yaml enforces the approved set'
 
-# ── the real tree, switch off: the committed set and the live matchers agree ────────────────
-if out="$(bash "$GUARD" 2>&1)"; then
-  pass 'real tree: the committed approved set agrees with the live per-consumer matchers (switch off)'
+# ── the real tree: every committed consumer uses exactly its approved pair ────────────────
+if out="$(APPROVED_REVISIONS_ENFORCE=1 bash "$GUARD" 2>&1)"; then
+  pass 'real tree: every per-consumer matcher uses its approved pair (enforced)'
 else
   fail 'real tree: guard refuses the committed state:'; printf '%s\n' "$out" >&2
 fi

--- a/scripts/tests/test-regenerate-publish-workflow-approved-revisions.sh
+++ b/scripts/tests/test-regenerate-publish-workflow-approved-revisions.sh
@@ -28,6 +28,11 @@ readonly workflow="${root_dir}/.github/workflows/regenerate-publish-workflow-app
 readonly generator='scripts/generate-publish-workflow-approved-revisions.sh'
 readonly guard='scripts/guard-publish-workflow-approved-revisions.sh'
 readonly data_file='scripts/publish-workflow-approved-revisions.tsv'
+readonly generated_paths='scripts/publish-workflow-approved-revisions.tsv
+k8s/bases/apps/github-config/oci-repository.yaml
+k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+k8s/providers/hetzner/apps/aws/oci-repository.yaml
+k8s/bases/apps/wedding-app/oci-repository.yaml'
 readonly endpoint_script='scripts/use-prod-stable-api-endpoint.sh'
 
 work_dir="$(mktemp -d)"
@@ -138,7 +143,7 @@ check() {
     *'${{'*) printf 'VIOLATION A7: the checkout ref is interpolated ("%s")\n' "${coref}"; return 1 ;;
   esac
 
-  # A8 — one open pull request at a time: a FIXED branch, a draft, signed, only the data file.
+  # A8 — one open pull request: a fixed branch, a draft, signed, exactly the set and matchers.
   [ -n "${pr_idx}" ] || { printf 'VIOLATION A8: no create-pull-request step\n'; return 1; }
   local branch
   branch="$(q "$f" ".jobs.regenerate.steps[${pr_idx}].with.branch")"
@@ -150,8 +155,8 @@ check() {
     { printf 'VIOLATION A8: the pull request is not opened as a draft\n'; return 1; }
   [ "$(q "$f" ".jobs.regenerate.steps[${pr_idx}].with.sign-commits")" = 'true' ] ||
     { printf 'VIOLATION A8: the pull-request commit is not API-signed\n'; return 1; }
-  [ "$(q "$f" ".jobs.regenerate.steps[${pr_idx}].with.add-paths")" = "${data_file}" ] ||
-    { printf 'VIOLATION A8: add-paths is not exactly %s\n' "${data_file}"; return 1; }
+  [ "$(q "$f" ".jobs.regenerate.steps[${pr_idx}].with.add-paths")" = "${generated_paths}" ] ||
+    { printf 'VIOLATION A8: add-paths must contain exactly the set and four consumer manifests\n'; return 1; }
   case "$(q "$f" ".jobs.regenerate.steps[${pr_idx}].with.token")" in
     *'steps.app-token.outputs.token'*) ;;
     *) printf 'VIOLATION A8: the pull request is not opened with the App token\n'; return 1 ;;
@@ -272,10 +277,32 @@ check() {
     *) printf 'VIOLATION A14: the pull-request step is conditional ("%s"), so a set that returns to baseline leaves a stale pull request open\n' "$(q "$f" ".jobs.regenerate.steps[${pr_idx}].if")"; return 1 ;;
   esac
 
+  # A15 — update the matchers before change detection and enforced validation.
+  local writer_idx moved_idx
+  writer_idx="$(yq -r '.jobs.regenerate.steps | to_entries | map(select(.value.run // "" | contains("write-publish-workflow-matchers.sh"))) | .[0].key // ""' "$f")"
+  moved_idx="$(yq -r '.jobs.regenerate.steps | to_entries | map(select(.value.id == "moved")) | .[0].key // ""' "$f")"
+  if ! { [ -n "${writer_idx}" ] && [ -n "${moved_idx}" ] &&
+    [ "${gen_idx}" -lt "${writer_idx}" ] && [ "${writer_idx}" -lt "${moved_idx}" ] &&
+    [ "${moved_idx}" -lt "${guard_idx}" ]; }; then
+    printf 'VIOLATION A15: require generator < writer < change detection < guard\n'; return 1
+  fi
+  [ "$(q "$f" ".jobs.regenerate.steps[${writer_idx}].if")" = '' ] ||
+    { printf 'VIOLATION A15: the matcher writer must run unconditionally after generation\n'; return 1; }
+  [ "$(q "$f" ".jobs.regenerate.steps[${guard_idx}].env.APPROVED_REVISIONS_ENFORCE")" = '1' ] ||
+    { printf 'VIOLATION A15: the regeneration guard must enforce exact approved revisions\n'; return 1; }
+
   printf 'ok\n'
 }
 
 # ── Control: the committed workflow passes ────────────────────────────────────────────────
+# Bind the workflow's explicit path fence to the consumer manifests the writer discovers.
+# A relocated consumer must update the automation boundary in the same change.
+discovered_paths="$(bash -c 'source "$1"; printf "%s" "$observed" | cut -f2' _ \
+  "${root_dir}/scripts/publish-workflow-approved-revisions.lib.sh")"
+actual_paths="$(printf '%s\n%s\n' "${data_file}" "${discovered_paths}" | sort)"
+[ "$(printf '%s\n' "${generated_paths}" | sort)" = "$actual_paths" ] ||
+  fail 'the regeneration path fence does not match the discovered consumer manifests'
+
 out="$(check "${workflow}")" || fail "the committed workflow violates its own contract: ${out}"
 [ "${out}" = 'ok' ] || fail "unexpected check output on the committed workflow: ${out}"
 
@@ -340,4 +367,52 @@ ablate A10 'a consumer added to the WRITE token' '(.jobs.regenerate.steps[] | se
 ablate A10 'a consumer dropped from the READ token' '(.jobs.regenerate.steps[] | select(.id == "consumer-token") | .with.repositories) = ".github\naws\nwedding-app\n"'
 ablate A14 'pull-request step re-gated on moved' '(.jobs.regenerate.steps[] | select(.uses // "" | contains("create-pull-request")) | .if) = "steps.moved.outputs.moved == '"'"'true'"'"'"'
 
-printf 'test-regenerate-publish-workflow-approved-revisions: 1 control + 39 ablations passed\n'
+ablate A15 'writer removed' 'del(.jobs.regenerate.steps[] | select(.run // "" | contains("write-publish-workflow-matchers.sh")))'
+ablate A15 'writer moved after guard' '.jobs.regenerate.steps = ([.jobs.regenerate.steps[] | select((.run // "" | contains("write-publish-workflow-matchers.sh")) | not)] + [.jobs.regenerate.steps[] | select(.run // "" | contains("write-publish-workflow-matchers.sh"))])'
+ablate A15 'writer gated off' '(.jobs.regenerate.steps[] | select(.run // "" | contains("write-publish-workflow-matchers.sh")) | .if) = "false"'
+ablate A15 'guard enforcement off' '(.jobs.regenerate.steps[] | select(.run // "" | contains("guard-publish-workflow-approved-revisions.sh")) | .env.APPROVED_REVISIONS_ENFORCE) = "0"'
+ablate A8 'consumer matcher omitted' '(.jobs.regenerate.steps[] | select(.uses // "" | contains("create-pull-request")) | .with.add-paths) = "scripts/publish-workflow-approved-revisions.tsv"'
+ablate A9 'writer failure ignored' '(.jobs.regenerate.steps[] | select(.run // "" | contains("write-publish-workflow-matchers.sh")) | .continue-on-error) = true'
+
+# Execute the actual change-detection step in a disposable checkout. This proves
+# that the PR boundary handles each matcher, staged changes, and unrelated paths.
+detection="${work_dir}/detect.sh"
+yq -r '.jobs.regenerate.steps[] | select(.id == "moved") | .run' "${workflow}" > "${detection}"
+checkout="${work_dir}/checkout"
+mkdir -p "${checkout}"
+(
+  cd "${checkout}"
+  git init -q
+  while IFS= read -r path; do
+    mkdir -p "$(dirname "$path")"
+    printf 'original\n' > "$path"
+    git add -- "$path"
+  done <<< "${generated_paths}"
+  git -c user.name=Test -c user.email=test@example.invalid -c commit.gpgsign=false commit -qm fixture
+  export GITHUB_OUTPUT="${work_dir}/outputs"
+  bash "${detection}" > "${work_dir}/detection.log"
+  grep -qx 'moved=false' "$GITHUB_OUTPUT" || fail 'unchanged checkout must report false'
+  while IFS= read -r path; do
+    : > "$GITHUB_OUTPUT"
+    printf 'updated\n' >> "$path"
+    bash "${detection}" > "${work_dir}/detection.log"
+    grep -qx 'moved=true' "$GITHUB_OUTPUT" || fail "allowed update was not detected: $path"
+    git add -- "$path"
+    : > "$GITHUB_OUTPUT"
+    bash "${detection}" > "${work_dir}/detection.log"
+    grep -qx 'moved=true' "$GITHUB_OUTPUT" || fail "staged update was not detected: $path"
+    git restore --staged --worktree -- "$path"
+  done <<< "${generated_paths}"
+  mkdir -p k8s/bases/apps/other
+  printf 'unrelated\n' > k8s/bases/apps/other/oci-repository.yaml
+  if bash "${detection}" > "${work_dir}/detection.log" 2>&1; then
+    fail 'unrelated untracked manifest was allowed'
+  fi
+  grep -Fq 'outside the approved set and matchers' "${work_dir}/detection.log" || fail 'unrelated-file refusal was not the expected cause'
+  git add -- k8s/bases/apps/other/oci-repository.yaml
+  if bash "${detection}" > "${work_dir}/detection.log" 2>&1; then
+    fail 'unrelated staged manifest was allowed'
+  fi
+)
+
+printf 'test-regenerate-publish-workflow-approved-revisions: 1 control + 45 ablations + change-detection cases passed\n'

--- a/scripts/tests/test-write-publish-workflow-matchers.sh
+++ b/scripts/tests/test-write-publish-workflow-matchers.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Exercise matcher regeneration against real YAML and the enforcing guard, without APIs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRITER="$ROOT/scripts/write-publish-workflow-matchers.sh"
+GUARD="$ROOT/scripts/guard-publish-workflow-approved-revisions.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+TREE="$WORK/consumer tree"
+SET="$TREE/scripts/approved.tsv"
+A=1111111111111111111111111111111111111111
+B=2222222222222222222222222222222222222222
+C=3333333333333333333333333333333333333333
+D=4444444444444444444444444444444444444444
+GENERIC_FILES=(
+  k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+  k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+  talos/cluster/verify-first-party-images.yaml
+)
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+fixture() {
+  rm -rf "$TREE"
+  mkdir -p "$TREE/scripts"
+  printf 'consumer\tworkflow\tapplied_tag\tapplied_digest\tapplied_signer_sha\tmain_pin_sha\tobserved_on\n' >"$SET"
+  local repo workflow package signer pin file
+  while read -r repo workflow package signer pin; do
+    file="$TREE/k8s/bases/apps/$package/oci-repository.yaml"
+    mkdir -p "$(dirname "$file")"
+    cat >"$file" <<EOF
+# Preserve this consumer comment.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: $package
+spec:
+  url: oci://ghcr.io/devantler-tech/$package/manifests
+  interval: 5m
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\.actions\.githubusercontent\.com\$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/$workflow\.yaml@[0-9a-f]{40}\$'
+EOF
+    printf '%s\t%s\t1.0.0\tsha256:%064d\t%s\t%s\t2026-09-05\n' \
+      "$repo" "$workflow" 0 "$signer" "$pin" >>"$SET"
+  done <<EOF
+.github publish-manifests github-config $A $B
+ascoachingogvaner publish-app ascoachingogvaner $C $B
+aws publish-manifests aws $A $A
+wedding-app publish-app wedding-app $A $B
+EOF
+  for file in "${GENERIC_FILES[@]}"; do
+    mkdir -p "$TREE/$(dirname "$file")"
+    cp "$ROOT/$file" "$TREE/$file"
+  done
+}
+
+write_matchers() {
+  APPROVED_REVISIONS_FILE="$SET" PUBLISH_CONSUMER_ROOT="$TREE" bash "$WRITER"
+}
+guard() {
+  APPROVED_REVISIONS_FILE="$SET" PUBLISH_CONSUMER_ROOT="$TREE" \
+    APPROVED_REVISIONS_ENFORCE=1 bash "$GUARD"
+}
+snapshot() {
+  (cd "$TREE" && find k8s talos -type f -exec shasum -a 256 {} \; | sort)
+}
+expect_atomic_refusal() {
+  local label="$1" needle="$2" before out
+  before="$(snapshot)"
+  if out="$(write_matchers 2>&1)"; then fail "$label: writer accepted an invalid input"; fi
+  case "$out" in *"$needle"*) ;; *) fail "$label: wrong refusal: $out" ;; esac
+  [ "$(snapshot)" = "$before" ] || fail "$label: a refused update changed a manifest"
+  printf 'ok: %s refuses without changing any manifest\n' "$label"
+}
+
+fixture
+if guard >"$WORK/guard.log" 2>&1; then fail 'pattern-form fixture unexpectedly passes enforcement'; fi
+grep -Fq 'pattern form' "$WORK/guard.log" || fail 'baseline refusal was not caused by the broad matcher'
+write_matchers >"$WORK/writer.log" 2>&1 || { cat "$WORK/writer.log" >&2; fail 'writer must narrow every registered consumer'; }
+guard >"$WORK/guard.log" 2>&1 || { cat "$WORK/guard.log" >&2; fail 'rewritten tree does not pass enforcement'; }
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/github-config/oci-repository.yaml")" = \
+  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@(1111111111111111111111111111111111111111|2222222222222222222222222222222222222222)$' ] || fail 'github-config did not receive its own exact pair'
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml")" = \
+  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(3333333333333333333333333333333333333333|2222222222222222222222222222222222222222)$' ] || fail 'consumer pairs crossed'
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/aws/oci-repository.yaml")" = \
+  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@1111111111111111111111111111111111111111$' ] || fail 'equal revisions were not deduplicated'
+[ "$(yq -r '.spec.interval' "$TREE/k8s/bases/apps/aws/oci-repository.yaml")" = 5m ] || fail 'unrelated YAML changed'
+grep -Fq '# Preserve this consumer comment.' "$TREE/k8s/bases/apps/aws/oci-repository.yaml" || fail 'consumer comment was lost'
+for file in "${GENERIC_FILES[@]}"; do cmp -s "$ROOT/$file" "$TREE/$file" || fail "generic subject $file changed"; done
+printf 'ok: exact consumer pairs, deduplication, unrelated fields and generic subjects\n'
+
+before="$(snapshot)"
+write_matchers >"$WORK/writer.log" 2>&1
+[ "$(snapshot)" = "$before" ] || fail 'unchanged input was not byte-idempotent'
+printf 'ok: unchanged input is a byte-identical no-op\n'
+
+# The real operational trigger: generator advances a pin, then writer converges before guard.
+awk -F '\t' -v OFS='\t' -v pin="$D" 'NR > 1 {$6=pin} {print}' "$SET" >"$WORK/moved.tsv"
+mv "$WORK/moved.tsv" "$SET"
+if guard >"$WORK/guard.log" 2>&1; then fail 'old matcher unexpectedly accepts a moved set'; fi
+grep -Fq 'not the generated pair' "$WORK/guard.log" || fail 'moved-set refusal had the wrong cause'
+write_matchers >"$WORK/writer.log" 2>&1
+guard >"$WORK/guard.log" 2>&1 || fail 'pin bump did not converge to a guard-clean tree'
+printf 'ok: a pin bump rewrites already narrowed matchers before enforcement\n'
+
+fixture
+sed '$d' "$SET" >"$WORK/incomplete.tsv"
+mv "$WORK/incomplete.tsv" "$SET"
+expect_atomic_refusal 'missing consumer' 'wedding-app'
+
+fixture
+yq -i '.spec.verify.matchOIDCIdentity += [{"issuer": ".*", "subject": ".*"}]' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml"
+expect_atomic_refusal 'additional identity' 'matchOIDCIdentity'
+
+fixture
+printf 'broken\n' >>"$SET"
+expect_atomic_refusal 'malformed final row' 'fields'
+
+fixture
+cp "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml" "$TREE/k8s/bases/apps/duplicate.yaml"
+expect_atomic_refusal 'duplicate consumer manifest' 'both'
+
+fixture
+SUBJECT='^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@main$' \
+  yq -i '.spec.verify.matchOIDCIdentity[0].subject = strenv(SUBJECT)' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml"
+expect_atomic_refusal 'unrecognised existing revision' 'revision'
+
+fixture
+cat >>"$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml" <<'EOF'
+---
+# This document is outside the matcher's ownership.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sibling
+data:
+  subject: untouched
+EOF
+write_matchers >"$WORK/writer.log" 2>&1
+[ "$(yq -r 'select(.kind == "ConfigMap") | .data.subject' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml")" = untouched ] ||
+  fail 'rewriting the OCIRepository changed an unrelated YAML document'
+guard >"$WORK/guard.log" 2>&1 || fail 'multi-document rewrite did not pass enforcement'
+printf 'ok: unrelated YAML documents retain their content\n'
+
+printf 'all matcher writer cases passed\n'

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -46,16 +46,21 @@ type workflow struct {
 // duplicate this file's parsing logic and trip the repository's duplication
 // gate for no benefit.
 type job struct {
-	Steps []step `yaml:"steps"`
+	Steps           []step `yaml:"steps"`
+	Needs           any    `yaml:"needs"`
+	If              string `yaml:"if"`
+	ContinueOnError any    `yaml:"continue-on-error"`
 }
 
 type step struct {
-	Run            string         `yaml:"run"`
-	Uses           string         `yaml:"uses"`
-	If             string         `yaml:"if"`
-	Shell          string         `yaml:"shell"`
-	TimeoutMinutes templatableInt `yaml:"timeout-minutes"`
-	With           stepInputs     `yaml:"with"`
+	Run             string            `yaml:"run"`
+	Uses            string            `yaml:"uses"`
+	If              string            `yaml:"if"`
+	Shell           string            `yaml:"shell"`
+	TimeoutMinutes  templatableInt    `yaml:"timeout-minutes"`
+	With            stepInputs        `yaml:"with"`
+	Env             map[string]string `yaml:"env"`
+	ContinueOnError any               `yaml:"continue-on-error"`
 }
 
 // templatableInt decodes an Actions integer field that MAY be written as an

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2919,9 +2919,9 @@ func cloneStringAnyMap(source map[string]any) map[string]any {
 	return clone
 }
 
-// authorizationSurfaceDocument removes only an immutable Helm dependency pin
-// from the approval projection. HelmRelease identity, chart/source identity,
-// values, post-renderers, substitutions, and reconciliation policy stay exact.
+// authorizationSurfaceDocument normalizes immutable Helm dependency pins and
+// strict signer subsets handled by the required approved-revisions guard.
+// Identity, source, values, post-renderers, substitutions and policy stay exact.
 // The required manifest job separately Helm-renders and security-scans the
 // selected chart version, so a routine Renovate pin does not require a manual
 // refresh of an otherwise unchanged authorization fingerprint.
@@ -2929,6 +2929,9 @@ func authorizationSurfaceDocument(
 	identity resourceIdentity,
 	document map[string]any,
 ) map[string]any {
+	if identity.kind == "OCIRepository" {
+		return publishMatcherSurfaceDocument(identity, document)
+	}
 	if !strings.HasPrefix(identity.apiVersion, "helm.toolkit.fluxcd.io/") || identity.kind != "HelmRelease" {
 		return document
 	}

--- a/scripts/validate-eks-ci-role-policy/publish_matcher_projection.go
+++ b/scripts/validate-eks-ci-role-policy/publish_matcher_projection.go
@@ -1,0 +1,79 @@
+package main
+
+import "strings"
+
+// publishMatcherSurfaceDocument recognizes only strict subsets of the shared
+// 40-hex signer pattern already covered by the authorization approval. The
+// required approved-revisions guard separately enforces each consumer's exact
+// generated pair. Issuer, workflow, artifact, identity count and all other
+// resource fields remain fingerprinted, so regeneration needs no hash refresh.
+func publishMatcherSurfaceDocument(identity resourceIdentity, document map[string]any) map[string]any {
+	if identity.apiVersion != "source.toolkit.fluxcd.io/v1" || identity.kind != "OCIRepository" {
+		return document
+	}
+	spec, ok := document["spec"].(map[string]any)
+	if !ok {
+		return document
+	}
+	var workflow string
+	switch spec["url"] {
+	case "oci://ghcr.io/devantler-tech/github-config/manifests", "oci://ghcr.io/devantler-tech/aws/manifests":
+		workflow = "publish-manifests"
+	case "oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests", "oci://ghcr.io/devantler-tech/wedding-app/manifests":
+		workflow = "publish-app"
+	default:
+		return document
+	}
+	verify, ok := spec["verify"].(map[string]any)
+	if !ok || verify["provider"] != "cosign" {
+		return document
+	}
+	identities, ok := verify["matchOIDCIdentity"].([]any)
+	if !ok || len(identities) != 1 {
+		return document
+	}
+	matcher, ok := identities[0].(map[string]any)
+	if !ok || matcher["issuer"] != `^https://token\.actions\.githubusercontent\.com$` {
+		return document
+	}
+	subject, ok := matcher["subject"].(string)
+	prefix := `^https://github\.com/devantler-tech/actions/\.github/workflows/` + workflow + `\.yaml@`
+	if !ok || !strings.HasPrefix(subject, prefix) || !strings.HasSuffix(subject, "$") {
+		return document
+	}
+	ref := strings.TrimSuffix(strings.TrimPrefix(subject, prefix), "$")
+	if !isExactPublishRevisionSet(ref) {
+		return document
+	}
+
+	projected := cloneStringAnyMap(document)
+	projectedSpec := cloneStringAnyMap(spec)
+	projectedVerify := cloneStringAnyMap(verify)
+	projectedMatcher := cloneStringAnyMap(matcher)
+	projectedMatcher["subject"] = prefix + `[0-9a-f]{40}$`
+	projectedVerify["matchOIDCIdentity"] = []any{projectedMatcher}
+	projectedSpec["verify"] = projectedVerify
+	projected["spec"] = projectedSpec
+	return projected
+}
+
+// isExactPublishRevisionSet accepts one concrete SHA or one parenthesized pair;
+// regular expressions, floating refs, and additional alternatives stay exact.
+func isExactPublishRevisionSet(ref string) bool {
+	if exactGitCommit.MatchString(ref) {
+		return true
+	}
+	if !strings.HasPrefix(ref, "(") || !strings.HasSuffix(ref, ")") {
+		return false
+	}
+	revisions := strings.Split(ref[1:len(ref)-1], "|")
+	if len(revisions) > 2 {
+		return false
+	}
+	for _, revision := range revisions {
+		if !exactGitCommit.MatchString(revision) {
+			return false
+		}
+	}
+	return true
+}

--- a/scripts/validate-eks-ci-role-policy/publish_matcher_projection_test.go
+++ b/scripts/validate-eks-ci-role-policy/publish_matcher_projection_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPublishMatcherProjectionAllowsOnlyNarrowerSignerSets proves that rotating
+// exact signer pairs preserves the existing approval without hiding other edits.
+func TestPublishMatcherProjectionAllowsOnlyNarrowerSignerSets(t *testing.T) {
+	const manifest = `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: consumer
+  namespace: consumer
+spec:
+  url: oci://ghcr.io/devantler-tech/github-config/manifests
+  ref:
+    semver: ">=1.0.0"
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@[0-9a-f]{40}$'
+`
+	entry := func(contents string) string {
+		t.Helper()
+		documents, err := decodeDocuments([]byte(contents))
+		if err != nil || len(documents) != 1 {
+			t.Fatalf("decode OCIRepository: documents=%d error=%v", len(documents), err)
+		}
+		before, err := canonicalFingerprint(documents[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err := authorizationSurfaceEntry(identityOf(documents[0]), documents[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		after, err := canonicalFingerprint(documents[0])
+		if err != nil || after != before {
+			t.Fatalf("projection mutated its input: before=%s after=%s error=%v", before, after, err)
+		}
+		return actual
+	}
+
+	a, b, c := strings.Repeat("1", 40), strings.Repeat("2", 40), strings.Repeat("3", 40)
+	consumers := []struct{ name, workflow string }{
+		{"github-config", "publish-manifests"},
+		{"ascoachingogvaner", "publish-app"},
+		{"aws", "publish-manifests"},
+		{"wedding-app", "publish-app"},
+	}
+	for _, consumer := range consumers {
+		t.Run(consumer.name, func(t *testing.T) {
+			original := strings.ReplaceAll(manifest, "github-config", consumer.name)
+			original = strings.ReplaceAll(original, "publish-manifests", consumer.workflow)
+			baseline := entry(original)
+			for _, ref := range []string{a, "(" + a + ")", "(" + a + "|" + b + ")", "(" + b + "|" + c + ")"} {
+				if entry(strings.Replace(original, "[0-9a-f]{40}", ref, 1)) != baseline {
+					t.Errorf("exact signer subset %q moved the approval fingerprint", ref)
+				}
+			}
+		})
+	}
+
+	baseline := entry(manifest)
+	narrowed := strings.Replace(manifest, "[0-9a-f]{40}", "("+a+"|"+b+")", 1)
+	mutations := []struct{ name, old, new string }{
+		{"different consumer", "github-config/manifests", "unregistered/manifests"},
+		{"different artifact", "github-config/manifests", "github-config/other"},
+		{"different workflow", "publish-manifests", "publish-app"},
+		{"different organization", "devantler-tech/actions", "untrusted/actions"},
+		{"different issuer", "token\\.actions\\.githubusercontent\\.com", ".*"},
+		{"different verifier", "provider: cosign", "provider: notation"},
+		{"different API", "source.toolkit.fluxcd.io/v1", "source.toolkit.fluxcd.io/v1beta2"},
+		{"different kind", "kind: OCIRepository", "kind: ConfigMap"},
+		{"floating tag", "semver: \">=1.0.0\"", "tag: latest"},
+		{"different namespace", "namespace: consumer", "namespace: privileged"},
+		{"additional identity", "    matchOIDCIdentity:\n", "    matchOIDCIdentity:\n      - issuer: '.*'\n        subject: '.*'\n"},
+		{"unanchored subject", "subject: '^https", "subject: 'https"},
+		{"unanchored suffix", b + ")$'", b + ")'"},
+		{"regex injection", "(" + a + "|" + b + ")", "(" + a + "|.*)"},
+		{"too many signers", "(" + a + "|" + b + ")", "(" + a + "|" + b + "|" + c + ")"},
+		{"branch signer", "(" + a + "|" + b + ")", "main"},
+		{"uppercase signer", "(" + a + "|" + b + ")", strings.Repeat("A", 40)},
+		{"wider character class", "(" + a + "|" + b + ")", "[0-9a-z]{40}"},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			changed := strings.Replace(narrowed, mutation.old, mutation.new, 1)
+			if changed == narrowed {
+				t.Fatal("mutation did not change the fixture")
+			}
+			if entry(changed) == baseline {
+				t.Fatal("a change beyond the exact signer subset escaped the approval fingerprint")
+			}
+		})
+	}
+}

--- a/scripts/validate-eks-ci-role-policy/publish_matcher_workflow_test.go
+++ b/scripts/validate-eks-ci-role-policy/publish_matcher_workflow_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 const approvedSignerGuard = "./scripts/guard-publish-workflow-approved-revisions.sh"
@@ -17,7 +20,6 @@ func TestApprovedSignerMembershipCoversPublicationRoutes(t *testing.T) {
 		file, gate, publisher, ref string
 	}{
 		{"ci.yaml", "changes", "deploy-prod", ""},
-		{"ci.yaml", "heal-prod-on-failure", "heal-prod-on-failure", "main"},
 		{"cd.yaml", "validate-eks-authorization", "deploy-prod", ""},
 		{"validate-main.yaml", "validate-eks-authorization", "", ""},
 		{"dr-rebuild.yaml", "supersession-gate", "rebuild", ""},
@@ -32,6 +34,82 @@ func TestApprovedSignerMembershipCoversPublicationRoutes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Recovery must use the policy shipped WITH the main checkout. During the
+// first narrowing rollout, main still legitimately has broad matchers. An
+// enforcing step in the speculative workflow would prevent restoring that
+// last deployed revision. Putting the guard first in the checked-out action
+// keeps new main strict without imposing future policy on an older revision.
+func TestApprovedSignerRecoveryUsesCheckedOutPolicy(t *testing.T) {
+	wf := loadWorkflows(t)["ci.yaml"]
+	if !restoresMainWithCheckedOutAction(wf.Jobs["heal-prod-on-failure"]) {
+		t.Error("recovery must use main's deploy action without a speculative signer-policy command")
+	}
+	body, err := os.ReadFile("../../.github/actions/deploy-prod/action.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var action struct {
+		Runs job `yaml:"runs"`
+	}
+	if err := yaml.Unmarshal(body, &action); err != nil {
+		t.Fatal(err)
+	}
+	if len(action.Runs.Steps) == 0 || !enforcesSignerMembership(action.Runs.Steps[0]) {
+		t.Error("the checked-out deploy action must enforce membership before tooling, credentials or publication")
+	}
+
+	valid := job{Steps: []step{
+		{Uses: "actions/checkout@pin", With: stepInputs{Ref: "main"}},
+		{Uses: prodDeployComposite},
+	}}
+	if !restoresMainWithCheckedOutAction(valid) {
+		t.Fatal("rejected recovery through main's versioned action")
+	}
+	for name, mutate := range map[string]func(*job){
+		"speculative policy": func(j *job) {
+			j.Steps = append(j.Steps[:1], step{Run: approvedSignerGuard}, j.Steps[1])
+		},
+		"no checkout":         func(j *job) { j.Steps = j.Steps[1:] },
+		"wrong ref":           func(j *job) { j.Steps[0].With.Ref = "" },
+		"skipped checkout":    func(j *job) { j.Steps[0].If = "false" },
+		"tolerated checkout":  func(j *job) { j.Steps[0].ContinueOnError = true },
+		"different publisher": func(j *job) { j.Steps[1].Uses = prodDeployComposite + "/publish-platform-manifests" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := job{Steps: append([]step(nil), valid.Steps...)}
+			mutate(&candidate)
+			if restoresMainWithCheckedOutAction(candidate) {
+				t.Fatal("accepted a recovery route detached from main's signer policy")
+			}
+		})
+	}
+}
+
+func restoresMainWithCheckedOutAction(j job) bool {
+	checkedOut := false
+	for _, s := range j.Steps {
+		if strings.Contains(s.Run, approvedSignerGuard) {
+			return false
+		}
+		if strings.HasPrefix(s.Uses, "actions/checkout@") {
+			if s.With.Ref != "main" || s.If != "" || errorIsTolerated(s.ContinueOnError) {
+				return false
+			}
+			checkedOut = true
+		}
+		if s.Uses == prodDeployComposite {
+			return checkedOut && s.If == "" && !errorIsTolerated(s.ContinueOnError)
+		}
+	}
+	return false
+}
+
+func enforcesSignerMembership(s step) bool {
+	return strings.TrimSpace(s.Run) == approvedSignerGuard &&
+		s.Env["APPROVED_REVISIONS_ENFORCE"] == "1" && s.If == "" &&
+		!errorIsTolerated(s.ContinueOnError) && (s.Shell == "" || s.Shell == "bash")
 }
 
 func approvedSignerRoute(wf workflow, gate, publisher, ref string) error {
@@ -81,9 +159,7 @@ func hasEnforcingSignerGuard(j job, ref string) bool {
 			}
 			checkedOut = true
 		}
-		if strings.TrimSpace(s.Run) == approvedSignerGuard && checkedOut &&
-			s.Env["APPROVED_REVISIONS_ENFORCE"] == "1" && s.If == "" &&
-			!errorIsTolerated(s.ContinueOnError) && (s.Shell == "" || s.Shell == "bash") {
+		if checkedOut && enforcesSignerMembership(s) {
 			guarded = true
 		}
 		if (s.Uses == prodDeployComposite || strings.HasPrefix(s.Uses, prodDeployComposite+"/")) && !guarded {

--- a/scripts/validate-eks-ci-role-policy/publish_matcher_workflow_test.go
+++ b/scripts/validate-eks-ci-role-policy/publish_matcher_workflow_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const approvedSignerGuard = "./scripts/guard-publish-workflow-approved-revisions.sh"
+
+// The fingerprint projection accepts fixed-SHA subsets of the previously
+// approved broad identity. Membership in the generated approval data is a
+// separate mandatory check, including on routes that publish without PR CI.
+func TestApprovedSignerMembershipCoversPublicationRoutes(t *testing.T) {
+	workflows := loadWorkflows(t)
+	for _, route := range []struct {
+		file, gate, publisher, ref string
+	}{
+		{"ci.yaml", "changes", "deploy-prod", ""},
+		{"ci.yaml", "heal-prod-on-failure", "heal-prod-on-failure", "main"},
+		{"cd.yaml", "validate-eks-authorization", "deploy-prod", ""},
+		{"validate-main.yaml", "validate-eks-authorization", "", ""},
+		{"dr-rebuild.yaml", "supersession-gate", "rebuild", ""},
+	} {
+		t.Run(route.file+"/"+route.gate, func(t *testing.T) {
+			wf, ok := workflows[route.file]
+			if !ok {
+				t.Fatalf("missing workflow %s", route.file)
+			}
+			if err := approvedSignerRoute(wf, route.gate, route.publisher, route.ref); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func approvedSignerRoute(wf workflow, gate, publisher, ref string) error {
+	g, ok := wf.Jobs[gate]
+	if !ok || !hasEnforcingSignerGuard(g, ref) {
+		return fmt.Errorf("%s must enforce approved signer membership on the checkout being published", gate)
+	}
+	if publisher == gate {
+		if !g.deploysProd() {
+			return fmt.Errorf("%s no longer identifies a publication route", publisher)
+		}
+		return nil
+	}
+	if g.If != "" || errorIsTolerated(g.ContinueOnError) {
+		return fmt.Errorf("%s must be a mandatory gate", gate)
+	}
+	if publisher == "" {
+		return nil
+	}
+	p, ok := wf.Jobs[publisher]
+	if !ok || !p.deploysProd() ||
+		(p.Needs != gate && !stringListIncludes(p.Needs, gate)) {
+		return fmt.Errorf("%s must depend on %s", publisher, gate)
+	}
+	// A status override could publish after the prerequisite failed or skipped.
+	for _, override := range []string{"always(", "failure(", "cancelled("} {
+		if strings.Contains(p.If, override) {
+			return fmt.Errorf("%s must require successful prerequisites", publisher)
+		}
+	}
+	if p.checksOutExplicitRef() {
+		return fmt.Errorf("%s must publish the revision checked by %s", publisher, gate)
+	}
+	return nil
+}
+
+func errorIsTolerated(value any) bool {
+	return value != nil && value != false
+}
+
+func hasEnforcingSignerGuard(j job, ref string) bool {
+	checkedOut, guarded := false, false
+	for _, s := range j.Steps {
+		if strings.HasPrefix(s.Uses, "actions/checkout@") {
+			if guarded || s.With.Ref != ref || s.If != "" || errorIsTolerated(s.ContinueOnError) {
+				return false
+			}
+			checkedOut = true
+		}
+		if strings.TrimSpace(s.Run) == approvedSignerGuard && checkedOut &&
+			s.Env["APPROVED_REVISIONS_ENFORCE"] == "1" && s.If == "" &&
+			!errorIsTolerated(s.ContinueOnError) && (s.Shell == "" || s.Shell == "bash") {
+			guarded = true
+		}
+		if (s.Uses == prodDeployComposite || strings.HasPrefix(s.Uses, prodDeployComposite+"/")) && !guarded {
+			return false
+		}
+	}
+	return guarded && !errorIsTolerated(j.ContinueOnError)
+}
+
+func TestApprovedSignerRouteRejectsBypasses(t *testing.T) {
+	fixture := func() workflow {
+		return workflow{Jobs: map[string]job{
+			"gate": {Steps: []step{
+				{Uses: "actions/checkout@pin"},
+				{Run: approvedSignerGuard, Env: map[string]string{"APPROVED_REVISIONS_ENFORCE": "1"}},
+			}},
+			"publish": {Needs: []any{"gate"}, Steps: []step{
+				{Uses: "actions/checkout@pin"}, {Uses: prodDeployComposite},
+			}},
+		}}
+	}
+	if err := approvedSignerRoute(fixture(), "gate", "publish", ""); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*job, *job){
+		"missing guard":         func(g, _ *job) { g.Steps = g.Steps[:1] },
+		"audit only":            func(g, _ *job) { g.Steps[1].Env["APPROVED_REVISIONS_ENFORCE"] = "0" },
+		"comment":               func(g, _ *job) { g.Steps[1].Run = "# " + approvedSignerGuard },
+		"echo":                  func(g, _ *job) { g.Steps[1].Run = "echo " + approvedSignerGuard },
+		"masked failure":        func(g, _ *job) { g.Steps[1].Run += " || true" },
+		"conditional step":      func(g, _ *job) { g.Steps[1].If = "false" },
+		"tolerated step":        func(g, _ *job) { g.Steps[1].ContinueOnError = true },
+		"conditional gate":      func(g, _ *job) { g.If = "false" },
+		"tolerated gate":        func(g, _ *job) { g.ContinueOnError = "${{ true }}" },
+		"no checkout":           func(g, _ *job) { g.Steps = g.Steps[1:] },
+		"different gate ref":    func(g, _ *job) { g.Steps[0].With.Ref = "main" },
+		"checkout after guard":  func(g, _ *job) { g.Steps = append(g.Steps, g.Steps[0]) },
+		"missing dependency":    func(_, p *job) { p.Needs = nil },
+		"failed prerequisite":   func(_, p *job) { p.If = "always()" },
+		"different publish ref": func(_, p *job) { p.Steps[0].With.Ref = "main" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			wf := fixture()
+			g, p := wf.Jobs["gate"], wf.Jobs["publish"]
+			mutate(&g, &p)
+			wf.Jobs["gate"], wf.Jobs["publish"] = g, p
+			if err := approvedSignerRoute(wf, "gate", "publish", ""); err == nil {
+				t.Fatal("accepted a route that can bypass signer approval")
+			}
+		})
+	}
+	// The restore job checks out main rather than the speculative merge ref.
+	// Its guard must precede publication inside that very same job.
+	g := fixture().Jobs["gate"]
+	g.Steps[0].With.Ref = "main"
+	g.Steps = append(g.Steps, step{Uses: prodDeployComposite})
+	if !hasEnforcingSignerGuard(g, "main") {
+		t.Fatal("rejected guarded restoration of main")
+	}
+	g.Steps[1], g.Steps[2] = g.Steps[2], g.Steps[1]
+	if hasEnforcingSignerGuard(g, "main") {
+		t.Fatal("accepted a guard that runs after publication")
+	}
+}

--- a/scripts/write-publish-workflow-matchers.sh
+++ b/scripts/write-publish-workflow-matchers.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Derive per-consumer cosign subjects from the generated approved revision set.
+# Validate every input and staged result before replacing any consumer manifest.
+# Generic multi-consumer subjects remain unchanged. Unchanged output preserves bytes.
+set -euo pipefail
+
+WRITER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/publish-workflow-approved-revisions.lib.sh
+source "$WRITER_DIR/publish-workflow-approved-revisions.lib.sh"
+
+readonly FIXED_REF_RE='^([0-9a-f]{40}|\([0-9a-f]{40}\)|\([0-9a-f]{40}\|[0-9a-f]{40}\))$'
+STAGED="$(mktemp -d "${TMPDIR:-/tmp}/write-publish-workflow-matchers.XXXXXX")"
+trap 'rm -rf "$STAGED"' EXIT
+
+# Include the generic files so the ordinary guard validates the complete scope.
+# The shared discovery has already rejected every unattributed source-tree subject.
+for generic in "${GENERIC_SUBJECT_FILES[@]}"; do
+  mkdir -p "$STAGED/$(dirname "$generic")"
+  cp "$SCAN_ROOT/$generic" "$STAGED/$generic"
+done
+
+for consumer in "${EXPECTED_CONSUMERS[@]}"; do
+  record="$(lookup "$observed" "$consumer")"
+  [ -n "$record" ] || refuse "no OCIRepository is attributed to registered consumer $consumer"
+  IFS=$'\t' read -r file workflow ref <<<"$record"
+  IFS=$'\t' read -r set_workflow signer pin <<<"$(lookup "$approved" "$consumer")"
+  [ "$workflow" = "$set_workflow" ] || refuse "$consumer: $file names $workflow but the approved set names $set_workflow"
+  [ "$ref" = "$PATTERN_REF" ] || [[ "$ref" =~ $FIXED_REF_RE ]] ||
+    refuse "$consumer: unrecognised existing revision '$ref'; review the source identity before rewriting"
+  [ ! -L "$SCAN_ROOT/$file" ] && [ -w "$SCAN_ROOT/$file" ] ||
+    refuse "$consumer: source manifest must be a writable regular file, not a symlink"
+
+  pair="$signer"
+  [ "$signer" = "$pin" ] || pair="($signer|$pin)"
+  subject="${SUBJECT_PREFIX}${workflow#publish-}"'\.yaml@'"$pair"'$'
+  mkdir -p "$STAGED/$(dirname "$file")"
+  # Select the actual OCIRepository document; unrelated documents remain unchanged.
+  # shellcheck disable=SC2016
+  MATCHER_SUBJECT="$subject" yq eval \
+    '(. | select(.kind == "OCIRepository") | .spec.verify.matchOIDCIdentity[0].subject) = strenv(MATCHER_SUBJECT)' \
+    "$SCAN_ROOT/$file" >"$STAGED/$file"
+done
+
+APPROVED_REVISIONS_FILE="$APPROVED_SET" PUBLISH_CONSUMER_ROOT="$STAGED" \
+  APPROVED_REVISIONS_ENFORCE=1 bash "$WRITER_DIR/guard-publish-workflow-approved-revisions.sh"
+
+changed=0
+for consumer in "${EXPECTED_CONSUMERS[@]}"; do
+  IFS=$'\t' read -r file _workflow _ref <<<"$(lookup "$observed" "$consumer")"
+  if ! cmp -s "$STAGED/$file" "$SCAN_ROOT/$file"; then
+    cat "$STAGED/$file" >"$SCAN_ROOT/$file"
+    changed=$((changed + 1))
+    printf 'updated %s\n' "$file"
+  fi
+done
+printf 'write-publish-workflow-matchers: %d consumer matcher(s) changed\n' "$changed"

--- a/scripts/write-publish-workflow-matchers.sh
+++ b/scripts/write-publish-workflow-matchers.sh
@@ -27,8 +27,9 @@ for consumer in "${EXPECTED_CONSUMERS[@]}"; do
   [ "$workflow" = "$set_workflow" ] || refuse "$consumer: $file names $workflow but the approved set names $set_workflow"
   [ "$ref" = "$PATTERN_REF" ] || [[ "$ref" =~ $FIXED_REF_RE ]] ||
     refuse "$consumer: unrecognised existing revision '$ref'; review the source identity before rewriting"
-  [ ! -L "$SCAN_ROOT/$file" ] && [ -w "$SCAN_ROOT/$file" ] ||
+  if [ -L "$SCAN_ROOT/$file" ] || [ ! -f "$SCAN_ROOT/$file" ] || [ ! -w "$SCAN_ROOT/$file" ]; then
     refuse "$consumer: source manifest must be a writable regular file, not a symlink"
+  fi
 
   pair="$signer"
   [ "$signer" = "$pin" ] || pair="($signer|$pin)"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Narrow each consumer’s accepted signing revisions to its approved deployed-signer/current-pin pair. Scheduled regeneration updates the matchers together with the approval data, and CI prevents broad matcher patterns from returning.

Implements #3569. Part of #3308. #3569 remains open for its post-deployment observation on the next consumer publication.
