### PR TITLE
fix(security): preserve runtime-assigned SELinux labels

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -8,7 +8,7 @@
 # - runAsNonRoot: true (C-0013) — pod + container
 # - runAsUser: 1000 + runAsGroup: 1000 (C-0013/C-0211 non-root user+group) — pod level
 # - fsGroup: 1000 + fsGroupChangePolicy: OnRootMismatch (C-0211) — pod level
-# - seLinuxOptions: {level: s0} (C-0211 CIS-5.7.3) — containers + initContainers
+# - seLinuxOptions: {} (C-0211 CIS-5.7.3) — containers + initContainers
 # - hostUsers: false — only in namespaces that explicitly opt in after userns
 #   validation
 #
@@ -37,13 +37,12 @@
 # - fsGroup uses a conditional anchor, so any workload that sets its own (every
 #   PVC-mounting workload in scope does) keeps it; only stateless pods get the
 #   default, where it governs emptyDir/projected-volume ownership harmlessly.
-# - seLinuxOptions is a no-op on this AppArmor cluster — runc ignores SELinux labels
-#   when SELinux isn't the active LSM (verified: Cilium already ships one and a probe
-#   pod ran fine) — but CIS-5.7.3 requires it and it is correct defense-in-depth on
-#   any SELinux node. level: s0 is the default non-privileged MCS level (not Cilium's
-#   spc_t, which is for privileged pods).
+# - Empty seLinuxOptions satisfies C-0211 without pinning a level or type.
+#   The runtime retains its default SELinux type and per-pod MCS categories on
+#   SELinux nodes; this AppArmor cluster ignores the options. Explicit pod or
+#   container options are preserved as whole objects, including empty mappings.
 #
-# Uses +(key) to never overwrite values explicitly set by Helm charts.
+# Uses +(key) anchors or presence guards to preserve explicit chart values.
 # Excluded namespaces require elevated privileges by design.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -197,8 +196,6 @@ spec:
                           - ALL
                       +(seccompProfile):
                         type: RuntimeDefault
-                      +(seLinuxOptions):
-                        level: s0
           - list: "request.object.spec.initContainers[]"
             patchStrategicMerge:
               spec:
@@ -213,8 +210,32 @@ spec:
                           - ALL
                       +(seccompProfile):
                         type: RuntimeDefault
-                      +(seLinuxOptions):
-                        level: s0
+          - list: "request.object.spec.containers"
+            preconditions:
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "false"
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/containers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
+          - list: "request.object.spec.initContainers[]"
+            preconditions:
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "false"
+                - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
+                  operator: Equals
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/initContainers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
     # Pods exempt from the pod-level runAsUser/runAsGroup injection in
     # add-pod-security-context (image-baked non-1000 UIDs: cert-manager, keda,
     # opencost; and tofu-controller runner pods) still must satisfy the rest of
@@ -262,9 +283,8 @@ spec:
     # seLinuxOptions, which are not privilege fields:
     # - fsGroupChangePolicy only governs ownership-relabel behaviour when the
     #   kubelet applies an fsGroup to a volume. It grants nothing.
-    # - seLinuxOptions {level: s0} is the default non-privileged MCS level and is
-    #   a no-op on this AppArmor cluster (runc ignores SELinux labels when SELinux
-    #   is not the active LSM), retained as CIS-5.7.3 defense-in-depth.
+    # - Empty seLinuxOptions keeps runtime SELinux label allocation, satisfies
+    #   C-0211, and is a no-op on this AppArmor cluster.
     # Excluding them cost both controls across the whole excluded population:
     # measured against live prod specs 2026-08-29, 210/210 pods in those twelve
     # namespaces have no fsGroupChangePolicy and 189/210 have at least one
@@ -301,56 +321,11 @@ spec:
           spec:
             securityContext:
               +(fsGroupChangePolicy): OnRootMismatch
-    # A pod-level seLinuxOptions that EXISTS but carries no `level` is the one
-    # shape neither rule above closes, and both still report success. The
-    # container foreach below deliberately skips it — a container-level object
-    # REPLACES the pod-level struct wholesale, so writing `level` there would
-    # discard the operator's sibling fields — and the pod rule above fills only
-    # fsGroupChangePolicy. Every container with no override therefore inherits
-    # `{user: system_u}` with no level, and the promised C-0211 field is never
-    # supplied. Measured 2026-08-30: `velero/podlevel-partial` came back with
-    # its containers inheriting a level-less object.
-    #
-    # Fill the missing leaf at POD scope, where it is free: the `+(level)`
-    # anchor preserves every sibling, and one write covers all containers and
-    # initContainers that do not override.
-    #
-    # The precondition scopes this to pods that ALREADY carry a pod-level
-    # object, so it never creates one where the author set none — that shape is
-    # the container rule's, and creating a pod-level object here would silently
-    # move ownership between rules and change the `plain` case.
-    - name: add-baseline-context-optin-pod-selinux-level
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-              operations:
-                - CREATE
-              namespaceSelector:
-                matchLabels:
-                  pod-security.devantler.tech/baseline-context: enabled
-      preconditions:
-        all:
-          - key: "{{ request.object.spec.securityContext.seLinuxOptions || '' }}"
-            operator: NotEquals
-            value: ''
-          - key: "{{ request.object.spec.securityContext.seLinuxOptions.level || '' }}"
-            operator: Equals
-            value: ''
-      mutate:
-        patchStrategicMerge:
-          spec:
-            securityContext:
-              seLinuxOptions:
-                +(level): s0
-    # The anchor is on the LEAF (`+(level)`), not the whole object. Anchoring
-    # `+(seLinuxOptions)` would fire only when the object is entirely absent, so a
-    # container carrying some other SELinux field with no `level` would be reported
-    # as mutated while `level` stayed unset — measured 2026-08-29: such a container
-    # came back `{user: system_u}`. The leaf anchor fills the missing field and
-    # preserves siblings. `tests/add-baseline-context` pins all three states; do not
-    # collapse this back to an object-level anchor.
+    # Default only a missing container object when no pod object is inherited.
+    # Kubernetes replaces the whole pod-level struct with a container override,
+    # even an empty one. Never fill individual leaves or shadow pod options.
+    # JSON Patch preserves the empty mapping that strategic merge omits; key
+    # presence guards supply the same preservation boundary as a +() anchor.
     - name: add-baseline-context-optin-containers
       match:
         any:
