### PR TITLE
fix(kyverno): refuse tenant selector keys that name a reserved identity, namespace or cluster

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-network-policies.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-network-policies.yaml
@@ -22,6 +22,25 @@
 #     `matchLabels`, or a `matchExpressions` entry whose operator is `In` — so
 #     `Exists`, `DoesNotExist` and `NotIn` are refused by default rather than
 #     enumerated.
+#   * A source/destination EndpointSelector whose KEYS name something the
+#     namespace boundary exists to hold out. A selector can be non-empty and
+#     use only whitelisted operators and still reach the same broad target an
+#     entity or a CIDR is refused for, because Cilium exposes three things as
+#     ordinary selectable labels: reserved identities (`reserved:world`,
+#     `reserved:host`, …), the pod namespace (`k8s:io.kubernetes.pod.namespace`
+#     and the `io.cilium.k8s.namespace.labels.` prefix — a selector is scoped
+#     to the policy's own namespace only while it carries no namespace key, so
+#     naming one overrides that scoping), and the cluster name
+#     (`io.cilium.k8s.policy.cluster`, the selector spelling of `cluster-mesh`).
+#     A key with no source prefix defaults to `any:`, which matches a label
+#     from EVERY source — reserved included — so the bare names (`world`,
+#     `host`, …) and the explicit `any:` spelling are refused alongside the
+#     `reserved:` one. A tenant label that happens to share a reserved name is
+#     written `k8s:cluster`: the prefix pins the source, so it can only ever
+#     match a pod label. Both `matchLabels` keys and `matchExpressions` keys are
+#     read, so the `In` form cannot smuggle a key the map form refuses. The
+#     carve-outs mirror the entity whitelist exactly: `reserved:kube-apiserver`
+#     on both sides, and `reserved:ingress` on the INGRESS side only.
 #   * Any entity but `kube-apiserver` — plus, on the INGRESS side only, `ingress`,
 #     the narrow identity Cilium gives traffic that has already passed the shared
 #     Gateway, which tenant-authored HTTPRoute workloads legitimately name.
@@ -99,8 +118,9 @@ metadata:
       Blocks tenant-applied CiliumNetworkPolicy resources in ksail tenant
       namespaces from dissolving the generated default-deny floor: every
       ingress source and egress destination selector must carry a real
-      constraint, only `kube-apiserver` (and `ingress` on the ingress side) may be
-      named as an entity, CIDR
+      constraint and may not name a reserved identity, another namespace or
+      another cluster by label key, only `kube-apiserver` (and `ingress` on the
+      ingress side) may be named as an entity, CIDR
       prefixes shorter than /16 are refused, and the generated `default-deny` and
       `allow-dns` names are reserved. Ordinary additive allow-lists are
       unaffected, as are policies applied by flux-system's kustomize-controller
@@ -137,8 +157,15 @@ spec:
         message: >-
           Every ingress source in a tenant CiliumNetworkPolicy must be
           constrained. A fromEndpoints selector with no matchLabels and no
-          matchExpressions allows all sources; only `kube-apiserver` and the
-          post-Gateway `ingress` identity may be named; and a CIDR prefix shorter than /16 reaches outside this
+          matchExpressions allows all sources; a selector key naming a reserved
+          identity (`reserved:host`, or its bare/`any:` spelling), another
+          namespace (`k8s:io.kubernetes.pod.namespace`,
+          `io.cilium.k8s.namespace.labels.*`) or another cluster
+          (`io.cilium.k8s.policy.cluster`) reaches the same broad source — pin a
+          tenant label with the `k8s:` prefix instead, and name the post-Gateway
+          identity as `reserved:ingress` or `fromEntities: [ingress]`; only
+          `kube-apiserver` and the post-Gateway `ingress` identity may be named
+          as an entity; and a CIDR prefix shorter than /16 reaches outside this
           namespace. A rule with only toPorts and no source at all allows every
           source on that port. Cilium unions allow rules, so one unconstrained
           source removes this namespace's isolation regardless of the generated
