### PR TITLE
fix(observability): keep Crossplane alert discovery within its processing budget

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,6 +352,7 @@ jobs:
               - 'scripts/tests/test-flux-reconcile-control-plane-restart.sh'
               - 'scripts/tests/test-opencost-usage-scraper.sh'
               - 'scripts/tests/test-crossplane-sync-exporter.sh'
+              - 'scripts/tests/test-crossplane-sync-alerter.sh'
               - 'scripts/tests/test-crossplane-egress-policy.sh'
               - 'scripts/tests/crossplane-egress-policy-rules.yaml'
               - 'scripts/tests/test-cnpg-degraded-alert.sh'
@@ -1109,6 +1110,10 @@ jobs:
         # reads exactly like a fleet with nothing wrong. Schema validation cannot
         # see any of it, so render the component contract instead.
         run: bash scripts/tests/test-crossplane-sync-exporter.sh
+
+      - name: 📡 Validate Crossplane sync alert delivery
+        if: needs.changes.outputs.k8s == 'true'
+        run: bash scripts/tests/test-crossplane-sync-alerter.sh
 
       - name: 🩺 Validate the CNPG degraded-cluster alert
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -74,6 +74,8 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
+            # The non-root sensor writes only paginated discovery responses.
+            fsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
             # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
@@ -104,13 +106,17 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 32Mi
+                  ephemeral-storage: 16Mi
                 limits:
                   cpu: 100m
                   memory: 64Mi
+                  ephemeral-storage: 32Mi
               volumeMounts:
                 - name: exporter-config
                   mountPath: /etc/crossplane-sync-exporter
                   readOnly: true
+                - name: scratch
+                  mountPath: /tmp
               command:
                 - /bin/sh
                 - -c
@@ -120,6 +126,8 @@ spec:
                   AM="http://alertmanager.kubescape.svc.cluster.local:9093"
                   KUBE_API="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
                   SA_DIR="/var/run/secrets/kubernetes.io/serviceaccount"