@@ -365,60 +340,32 @@ spec:
       mutate:
         foreach:
           - list: "request.object.spec.containers"
-            # A container-level seLinuxOptions REPLACES the pod-level struct wholesale
-            # (kubelet DetermineEffectiveSecurityContext), so injecting `level` into a
-            # container that has none would discard the pod's ENTIRE SELinux identity for
-            # that container — measured 2026-08-29: a pod declaring
-            # `{user: system_u, level: s9}` came back with the container on `{level: s0}`,
-            # losing both the operator's level and its user. Inject only when the pod sets
-            # no SELinux options at all, or when the container already overrides them.
-            # "Overrides" is tested by KEY PRESENCE, not truthiness: a container that sets
-            # `seLinuxOptions: {}` is an override Kubernetes honours (the pod-level object no
-            # longer applies to it), yet the empty mapping is falsy to JMESPath, so an
-            # `|| ''` test read it as absent and left that container with no level at all.
             preconditions:
-              any:
-                - key: "{{ request.object.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                containers:
-                  - (name): "{{element.name}}"
-                    securityContext:
-                      seLinuxOptions:
-                        +(level): s0
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/containers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
           - list: "request.object.spec.initContainers[]"
-            # A container-level seLinuxOptions REPLACES the pod-level struct wholesale
-            # (kubelet DetermineEffectiveSecurityContext), so injecting `level` into a
-            # container that has none would discard the pod's ENTIRE SELinux identity for
-            # that container — measured 2026-08-29: a pod declaring
-            # `{user: system_u, level: s9}` came back with the container on `{level: s0}`,
-            # losing both the operator's level and its user. Inject only when the pod sets
-            # no SELinux options at all, or when the container already overrides them.
-            # "Overrides" is tested by KEY PRESENCE, not truthiness: a container that sets
-            # `seLinuxOptions: {}` is an override Kubernetes honours (the pod-level object no
-            # longer applies to it), yet the empty mapping is falsy to JMESPath, so an
-            # `|| ''` test read it as absent and left that container with no level at all.
             preconditions:
-              any:
-                - key: "{{ request.object.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                initContainers:
-                  - (name): "{{element.name}}"
-                    securityContext:
-                      seLinuxOptions:
-                        +(level): s0
-    # CONTROLLER-KIND COUNTERPARTS of the three opt-in rules above. Those rules
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/initContainers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
+    # CONTROLLER-KIND COUNTERPARTS of the two opt-in rules above. Those rules
     # match `Pod` and this policy generates no autogen rules (its live
     # `status.autogen` is empty), so they mutate only at pod admission and the
     # STORED controller spec — the one Kubescape scores for C-0211 — is never
@@ -486,7 +433,7 @@ spec:
     # CREATE-only. A Job spawned from a mutated CronJob already carries the
     # fields; a standalone Job gets them at creation.
     #
-    # Same two fields, same leaf-level SELinux anchors and the same
+    # Same two fields, same whole-object SELinux guards and the same
     # wholesale-replace guards as the pod rules; only the path differs
     # (`spec.template.spec`, and `spec.jobTemplate.spec.template.spec` for
     # CronJobs). `tests/add-baseline-context` pins every state for the
@@ -520,44 +467,6 @@ spec:
               spec:
                 securityContext:
                   +(fsGroupChangePolicy): OnRootMismatch
-    - name: add-baseline-context-optin-controllers-pod-selinux-level
-      match:
-        any:
-          - resources:
-              kinds:
-                - Deployment
-                - StatefulSet
-                - DaemonSet
-              operations:
-                - CREATE
-                - UPDATE
-              namespaceSelector:
-                matchLabels:
-                  pod-security.devantler.tech/baseline-context-controllers: enabled
-          - resources:
-              kinds:
-                - Job
-              operations:
-                - CREATE
-              namespaceSelector:
-                matchLabels:
-                  pod-security.devantler.tech/baseline-context-controllers: enabled
-      preconditions:
-        all:
-          - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
-            operator: NotEquals
-            value: ''
-          - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions.level || '' }}"
-            operator: Equals
-            value: ''
-      mutate:
-        patchStrategicMerge:
-          spec:
-            template:
-              spec:
-                securityContext:
-                  seLinuxOptions:
-                    +(level): s0
     - name: add-baseline-context-optin-controllers-containers
       match:
         any:
@@ -584,40 +493,30 @@ spec:
         foreach:
           - list: "request.object.spec.template.spec.containers"
             preconditions:
-              any:
-                - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.template.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                template:
-                  spec:
-                    containers:
-                      - (name): "{{element.name}}"
-                        securityContext:
-                          seLinuxOptions:
-                            +(level): s0
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
           - list: "request.object.spec.template.spec.initContainers[]"
             preconditions:
-              any:
-                - key: "{{ request.object.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.template.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                template:
-                  spec:
-                    initContainers:
-                      - (name): "{{element.name}}"
-                        securityContext:
-                          seLinuxOptions:
-                            +(level): s0
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
     - name: add-baseline-context-optin-cronjobs
       match:
         any:
@@ -639,36 +538,6 @@ spec:
                   spec:
                     securityContext:
                       +(fsGroupChangePolicy): OnRootMismatch
-    - name: add-baseline-context-optin-cronjobs-pod-selinux-level
-      match:
-        any:
-          - resources:
-              kinds:
-                - CronJob
-              operations:
-                - CREATE
-                - UPDATE
-              namespaceSelector:
-                matchLabels:
-                  pod-security.devantler.tech/baseline-context-controllers: enabled
-      preconditions:
-        all:
-          - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
-            operator: NotEquals
-            value: ''
-          - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.level || '' }}"
-            operator: Equals
-            value: ''
-      mutate:
-        patchStrategicMerge:
-          spec:
-            jobTemplate:
-              spec:
-                template:
-                  spec:
-                    securityContext:
-                      seLinuxOptions:
-                        +(level): s0
     - name: add-baseline-context-optin-cronjobs-containers
       match:
         any:
