### PR TITLE
fix(security): pin the ksail release identity to its release-tag grammar in both image verifiers

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -122,12 +122,20 @@ spec:
           identities:
             - issuer: https://token.actions.githubusercontent.com
               subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$
+    # ksail images are signed by ksail's OWN release pipeline (cd.yaml). The
+    # ref is pinned to the release-tag GRAMMAR, not merely to `v*`: cd.yaml
+    # signs on any `v*` tag push and checks nothing about the tag itself, so a
+    # `v.+` ref clause would accept refs/tags/vanything and refs/tags/v/../evil,
+    # which are tags in shape only. Same OCI-semver grammar and same DELIBERATE
+    # no-length-cap difference as the provider identity above; kept
+    # byte-identical to the Talos ImageVerificationConfig rule by the inventory
+    # test. The publisher's own check is tracked at devantler-tech/ksail#6895.
     - name: ksailcd
       cosign:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$
   validations:
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)

--- a/scripts/tests/test-inventory-first-party-image-signatures.sh
+++ b/scripts/tests/test-inventory-first-party-image-signatures.sh
@@ -372,6 +372,87 @@ else
   failures=$((failures + 1))
 fi
 
+# --- 12b. the ksail identity pins the SAME RELEASE-TAG GRAMMAR ---------------
+# ksail's cd.yaml signs on any `v*` tag push and performs no grammar check of its own
+# (devantler-tech/ksail#6895 tracks the publisher's half), so the refs that can reach a
+# signature are exactly `v*` — wider than "a release". `v.+$` constrained only the first
+# character after the slash, so refs/tags/vanything and refs/tags/v/../evil satisfied every
+# clause of the identity. Same parity rule as section 12: admission (Kyverno) and the kubelet
+# pull (Talos) must carry the same identity AND issuer, or a ksail image accepted by one is
+# refused by the other as an ImagePullBackOff neither file explains alone.
+talos_ksail_identity="$(yq -r '.rules[] | select(.image == "ghcr.io/devantler-tech/ksail*") | .keyless.subjectRegex' "$real")"
+talos_ksail_issuer="$(yq -r '.rules[] | select(.image == "ghcr.io/devantler-tech/ksail*") | .keyless.issuer' "$real")"
+kyverno_ksail_identity="$(yq -r '.spec.attestors[] | select(.name == "ksailcd") | .cosign.keyless.identities[].subjectRegExp' "$kyverno_policy")"
+kyverno_ksail_issuer="$(yq -r '.spec.attestors[] | select(.name == "ksailcd") | .cosign.keyless.identities[].issuer' "$kyverno_policy")"
+
+if [ -z "$talos_ksail_identity" ] || [ "$talos_ksail_identity" = "null" ]; then
+  echo "FAIL  no ksail subjectRegex in ${real}"
+  failures=$((failures + 1))
+elif [ "$talos_ksail_identity" != "$kyverno_ksail_identity" ]; then
+  echo "FAIL  the ksail identity differs between the Talos and Kyverno verifiers"
+  echo "        talos:   ${talos_ksail_identity}"
+  echo "        kyverno: ${kyverno_ksail_identity}"
+  failures=$((failures + 1))
+elif [ -z "$talos_ksail_issuer" ] || [ "$talos_ksail_issuer" = "null" ] || [ "$talos_ksail_issuer" != "$kyverno_ksail_issuer" ]; then
+  echo "FAIL  the ksail ISSUER differs between the Talos and Kyverno verifiers"
+  echo "        talos:   ${talos_ksail_issuer}"
+  echo "        kyverno: ${kyverno_ksail_issuer}"
+  failures=$((failures + 1))
+else
+  echo "ok    ksail identity: Talos and Kyverno carry the same regex and issuer"
+fi
+
+# The identity binds nothing unless Kyverno ROUTES ghcr.io/devantler-tech/ksail* images to it —
+# the same guard section 12 applies to the provider attestor.
+ksail_validation="$(yq -r '
+  [ .spec.validations[]
+    | select(.expression | test("startsWith\\(.ghcr\\.io/devantler-tech/ksail.\\)"))
+    | select(.expression | test("attestors\\.ksailcd")) ] | length' "$kyverno_policy")"
+if [ "$ksail_validation" != "1" ]; then
+  echo "FAIL  expected exactly 1 Kyverno validation routing ksail* to attestors.ksailcd, found ${ksail_validation}"
+  failures=$((failures + 1))
+else
+  echo "ok    ksail identity: Kyverno routes ksail* to attestors.ksailcd"
+fi
+
+# accept -> a real release tag (semantic-release publishes vMAJOR.MINOR.PATCH, prereleases allowed).
+# reject -> a ref that is a tag only in shape; the verifier must not accept what a release never is.
+ksail_identity_prefix='https://github.com/devantler-tech/ksail/.github/workflows/cd.yaml@refs/tags/'
+ksail_grammar_failures=0
+ksail_grammar_checked=0
+for tc in \
+  'accept v7.181.8' 'accept v0.1.0' 'accept v10.20.30' 'accept v8.0.0-beta.1' \
+  'accept v1.0.0-rc.1.2' 'accept v1.0.0-0' 'accept v1.0.0-alpha' \
+  'reject vanything' 'reject v/../evil' 'reject v1latest' 'reject v1/anything' 'reject v1.0' \
+  'reject v1' 'reject v1.0.0/../evil' 'reject v01.0.0' 'reject v1.0.0-' 'reject v1.0.0-rc.1/evil' \
+  'reject v1.0.0-01' 'reject v1.0.0..0'; do
+  ksail_grammar_checked=$((ksail_grammar_checked + 1))
+  want="${tc%% *}"
+  tag="${tc##* }"
+  if printf '%s' "${ksail_identity_prefix}${tag}" | grep -Eq "$talos_ksail_identity"; then
+    got=accept
+  else
+    got=reject
+  fi
+  if [ "$got" != "$want" ]; then
+    echo "FAIL  ksail identity should ${want} refs/tags/${tag}, got ${got}"
+    ksail_grammar_failures=$((ksail_grammar_failures + 1))
+  fi
+done
+failures=$((failures + ksail_grammar_failures))
+if [ "$ksail_grammar_failures" -eq 0 ]; then
+  echo "ok    ksail identity: release-tag grammar (${ksail_grammar_checked} tags)"
+fi
+
+# The same deliberate difference as the provider identity: no length cap, pinned so a change
+# on either side is deliberate rather than silent.
+if printf '%s' "${ksail_identity_prefix}${over_length_tag}" | grep -Eq "$talos_ksail_identity"; then
+  echo "ok    ksail identity: the 128-char tag cap is deliberately NOT mirrored"
+else
+  echo "FAIL  the ksail identity now rejects a 129-char tag: update the DELIBERATE DIFFERENCE comment in both verifier files"
+  failures=$((failures + 1))
+fi
+
 # --- 9. THE DEFAULT PROBE PATH: no secret may reach argv -------------------
 # Every case above goes through INVENTORY_PROBE_CMD, so none of them exercises the real probe —
 # the credential lookup, the Basic-authenticated token exchange, the Bearer manifest read, and the

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -104,10 +104,18 @@ rules:
   # catch-all below (first-match-wins). Requires ksail >= the first release
   # that ships the GoReleaser docker_signs cosign step (devantler-tech/ksail
   # #5165) AND the ksail-operator HelmRelease pinned to that signed image tag.
