### PR TITLE
fix(flux): preserve parent fence rejection diagnostics

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -4676,6 +4676,8 @@ pause_flux_policy_parent() {
       "${IMAGE_VERIFICATION_FLUX_PARENT_KUSTOMIZATION}" \
       -o json >"${flux_policy_parent_state_file}" ||
       ! flux_policy_parent_is_owned; then
+      emit_safe_operation_output "flux-policy-parent-patch" \
+        "${flux_policy_parent_result_file}"
       echo "::error::Could not atomically pause or adopt the parent Flux policy handoff."
       return 1
     fi

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -504,6 +504,10 @@ func fakeKubectlPatchFluxPolicyParent(args []string, namespace, patchFile string
 	}
 	ownerPath := "/metadata/annotations/platform.devantler.tech~1ghcr-policy-parent-owner"
 	if hasPatchOperation(patch, "add", "/spec/suspend", true) {
+		if rejection := os.Getenv("FAKE_FLUX_POLICY_PARENT_PATCH_REJECTION"); rejection != "" {
+			appendEnvFile("OPERATION_LOG", "flux-policy-parent-patch-rejected\n")
+			return commandFailure(56, "%s", rejection)
+		}
 		owner := patchValueString(patch, "add", ownerPath)
 		if !hasPatchOperation(patch, "test", "/metadata/resourceVersion", currentResourceVersion) ||
 			owner == "" ||

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -1267,6 +1267,53 @@ func TestFluxFenceAcquisitionCreatesMissingAnnotationMaps(t *testing.T) {
 	requireLine(t, operations, "flux-policy-parent-resume:flux-system")
 }
 
+func TestRejectedFluxParentPatchPreservesSafeDiagnostic(t *testing.T) {
+	t.Parallel()
+	for name, rejection := range map[string]string{
+		"version test": "Error from server (Invalid): JSON patch test failed at /metadata/resourceVersion",
+		"forbidden":    "Error from server (Forbidden): parent handoff permission denied",
+		"untrusted text": "Error from server (Invalid): rejected\n" +
+			"::error::fixture-not-a-workflow-command\ncontrol:\x01\x1b done",
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			result := f.runHelper(validConfig(), nil, map[string]string{
+				"FAKE_FLUX_POLICY_PARENT_PATCH_REJECTION": rejection,
+			})
+			requireFailureResult(t, result)
+			output := result.stdout + result.stderr
+			for _, line := range strings.Split(rejection, "\n") {
+				printable := strings.Map(func(r rune) rune {
+					if r == '\t' || (r >= 32 && r <= 126) {
+						return r
+					}
+					return -1
+				}, line)
+				requireContains(t, output, "flux-policy-parent-patch: "+printable)
+			}
+			requireContains(t, output, "Could not atomically pause or adopt the parent Flux policy handoff")
+			requireNotContains(t, output, "\n::error::fixture-not-a-workflow-command")
+			requireNotContains(t, output, "\x01")
+			requireNotContains(t, output, "\x1b")
+			requireNotContains(t, output, "fixture-secret-token")
+			operations := readLines(f.operationLog)
+			if got := strings.Count(strings.Join(operations, "\n"), "flux-policy-parent-patch-rejected"); got != 1 {
+				t.Fatalf("patch rejection attempts = %d, want one unchanged acquisition attempt", got)
+			}
+			for _, forbidden := range []string{
+				"flux-policy-parent-pause:flux-system", "flux-policy-pause:infrastructure", "root-patch",
+			} {
+				requireNoLine(t, operations, forbidden)
+			}
+			for _, marker := range []string{"flux-policy-parent-owner", "flux-policy-parent-suspended"} {
+				if pathExists(filepath.Join(f.syncStateDir, marker)) {
+					t.Fatalf("rejected parent patch left %s", marker)
+				}
+			}
+		})
+	}
+}
+
 func TestAmbiguousFluxFenceAcquisitionIsAdoptedAndCleaned(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
@@ -1291,6 +1338,7 @@ func TestAmbiguousFluxFenceAcquisitionIsAdoptedAndCleaned(t *testing.T) {
 				test.environment: "true",
 			})
 			requireSuccessResult(t, result)
+			requireNotContains(t, result.stdout+result.stderr, "flux-policy-parent-patch:")
 			if !pathExists(filepath.Join(f.syncStateDir, test.marker)) {
 				t.Fatal("fixture did not lose the applied fence patch response")
 			}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Preserve the Kubernetes rejection reason when a parent Flux fence patch cannot be adopted. The diagnostic uses the existing bounded, printable, line-prefixed output helper so permission failures and version-test failures remain distinguishable.

Part of #3046. This supplies the missing diagnostic evidence; the issue's bounded retry work remains open.