@@ -155,6 +182,27 @@ spec:
               - key: "{{ length(request.object.spec.ingress[].fromEndpoints[] || `[]`) }}"
                 operator: NotEquals
                 value: "{{ length(request.object.spec.ingress[].fromEndpoints[] || `[]` | [?matchLabels || length(matchExpressions[?operator == 'In'] || `[]`) > `0`]) }}"
+              # WHITELIST OF KEYS: a selector that passed the presence check
+              # above is still unconstrained when what it NAMES is a reserved
+              # identity, another namespace or another cluster — Cilium exposes
+              # all three as ordinary labels (see the header). Read every key a
+              # selector carries, matchLabels AND matchExpressions, and count
+              # the selectors naming one; that count must be zero. Keys are
+              # matched in all three source spellings — `reserved:`/`k8s:`, the
+              # explicit `any:`, and no prefix at all (which Cilium defaults to
+              # `any:`) — so the map form and the `In` form fail the same way.
+              # Carved out, mirroring the entity whitelist: `reserved:kube-apiserver`
+              # and, on this side only, `reserved:ingress` (each with its
+              # bare/`any:` spelling) — the selector forms of the two entities
+              # the next condition permits.
+              # `[.]` rather than `\.` in the pattern: this scalar is
+              # double-quoted YAML, where a backslash escape would not survive.
+              # `(matchLabels && keys(matchLabels)) || `[]`` rather than
+              # `keys(matchLabels || `{}`)`: keys() of a missing map errors,
+              # and a Kyverno condition that errors never denies.
+              - key: "{{ length(request.object.spec.ingress[].fromEndpoints[] || `[]` | [?length([(matchLabels && keys(matchLabels)) || `[]`, matchExpressions[].key || `[]`][] | [?regex_match('^(reserved:|(any:)?(unknown|host|world|world-ipv4|world-ipv6|unmanaged|health|init|remote-node|kube-apiserver|ingress|cluster|cluster-mesh|all|none)$|(k8s:|any:)?io[.]kubernetes[.]pod[.]namespace$|(k8s:|any:)?io[.]cilium[.]k8s[.](namespace[.]labels[.]|policy[.]cluster$))', @) && @ != 'reserved:kube-apiserver' && @ != 'kube-apiserver' && @ != 'any:kube-apiserver' && @ != 'reserved:ingress' && @ != 'ingress' && @ != 'any:ingress']) > `0`]) }}"
+                operator: GreaterThan
+                value: 0
               # A rule carrying ONLY toPorts and no layer-3 stanza is a fifth
               # spelling of allow-all: Cilium's own layer-4 examples pair a port
               # with a source, and a port-only ingress rule permits every source
@@ -215,8 +263,14 @@ spec:
         message: >-
           Every egress destination in a tenant CiliumNetworkPolicy must be
           constrained. A toEndpoints selector with no matchLabels and no
-          matchExpressions allows all destinations; `kube-apiserver` is the only
-          entity a tenant may name; and a CIDR prefix shorter than /16 reaches outside this
+          matchExpressions allows all destinations; a selector key naming a
+          reserved identity (`reserved:world`, or its bare/`any:` spelling),
+          another namespace (`k8s:io.kubernetes.pod.namespace`,
+          `io.cilium.k8s.namespace.labels.*`) or another cluster
+          (`io.cilium.k8s.policy.cluster`) reaches the same broad destination —
+          pin a tenant label with the `k8s:` prefix instead; `kube-apiserver` is
+          the only entity a tenant may name; and a CIDR prefix shorter than /16
+          reaches outside this
           namespace, as do a rule with only toPorts, a toFQDNs pattern of `*`,
           and a toServices entry that names no service.
           Name the destinations this workload actually needs.
@@ -226,6 +280,13 @@ spec:
               - key: "{{ length(request.object.spec.egress[].toEndpoints[] || `[]`) }}"
                 operator: NotEquals
                 value: "{{ length(request.object.spec.egress[].toEndpoints[] || `[]` | [?matchLabels || length(matchExpressions[?operator == 'In'] || `[]`) > `0`]) }}"