+                  CRD_PAGE="/tmp/crossplane-crds.json"
+                  trap 'rm -f "$CRD_PAGE"' 0
                   curl_retry() {
                     curl -sS --retry 5 --retry-delay 2 --retry-all-errors \
                       --retry-connrefused --max-time 30 --retry-max-time 30 "$@"
@@ -149,6 +157,7 @@ spec:
                   # deployed, remote_write broken) and 0 means the scrape fails.
                   # Both are sensor failures, and both must alert -- otherwise the
                   # quiet that follows reads exactly like a healthy fleet.
+                  echo "querying exporter health"
                   UP=$(q 'up{job="crossplane-sync-exporter"}')
                   if [ "$(printf '%s' "$UP" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query failed"; exit 1
@@ -164,6 +173,7 @@ spec:
                   # watched managed resources are syncing": the exact silence the
                   # alert exists to break, now with a green sensor in front of it.
                   # So zero condition series is a sensor failure in its own right.
+                  echo "querying exporter metric coverage"
                   COV=$(q 'count(crossplane_managed_resource_condition{condition="Synced"})')
                   if [ "$(printf '%s' "$COV" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for exporter coverage failed"; exit 1
@@ -177,32 +187,46 @@ spec:
                   # A newly installed provider or kind must not silently inherit
                   # broad RBAC. Compare CRD discovery with the exact inventory;
                   # a gap alerts until its GVK and read permission are reviewed.
-                  # Kubernetes pagination bounds each response so complete CRD
-                  # schemas are never buffered for the whole cluster at once.
+                  # Download each bounded page to disk, then retain only the
+                  # discovery fields. Full CRD schemas can be megabytes; moving
+                  # them through shell variables and repeated jq invocations
+                  # consumes the sensor's CPU budget before it can send alerts.
                   CRD_API="$KUBE_API/apis/apiextensions.k8s.io/v1/customresourcedefinitions"
                   cursor=""
                   missing=""
+                  page_count=0
+                  echo "checking managed-kind discovery coverage"
                   while :; do
                     if [ -n "$cursor" ]; then
-                      CRDS=$(curl_retry --fail --get \
+                      curl_retry --fail --get \
+                        --output "$CRD_PAGE" --max-filesize 16777216 \
                         --cacert "$SA_DIR/ca.crt" \
                         -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
                         --data-urlencode "limit=25" \
                         --data-urlencode "continue=$cursor" \
-                        "$CRD_API") || {
+                        "$CRD_API" || {
                           echo "ERROR: Kubernetes CRD discovery failed"
                           exit 1
                         }
                     else
-                      CRDS=$(curl_retry --fail --get \
+                      curl_retry --fail --get \
+                        --output "$CRD_PAGE" --max-filesize 16777216 \
                         --cacert "$SA_DIR/ca.crt" \
                         -H "Authorization: Bearer $(cat "$SA_DIR/token")" \
                         --data-urlencode "limit=25" \
-                        "$CRD_API") || {
+                        "$CRD_API" || {
                           echo "ERROR: Kubernetes CRD discovery failed"
                           exit 1
                         }
                     fi
+                    # Check curl separately: POSIX sh has no pipefail, so a
+                    # curl | jq pipeline could accept a failed partial transfer.
+                    CRDS=$(jq -c '{kind, metadata: {continue: .metadata.continue},
+                      items: [.items[] | {spec: {group: .spec.group, names: .spec.names,
+                        versions: [.spec.versions[] | {name, served}]}}]}' "$CRD_PAGE") || {
+                        echo "ERROR: could not decode Kubernetes CRD discovery"
+                        exit 1
+                      }
                     if [ "$(printf '%s' "$CRDS" | jq -r '.kind // ""')" != "CustomResourceDefinitionList" ]; then
                       echo "ERROR: Kubernetes CRD discovery returned an unexpected response"
                       exit 1
@@ -214,6 +238,8 @@ spec:
                       exit 1
                     fi
                     missing=$(printf '%s\n%s\n' "$missing" "$page_missing")
+                    page_count=$((page_count + 1))
+                    echo "checked discovery page $page_count"
                     cursor=$(printf '%s' "$CRDS" | jq -r '.metadata.continue // ""')
                     [ -n "$cursor" ] || break
                   done
@@ -330,6 +356,7 @@ spec:
                   # reconciliation. Keep paused series in COV above so they still
                   # prove the exporter is alive, but exclude them from every
                   # selector participating in this joined history predicate.
+                  echo "querying stuck managed resources"
                   STUCK=$(q 'crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"} == 0 and on (customresource_group, customresource_version, customresource_kind, name, namespace) (max by (customresource_group, customresource_version, customresource_kind, name, namespace) (max_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) == 0) and on (customresource_group, customresource_version, customresource_kind, name, namespace) (count by (customresource_group, customresource_version, customresource_kind, name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[3m] offset 15m)) > 0) and on (customresource_group, customresource_version, customresource_kind, name, namespace) (sum by (customresource_group, customresource_version, customresource_kind, name, namespace) (count_over_time(crossplane_managed_resource_condition{condition="Synced",reason!="ReconcilePaused"}[15m])) >= 12)')
                   if [ "$(printf '%s' "$STUCK" | jq -r '.status')" != "success" ]; then
                     echo "ERROR: Prometheus query for stuck resources failed"; exit 1
@@ -404,3 +431,6 @@ spec:
             - name: exporter-config
               configMap:
                 name: crossplane-sync-exporter
+            - name: scratch
+              emptyDir:
+                sizeLimit: 32Mi

--- a/scripts/tests/test-crossplane-sync-alerter.sh
+++ b/scripts/tests/test-crossplane-sync-alerter.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+# Exercise the deployed sensor with paginated API responses and captured alerts.
+# Only network calls and in-cluster mount paths are replaced.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+manifest="${root_dir}/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml"
+config="${root_dir}/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml"
+work_dir="$(mktemp -d)"
+trap 'chmod -R u+w "${work_dir}"; rm -rf "${work_dir}"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+pod_path='.spec.jobTemplate.spec.template.spec'
+scratch_volume="$(yq -r "${pod_path}.containers[] | select(.name == \"alerter\") | .volumeMounts[] | select(.mountPath == \"/tmp\") | .name" "${manifest}")"
+[ -n "$scratch_volume" ] || fail 'the non-root sensor needs a writable scratch mount'
+yq -e "${pod_path}.volumes[] | select(.name == \"${scratch_volume}\") | .emptyDir.sizeLimit == \"32Mi\"" \
+  "${manifest}" >/dev/null || fail 'scratch storage must have a bounded emptyDir'
+[ "$(yq -r "${pod_path}.securityContext.fsGroup" "${manifest}")" = \
+  "$(yq -r "${pod_path}.securityContext.runAsUser" "${manifest}")" ] || fail 'the sensor must be able to write its scratch volume'
+yq -e "${pod_path}.containers[] | select(.name == \"alerter\") | .securityContext.readOnlyRootFilesystem == true" \
+  "${manifest}" >/dev/null || fail 'scratch storage must not require a writable root filesystem'
+
+yq -r '.spec.jobTemplate.spec.template.spec.containers[] | select(.name == "alerter") | .command[2]' \
+  "${manifest}" >"${work_dir}/sensor.sh"
+mkdir -p "${work_dir}/config" "${work_dir}/sa" "${work_dir}/bin"
+yq -r '.data."managed-resources.tsv"' "${config}" >"${work_dir}/config/managed-resources.tsv"
+yq -r '.data."managed-coverage-gaps.jq"' "${config}" >"${work_dir}/config/managed-coverage-gaps.jq"
+printf 'fixture-token\n' >"${work_dir}/sa/token"
+printf 'fixture-ca\n' >"${work_dir}/sa/ca.crt"
+
+cat >"${work_dir}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+query='' cursor='' output='' payload='' limit='' url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-urlencode)
+      case "$2" in
+        query=*) query="${2#query=}" ;;
+        continue=*) cursor="${2#continue=}" ;;
+        limit=*) limit="${2#limit=}" ;;
+      esac
+      shift 2 ;;
+    --output|-o) output="$2"; shift 2 ;;
+    -d|--data) payload="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  */api/v1/query)
+    case "$query" in
+      'up{'*) cat "${CASE_DIR}/up.json" ;;
+      count\(*) cat "${CASE_DIR}/coverage.json" ;;
+      crossplane_*) cat "${CASE_DIR}/stuck.json" ;;
+      *) exit 90 ;;
+    esac ;;
+  */customresourcedefinitions)
+    [ "$limit" = 25 ] || exit 91
+    case "$cursor" in
+      '') page=1 ;;
+      'next+/=page') page=2 ;;
+      *) exit 92 ;;
+    esac
+    printf '%s\n' "$page" >>"${CASE_DIR}/pages.log"
+    if [ "$page" = 2 ] && [ -e "${CASE_DIR}/fail-download" ]; then
+      # A partial transfer must never reuse the preceding complete page.
+      [ -z "$output" ] || printf '{"kind":' >"$output"
+      exit 18
+    fi
+    if [ -n "$output" ]; then
+      cat "${CASE_DIR}/page-${page}.json" >"$output" || exit 23
+    else
+      cat "${CASE_DIR}/page-${page}.json"
+    fi ;;
+  */api/v2/alerts)
+    printf '%s\n' "$payload" >"${CASE_DIR}/alerts.json"
+    [ ! -e "${CASE_DIR}/reject-alerts" ] || exit 22 ;;
+  *) exit 93 ;;
+esac
+STUB
+chmod +x "${work_dir}/bin/curl"
+
+new_case() {
+  case_dir="${work_dir}/$1"
+  mkdir -p "${case_dir}/tmp"
+  printf '%s\n' '{"status":"success","data":{"result":[{"value":[1,"1"]}]}}' >"${case_dir}/up.json"
+  cp "${case_dir}/up.json" "${case_dir}/coverage.json"
+  printf '%s\n' '{"status":"success","data":{"result":[]}}' >"${case_dir}/stuck.json"
+  # Large schemas have no bearing on the small identity/served-version result.
+  jq -n '{kind:"CustomResourceDefinitionList",metadata:{continue:"next+/=page"},items:[{
+    spec:{group:"repo.github.m.upbound.io",names:{kind:"Repository",categories:["managed"]},
+      versions:[{name:"v1alpha1",served:true,schema:{description:("x" * 524288)}}]}}]}' >"${case_dir}/page-1.json"
+  printf '%s\n' '{"kind":"CustomResourceDefinitionList","metadata":{},"items":[]}' >"${case_dir}/page-2.json"
+  # Rewrite /tmp first so later inserted absolute fixture paths are not rewritten.
+  sed -e "s#/tmp/#${case_dir}/tmp/#g" \
+    -e "s#/var/run/secrets/kubernetes.io/serviceaccount#${work_dir}/sa#g" \
+    -e "s#/etc/crossplane-sync-exporter#${work_dir}/config#g" \
+    "${work_dir}/sensor.sh" >"${case_dir}/sensor.sh"
+}
+
+run_case() {
+  result=0
+  PATH="${work_dir}/bin:${PATH}" CASE_DIR="${case_dir}" \
+    KUBERNETES_SERVICE_HOST=api.example.invalid KUBERNETES_SERVICE_PORT_HTTPS=443 \
+    sh "${case_dir}/sensor.sh" >"${case_dir}/output.log" 2>&1 || result=$?
+}
+
+new_case healthy
+run_case
+[ "$result" = 0 ] || fail 'healthy complete inventory must succeed'
+[ "$(cat "${case_dir}/pages.log")" = $'1\n2' ] || fail 'every continuation page must be read exactly once'
+[ ! -e "${case_dir}/alerts.json" ] || fail 'healthy resources must not alert'
+grep -q 'all watched managed resources are syncing' "${case_dir}/output.log" || fail 'healthy result must be explicit'
+
+new_case coverage-gap
+jq '.items = [{spec:{group:"new.example.invalid",names:{kind:"Widget",categories:["managed"]},versions:[{name:"v1",served:true}]}}]' \
+  "${case_dir}/page-2.json" >"${case_dir}/replacement.json"
+mv "${case_dir}/replacement.json" "${case_dir}/page-2.json"
+run_case
+[ "$result" = 0 ] || fail 'a coverage gap must be delivered successfully'
+jq -e 'length == 1 and .[0].labels.alertname == "CrossplaneSyncExporterCoverageGap"
+  and (.[0].annotations.description | contains("new.example.invalid/Widget"))' \
+  "${case_dir}/alerts.json" >/dev/null || fail 'a kind on the final page must alert'
+
+new_case exporter-down
+cp "${case_dir}/stuck.json" "${case_dir}/up.json"
+run_case
+[ "$result" = 0 ] || fail 'exporter failure must reach alert delivery'
+jq -e 'length == 1 and .[0].labels.alertname == "CrossplaneSyncExporterDown"' \
+  "${case_dir}/alerts.json" >/dev/null || fail 'missing exporter samples must alert'
+
+new_case stuck
+printf '%s\n' '{"status":"success","data":{"result":[{"metric":{"name":"sample","namespace":"tenant","reason":"ReconcileError","customresource_group":"repo.github.m.upbound.io","customresource_version":"v1alpha1","customresource_kind":"Repository"},"value":[1,"0"]}]}}' >"${case_dir}/stuck.json"
+run_case
+[ "$result" = 0 ] || fail 'stuck-resource alert must be delivered'
+jq -e 'length == 1 and .[0].labels.alertname == "CrossplaneManagedResourceNotSynced"
+  and .[0].labels.resource == "sample" and .[0].labels.resource_kind == "Repository"
+  and .[0].annotations.reason == "ReconcileError" and (.[0].labels | has("reason") | not)' \
+  "${case_dir}/alerts.json" >/dev/null || fail 'stuck alert must retain resource identity and reason'
+touch "${case_dir}/reject-alerts"
+run_case
+[ "$result" != 0 ] || fail 'rejected alert delivery must fail the job'
+
+for problem in fail-download malformed-json unexpected-kind; do
+  new_case "$problem"
+  case "$problem" in
+    fail-download) touch "${case_dir}/fail-download" ;;
+    malformed-json) printf '{' >"${case_dir}/page-2.json" ;;
+    unexpected-kind) printf '{"kind":"Status","items":[]}' >"${case_dir}/page-2.json" ;;
+  esac
+  run_case
+  [ "$result" != 0 ] || fail "$problem must fail rather than claim complete coverage"
+  [ ! -e "${case_dir}/alerts.json" ] || fail "$problem must not deliver partial results"
+  ! grep -q 'all watched managed resources are syncing' "${case_dir}/output.log" || fail "$problem reported healthy"
+done
+
+# A full scratch volume is an I/O failure, never an empty healthy inventory.
+# Use a regular file where the scratch directory should be; works even as root.
+new_case unavailable-scratch
+rmdir "${case_dir}/tmp"
+printf 'not a directory\n' >"${case_dir}/tmp"
+run_case
+[ "$result" != 0 ] || fail 'unavailable scratch storage must fail discovery'
+[ ! -e "${case_dir}/alerts.json" ] || fail 'scratch failure must not deliver partial results'
+
+printf 'PASS: Crossplane sync alert delivery and paginated discovery\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Crossplane drift monitor repeatedly runs out of time, leaving failed reconciliations unreported.

## What

Reduce the work needed to check complete discovery coverage, preserve failure handling, and add regression coverage for alert delivery. Local processing measurements are about five times faster; successful scheduled runs after deployment remain the recovery check.

Part of #3625 — keep the issue open until deployed scheduled runs confirm recovery.
