### PR TITLE
fix(ci): reject malformed and incomplete publication evidence

### DIFF
--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -430,6 +430,10 @@ tag_commit() {
   printf '%s\n' "$sha"
 }
 
+# Classify publication for <repo> <tag> <expected-commit-sha> using complete Actions data.
+# Returns 0 for a matching success, 1 for no success or an invalid expected SHA,
+# 2 for success only at another commit, and 3 when the response cannot establish an answer.
+# Keeps stdout empty; query results produce one bounded diagnostic on stderr.
 tag_was_published() {
   local repo="$1" tag="$2" sha="$3" runs summary diagnostic
   # The commit is REQUIRED, never defaulted: an empty expected SHA would make the match below

--- a/scripts/report-publish-workflow-signing-revisions.sh
+++ b/scripts/report-publish-workflow-signing-revisions.sh
@@ -431,14 +431,15 @@ tag_commit() {
 }
 
 tag_was_published() {
-  local repo="$1" tag="$2" sha="$3" runs
+  local repo="$1" tag="$2" sha="$3" runs summary diagnostic
   # The commit is REQUIRED, never defaulted: an empty expected SHA would make the match below
   # vacuous and restore exactly the moved-tag hole this argument exists to close.
   is_sha "$sha" || return 1
   # Scoped to this tag rather than fetching the newest 100 runs of the whole repository: on a
   # repository with frequent pushes a candidate release's run falls off that first page, every
   # retry re-fetches the same incomplete page, and a healthy consumer stays UNRESOLVED until the
-  # next release. Filtering by ref makes the result set small enough that one page is complete.
+  # next release. Filtering by ref usually fits one page; the count check below refuses an
+  # incomplete page rather than assuming that a missing run never published.
   # The tag goes in as a PARAMETER, not interpolated into the query string. A tag may
   # carry SemVer build metadata (`v2.0.0+build.1`) and this script resolves such tags as
   # themselves, so a raw `+` reaches the wire unencoded, where query parsing reads it as a
@@ -450,37 +451,59 @@ tag_was_published() {
   # caller's walk then stepped BACKWARD and reported an older release's signing revision as
   # the signer of what is deployed -- a confident wrong answer built from a transient error.
   # Exit 3 says the question could not be answered, so the caller refuses instead of guessing.
-  runs="$(gh_retry api --method GET "repos/devantler-tech/${repo}/actions/runs" \
-    --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)" || return 3
-  # `head_sha` pins the run to the commit the tag resolves to TODAY. A historical run for a
-  # since-moved tag still carries the old commit and no longer counts as evidence that the
-  # artifact the current commit describes was ever published.
-  if printf '%s' "$runs" |
-    jq -r --arg t "$tag" --arg s "$sha" '
-      [.workflow_runs[]
-       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml"
-                and .head_sha == $s)
-       | .conclusion] | .[]' 2>/dev/null |
-    grep -qx 'success'; then
-    return 0
+  # Only bounded, escaped identifiers and fixed classifications/counts enter the log.
+  # Response bodies, arbitrary fields and parser/API errors never become diagnostics.
+  printf -v diagnostic 'publication-evidence repo=%q tag=%q' "${repo:0:128}" "${tag:0:128}"
+  if ! runs="$(gh_retry api --method GET "repos/devantler-tech/${repo}/actions/runs" \
+    --raw-field "branch=${tag}" --raw-field event=push --raw-field per_page=100)"; then
+    printf '%s response=query-failed classification=query-unknown\n' "$diagnostic" >&2
+    return 3
   fi
-  # 🔴 A MOVED TAG IS NOT THE SAME AS AN UNPUBLISHED ONE, and collapsing them would swap one
-  # wrong answer for another. "Never published" is ordinary — the walk steps to the previous
-  # release. But a tag with a successful run at a DIFFERENT commit has published something,
-  # just not what it now points at; walking silently past it would report an older release's
-  # workflow revision as the signer of what is deployed, which is the confident wrong answer
-  # this report exists to avoid. It is an anomaly, so it is surfaced by name (exit 2) and the
-  # caller refuses rather than guessing which commit the deployed artifact came from.
-  if printf '%s' "$runs" |
-    jq -r --arg t "$tag" --arg s "$sha" '
-      [.workflow_runs[]
-       | select(.head_branch == $t and .path == ".github/workflows/cd.yaml"
-                and .head_sha != null and .head_sha != $s)
-       | .conclusion] | .[]' 2>/dev/null |
-    grep -qx 'success'; then
-    return 2
+  # A successful HTTP read can still be malformed or incomplete. In a jq|grep condition,
+  # parser errors used to mean "unpublished", while .workflow_runs[] also accepted object
+  # values as runs. Validate one document and every classification field before selecting.
+  if ! summary="$(printf '%s' "$runs" | jq -ers --arg t "$tag" --arg s "$sha" '
+    if length != 1 then error("expected one response") else .[0] end
+    | if type == "object"
+         and has("total_count") and has("workflow_runs")
+         and (.total_count | type == "number" and . >= 0 and . <= 9007199254740991 and floor == .)
+         and (.workflow_runs | type == "array")
+         and all(.workflow_runs[];
+           type == "object"
+           and has("head_branch") and has("path") and has("head_sha") and has("conclusion")
+           and (.head_branch | type == "string" or type == "null")
+           and (.path | type == "string")
+           and (.head_sha | type == "string" and test("^[0-9a-f]{40}$"))
+           and (.conclusion | type == "string" or type == "null"))
+      then . else error("invalid response shape") end
+    | .workflow_runs as $runs
+    | [$runs[] | select(.head_branch == $t and .path == ".github/workflows/cd.yaml")] as $matching
+    # Keep comparisons in jq: valid JSON integers can use exponent notation, which
+    # shell integer tests reject. Arithmetic normalizes their diagnostic spelling;
+    # the validation above bounds counts to integers jq can represent exactly.
+    | [(.total_count == ($runs | length)), (.total_count + 0), ($runs | length), ($matching | length),
+       ([$matching[] | select(.head_sha == $s and .conclusion == "success")] | length),
+       ([$matching[] | select(.head_sha != $s and .conclusion == "success")] | length)]
+    | @tsv' 2>/dev/null)"; then
+    printf '%s response=invalid classification=query-unknown\n' "$diagnostic" >&2
+    return 3
   fi
-  return 1
+  local complete total returned matching successful_current successful_other response=complete classification rc
+  IFS=$'\t' read -r complete total returned matching successful_current successful_other <<<"$summary"
+  if [ "$complete" != true ]; then
+    response=incomplete classification=query-unknown rc=3
+  # `head_sha` binds publication to the tag current commit. Preserve successful current
+  # publication precedence; only a success at another commit is a moved-tag anomaly.
+  elif [ "$successful_current" -gt 0 ]; then
+    classification=published rc=0
+  elif [ "$successful_other" -gt 0 ]; then
+    classification=moved-tag rc=2
+  else
+    classification=unpublished rc=1
+  fi
+  printf '%s response=%s total=%s returned=%s matching=%s successful-current=%s successful-other=%s classification=%s\n' \
+    "$diagnostic" "$response" "$total" "$returned" "$matching" "$successful_current" "$successful_other" "$classification" >&2
+  return "$rc"
 }
 
 # The tag that produced the DEPLOYED artifact.

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -1482,6 +1482,9 @@ fi
 #     only the network response replaced; its stdout must remain empty and its one
 #     diagnostic line must not expose arbitrary response fields or parser errors.
 # ---------------------------------------------------------------------------
+# Check <name> <expected-status> <publication-classification> <response-classification> <body>.
+# Runs the real publication classifier with an offline response, accumulating failures
+# for the exit status, empty stdout, diagnostic classification and response-data leakage.
 publication_response_case() {
   local name="$1" expected="$2" classification="$3" response="$4" body="$5" rc=0
   local fixture="$WORK/response-$name.json" out="$WORK/response-$name.out" err="$WORK/response-$name.err"

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -645,11 +645,15 @@ case "$args" in
       printf 'API rate limit exceeded\n' >&2
       exit 1
     fi
+    if [ -n "${BM_RUNS_RESPONSE_TAG:-}" ] && [ "$bm_ref" = "$BM_RUNS_RESPONSE_TAG" ]; then
+      cat "$BM_RUNS_RESPONSE_FILE"
+      exit 0
+    fi
     # A tag that was QUERIED SUCCESSFULLY and simply never published: the run exists and
     # failed. This is the ordinary case the walk is built for, and it is what separates
     # "the answer is no" from "there is no answer".
     if [ -n "${BM_UNPUBLISHED_TAG:-}" ] && [ "$bm_ref" = "$BM_UNPUBLISHED_TAG" ]; then
-      printf '{"workflow_runs":[{"name":"CD","conclusion":"failure","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' \
+      printf '{"total_count":1,"workflow_runs":[{"name":"CD","conclusion":"failure","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' \
         "$bm_ref" "${BM_TAG_SHA:-$BM_SHA_C}"
       exit 0
     fi
@@ -660,7 +664,7 @@ case "$args" in
     # Its run carries that same commit, or the tag would read as MOVED and refuse.
     [ -n "${BM_OWNCOMMIT_TAG:-}" ] && [ "$bm_ref" = "$BM_OWNCOMMIT_TAG" ] && bm_run_sha="$BM_SHA_B"
     [ "$bm_ref" = "${BM_MOVED_TAG:-}" ] && bm_run_sha="$BM_SHA_A"
-    printf '{"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' "$bm_ref" "$bm_run_sha"
+    printf '{"total_count":1,"workflow_runs":[{"name":"CD","conclusion":"success","path":".github/workflows/cd.yaml","head_branch":"%s","head_sha":"%s"}]}\n' "$bm_ref" "$bm_run_sha"
     ;;
   *"/contents/.github/workflows/cd.yaml"*)
     # The pin DEPENDS ON THE REF, which is what makes the walk's choice observable: the
@@ -1471,8 +1475,91 @@ else
   pass 'an exact manifest tag must exist under the exact spelling Flux requests'
 fi
 
+# ---------------------------------------------------------------------------
+# 29. AN HTTP-SUCCESS BODY IS NOT NECESSARILY COMPLETE PUBLICATION EVIDENCE.
+#     Parse errors used to become "unpublished", and an object instead of an array
+#     could even count as a successful publication. Exercise the real function with
+#     only the network response replaced; its stdout must remain empty and its one
+#     diagnostic line must not expose arbitrary response fields or parser errors.
+# ---------------------------------------------------------------------------
+publication_response_case() {
+  local name="$1" expected="$2" classification="$3" response="$4" body="$5" rc=0
+  local fixture="$WORK/response-$name.json" out="$WORK/response-$name.out" err="$WORK/response-$name.err"
+  printf '%s\n' "$body" >"$fixture"
+  BM_RUNS_RESPONSE_TAG=v2.0.0 BM_RUNS_RESPONSE_FILE="$fixture" PATH="$bm_bin:$PATH" \
+    bash -c 'source "$1"; tag_was_published wedding-app v2.0.0 "$2"' \
+    bash "$SCRIPT" "$SHA_C" >"$out" 2>"$err" || rc=$?
+  local before="$failures"
+  [ "$rc" -eq "$expected" ] || fail "$name classified as $rc, expected $expected"
+  [ ! -s "$out" ] || fail "$name polluted the publication result on stdout"
+  grep -q "response=$response" "$err" || fail "$name omitted its response classification"
+  grep -q "classification=$classification" "$err" || fail "$name omitted its publication classification"
+  [ "$(wc -l <"$err" | tr -d ' ')" -eq 1 ] || fail "$name emitted more or less than one diagnostic line"
+  if grep -q 'RESPONSE_ONLY_SENTINEL' "$out" "$err"; then
+    fail "$name leaked arbitrary response content"
+  fi
+  [ "$failures" -ne "$before" ] || pass "publication response $name preserves status, stdout and safe diagnostics"
+}
+
+pr_success="$(jq -cn --arg sha "$SHA_C" '{total_count:1,workflow_runs:[{name:"RESPONSE_ONLY_SENTINEL",head_branch:"v2.0.0",path:".github/workflows/cd.yaml",head_sha:$sha,conclusion:"success"}]}')"
+publication_response_case success 0 published complete "$pr_success"
+publication_response_case empty 1 unpublished complete '{"total_count":0,"workflow_runs":[],"private":"RESPONSE_ONLY_SENTINEL"}'
+publication_response_case failed 1 unpublished complete "$(jq '.workflow_runs[0].conclusion="failure"' <<<"$pr_success")"
+publication_response_case pending 1 unpublished complete "$(jq '.workflow_runs[0].conclusion=null' <<<"$pr_success")"
+publication_response_case other-workflow 1 unpublished complete "$(jq '.workflow_runs[0].path=".github/workflows/ci.yaml"' <<<"$pr_success")"
+publication_response_case other-tag 1 unpublished complete "$(jq '.workflow_runs[0].head_branch="v1.0.0"' <<<"$pr_success")"
+publication_response_case null-branch 1 unpublished complete "$(jq '.workflow_runs[0].head_branch=null' <<<"$pr_success")"
+publication_response_case moved 2 moved-tag complete "$(jq --arg sha "$SHA_A" '.workflow_runs[0].head_sha=$sha' <<<"$pr_success")"
+publication_response_case current-and-moved 0 published complete "$(jq --arg sha "$SHA_A" '.total_count=2 | .workflow_runs += [(.workflow_runs[0] | .head_sha=$sha)]' <<<"$pr_success")"
+publication_response_case invalid-json 3 query-unknown invalid 'RESPONSE_ONLY_SENTINEL is not JSON'
+publication_response_case multiple-documents 3 query-unknown invalid "$pr_success $pr_success"
+publication_response_case null-root 3 query-unknown invalid null
+publication_response_case array-root 3 query-unknown invalid "[$pr_success]"
+publication_response_case null-runs 3 query-unknown invalid '{"total_count":0,"workflow_runs":null}'
+publication_response_case missing-runs 3 query-unknown invalid '{"total_count":0}'
+publication_response_case object-runs 3 query-unknown invalid "$(jq '.workflow_runs={wrong:.workflow_runs[0]}' <<<"$pr_success")"
+publication_response_case missing-count 3 query-unknown invalid "$(jq 'del(.total_count)' <<<"$pr_success")"
+publication_response_case string-count 3 query-unknown invalid "$(jq '.total_count="1"' <<<"$pr_success")"
+publication_response_case negative-count 3 query-unknown invalid "$(jq '.total_count=-1' <<<"$pr_success")"
+publication_response_case fractional-count 3 query-unknown invalid "$(jq '.total_count=1.5' <<<"$pr_success")"
+publication_response_case oversized-count 3 query-unknown invalid "$(jq '.total_count=1e30' <<<"$pr_success")"
+publication_response_case exponent-count 0 published complete "$(printf '%s' "$pr_success" | sed 's/"total_count":1/"total_count":1e0/')"
+publication_response_case exponent-incomplete-count 3 query-unknown incomplete "$(printf '%s' "$pr_success" | sed 's/"total_count":1/"total_count":1e3/')"
+publication_response_case inconsistent-count 3 query-unknown incomplete "$(jq '.total_count=0' <<<"$pr_success")"
+publication_response_case truncated-success 3 query-unknown incomplete "$(jq '.total_count=101' <<<"$pr_success")"
+publication_response_case truncated-full-page 3 query-unknown incomplete "$(jq '.total_count=101 | .workflow_runs=[range(0;100) | {head_branch:"v2.0.0",path:".github/workflows/cd.yaml",head_sha:"3333333333333333333333333333333333333333",conclusion:"failure"}]' <<<"$pr_success")"
+publication_response_case null-row 3 query-unknown invalid "$(jq '.workflow_runs=[null]' <<<"$pr_success")"
+publication_response_case missing-field 3 query-unknown invalid "$(jq 'del(.workflow_runs[0].conclusion)' <<<"$pr_success")"
+publication_response_case malformed-sha 3 query-unknown invalid "$(jq '.workflow_runs[0].head_sha="short"' <<<"$pr_success")"
+publication_response_case malformed-path 3 query-unknown invalid "$(jq '.workflow_runs[0].path=[]' <<<"$pr_success")"
+publication_response_case malformed-branch 3 query-unknown invalid "$(jq '.workflow_runs[0].head_branch=123' <<<"$pr_success")"
+publication_response_case malformed-conclusion 3 query-unknown invalid "$(jq '.workflow_runs[0].conclusion=false' <<<"$pr_success")"
+
+# Count summaries preserve the distinction between unrelated runs and publications.
+grep -q 'total=1 returned=1 matching=1 successful-current=1 successful-other=0' "$WORK/response-success.err" ||
+  fail 'the successful response omitted the counts that explain its selection'
+grep -q 'total=101 returned=100' "$WORK/response-truncated-full-page.err" ||
+  fail 'the incomplete response omitted its advertised and observed counts'
+
+# A malformed/incomplete newest candidate must stop the REAL semver walk, even when
+# the registry would permit falling back. The old parser silently resolved 1.9.0.
+for pr_case in null-runs truncated-full-page; do
+  pr_out="$WORK/response-walk-$pr_case.out"
+  if BM_WEDDING_TAGS='v2.0.0\nv1.9.0\n' BM_WEDDING_REGISTRY_TAGS='1.9.0\n' \
+    BM_RUNS_RESPONSE_TAG=v2.0.0 BM_RUNS_RESPONSE_FILE="$WORK/response-$pr_case.json" \
+    BM_SHA_A="$SHA_A" BM_SHA_B="$SHA_B" BM_SHA_C="$SHA_C" PATH="$bm_bin:$PATH" \
+    PUBLISH_CONSUMER_ROOT="$bm_root" "$SCRIPT" >"$pr_out" 2>&1; then
+    fail "$pr_case workflow response was silently walked past to an older version"
+  else
+    grep -q '^UNRESOLVED wedding-app' "$pr_out" || fail "$pr_case did not leave its consumer unresolved"
+    grep -q 'could not read the workflow runs for tag v2.0.0' "$pr_out" || fail "$pr_case refused for an unrelated reason"
+    [ "$(grep -c '^IN-SYNC' "$pr_out" || true)" -eq "$expected_insync" ] || fail "$pr_case affected other consumers"
+    pass "$pr_case publication evidence stops the semver walk"
+  fi
+done
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1
 fi
-printf '\nPASS: publish-workflow signing-revision report (28 cases)\n'
+printf '\nPASS: publish-workflow signing-revision report (29 groups)\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

The signing-revision reporter can treat malformed Actions responses as unpublished and walk to an older release; an object-shaped run list can even count as published. It now validates one complete response before classifying publication and returns unknown for malformed or incomplete evidence. The existing refusal paths stop resolution when that evidence is unknown.

One bounded diagnostic line records escaped identifiers, response completeness, counts and classification on stderr. It includes no raw response or parser/API error text and preserves the report's stdout format.

Validation: the existing resolver suite passes 29 groups and 83 assertions, including 32 response cases and two real semver-walk regressions. The independent 12-case proof, ShellCheck, syntax and diff checks pass. Independent full-diff review is clean. A read-only live exercise classified the exact publication record as complete and published.

Related to #3621. This fixes independently reproduced response handling and adds the evidence needed to diagnose CI; the original failure's cause remains unproven, so this PR does not close that issue.