+              # Selector KEY whitelist — same shape and reasoning as the ingress
+              # rule. The only carve-out here is `reserved:kube-apiserver` (with
+              # its bare/`any:` spelling), mirroring the egress entity whitelist;
+              # `reserved:ingress` is a SOURCE identity and has no egress case.
+              - key: "{{ length(request.object.spec.egress[].toEndpoints[] || `[]` | [?length([(matchLabels && keys(matchLabels)) || `[]`, matchExpressions[].key || `[]`][] | [?regex_match('^(reserved:|(any:)?(unknown|host|world|world-ipv4|world-ipv6|unmanaged|health|init|remote-node|kube-apiserver|ingress|cluster|cluster-mesh|all|none)$|(k8s:|any:)?io[.]kubernetes[.]pod[.]namespace$|(k8s:|any:)?io[.]cilium[.]k8s[.](namespace[.]labels[.]|policy[.]cluster$))', @) && @ != 'reserved:kube-apiserver' && @ != 'kube-apiserver' && @ != 'any:kube-apiserver']) > `0`]) }}"
+                operator: GreaterThan
+                value: 0
               # Port-only egress rules permit every destination on that port —
               # see the ingress note above.
               - key: "{{ length(request.object.spec.egress[] || `[]`) }}"

--- a/scripts/tests/test-restrict-tenant-network-policies.sh
+++ b/scripts/tests/test-restrict-tenant-network-policies.sh
@@ -30,11 +30,11 @@ expect_summary() {
   fi
 }
 
-# 1. The tenant fixture set: 33 boundary-dissolving shapes denied, the ordinary
+# 1. The tenant fixture set: 45 boundary-dissolving shapes denied, the ordinary
 #    additive allow-lists admitted. A drop in the fail count means a shape that
 #    used to be refused now admits.
 apply "${tests}/resources.yaml" "${tests}/values.yaml" "${tests}/user-info.yaml"
-expect_summary "pass: 137, fail: 33, warn: 0, error: 0, skip: 0" \
+expect_summary "pass: 185, fail: 45, warn: 0, error: 0, skip: 0" \
   "tenant CiliumNetworkPolicy boundary"
 
 # 2. Carve-out: kyverno's background controller owns the generated floor. These
@@ -47,10 +47,14 @@ expect_summary "pass: 0, fail: 0, warn: 0, error: 0, skip: 0" \
 
 # 3. CONTROL for 2: the identical bodies, in the identical namespace, submitted
 #    by the TENANT. Only the applying identity differs. Without this the zero
-#    above is indistinguishable from the policy simply not matching.
+#    above is indistinguishable from the policy simply not matching. Both bodies
+#    fail the reserved-name rule; allow-dns ALSO fails the egress rule, because
+#    it reaches CoreDNS by naming kube-system through the namespace label — the
+#    cross-namespace selector a tenant is refused (#3399). The generated floor
+#    is exempt from that only through its applying identity, which is the point.
 apply "${tests}/kyverno-author/resources.yaml" \
   "${tests}/kyverno-author/values.yaml" "${tests}/user-info.yaml"
-expect_summary "pass: 8, fail: 2, warn: 0, error: 0, skip: 0" \
+expect_summary "pass: 7, fail: 3, warn: 0, error: 0, skip: 0" \
   "control: a tenant must NOT be able to author the reserved generated names"
 
 # 4. Carve-out: platform-authored policies applied by flux-system's

--- a/tests/restrict-tenant-network-policies/kyverno-test.yaml
+++ b/tests/restrict-tenant-network-policies/kyverno-test.yaml
@@ -154,3 +154,51 @@ results:
       - tenant-ns/allow-web-egress-selected-service
     kind: CiliumNetworkPolicy
     result: pass