@@ -685,41 +554,27 @@ spec:
         foreach:
           - list: "request.object.spec.jobTemplate.spec.template.spec.containers"
             preconditions:
-              any:
-                - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.jobTemplate.spec.template.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                jobTemplate:
-                  spec:
-                    template:
-                      spec:
-                        containers:
-                          - (name): "{{element.name}}"
-                            securityContext:
-                              seLinuxOptions:
-                                +(level): s0
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/jobTemplate/spec/template/spec/containers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}
           - list: "request.object.spec.jobTemplate.spec.template.spec.initContainers[]"
             preconditions:
-              any:
-                - key: "{{ request.object.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions || '' }}"
+              all:
+                - key: "{{ to_string(contains(keys(request.object.spec.jobTemplate.spec.template.spec.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: ''
+                  value: "false"
                 - key: "{{ to_string(contains(keys(element.securityContext || `{}`), 'seLinuxOptions')) }}"
                   operator: Equals
-                  value: "true"
-            patchStrategicMerge:
-              spec:
-                jobTemplate:
-                  spec:
-                    template:
-                      spec:
-                        initContainers:
-                          - (name): "{{element.name}}"
-                            securityContext:
-                              seLinuxOptions:
-                                +(level): s0
+                  value: "false"
+            patchesJson6902: |-
+              - op: add
+                path: /spec/jobTemplate/spec/template/spec/initContainers/{{elementIndex}}/securityContext/seLinuxOptions
+                value: {}

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -258,8 +258,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-posture-staleness-alert.yaml
@@ -303,8 +303,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-stranded-volume-attach-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-stranded-volume-attach-alert.yaml
@@ -284,8 +284,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job.yaml
@@ -127,8 +127,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
@@ -23,10 +23,9 @@ metadata:
     # seLinuxOptions at all. That last shape matters — with no pod-level SELinux
     # object anywhere, only the two straightforward rules apply
     # (add-baseline-context-optin-namespaces supplies fsGroupChangePolicy,
-    # add-baseline-context-optin-containers supplies level: s0 per container).
-    # add-baseline-context-optin-pod-selinux-level requires a pre-existing
-    # pod-level object, so it cannot fire here; none of the wholesale-replace
-    # hazards that rule exists for are reachable in this namespace.
+    # add-baseline-context-optin-containers supplies an empty SELinux object).
+    # Explicit pod options remain inherited; none of the wholesale-replace
+    # hazards are reachable in this measured namespace shape.
     #
     # The rules are CREATE-only, so running pods are unaffected until they are
     # next recreated.

--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
@@ -66,9 +66,8 @@ spec:
   # - fsGroupChangePolicy governs the kubelet's volume ownership pass, which runs only
   #   when a pod sets fsGroup. This pod sets none, and its only volumes are an emptyDir
   #   and the projected service-account token — no PVC, no hostPath.
-  # - seLinuxOptions {level: s0} is the default non-privileged MCS level and a no-op on
-  #   this AppArmor cluster (runc ignores SELinux labels when SELinux is not the active
-  #   LSM), retained as CIS-5.7.3 defense-in-depth on any SELinux node.
+  # - Empty seLinuxOptions satisfies C-0211 while leaving SELinux type and MCS
+  #   categories to the runtime. It is a no-op on this AppArmor cluster.
   #
   # Neither carries the runAsGroup-without-runAsUser coupling documented above, so
   # neither can stop the sandbox building.
@@ -108,8 +107,7 @@ spec:
                 value: 65532
               - op: add
                 path: /spec/template/spec/containers/0/securityContext/seLinuxOptions
-                value:
-                  level: s0
+                value: {}
           - target:
               kind: Deployment
               name: flux-operator

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -55,12 +55,11 @@ spec:
         # readOnlyRootFilesystem is safe here (unlike the main server below).
         # UID 65532 matches this image's baked nonroot user.
         securityContext:
-          # SELinux level for the plugin-copy initContainer's stored template
+          # Runtime-selected SELinux labels for the plugin-copy initContainer's stored template
           # (#3522). The pod declares no seLinuxOptions, so this container-level
           # object replaces no inherited struct -- the wholesale-replace hazard
           # in #3469 is unreachable here.
-          seLinuxOptions:
-            level: s0
+          seLinuxOptions: {}
           runAsNonRoot: true
           runAsUser: 65532
           allowPrivilegeEscalation: false
@@ -103,10 +102,9 @@ spec:
       seccompProfile:
         type: RuntimeDefault
     containerSecurityContext:
-      # SELinux level for the server container's stored template (#3522).
+      # Runtime-selected SELinux labels for the server container's stored template (#3522).
       # The pod sets no seLinuxOptions, so this replaces no inherited struct.
-      seLinuxOptions:
-        level: s0
+      seLinuxOptions: {}
       runAsNonRoot: true
       runAsUser: 65532
       allowPrivilegeEscalation: false
@@ -240,8 +238,7 @@ spec:
       # The DaemonSet declares no pod-level seLinuxOptions, so this
       # container-level object replaces no inherited struct (#3469).
       containerSecurityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
       updateStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -84,8 +84,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
           resources:
             requests:
               cpu: 10m
@@ -115,8 +114,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
           resources:
             requests:
               cpu: 20m

--- a/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
+++ b/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
@@ -86,8 +86,7 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
           resources:
             requests:
               cpu: 10m
@@ -143,8 +142,7 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
           resources:
             requests:
               cpu: 10m

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -230,8 +230,7 @@ spec:
             value: OnRootMismatch
           - op: add
             path: /spec/template/spec/containers/0/securityContext/seLinuxOptions