+  # The ref is pinned to the release-tag GRAMMAR, not merely to `v*`: cd.yaml
+  # signs on any `v*` tag push and checks nothing about the tag itself, so a
+  # `v.+` ref clause would accept refs/tags/vanything and refs/tags/v/../evil,
+  # which are tags in shape only. The grammar is the same OCI-semver form as
+  # the provider identity below, carries the same DELIBERATE no-length-cap
+  # difference (pinned by the inventory test), and is kept byte-identical to
+  # the Kyverno attestor by that test. The publisher's own check is tracked at
+  # devantler-tech/ksail#6895.
   - image: ghcr.io/devantler-tech/ksail*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+      subjectRegex: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$
   # Crossplane PROVIDER package images (ghcr.io/devantler-tech/provider-upjet-*)
   # are signed by each provider repo's OWN publish-provider-package.yml — a
   # different keyless identity than publish-app.yaml, because the upstream


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Both places that verify ksail's image signatures — the node-level pull check and the pod-admission check — accept a signature made "from a release tag", but spelled that condition as `v` followed by anything. ksail's release pipeline signs on any `v*` tag push and checks nothing about the tag, so a tag that only looks like a release (`vanything`, `v/../evil`) would satisfy the identity on both paths. Defense in depth rather than a live bypass: producing such a tag still needs push rights on the ksail repository.

### What

Both verifiers now pin the ksail identity to the same release-version grammar the Crossplane provider identity already uses, and the inventory test proves the two files stay identical, that admission still routes ksail images to that identity, and that real release tags pass while shape-only tags are refused. The publisher-side check for ksail's own workflow is captured separately as devantler-tech/ksail#6895.

**Security floor gained:** a ksail signature from a non-release `v*` ref no longer satisfies either verifier. **Everyday path cost:** unchanged; every real ksail release tag is a semantic version and still passes.

Fixes #3427