+  # ── Selector KEYS that name an identity, a namespace or a cluster ──────────
+  # Every one of these is non-empty and uses only whitelisted operators, so the
+  # presence and operator checks read it as constrained. Cilium exposes reserved
+  # identities, the pod namespace and the cluster name as selectable labels, so
+  # each reaches a destination the entity whitelist or the namespace scoping
+  # refuses. All were measured ADMITTED before the key check landed.
+  - policy: restrict-tenant-network-policies
+    rule: cnp-egress-destinations-must-be-constrained
+    resources:
+      - tenant-ns/attack-selector-reserved-world-egress
+      - tenant-ns/attack-selector-bare-world-egress
+      - tenant-ns/attack-selector-any-host-egress
+      - tenant-ns/attack-selector-reserved-expression-egress
+      - tenant-ns/attack-selector-cross-namespace-egress
+      - tenant-ns/attack-selector-cross-namespace-expression-egress
+      - tenant-ns/attack-selector-namespace-labels-egress
+      - tenant-ns/attack-selector-cluster-name-egress
+      - tenant-ns/attack-selector-reserved-beside-constrained-egress
+    kind: CiliumNetworkPolicy
+    result: fail
+  - policy: restrict-tenant-network-policies
+    rule: cnp-ingress-sources-must-be-constrained
+    resources:
+      - tenant-ns/attack-selector-reserved-host-ingress
+      - tenant-ns/attack-selector-cross-namespace-ingress
+      - tenant-ns/attack-selector-bare-namespace-ingress
+    kind: CiliumNetworkPolicy
+    result: fail
+  # CONTROL: the ingress-side `reserved:ingress` carve-out, and source-prefixed
+  # ordinary keys (including a k8s label named like a reserved identity), stay
+  # admitted by BOTH rules — a key check that refused these would refuse the
+  # spelling its own message recommends.
+  - policy: restrict-tenant-network-policies
+    rule: cnp-ingress-sources-must-be-constrained
+    resources:
+      - tenant-ns/allow-web-ingress-from-ingress-selector
+      - tenant-ns/allow-web-egress-k8s-prefixed-labels
+      - tenant-ns/allow-web-egress-to-kube-apiserver-selector
+    kind: CiliumNetworkPolicy
+    result: pass
+  - policy: restrict-tenant-network-policies
+    rule: cnp-egress-destinations-must-be-constrained
+    resources:
+      - tenant-ns/allow-web-ingress-from-ingress-selector
+      - tenant-ns/allow-web-egress-k8s-prefixed-labels
+      - tenant-ns/allow-web-egress-to-kube-apiserver-selector
+    kind: CiliumNetworkPolicy
+    result: pass

--- a/tests/restrict-tenant-network-policies/resources.yaml
+++ b/tests/restrict-tenant-network-policies/resources.yaml
@@ -679,3 +679,280 @@ spec:
             serviceName: db
         - k8sServiceSelector:
             selector: {}