-            value:
-              level: s0
+            value: {}
       # Enforce cosign signature verification on the ROOT source — the
       # flux-system OCIRepository every controller, tenant binding and policy
       # arrives through. Without this the root artifact is pulled from a mutable

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
@@ -101,8 +101,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-crossplane-sync-alerter.yaml
@@ -95,8 +95,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-custom-cloud-pricing.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-custom-cloud-pricing.yaml
@@ -97,8 +97,7 @@ spec:
                 runAsUser: 65532
                 runAsGroup: 65532
                 # CIS-5.7.3 (C-0211); a documented no-op on this AppArmor cluster.
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
                 capabilities:
                   drop:
                     - ALL

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
@@ -57,8 +57,7 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
               resources:
                 requests:
                   cpu: 10m

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-family-aws.yaml
@@ -50,8 +50,7 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
               resources:
                 requests:
                   cpu: 10m

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-upjet-unifi.yaml
@@ -51,8 +51,7 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
               resources:
                 requests:
                   cpu: 10m

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config.yaml
@@ -52,8 +52,7 @@ spec:
                     - ALL
                 seccompProfile:
                   type: RuntimeDefault
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
               resources:
                 requests:
                   cpu: 10m

--- a/scripts/tests/test-add-baseline-context.sh
+++ b/scripts/tests/test-add-baseline-context.sh
@@ -49,18 +49,18 @@ check() {
 # container and initContainer. These are the assertions the vacuity trap hides.
 check plain-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in pod did not receive fsGroupChangePolicy"
-check plain-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in container did not receive seLinuxOptions"
-check plain-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in initContainer did not receive seLinuxOptions"
+check plain-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in container did not retain an empty seLinuxOptions object"
+check plain-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in initContainer did not retain an empty seLinuxOptions object"
 
 # A pod with no initContainers at all is the common shape; the foreach over
 # `spec.initContainers[]` must tolerate the field being absent rather than
 # erroring, which would drop the container mutation with it.
 check no-init-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "pod without initContainers did not receive fsGroupChangePolicy"
-check no-init-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "pod without initContainers did not receive seLinuxOptions"
+check no-init-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "pod without initContainers did not retain an empty seLinuxOptions object"
 
 # Conditional anchors — a workload that sets its own values keeps them.
 check preset-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
@@ -70,17 +70,14 @@ check preset-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.le
 check preset-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
   s9 "preset initContainer seLinuxOptions was overwritten"
 
-# A container that already carries a PARTIAL seLinuxOptions object — a sibling
-# field set, `level` absent. Anchoring the whole object would see it present and
-# skip, leaving `level` unset while the rule still reports as applied; anchoring
-# the leaf fills the gap and preserves the sibling. Measured 2026-08-29: with the
-# object-level anchor this came back `{user: system_u}` with no level at all.
+# Existing container options are complete operator choices, including an unset
+# level. Preserve the object so the runtime assigns the MCS categories.
 check partial-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "partial container seLinuxOptions did not receive the missing level"
+  null "partial container seLinuxOptions overrode runtime level selection"
 check partial-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.user' \
   system_u "partial container seLinuxOptions lost its pre-existing user"
 check partial-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "partial initContainer seLinuxOptions did not receive the missing level"
+  null "partial initContainer seLinuxOptions overrode runtime level selection"
 check partial-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.user' \
   system_u "partial initContainer seLinuxOptions lost its pre-existing user"
 
@@ -111,17 +108,10 @@ check podlevel-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "pod-level rule did not fire on the podlevel fixture"
 
 
-# A pod-level SELinux object that EXISTS but has no `level`, with containers
-# carrying none of their own. The container foreach must stay skipped for this
-# shape — writing a container-level object would replace the pod struct wholesale
-# and drop `user` — so the missing field can only be supplied at pod scope.
-# Measured 2026-08-30 with add-baseline-context-optin-pod-selinux-level removed:
-# both containers inherited `{user: system_u}` with no level, so C-0211 went
-# unmet while every rule still reported success. The fsGroupChangePolicy
-# assertion proves the fixture is processed at all, so a rule that stopped
-# matching cannot make the others pass vacuously.
+# Partial pod options remain inherited as a whole; leave level selection to the
+# runtime and preserve the operator's user. The fsGroup check prevents vacuity.
 check podlevel-partial-mutated.yaml '.spec.securityContext.seLinuxOptions.level' \
-  s0 "partial pod-level seLinuxOptions did not receive the missing level"
+  null "partial pod-level seLinuxOptions overrode runtime level selection"
 check podlevel-partial-mutated.yaml '.spec.securityContext.seLinuxOptions.user' \
   system_u "partial pod-level seLinuxOptions lost its pre-existing user"
 check podlevel-partial-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
@@ -142,10 +132,10 @@ check podlevel-partial-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' 
 # rollout guardrail is explicit that each namespace is proven, not assumed.
 check coroot-node-agent-mutated.yaml '.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "observability pod did not receive fsGroupChangePolicy"
-check coroot-node-agent-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "observability container did not receive seLinuxOptions"
-check coroot-node-agent-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "observability initContainer did not receive seLinuxOptions"
+check coroot-node-agent-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "observability container did not retain an empty seLinuxOptions object"
+check coroot-node-agent-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "observability initContainer did not retain an empty seLinuxOptions object"
 check coroot-node-agent-mutated.yaml '.spec.securityContext.seLinuxOptions' \
   null "pod-scope SELinux fill created an object where the author set none"
 
@@ -162,10 +152,10 @@ check coroot-node-agent-mutated.yaml '.spec.securityContext.seLinuxOptions' \
 # template and on every container and initContainer.
 check operator-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in Deployment template did not receive fsGroupChangePolicy"
-check operator-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in Deployment container did not receive seLinuxOptions"
-check operator-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in Deployment initContainer did not receive seLinuxOptions"
+check operator-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in Deployment container did not retain an empty seLinuxOptions object"
+check operator-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in Deployment initContainer did not retain an empty seLinuxOptions object"
 check operator-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions' \
   null "controller pod-scope SELinux fill created an object where the author set none"
 
@@ -173,25 +163,25 @@ check operator-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxO
 # field rather than dropping the container mutation with it.
 check server-sts-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in StatefulSet template did not receive fsGroupChangePolicy"
-check server-sts-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in StatefulSet container did not receive seLinuxOptions"
+check server-sts-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in StatefulSet container did not retain an empty seLinuxOptions object"
 
 # A privileged DaemonSet, the shape Longhorn actually runs: privilege is
 # untouched and the two fields are supplied beside it.
 check manager-ds-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in DaemonSet template did not receive fsGroupChangePolicy"
-check manager-ds-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in DaemonSet container did not receive seLinuxOptions"
+check manager-ds-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in DaemonSet container did not retain an empty seLinuxOptions object"
 check manager-ds-mutated.yaml '.spec.template.spec.containers[0].securityContext.privileged' \
   true "controller rule changed a privilege field it must not touch"
 
 # The jobTemplate path.
 check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in CronJob template did not receive fsGroupChangePolicy"
-check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in CronJob container did not receive seLinuxOptions"
-check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in CronJob initContainer did not receive seLinuxOptions"
+check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in CronJob container did not retain an empty seLinuxOptions object"
+check nightly-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in CronJob initContainer did not retain an empty seLinuxOptions object"
 
 # OFF state — an unlabelled namespace's controllers are untouched.
 check unlabelled-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
@@ -218,10 +208,9 @@ check podlevel-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxO
 check podlevel-deploy-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "controller rule did not fire on the podlevel-deploy fixture"
 
-# The pod-level-object-without-level shape at controller scope: only the
-# pod-scope fill may supply the level, preserving the sibling user.
+# Partial pod options on a controller also retain runtime level selection.
 check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.level' \
-  s0 "partial Deployment pod-level seLinuxOptions did not receive the missing level"
+  null "partial Deployment pod-level seLinuxOptions overrode runtime level selection"
 check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.user' \
   system_u "partial Deployment pod-level seLinuxOptions lost its pre-existing user"
 check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
@@ -230,15 +219,12 @@ check podlevel-partial-deploy-mutated.yaml '.spec.template.spec.containers[0].se
 # A standalone Job (CREATE-only kind) takes the template path like the others.
 check oneshot-job-mutated.yaml '.spec.template.spec.securityContext.fsGroupChangePolicy' \
   OnRootMismatch "opted-in Job template did not receive fsGroupChangePolicy"
-check oneshot-job-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "opted-in Job container did not receive seLinuxOptions"
+check oneshot-job-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "opted-in Job container did not retain an empty seLinuxOptions object"
 
-# The jobTemplate pod-scope fill: a CronJob whose pod-level SELinux object has no
-# `level` receives it there, keeps its `user`, and its containers stay untouched.
-# Measured on this fixture with the rule deleted: the fixture reads Excluded and
-# `kyverno test` still passes, so this is the only gate that sees the rule.
+# Partial CronJob pod options are inherited without adding a fixed level.
 check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.level' \
-  s0 "partial CronJob pod-level seLinuxOptions did not receive the missing level"
+  null "partial CronJob pod-level seLinuxOptions overrode runtime level selection"
 check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions.user' \
   system_u "partial CronJob pod-level seLinuxOptions lost its pre-existing user"
 check podlevel-partial-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
@@ -262,29 +248,69 @@ check podlabel-only-deploy-mutated.yaml '.spec.template.spec.securityContext.fsG
 check podlabel-only-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
   null "pod-rule label alone injected seLinuxOptions into a controller"
 
-# An EXPLICITLY EMPTY container-level SELinux object under a complete pod-level object.
-# Kubernetes treats the non-null empty object as an override (DetermineEffectiveSecurityContext),
-# so the effective container context has NO level — and to JMESPath the empty mapping is
-# falsy, so an `|| ''` presence test read it as absent and left it that way. Measured on
-# the previous head: `{}` came back unchanged at pod and controller scope. The key-presence
-# test fills the level; the sibling container that sets nothing stays untouched because the
-# pod-level object still governs it.
-check empty-override-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "empty container-level SELinux override did not receive the missing level (pod)"
-check empty-override-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "empty initContainer-level SELinux override did not receive the missing level (pod)"
+# An explicitly empty container object is a complete override. Preserve it while
+# leaving siblings that inherit the pod options untouched.
+check empty-override-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "empty container-level SELinux override was not preserved (pod)"
+check empty-override-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "empty initContainer-level SELinux override was not preserved (pod)"
 check empty-override-mutated.yaml '.spec.containers[1].securityContext.seLinuxOptions' \
   null "a container with no override was injected beside an empty-override sibling (pod)"
 check empty-override-mutated.yaml '.spec.securityContext.seLinuxOptions.level' \
   s9 "pod-level level was not preserved beside an empty container override (pod)"
-check empty-override-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions.level' \
-  s0 "empty container-level SELinux override did not receive the missing level (Deployment)"
-check empty-override-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions.level' \
-  s0 "empty initContainer-level SELinux override did not receive the missing level (Deployment)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "empty container-level SELinux override was not preserved (Deployment)"
+check empty-override-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "empty initContainer-level SELinux override was not preserved (Deployment)"
 check empty-override-deploy-mutated.yaml '.spec.template.spec.containers[1].securityContext.seLinuxOptions' \
   null "a container with no override was injected beside an empty-override sibling (Deployment)"
 check empty-override-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions.level' \
   s9 "pod-level level was not preserved beside an empty container override (Deployment)"
+
+# General namespaces must retain every other security default while preserving
+# whole pod options, including empty maps, on both container paths.
+check general-plain-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  '{}' "general-plain containers changed SELinux defaults or inheritance"
+check general-plain-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  '{}' "general-plain initContainers changed SELinux defaults or inheritance"
+check general-plain-mutated.yaml '.spec.containers[0].securityContext.allowPrivilegeEscalation' \
+  false "general-plain lost independent container hardening"
+check general-podlevel-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  null "general-podlevel containers changed SELinux defaults or inheritance"
+check general-podlevel-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "general-podlevel initContainers changed SELinux defaults or inheritance"
+check general-podlevel-mutated.yaml '.spec.containers[0].securityContext.allowPrivilegeEscalation' \
+  false "general-podlevel lost independent container hardening"
+check general-partial-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  'user: system_u' "general-partial containers changed SELinux defaults or inheritance"
+check general-partial-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  'user: system_u' "general-partial initContainers changed SELinux defaults or inheritance"
+check general-partial-mutated.yaml '.spec.containers[0].securityContext.allowPrivilegeEscalation' \
+  false "general-partial lost independent container hardening"
+check general-empty-pod-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  null "general-empty-pod containers changed SELinux defaults or inheritance"
+check general-empty-pod-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "general-empty-pod initContainers changed SELinux defaults or inheritance"
+check general-empty-pod-mutated.yaml '.spec.containers[0].securityContext.allowPrivilegeEscalation' \
+  false "general-empty-pod lost independent container hardening"
+check general-empty-pod-mutated.yaml '.spec.securityContext.seLinuxOptions' \
+  '{}' "general-empty-pod changed explicit empty pod options"
+check empty-pod-mutated.yaml '.spec.containers[0].securityContext.seLinuxOptions' \
+  null "empty-pod containers changed SELinux defaults or inheritance"
+check empty-pod-mutated.yaml '.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "empty-pod initContainers changed SELinux defaults or inheritance"
+check empty-pod-mutated.yaml '.spec.securityContext.seLinuxOptions' \
+  '{}' "empty-pod changed explicit empty pod options"
+check empty-pod-deploy-mutated.yaml '.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "empty-pod-deploy containers changed SELinux defaults or inheritance"
+check empty-pod-deploy-mutated.yaml '.spec.template.spec.initContainers[0].securityContext.seLinuxOptions' \
+  null "empty-pod-deploy initContainers changed SELinux defaults or inheritance"
+check empty-pod-deploy-mutated.yaml '.spec.template.spec.securityContext.seLinuxOptions' \
+  '{}' "empty-pod-deploy changed explicit empty pod options"
+check empty-pod-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.containers[0].securityContext.seLinuxOptions' \
+  null "empty-pod-cronjob containers changed SELinux defaults or inheritance"
+check empty-pod-cronjob-mutated.yaml '.spec.jobTemplate.spec.template.spec.securityContext.seLinuxOptions' \
+  '{}' "empty-pod-cronjob changed explicit empty pod options"
 
 # ROLLOUT INVENTORY. The rules above ship default-off, so what they actually do
 # in the cluster is decided entirely by which namespaces carry the opt-in label —

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1746,7 +1746,15 @@ const (
 // and before it:
 //
 //	ab05bc2c95924e372c038f878872aa94e3bd81380daa96a283bd7f74e2132a69
-const expectedRenderedSurfaceSHA = "1fc28a50d08f48c8cc32eb36fe012dc1322f602282ca47b02c418376a7e6dcca"
+//
+// Re-approved for #3477: SELinux defaults leave label allocation to the runtime.
+// kubectl v1.36.2 / Kustomize v5.8.1 rendered all five overlays on base 19642fe9
+// and this tree: 553 identities on each side, zero additions/removals/duplicates.
+// All 82 grant-bearing RBAC and ServiceAccount documents are unchanged; the 16
+// changed documents contain only the reviewed SELinux policy/template updates.
+// Removing one Namespace in a negative control reports exactly one removal.
+// Previous aggregate: 1fc28a50d08f48c8cc32eb36fe012dc1322f602282ca47b02c418376a7e6dcca.
+const expectedRenderedSurfaceSHA = "d76e357336f1c4817766463bf7990648b5c8b019939aaf680606929d51bd46b4"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/tests/add-baseline-context/kyverno-test.yaml
+++ b/tests/add-baseline-context/kyverno-test.yaml
@@ -32,25 +32,10 @@ results:
     resources:
       - velero/plain
       - velero/no-init
-      - velero/partial
       - observability/coroot-node-agent
     kind: Pod
     result: pass
     patchedResources: patched-resources.yaml
-  # The pod-scope SELinux fill closes the one shape the container foreach must
-  # leave alone: a pod-level object that exists but carries no `level`. It fires
-  # for exactly that shape and nothing else.
-  - policy: add-security-context
-    rule: add-baseline-context-optin-pod-selinux-level
-    resources:
-      - velero/podlevel-partial
-    kind: Pod
-    result: pass
-    patchedResources: patched-resources.yaml
-  # OFF state, and the anchor-preservation case. chaos-mesh carries no opt-in
-  # label so neither rule may touch it; velero/preset already sets both fields to
-  # non-default values, so the conditional anchors leave it unchanged and the
-  # mutation is reported as skipped.
   - policy: add-security-context
     rule: add-baseline-context-optin-namespaces
     resources:
@@ -62,32 +47,12 @@ results:
     rule: add-baseline-context-optin-containers
     resources:
       - chaos-mesh/unlabelled
+      - velero/partial
       - velero/preset
       - velero/podlevel
       - velero/podlevel-partial
     kind: Pod
     result: skip
-  # The pod-scope fill must NOT fire anywhere else: not where the pod sets no
-  # SELinux object at all (that shape belongs to the container rule), and not
-  # where the pod-level object is already complete.
-  - policy: add-security-context
-    rule: add-baseline-context-optin-pod-selinux-level
-    resources:
-      - chaos-mesh/unlabelled
-      - velero/plain
-      - velero/no-init
-      - velero/partial
-      - velero/preset
-      - velero/podlevel
-      # The observability fixture sets no pod-level SELinux object, so this rule
-      # must not fire there either — that shape belongs to the container rule.
-      - observability/coroot-node-agent
-    kind: Pod
-    result: skip
-  # --- Controller kinds ---------------------------------------------------
-  # The stored controller spec is what Kubescape scores and the pod rules never
-  # reach it, so every state above is pinned again at the controller object.
-  # ON state, template path.
   - policy: add-security-context
     rule: add-baseline-context-optin-controllers
     resources:
@@ -145,15 +110,6 @@ results:
     kind: CronJob
     result: pass
     patchedResources: patched-resources.yaml
-  # The pod-scope SELinux fill at controller scope: fires only on the
-  # pod-level-object-without-level shape.
-  - policy: add-security-context
-    rule: add-baseline-context-optin-controllers-pod-selinux-level
-    resources:
-      - velero/podlevel-partial-deploy
-    kind: Deployment
-    result: pass
-    patchedResources: patched-resources.yaml
   - policy: add-security-context
     rule: add-baseline-context-optin-controllers
     resources:
@@ -180,22 +136,6 @@ results:
     kind: Deployment
     result: skip
   - policy: add-security-context
-    rule: add-baseline-context-optin-controllers-pod-selinux-level
-    resources:
-      - chaos-mesh/unlabelled-deploy
-      - velero/preset-deploy
-      - velero/podlevel-deploy
-      - observability/operator-deploy
-    kind: Deployment
-    result: skip
-  - policy: add-security-context
-    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
-    resources:
-      - observability/nightly-cronjob
-    kind: CronJob
-    result: skip
-  # A standalone Job (CREATE-only kind) takes the template path.
-  - policy: add-security-context
     rule: add-baseline-context-optin-controllers
     resources:
       - observability/oneshot-job
@@ -209,16 +149,6 @@ results:
     kind: Job
     result: pass
     patchedResources: patched-resources.yaml
-  # The jobTemplate pod-scope fill fires on exactly the partial pod-level shape
-  # and nowhere else; the CronJob rules still land fsGroupChangePolicy on the
-  # pod-level fixtures and keep the container foreach out.
-  - policy: add-security-context
-    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
-    resources:
-      - velero/podlevel-partial-cronjob
-    kind: CronJob
-    result: pass
-    patchedResources: patched-resources.yaml
   - policy: add-security-context
     rule: add-baseline-context-optin-cronjobs
     resources:
@@ -227,12 +157,6 @@ results:
     kind: CronJob
     result: pass
     patchedResources: patched-resources.yaml
-  - policy: add-security-context
-    rule: add-baseline-context-optin-cronjobs-pod-selinux-level
-    resources:
-      - velero/podlevel-cronjob
-    kind: CronJob
-    result: skip
   - policy: add-security-context
     rule: add-baseline-context-optin-cronjobs-containers
     resources:
@@ -253,23 +177,19 @@ results:
       - kubescape/podlabel-only-deploy
     kind: Deployment
     result: skip
-  # An explicitly EMPTY container-level SELinux object under a complete pod-level
-  # object is an override Kubernetes honours, so the container rule must fill its
-  # level (and leave the sibling container that sets nothing alone).
+  # Explicit empty container overrides are preserved unchanged.
   - policy: add-security-context
     rule: add-baseline-context-optin-containers
     resources:
       - velero/empty-override
     kind: Pod
-    result: pass
-    patchedResources: patched-resources.yaml
+    result: skip
   - policy: add-security-context
     rule: add-baseline-context-optin-controllers-containers
     resources:
       - velero/empty-override-deploy
     kind: Deployment
-    result: pass
-    patchedResources: patched-resources.yaml
+    result: skip
   - policy: add-security-context
     rule: add-baseline-context-optin-controllers
     resources:

--- a/tests/add-baseline-context/patched-resources.yaml
+++ b/tests/add-baseline-context/patched-resources.yaml
@@ -9,14 +9,12 @@ spec:
     - name: init
       image: velero/velero-plugin:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   containers:
     - name: app
       image: velero/velero:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
 ---
@@ -30,8 +28,7 @@ spec:
     - name: app
       image: velero/velero:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
 ---
@@ -46,14 +43,12 @@ spec:
       image: velero/velero-plugin:v1.0.0
       securityContext:
         seLinuxOptions:
-          level: s0
           user: system_u
   containers:
     - name: app
       image: velero/velero:v1.0.0
       securityContext:
         seLinuxOptions:
-          level: s0
           user: system_u
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
@@ -91,7 +86,6 @@ spec:
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
     seLinuxOptions:
-      level: s0
       user: system_u
 ---
 apiVersion: v1
@@ -109,14 +103,12 @@ spec:
     - name: init
       image: ghcr.io/coroot/coroot-node-agent:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   containers:
     - name: node-agent
       image: ghcr.io/coroot/coroot-node-agent:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   securityContext:
     fsGroupChangePolicy: OnRootMismatch
 ---
@@ -138,14 +130,12 @@ spec:
         - name: init
           image: ghcr.io/coroot/coroot-operator:1.9.5
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       containers:
         - name: operator
           image: ghcr.io/coroot/coroot-operator:1.9.5
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       securityContext:
         fsGroupChangePolicy: OnRootMismatch
 ---
@@ -168,8 +158,7 @@ spec:
         - name: server
           image: ghcr.io/coroot/coroot:1.22.2
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       securityContext:
         fsGroupChangePolicy: OnRootMismatch
 ---
@@ -192,8 +181,7 @@ spec:
           image: longhornio/longhorn-manager:v1.9.0
           securityContext:
             privileged: true
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       securityContext:
         fsGroupChangePolicy: OnRootMismatch
 ---
@@ -213,14 +201,12 @@ spec:
             - name: init
               image: ghcr.io/coroot/coroot:1.22.2
               securityContext:
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
           containers:
             - name: job
               image: ghcr.io/coroot/coroot:1.22.2
               securityContext:
-                seLinuxOptions:
-                  level: s0
+                seLinuxOptions: {}
           securityContext:
             fsGroupChangePolicy: OnRootMismatch
 ---
@@ -267,7 +253,6 @@ spec:
       securityContext:
         seLinuxOptions:
           user: system_u
-          level: s0
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: init
@@ -289,8 +274,7 @@ spec:
         - name: job
           image: ghcr.io/coroot/coroot:1.22.2
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       securityContext:
         fsGroupChangePolicy: OnRootMismatch
 ---
@@ -309,7 +293,6 @@ spec:
           securityContext:
             seLinuxOptions:
               user: system_u
-              level: s0
             fsGroupChangePolicy: OnRootMismatch
           initContainers:
             - name: init
@@ -354,14 +337,12 @@ spec:
     - name: init
       image: velero/velero-plugin:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
   containers:
     - name: app
       image: velero/velero:v1.0.0
       securityContext:
-        seLinuxOptions:
-          level: s0
+        seLinuxOptions: {}
     - name: plain
       image: velero/velero:v1.0.0
 ---
@@ -388,13 +369,11 @@ spec:
         - name: init
           image: velero/velero:v1.16.0
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
       containers:
         - name: velero
           image: velero/velero:v1.16.0
           securityContext:
-            seLinuxOptions:
-              level: s0
+            seLinuxOptions: {}
         - name: plain
           image: velero/velero:v1.16.0

--- a/tests/add-baseline-context/resources.yaml
+++ b/tests/add-baseline-context/resources.yaml
@@ -61,12 +61,7 @@ spec:
     - name: app
       image: velero/velero:v1.0.0
 ---
-# Opted-in namespace whose container already carries a PARTIAL seLinuxOptions —
-# some other field set, `level` absent. A conditional anchor on the whole object
-# (`+(seLinuxOptions)`) sees it present and skips, leaving `level` unset while
-# still reporting the rule as applied. Anchoring the leaf (`+(level)`) instead
-# fills in the missing field and preserves the sibling. Measured 2026-08-29:
-# with the object-level anchor this pod came back `{user: system_u}` — no level.
+# Partial container options retain every operator field and leave level unset.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -111,14 +106,7 @@ spec:
     - name: app
       image: velero/velero:v1.0.0
 ---
-# Opted-in namespace whose POD-level securityContext declares a PARTIAL SELinux
-# object — a sibling field set, `level` absent — with containers carrying none of
-# their own. The container foreach must still skip (a container-level object
-# would replace the pod struct wholesale and drop `user`), so nothing below the
-# pod can supply the missing field; without a pod-scope fill the containers
-# inherit a level-less object and C-0211 stays unmet while every rule reports
-# success. This is the shape `podlevel` does not cover: that one is already
-# complete (`level: s9`).
+# Partial pod options remain inherited as a whole with runtime-selected level.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -141,13 +129,8 @@ spec:
 # initContainers carrying no seLinuxOptions at all — no pod-level SELinux object
 # anywhere in the namespace.
 #
-# That is the plain shape, so the two straightforward rules do all the work and
-# add-baseline-context-optin-pod-selinux-level cannot fire (it requires a
-# pre-existing pod-level object). Pinned as its own case rather than leaning on
-# velero/plain because the issue's guardrail is explicit that a rollout proves
-# each namespace rather than assuming the previous one generalises — and because
-# this fixture records WHICH shape was onboarded, so a future namespace
-# presenting a different one is not silently assumed covered.
+# This fixture pins the opted-in observability shape separately from velero.
+# Both fields are supplied without creating a pod-level SELinux object.
 #
 # hostPID and the hostPath volume are coroot's node-agent (eBPF collection); no
 # rule reads them, they are here so the fixture is recognisably the real workload.
@@ -313,7 +296,7 @@ spec:
 ---
 # A complete pod-level SELinux object with containers carrying none: the
 # container foreach must stay out (a container-level object would replace the
-# pod struct wholesale), the pod-scope fill must not fire (level present), and
+# pod struct wholesale), and
 # fsGroupChangePolicy still lands.
 apiVersion: apps/v1
 kind: Deployment
@@ -340,8 +323,7 @@ spec:
         - name: velero
           image: velero/velero:v1.16.0
 ---
-# A pod-level SELinux object that EXISTS but has no `level`: only the pod-scope
-# fill may supply it, preserving the sibling `user`.
+# Partial pod options on a Deployment remain inherited without a fixed level.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -380,8 +362,7 @@ spec:
         - name: job
           image: ghcr.io/coroot/coroot:1.22.2
 ---
-# A CronJob whose pod-level SELinux object exists but has no `level`: only the
-# jobTemplate pod-scope fill may supply it, preserving the sibling `user`.
+# Partial pod options on a CronJob remain inherited without a fixed level.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -404,8 +385,7 @@ spec:
             - name: velero
               image: velero/velero:v1.16.0
 ---
-# A CronJob with a complete pod-level SELinux object: the container foreach and
-# the pod-scope fill both stay out; fsGroupChangePolicy still lands.
+# A CronJob with complete pod options: the container foreach stays out; fsGroupChangePolicy still lands.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -447,12 +427,7 @@ spec:
         - name: app
           image: quay.io/kubescape/operator:v0.2.0
 ---
-# A container that EXPLICITLY sets `seLinuxOptions: {}` under a complete pod-level
-# object. Kubernetes treats that non-null empty object as an override, so the
-# effective container context has no level unless the rule fills it — but the
-# empty mapping is falsy to JMESPath, so an `|| ''` presence test reads it as
-# absent and the container is left without a level. The key-presence test
-# distinguishes the two shapes. Pinned at pod scope (this) and controller scope.
+# Explicit empty container options override the pod object and stay empty.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -506,3 +481,130 @@ spec:
             seLinuxOptions: {}
         - name: plain
           image: velero/velero:v1.16.0
+---
+# Runtime default and inheritance regression.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: general-plain
+  namespace: default
+spec:
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+---
+# Runtime default and inheritance regression.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: general-podlevel
+  namespace: default
+spec:
+  securityContext:
+    seLinuxOptions:
+      user: system_u
+      level: s9
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+---
+# Runtime default and inheritance regression.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: general-partial
+  namespace: default
+spec:
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+      securityContext:
+        seLinuxOptions:
+          user: system_u
+---
+# Runtime default and inheritance regression.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: general-empty-pod
+  namespace: default
+spec:
+  securityContext:
+    seLinuxOptions: {}
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+---
+# Runtime default and inheritance regression.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: empty-pod
+  namespace: velero
+spec:
+  securityContext:
+    seLinuxOptions: {}
+  initContainers:
+    - name: init
+      image: velero/velero-plugin:v1.0.0
+  containers:
+    - name: app
+      image: velero/velero:v1.0.0
+---
+# Runtime default and inheritance regression.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-pod-deploy
+  namespace: velero
+spec:
+  selector:
+    matchLabels:
+      app: podlevel-deploy
+  template:
+    metadata:
+      labels:
+        app: podlevel-deploy
+    spec:
+      securityContext:
+        seLinuxOptions: {}
+      initContainers:
+        - name: init
+          image: velero/velero:v1.16.0
+      containers:
+        - name: velero
+          image: velero/velero:v1.16.0
+---
+# Runtime default and inheritance regression.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: empty-pod-cronjob
+  namespace: velero
+spec:
+  schedule: "0 5 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            seLinuxOptions: {}
+          containers:
+            - name: velero
+              image: velero/velero:v1.16.0


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The security defaults force every workload to the same SELinux level. That would weaken isolation if an SELinux node pool is introduced.

## What

Leave SELinux labels to the runtime while retaining the scanner's required object. Preserve operator settings and inheritance, update the stored workload templates, and cover both defaulted and explicit settings with regressions.

Fixes #3477
Fixes #3578