+---
+# ── DENY cases: selector KEYS that name an identity, a namespace or a cluster ─
+# Each selector below is non-empty and uses only the whitelisted operators, so
+# every earlier condition reads it as "constrained". What it names is the
+# problem: Cilium exposes reserved identities, the pod namespace and the cluster
+# name as ordinary selectable labels, so a selector can reach the same broad
+# destination an entity or a CIDR is refused for. Each was measured ADMITTED
+# before the key check landed.
+# ATTACK: the world identity, spelled as a label instead of an entity.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-reserved-world-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            reserved:world: ""
+---
+# ATTACK: the same identity with NO source prefix. Cilium defaults a
+# prefix-less selector key to `any:`, which matches a label from every source
+# — reserved included — so `world` alone selects the world identity.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-bare-world-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            world: ""
+---
+# ATTACK: the explicit `any:` spelling of the host identity.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-any-host-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            any:host: ""
+---
+# ATTACK: a reserved identity named through the matchExpressions `In` form,
+# which the operator whitelist accepts.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-reserved-expression-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchExpressions:
+            - key: reserved:remote-node
+              operator: In
+              values:
+                - ""
+---
+# ATTACK: another namespace, named through the namespace label. Cilium scopes a
+# toEndpoints selector to the policy's own namespace only when no namespace
+# key is present; this key overrides that scoping.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-cross-namespace-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+---
+# ATTACK: the same namespace key through the `In` form, listing two namespaces.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-cross-namespace-expression-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+                - kube-system
+                - flux-system
+---
+# ATTACK: a namespace selected by one of ITS labels rather than its name — the
+# `io.cilium.k8s.namespace.labels.` prefix Cilium projects onto every pod.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-namespace-labels-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: kube-system
+---
+# ATTACK: another cluster, named through the cluster-name label — the selector
+# spelling of the refused `cluster-mesh` entity.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-cluster-name-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.cilium.k8s.policy.cluster: other-cluster
+---
+# ATTACK: a reserved identity sitting BESIDE a properly pinned selector. Cilium
+# unions allow rules, so the broad entry decides — the check has to be per
+# selector, not "does this policy pin any ordinary label".
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-reserved-beside-constrained-egress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: db
+        - matchLabels:
+            reserved:world: ""
+---
+# ATTACK, ingress side: the host identity as a source label.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-reserved-host-ingress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            reserved:host: ""
+---
+# ATTACK, ingress side: every pod of another namespace as a source.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-cross-namespace-ingress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+---
+# ATTACK, ingress side: the namespace key with NO source prefix (`any:`).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: attack-selector-bare-namespace-ingress
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+---
+# ── ADMIT cases: the narrow identity, and ordinary source-prefixed keys ───────
+# OK: the post-Gateway `ingress` identity as a SOURCE label — the selector
+# spelling of the `fromEntities: [ingress]` carve-out, and the one reserved
+# identity a tenant workload legitimately names on the ingress side.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-web-ingress-from-ingress-selector
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            reserved:ingress: ""
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+# OK: ordinary workload labels written WITH the `k8s:` source prefix, including
+# a Kubernetes label that happens to be named like a reserved identity. The
+# prefix pins the source, so `k8s:cluster` can only ever match a pod label and
+# never the identity — this is the spelling the deny message points a tenant
+# at, so it has to keep passing.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-web-egress-k8s-prefixed-labels
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:app: db
+            k8s:cluster: blue
+          matchExpressions:
+            - key: k8s:tier
+              operator: In
+              values:
+                - backend
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+# OK: the kube-apiserver identity as a DESTINATION label — the selector
+# spelling of the `toEntities: [kube-apiserver]` carve-out, so the key check
+# mirrors the entity whitelist on the egress side exactly as it does on ingress.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-web-egress-to-kube-apiserver-selector
+  namespace: tenant-ns
+spec:
+  endpointSelector:
+    matchLabels:
+      app: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            reserved:kube-apiserver: ""
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Tenants write their own Cilium network policies inside their namespace, and the platform's admission guard refuses the spellings that would dissolve the namespace boundary — naming `world` as an entity, a wide CIDR, an empty selector. Two review findings showed a gap: a selector can reach the same broad targets by **label key**, because Cilium exposes reserved identities (`world`, `host`, …), the pod namespace and the cluster name as ordinary selectable labels — and the guard only checked that a selector was non-empty. Twelve such policies were measured admitted.

### What

The guard now reads every selector key (map and expression forms, in every source spelling) and refuses one that names a reserved identity, another namespace or another cluster. The two identities the entity whitelist already permits stay allowed in selector form too (`kube-apiserver`, and `ingress` on the ingress side), and the deny message names the spelling a tenant should use instead. Ordinary tenant allow-lists are unaffected.

**Security floor gained:** a tenant policy can no longer reach reserved identities, other namespaces or other clusters through a selector. **Everyday path cost:** unchanged for ordinary labels; a tenant label that happens to share a reserved name (for example `cluster`) is written with the `k8s:` prefix, which the deny message says.

Fixes #3397
Fixes #3399
