### PR TITLE
test(security): prove repository-scoped private package access

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,11 @@ jobs:
           shellcheck scripts/tests/test-check-first-party-package-signatures.sh
           bash scripts/tests/test-check-first-party-package-signatures.sh
 
+      - name: 🔐 Validate the scoped package-access experiment
+        # Always run, including workflow-only changes. The real registry proof
+        # is manual and uses credentials only after this code reaches main.
+        run: go test ./scripts/prove-scoped-package-access
+
       # The guard above proves every matcher pins A revision. It cannot say WHICH, and
       # narrowing them to approved revisions (#2818) needs that fact for each consumer.
       # This runs the hermetic half of the report that computes it: the network resolver

--- a/.github/workflows/prove-scoped-package-access.yaml
+++ b/.github/workflows/prove-scoped-package-access.yaml
@@ -1,0 +1,81 @@
+name: Prove Scoped Package Access
+
+# #3274 is an experiment, not an authentication cutover. Only reviewed main may
+# use the existing App and Flux pull credentials; PRs run the hermetic tests.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: prove-scoped-package-access
+  cancel-in-progress: false
+
+jobs:
+  prove:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout reviewed main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Build the probe and install the pinned image reader
+        env:
+          # renovate: datasource=github-releases depName=google/go-containerregistry
+          CRANE_VERSION: v0.21.9
+        run: |
+          go build -o "$RUNNER_TEMP/prove-scoped-package-access" ./scripts/prove-scoped-package-access
+          go install "github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}"
+
+      - name: Setup KSail for the existing encrypted pull credential
+        env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
+          KSAIL_VERSION: "7.181.2"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: .github/scripts/setup-ksail.sh
+
+      - name: Stage the independent baseline credential
+        env:
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          set -euo pipefail
+          source scripts/ghcr-auth-lib.sh
+          umask 077
+          baseline_dir="$RUNNER_TEMP/scoped-package-baseline"
+          mkdir -p "$baseline_dir"
+          chmod 700 "$baseline_dir"
+          decrypt_flux_ghcr_docker_config "$baseline_dir/config.json"
+
+      - name: Mint the repository-scoped candidate
+        id: candidate
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: devantler-tech
+          repositories: wedding-app
+          permission-packages: read
+
+      - name: Prove own-image pull and cross-repository denial
+        env:
+          SCOPED_APP_TOKEN: ${{ steps.candidate.outputs.token }}
+          DOCKER_CONFIG: ${{ runner.temp }}/scoped-package-baseline
+        run: |
+          set -o pipefail
+          "$RUNNER_TEMP/prove-scoped-package-access" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove the baseline credential
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/scoped-package-baseline"

--- a/scripts/prove-scoped-package-access/README.md
+++ b/scripts/prove-scoped-package-access/README.md
@@ -1,0 +1,44 @@
+# Repository-scoped GHCR access experiment
+
+`Prove Scoped Package Access` is the manual CI experiment for #3274. It uses the
+existing App credentials to mint a token with `packages: read` for `wedding-app`
+only. The existing encrypted Flux pull credential supplies the independent
+baseline. No cluster access, package publication or authentication cutover occurs.
+
+The probe verifies the candidate's complete repository scope and both packages'
+private visibility and exact repository association through GitHub's API. It
+resolves the two current `latest` manifests to immutable digests, establishes
+anonymous denial, and fully downloads both images with the baseline credential.
+The candidate must fully download its own image and be denied the other image's
+manifest. Positive controls run again afterward.
+
+Full downloads use a fresh credential directory and destination for every
+[`crane pull`](https://github.com/google/go-containerregistry/blob/v0.21.9/cmd/crane/doc/crane_pull.md),
+without a daemon or shared layer cache. Images are never executed. Credentials,
+raw network responses, image manifests and image contents are excluded from the
+result; temporary credentials and downloads are deleted after each pull.
+
+Run the existing workflow against `main`:
+
+```sh
+gh workflow run prove-scoped-package-access.yaml --repo devantler-tech/platform --ref main
+```
+
+The process and workflow preserve three outcomes:
+
+| Exit | Result | Meaning |
+| --- | --- | --- |
+| 0 | PASS | Own full pull and cross-package denial passed with every control. |
+| 1 | FAIL | A valid scoped token could not read its own package, or could read the other package. |
+| 2 | UNKNOWN | Metadata, privacy, token scope, full download or availability could not be established. |
+
+A missing image, throttling, server error, redirect or malformed response never
+counts as a successful restriction. A failed or unknown run does not authorize
+registry-authentication changes. The spike's result must be recorded before its
+dependent implementation advances.
+
+The hermetic regression suite uses local HTTP fixtures and synthetic credentials:
+
+```sh
+go test ./scripts/prove-scoped-package-access
+```

--- a/scripts/prove-scoped-package-access/main.go
+++ b/scripts/prove-scoped-package-access/main.go
@@ -26,6 +26,7 @@ type proof struct {
 	pull                func(context.Context, credential, string) error
 }
 
+// restrictedClient bounds each request and prevents credentials following redirects.
 func restrictedClient() *http.Client {
 	return &http.Client{Timeout: 30 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
@@ -47,7 +48,8 @@ func (p proof) request(ctx context.Context, endpoint, authorization string) (int
 	if err != nil {
 		return 0, nil, errors.New("request unavailable")
 	}
-	defer response.Body.Close()
+	// A read-only response has no pending write to commit on close.
+	defer func() { _ = response.Body.Close() }()
 	data, err := io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
 	if err != nil || len(data) > 4<<20 {
 		return 0, nil, errors.New("response unavailable or oversized")
@@ -55,15 +57,18 @@ func (p proof) request(ctx context.Context, endpoint, authorization string) (int
 	return response.StatusCode, data, nil
 }
 
+// metadata accepts only a complete successful API response that decodes into target.
 func (p proof) metadata(ctx context.Context, endpoint, token string, target any) bool {
 	status, data, err := p.request(ctx, p.apiURL+endpoint, "Bearer "+token)
 	return err == nil && status == http.StatusOK && json.Unmarshal(data, target) == nil
 }
 
+// denied classifies the authorization statuses returned by manifest after validation.
 func denied(status int) bool {
 	return status == http.StatusUnauthorized || status == http.StatusForbidden
 }
 
+// authorizationDenial distinguishes registry authorization failures from proxy errors.
 func authorizationDenial(status int, data []byte) bool {
 	if !denied(status) {
 		return false
@@ -142,12 +147,16 @@ func (p proof) manifest(ctx context.Context, auth credential, repository, ref st
 	return status, digest
 }
 
+// result emits only the fixed verdict and reason; missing output cannot count as success.
 func (p proof) result(code int, reason string) int {
 	verdict := []string{"PASS", "FAIL", "UNKNOWN"}[code]
-	fmt.Fprintf(p.output, "scoped_package_proof=%s reason=%s\n", verdict, reason)
+	if _, err := fmt.Fprintf(p.output, "scoped_package_proof=%s reason=%s\n", verdict, reason); err != nil {
+		return 2
+	}
 	return code
 }
 
+// run compares immutable private packages with independent baseline and anonymous controls.
 func (p proof) run(ctx context.Context) int {
 	if p.baseline.username == "" || p.baseline.password == "" || p.scoped.password == "" || p.baseline.password == p.scoped.password {
 		return p.result(2, "independent_credentials_required")
@@ -235,13 +244,14 @@ func (p proof) run(ctx context.Context) int {
 	return p.result(0, "own_full_pull_and_cross_package_denial_verified")
 }
 
+// readBaseline requires an explicit inline GHCR identity without ambient credential helpers.
 func readBaseline(directory string) (credential, error) {
 	if directory == "" {
 		return credential{}, errors.New("explicit Docker config required")
 	}
 	data, err := os.ReadFile(filepath.Join(directory, "config.json"))
 	if err != nil {
-		return credential{}, errors.New("Docker config unavailable")
+		return credential{}, errors.New("docker config unavailable")
 	}
 	var config struct {
 		CredsStore  string                                               `json:"credsStore"`
@@ -269,19 +279,24 @@ func readBaseline(directory string) (credential, error) {
 		}
 		return credential{user, password}, nil
 	}
-	return credential{}, errors.New("GHCR credential missing")
+	return credential{}, errors.New("ghcr credential missing")
 }
 
-func pullImage(ctx context.Context, auth credential, image string) error {
+// pullImage downloads all image blobs using a fresh private credential and destination directory.
+func pullImage(ctx context.Context, auth credential, image string) (result error) {
 	directory, err := os.MkdirTemp("", "scoped-package-pull-")
 	if err != nil {
 		return errors.New("private config unavailable")
 	}
-	defer os.RemoveAll(directory)
-	data, _ := json.Marshal(map[string]any{"auths": map[string]any{"ghcr.io": map[string]string{
+	defer func() {
+		if os.RemoveAll(directory) != nil {
+			result = errors.New("private config cleanup unavailable")
+		}
+	}()
+	data, err := json.Marshal(map[string]map[string]map[string]string{"auths": {"ghcr.io": {
 		"auth": base64.StdEncoding.EncodeToString([]byte(auth.username + ":" + auth.password)),
 	}}})
-	if os.WriteFile(filepath.Join(directory, "config.json"), data, 0600) != nil {
+	if err != nil || os.WriteFile(filepath.Join(directory, "config.json"), data, 0600) != nil {
 		return errors.New("private config unavailable")
 	}
 	// A fresh destination and no cache are essential: a Docker daemon could reuse
@@ -296,6 +311,7 @@ func pullImage(ctx context.Context, auth credential, image string) error {
 	return nil
 }
 
+// main fixes the credential-bearing endpoints and imposes an overall experiment deadline.
 func main() {
 	baseline, err := readBaseline(os.Getenv("DOCKER_CONFIG"))
 	if err != nil {

--- a/scripts/prove-scoped-package-access/main.go
+++ b/scripts/prove-scoped-package-access/main.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type credential struct{ username, password string }
+type proof struct {
+	apiURL, registryURL string
+	client              *http.Client
+	output              io.Writer
+	baseline, scoped    credential
+	pull                func(context.Context, credential, string) error
+}
+
+func restrictedClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+}
+
+// URLs and repositories are deliberately fixed in main: this credential-bearing
+// experiment is not a general registry client or an arbitrary URL fetcher.
+func (p proof) request(ctx context.Context, endpoint, authorization string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, nil, errors.New("invalid request")
+	}
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.github+json")
+	response, err := p.client.Do(req)
+	if err != nil {
+		return 0, nil, errors.New("request unavailable")
+	}
+	defer response.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
+	if err != nil || len(data) > 4<<20 {
+		return 0, nil, errors.New("response unavailable or oversized")
+	}
+	return response.StatusCode, data, nil
+}
+
+func (p proof) metadata(ctx context.Context, endpoint, token string, target any) bool {
+	status, data, err := p.request(ctx, p.apiURL+endpoint, "Bearer "+token)
+	return err == nil && status == http.StatusOK && json.Unmarshal(data, target) == nil
+}
+
+func denied(status int) bool {
+	return status == http.StatusUnauthorized || status == http.StatusForbidden
+}
+
+func authorizationDenial(status int, data []byte) bool {
+	if !denied(status) {
+		return false
+	}
+	var response struct {
+		Errors []struct {
+			Code string `json:"code"`
+		} `json:"errors"`
+	}
+	if json.Unmarshal(data, &response) != nil || len(response.Errors) == 0 {
+		return false
+	}
+	for _, failure := range response.Errors {
+		if failure.Code != "UNAUTHORIZED" && failure.Code != "DENIED" {
+			return false
+		}
+	}
+	return true
+}
+
+// Resolve a manifest through GHCR's token exchange using a single identity. A
+// missing tag, throttling, a redirect, malformed JSON or transport failure is
+// never treated as an authorization denial.
+func (p proof) manifest(ctx context.Context, auth credential, repository, ref string) (int, string) {
+	authorization := ""
+	if auth.password != "" {
+		authorization = "Basic " + base64.StdEncoding.EncodeToString([]byte(auth.username+":"+auth.password))
+	}
+	query := url.Values{"service": {"ghcr.io"}, "scope": {"repository:devantler-tech/" + repository + ":pull"}}
+	status, data, err := p.request(ctx, p.registryURL+"/token?"+query.Encode(), authorization)
+	if err != nil {
+		return 0, ""
+	}
+	if authorizationDenial(status, data) {
+		return status, ""
+	}
+	var token struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if status != 200 || json.Unmarshal(data, &token) != nil {
+		return 0, ""
+	}
+	if token.Token == "" {
+		token.Token = token.AccessToken
+	}
+	if token.Token == "" {
+		return 0, ""
+	}
+	status, data, err = p.request(ctx, p.registryURL+"/v2/devantler-tech/"+repository+"/manifests/"+ref, "Bearer "+token.Token)
+	if err != nil {
+		return 0, ""
+	}
+	if denied(status) && !authorizationDenial(status, data) {
+		return 0, ""
+	}
+	if status != 200 {
+		return status, ""
+	}
+	var manifest struct {
+		SchemaVersion int    `json:"schemaVersion"`
+		MediaType     string `json:"mediaType"`
+	}
+	if json.Unmarshal(data, &manifest) != nil || manifest.SchemaVersion != 2 {
+		return 0, ""
+	}
+	switch manifest.MediaType {
+	case "application/vnd.oci.image.index.v1+json", "application/vnd.oci.image.manifest.v1+json", "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.docker.distribution.manifest.v2+json":
+	default:
+		return 0, ""
+	}
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	if strings.HasPrefix(ref, "sha256:") && ref != digest {
+		return 0, ""
+	}
+	return status, digest
+}
+
+func (p proof) result(code int, reason string) int {
+	verdict := []string{"PASS", "FAIL", "UNKNOWN"}[code]
+	fmt.Fprintf(p.output, "scoped_package_proof=%s reason=%s\n", verdict, reason)
+	return code
+}
+
+func (p proof) run(ctx context.Context) int {
+	if p.baseline.username == "" || p.baseline.password == "" || p.scoped.password == "" || p.baseline.password == p.scoped.password {
+		return p.result(2, "independent_credentials_required")
+	}
+	var scope struct {
+		TotalCount   int `json:"total_count"`
+		Repositories []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
+	}
+	if !p.metadata(ctx, "/installation/repositories?per_page=100", p.scoped.password, &scope) || scope.TotalCount != 1 || len(scope.Repositories) != 1 || scope.Repositories[0].FullName != "devantler-tech/wedding-app" {
+		return p.result(2, "token_repository_scope_unverified")
+	}
+	repositories := []string{"wedding-app", "ascoachingogvaner"}
+	digests := make([]string, 2)
+	for i, repository := range repositories {
+		var metadata struct {
+			Name        string `json:"name"`
+			PackageType string `json:"package_type"`
+			Visibility  string `json:"visibility"`
+			Owner       struct {
+				Login string `json:"login"`
+			} `json:"owner"`
+			Repository struct {
+				FullName string `json:"full_name"`
+			} `json:"repository"`
+		}
+		if !p.metadata(ctx, "/orgs/devantler-tech/packages/container/"+repository, p.baseline.password, &metadata) || metadata.Name != repository || metadata.PackageType != "container" || metadata.Visibility != "private" || metadata.Owner.Login != "devantler-tech" || metadata.Repository.FullName != "devantler-tech/"+repository {
+			return p.result(2, "private_package_association_unverified")
+		}
+		status, digest := p.manifest(ctx, p.baseline, repository, "latest")
+		if status != 200 {
+			return p.result(2, "baseline_manifest_unavailable")
+		}
+		digests[i] = digest
+		status, _ = p.manifest(ctx, credential{}, repository, digest)
+		if !denied(status) {
+			return p.result(2, "anonymous_denial_unverified")
+		}
+		if p.pull(ctx, p.baseline, "ghcr.io/devantler-tech/"+repository+"@"+digest) != nil {
+			return p.result(2, "baseline_full_pull_unavailable")
+		}
+	}
+	// A successful own pull includes the image's blobs, not just its manifest.
+	ownStatus, _ := p.manifest(ctx, p.scoped, repositories[0], digests[0])
+	if ownStatus != 200 && !denied(ownStatus) {
+		return p.result(2, "scoped_own_read_unavailable")
+	}
+	ownImage := "ghcr.io/devantler-tech/" + repositories[0] + "@" + digests[0]
+	if ownStatus == 200 && p.pull(ctx, p.scoped, ownImage) != nil {
+		return p.result(2, "scoped_own_full_pull_unavailable")
+	}
+	crossStatus, _ := p.manifest(ctx, p.scoped, repositories[1], digests[1])
+	if crossStatus != 200 && !denied(crossStatus) {
+		return p.result(2, "scoped_cross_read_unavailable")
+	}
+	// Repeat both baselines and the scoped positive after the negative. An expired
+	// token or registry incident during the comparison cannot pass the boundary.
+	for i, repository := range repositories {
+		status, _ := p.manifest(ctx, p.baseline, repository, digests[i])
+		if status != 200 {
+			return p.result(2, "baseline_postcheck_unavailable")
+		}
+	}
+	postOwnStatus, _ := p.manifest(ctx, p.scoped, repositories[0], digests[0])
+	if postOwnStatus != ownStatus {
+		return p.result(2, "scoped_own_postcheck_changed")
+	}
+	// Rebind the installation identity too; otherwise two denied reads from an
+	// expired token would falsely refute an otherwise usable authentication path.
+	scope.TotalCount = 0
+	scope.Repositories = nil
+	if !p.metadata(ctx, "/installation/repositories?per_page=100", p.scoped.password, &scope) || scope.TotalCount != 1 || len(scope.Repositories) != 1 || scope.Repositories[0].FullName != "devantler-tech/wedding-app" {
+		return p.result(2, "token_repository_scope_postcheck_unverified")
+	}
+	if denied(ownStatus) {
+		return p.result(1, "scoped_own_package_denied")
+	}
+	if p.pull(ctx, p.scoped, ownImage) != nil {
+		return p.result(2, "scoped_own_full_pull_postcheck_unavailable")
+	}
+	if crossStatus == 200 {
+		return p.result(1, "out_of_scope_package_readable")
+	}
+	return p.result(0, "own_full_pull_and_cross_package_denial_verified")
+}
+
+func readBaseline(directory string) (credential, error) {
+	if directory == "" {
+		return credential{}, errors.New("explicit Docker config required")
+	}
+	data, err := os.ReadFile(filepath.Join(directory, "config.json"))
+	if err != nil {
+		return credential{}, errors.New("Docker config unavailable")
+	}
+	var config struct {
+		CredsStore  string                                               `json:"credsStore"`
+		CredHelpers map[string]string                                    `json:"credHelpers"`
+		Auths       map[string]struct{ Auth, Username, Password string } `json:"auths"`
+	}
+	if json.Unmarshal(data, &config) != nil || config.CredsStore != "" || len(config.CredHelpers) != 0 {
+		return credential{}, errors.New("inline credential required")
+	}
+	for _, key := range []string{"ghcr.io", "https://ghcr.io/v1/"} {
+		entry, exists := config.Auths[key]
+		if !exists {
+			continue
+		}
+		user, password := entry.Username, entry.Password
+		if entry.Auth != "" {
+			decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+			if err != nil {
+				return credential{}, errors.New("malformed credential")
+			}
+			user, password, _ = strings.Cut(string(decoded), ":")
+		}
+		if user == "" || password == "" {
+			return credential{}, errors.New("incomplete credential")
+		}
+		return credential{user, password}, nil
+	}
+	return credential{}, errors.New("GHCR credential missing")
+}
+
+func pullImage(ctx context.Context, auth credential, image string) error {
+	directory, err := os.MkdirTemp("", "scoped-package-pull-")
+	if err != nil {
+		return errors.New("private config unavailable")
+	}
+	defer os.RemoveAll(directory)
+	data, _ := json.Marshal(map[string]any{"auths": map[string]any{"ghcr.io": map[string]string{
+		"auth": base64.StdEncoding.EncodeToString([]byte(auth.username + ":" + auth.password)),
+	}}})
+	if os.WriteFile(filepath.Join(directory, "config.json"), data, 0600) != nil {
+		return errors.New("private config unavailable")
+	}
+	// A fresh destination and no cache are essential: a Docker daemon could reuse
+	// the baseline's layers and let the candidate pass without downloading them.
+	command := exec.CommandContext(ctx, "crane", "pull", "--platform", "linux/amd64", image, filepath.Join(directory, "image.tar"))
+	// No ambient credential helper, cloud credential, token, or raw tool error is
+	// forwarded. Pulling downloads data only; no container is created or executed.
+	command.Env = []string{"PATH=" + os.Getenv("PATH"), "DOCKER_CONFIG=" + directory}
+	if command.Run() != nil {
+		return errors.New("full pull unavailable")
+	}
+	return nil
+}
+
+func main() {
+	baseline, err := readBaseline(os.Getenv("DOCKER_CONFIG"))
+	if err != nil {
+		fmt.Println("scoped_package_proof=UNKNOWN reason=baseline_credential_unavailable")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	p := proof{apiURL: "https://api.github.com", registryURL: "https://ghcr.io", client: restrictedClient(), output: os.Stdout,
+		baseline: baseline, scoped: credential{"x-access-token", os.Getenv("SCOPED_APP_TOKEN")}, pull: pullImage}
+	os.Exit(p.run(ctx))
+}

--- a/scripts/prove-scoped-package-access/main_test.go
+++ b/scripts/prove-scoped-package-access/main_test.go
@@ -14,6 +14,21 @@ import (
 	"testing"
 )
 
+// TestMissingResultCannotPass models a runner losing the experiment's output stream.
+func TestMissingResultCannotPass(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	if got := (proof{output: writer}).result(0, "own_full_pull_and_cross_package_denial_verified"); got != 2 {
+		t.Fatalf("missing result returned %d, want UNKNOWN", got)
+	}
+}
+
 // The registry serves the SAME immutable manifests to each identity. Only its
 // authorization decision varies, so absence and availability cannot stand in
 // for a working repository boundary.
@@ -31,6 +46,7 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 		{"metadata permission denied", "metadata-403", 2},
 		{"extra repository in installation token", "wide-token", 2},
 		{"truncated repository listing", "partial-token", 2},
+		{"single foreign repository in installation token", "wrong-repository-token", 2},
 		{"missing independent credential", "no-baseline", 2},
 		{"same credential is not an independent control", "same-token", 2},
 		{"invalid scoped token", "invalid-token", 2},
@@ -65,11 +81,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 				switch {
 				case r.URL.Path == "/installation/repositories":
 					if crossed && tc.fault == "empty-scope-postcheck" {
-						fmt.Fprint(w, `{}`)
+						_, _ = fmt.Fprint(w, `{}`)
 						return
 					}
 					if crossed && tc.fault == "partial-scope-postcheck" {
-						fmt.Fprint(w, `{"total_count":1}`)
+						_, _ = fmt.Fprint(w, `{"total_count":1}`)
 						return
 					}
 					if r.Header.Get("Authorization") != "Bearer scoped-secret" {
@@ -80,10 +96,17 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 						return
 					}
 					count := 1
+					listing := `{"full_name":"devantler-tech/wedding-app"}`
 					if tc.fault == "wide-token" || tc.fault == "partial-token" {
 						count = 2
 					}
-					fmt.Fprintf(w, `{"total_count":%d,"repositories":[{"full_name":"devantler-tech/wedding-app"}]}`, count)
+					if tc.fault == "wide-token" {
+						listing += `,{"full_name":"devantler-tech/ascoachingogvaner"}`
+					}
+					if tc.fault == "wrong-repository-token" {
+						listing = `{"full_name":"devantler-tech/ascoachingogvaner"}`
+					}
+					_, _ = fmt.Fprintf(w, `{"total_count":%d,"repositories":[%s]}`, count, listing)
 				case strings.HasPrefix(r.URL.Path, "/orgs/devantler-tech/packages/container/"):
 					if r.Header.Get("Authorization") != "Bearer baseline-secret" {
 						t.Error("package association not checked independently")
@@ -101,11 +124,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 					if tc.fault == "wrong-link" {
 						linked = "some-other-repository"
 					}
-					fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, name, "devantler-tech/"+linked)
+					_, _ = fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, name, "devantler-tech/"+linked)
 				case r.URL.Path == "/token":
 					_, secret, _ := r.BasicAuth()
 					if tc.fault == "bad-token" {
-						fmt.Fprint(w, `{broken`)
+						_, _ = fmt.Fprint(w, `{broken`)
 						return
 					}
 					if secret == "" {
@@ -117,13 +140,13 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 					own := strings.Contains(r.URL.Path, "/wedding-app/")
 					if credential == "anonymous" && tc.fault != "public" {
 						w.WriteHeader(401)
-						fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED"}]}`)
+						_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED"}]}`)
 						return
 					}
 					if credential == "scoped-secret" {
 						if own && (tc.fault == "own-denied" || (crossed && tc.fault == "expired-after-cross")) {
 							w.WriteHeader(403)
-							fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
+							_, _ = fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
 							return
 						}
 						if !own {
@@ -141,11 +164,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 								return
 							case "cross-unclassified-403":
 								w.WriteHeader(403)
-								fmt.Fprint(w, "proxy unavailable")
+								_, _ = fmt.Fprint(w, "proxy unavailable")
 								return
 							default:
 								w.WriteHeader(403)
-								fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
+								_, _ = fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
 								return
 							}
 						}
@@ -156,10 +179,10 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 					}
 					w.Header().Set("Docker-Content-Digest", digest)
 					if tc.fault == "bad-manifest" {
-						fmt.Fprint(w, `{broken`)
+						_, _ = fmt.Fprint(w, `{broken`)
 						return
 					}
-					fmt.Fprint(w, manifest)
+					_, _ = fmt.Fprint(w, manifest)
 				default:
 					t.Errorf("unexpected request %s", r.URL.Path)
 					w.WriteHeader(404)
@@ -190,6 +213,9 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("exit=%d want=%d, output=%s", got, tc.want, output.String())
 			}
+			if tc.fault == "wrong-repository-token" && (len(pulls) != 0 || !strings.Contains(output.String(), "reason=token_repository_scope_unverified\n")) {
+				t.Errorf("foreign repository scope was not rejected before any pull: pulls=%d output=%s", len(pulls), output.String())
+			}
 			if strings.Contains(output.String(), "secret") {
 				t.Errorf("credential or raw error leaked: %s", output.String())
 			}
@@ -203,6 +229,7 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 	}
 }
 
+// TestInlineBaselineCredentialValidation rejects implicit or incomplete registry identities.
 func TestInlineBaselineCredentialValidation(t *testing.T) {
 	for _, tc := range []struct {
 		name, data string
@@ -233,6 +260,7 @@ func TestInlineBaselineCredentialValidation(t *testing.T) {
 	}
 }
 
+// TestFullPullUsesFreshPrivateConfigAndNoAmbientCredentials exercises the subprocess boundary and cleanup.
 func TestFullPullUsesFreshPrivateConfigAndNoAmbientCredentials(t *testing.T) {
 	for _, exit := range []int{0, 1} {
 		t.Run(fmt.Sprint(exit), func(t *testing.T) {

--- a/scripts/prove-scoped-package-access/main_test.go
+++ b/scripts/prove-scoped-package-access/main_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The registry serves the SAME immutable manifests to each identity. Only its
+// authorization decision varies, so absence and availability cannot stand in
+// for a working repository boundary.
+func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
+	for _, tc := range []struct {
+		name, fault string
+		want        int
+	}{
+		{"scoped own pull and cross denial", "", 0},
+		{"cross package readable is a failed boundary", "cross-readable", 1},
+		{"valid scoped token cannot read its own package", "own-denied", 1},
+		{"public cross package is not a negative control", "public", 2},
+		{"wrong package repository association", "wrong-link", 2},
+		{"missing package metadata", "metadata-404", 2},
+		{"metadata permission denied", "metadata-403", 2},
+		{"extra repository in installation token", "wide-token", 2},
+		{"truncated repository listing", "partial-token", 2},
+		{"missing independent credential", "no-baseline", 2},
+		{"same credential is not an independent control", "same-token", 2},
+		{"invalid scoped token", "invalid-token", 2},
+		{"baseline cannot pull", "baseline-pull", 2},
+		{"own full pull fails after manifest access", "own-pull", 2},
+		{"cross 404 does not prove denial", "cross-404", 2},
+		{"cross 429 does not prove denial", "cross-429", 2},
+		{"cross 500 does not prove denial", "cross-500", 2},
+		{"unclassified 403 does not prove denial", "cross-unclassified-403", 2},
+		{"registry token response malformed", "bad-token", 2},
+		{"manifest response malformed", "bad-manifest", 2},
+		{"credential expires during experiment", "expired-after-cross", 2},
+		{"baseline fails after cross denial", "baseline-after-cross", 2},
+		{"empty scope postcheck cannot retain earlier fields", "empty-scope-postcheck", 2},
+		{"partial scope postcheck cannot retain earlier fields", "partial-scope-postcheck", 2},
+		{"redirect cannot receive a credential", "redirect", 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var redirected, crossed bool
+			const manifest = `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":2},"layers":[]}`
+			digest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest)))
+			sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				redirected = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer sink.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.fault == "redirect" {
+					http.Redirect(w, r, sink.URL, http.StatusTemporaryRedirect)
+					return
+				}
+				switch {
+				case r.URL.Path == "/installation/repositories":
+					if crossed && tc.fault == "empty-scope-postcheck" {
+						fmt.Fprint(w, `{}`)
+						return
+					}
+					if crossed && tc.fault == "partial-scope-postcheck" {
+						fmt.Fprint(w, `{"total_count":1}`)
+						return
+					}
+					if r.Header.Get("Authorization") != "Bearer scoped-secret" {
+						t.Error("repository scope queried with the wrong credential")
+					}
+					if tc.fault == "invalid-token" {
+						w.WriteHeader(401)
+						return
+					}
+					count := 1
+					if tc.fault == "wide-token" || tc.fault == "partial-token" {
+						count = 2
+					}
+					fmt.Fprintf(w, `{"total_count":%d,"repositories":[{"full_name":"devantler-tech/wedding-app"}]}`, count)
+				case strings.HasPrefix(r.URL.Path, "/orgs/devantler-tech/packages/container/"):
+					if r.Header.Get("Authorization") != "Bearer baseline-secret" {
+						t.Error("package association not checked independently")
+					}
+					if tc.fault == "metadata-404" {
+						w.WriteHeader(404)
+						return
+					}
+					if tc.fault == "metadata-403" {
+						w.WriteHeader(403)
+						return
+					}
+					name := strings.TrimPrefix(r.URL.Path, "/orgs/devantler-tech/packages/container/")
+					linked := name
+					if tc.fault == "wrong-link" {
+						linked = "some-other-repository"
+					}
+					fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, name, "devantler-tech/"+linked)
+				case r.URL.Path == "/token":
+					_, secret, _ := r.BasicAuth()
+					if tc.fault == "bad-token" {
+						fmt.Fprint(w, `{broken`)
+						return
+					}
+					if secret == "" {
+						secret = "anonymous"
+					}
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": secret})
+				case strings.Contains(r.URL.Path, "/manifests/"):
+					credential := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+					own := strings.Contains(r.URL.Path, "/wedding-app/")
+					if credential == "anonymous" && tc.fault != "public" {
+						w.WriteHeader(401)
+						fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED"}]}`)
+						return
+					}
+					if credential == "scoped-secret" {
+						if own && (tc.fault == "own-denied" || (crossed && tc.fault == "expired-after-cross")) {
+							w.WriteHeader(403)
+							fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
+							return
+						}
+						if !own {
+							crossed = true
+							switch tc.fault {
+							case "cross-readable":
+							case "cross-404":
+								w.WriteHeader(404)
+								return
+							case "cross-429":
+								w.WriteHeader(429)
+								return
+							case "cross-500":
+								w.WriteHeader(500)
+								return
+							case "cross-unclassified-403":
+								w.WriteHeader(403)
+								fmt.Fprint(w, "proxy unavailable")
+								return
+							default:
+								w.WriteHeader(403)
+								fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
+								return
+							}
+						}
+					}
+					if credential == "baseline-secret" && crossed && tc.fault == "baseline-after-cross" {
+						w.WriteHeader(503)
+						return
+					}
+					w.Header().Set("Docker-Content-Digest", digest)
+					if tc.fault == "bad-manifest" {
+						fmt.Fprint(w, `{broken`)
+						return
+					}
+					fmt.Fprint(w, manifest)
+				default:
+					t.Errorf("unexpected request %s", r.URL.Path)
+					w.WriteHeader(404)
+				}
+			}))
+			defer server.Close()
+			var output bytes.Buffer
+			var pulls []string
+			p := proof{apiURL: server.URL, registryURL: server.URL, client: restrictedClient(), output: &output,
+				baseline: credential{"baseline-user", "baseline-secret"}, scoped: credential{"x-access-token", "scoped-secret"},
+				pull: func(ctx context.Context, auth credential, image string) error {
+					if !strings.HasSuffix(image, "@"+digest) {
+						t.Errorf("pull is not bound to measured digest: %s", image)
+					}
+					pulls = append(pulls, auth.password+":"+image)
+					if (auth.password == "baseline-secret" && tc.fault == "baseline-pull") || (auth.password == "scoped-secret" && tc.fault == "own-pull") {
+						return fmt.Errorf("secret-containing raw failure baseline-secret scoped-secret")
+					}
+					return nil
+				}}
+			if tc.fault == "no-baseline" {
+				p.baseline = credential{}
+			}
+			if tc.fault == "same-token" {
+				p.baseline = p.scoped
+			}
+			got := p.run(context.Background())
+			if got != tc.want {
+				t.Errorf("exit=%d want=%d, output=%s", got, tc.want, output.String())
+			}
+			if strings.Contains(output.String(), "secret") {
+				t.Errorf("credential or raw error leaked: %s", output.String())
+			}
+			if redirected {
+				t.Error("followed redirect with a credential")
+			}
+			if tc.want == 0 && len(pulls) < 4 {
+				t.Errorf("success without independent baseline pulls and repeated scoped own pull: %v", pulls)
+			}
+		})
+	}
+}
+
+func TestInlineBaselineCredentialValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, data string
+		valid      bool
+	}{
+		{"encoded", `{"auths":{"ghcr.io":{"auth":"dTpw"}}}`, true},
+		{"explicit", `{"auths":{"ghcr.io":{"username":"u","password":"p"}}}`, true},
+		{"legacy", `{"auths":{"https://ghcr.io/v1/":{"auth":"dTpw"}}}`, true},
+		{"absent", `{}`, false},
+		{"malformed", `{broken`, false},
+		{"half", `{"auths":{"ghcr.io":{"username":"u"}}}`, false},
+		{"bad encoded", `{"auths":{"ghcr.io":{"auth":"%%%%"}}}`, false},
+		{"helper", `{"credsStore":"osxkeychain","auths":{"ghcr.io":{"auth":"dTpw"}}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			directory := t.TempDir()
+			if err := os.WriteFile(filepath.Join(directory, "config.json"), []byte(tc.data), 0600); err != nil {
+				t.Fatal(err)
+			}
+			credential, err := readBaseline(directory)
+			if (err == nil) != tc.valid {
+				t.Fatalf("valid=%v, err=%v", tc.valid, err)
+			}
+			if tc.valid && (credential.username != "u" || credential.password != "p") {
+				t.Fatal("wrong synthetic credential")
+			}
+		})
+	}
+}
+
+func TestFullPullUsesFreshPrivateConfigAndNoAmbientCredentials(t *testing.T) {
+	for _, exit := range []int{0, 1} {
+		t.Run(fmt.Sprint(exit), func(t *testing.T) {
+			directory := t.TempDir()
+			capture := filepath.Join(directory, "capture")
+			// Use a process fixture so argv, environment and actual file cleanup are
+			// tested at the transport boundary, not through an injected classifier.
+			program := fmt.Sprintf(`#!/bin/sh
+set -eu
+printf '%%s\n' "$@" > '%s.args'
+printf '%%s' "$DOCKER_CONFIG" > '%s.path'
+env > '%s.env'
+cat "$DOCKER_CONFIG/config.json" > '%s.config'
+printf 'fixture image tarball' > "$5"
+exit %d
+`, capture, capture, capture, capture, exit)
+			if err := os.WriteFile(filepath.Join(directory, "crane"), []byte(program), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("SCOPED_APP_TOKEN", "ambient-secret")
+			t.Setenv("DOCKER_AUTH_CONFIG", "ambient-secret")
+			t.Setenv("DOCKER_CONFIG", "must-not-be-used")
+			image := "ghcr.io/devantler-tech/wedding-app@sha256:" + strings.Repeat("a", 64)
+			err := pullImage(context.Background(), credential{"u", "p"}, image)
+			if (err == nil) != (exit == 0) {
+				t.Fatalf("unexpected pull result: %v", err)
+			}
+			read := func(suffix string) string {
+				data, err := os.ReadFile(capture + suffix)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return string(data)
+			}
+			configPath := read(".path")
+			if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+				t.Fatal("temporary credential/image directory survived")
+			}
+			if read(".args") != "pull\n--platform\nlinux/amd64\n"+image+"\n"+configPath+"/image.tar\n" {
+				t.Fatalf("unexpected argv: %s", read(".args"))
+			}
+			if strings.Contains(read(".env"), "ambient-secret") || strings.Contains(read(".env"), "must-not-be-used") {
+				t.Fatal("ambient auth forwarded")
+			}
+			if read(".config") != `{"auths":{"ghcr.io":{"auth":"dTpw"}}}` {
+				t.Fatal("wrong pull identity")
+			}
+		})
+	}
+}

--- a/scripts/prove-scoped-package-access/workflow_test.go
+++ b/scripts/prove-scoped-package-access/workflow_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This credentialed experiment must never become a PR-triggered job or inherit
+// the App installation's write permissions when its workflow is edited.
+func TestWorkflowKeepsTheProofManualAndTheCandidateReadOnly(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/prove-scoped-package-access.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		On          map[string]any    `yaml:"on"`
+		Permissions map[string]string `yaml:"permissions"`
+		Jobs        map[string]struct {
+			If          string            `yaml:"if"`
+			Permissions map[string]string `yaml:"permissions"`
+			Steps       []struct {
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	if len(workflow.On) != 1 {
+		t.Fatal("proof must have one manual trigger")
+	}
+	if _, ok := workflow.On["workflow_dispatch"]; !ok {
+		t.Fatal("proof must require manual dispatch")
+	}
+	if len(workflow.Permissions) != 0 {
+		t.Fatal("root token permissions must be empty")
+	}
+	if len(workflow.Jobs) != 1 {
+		t.Fatal("additional credentialed jobs require review of this boundary")
+	}
+	job := workflow.Jobs["prove"]
+	if job.If != "github.ref == 'refs/heads/main'" {
+		t.Fatal("proof must be restricted to reviewed main")
+	}
+	if len(job.Permissions) != 1 || job.Permissions["contents"] != "read" {
+		t.Fatal("workflow token must only read contents")
+	}
+	mints := 0
+	for _, step := range job.Steps {
+		if !strings.HasPrefix(step.Uses, "actions/create-github-app-token@") {
+			continue
+		}
+		mints++
+		if step.With["owner"] != "devantler-tech" || step.With["repositories"] != "wedding-app" {
+			t.Fatal("candidate repository scope widened")
+		}
+		if step.With["permission-packages"] != "read" {
+			t.Fatal("candidate needs explicit packages read only")
+		}
+		for key := range step.With {
+			if strings.HasPrefix(key, "permission-") && key != "permission-packages" {
+				t.Fatalf("unexpected App grant %s", key)
+			}
+		}
+		if step.With["skip-token-revoke"] == "true" {
+			t.Fatal("candidate must be revoked by the action's cleanup")
+		}
+	}
+	if mints != 1 {
+		t.Fatal("exactly one candidate token is required")
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The planned registry login change depends on proving that an app can download its own private image while being denied another app's image. That evidence is still missing.

## What

Add a controlled, manually started experiment that distinguishes success, failure and incomplete evidence. It uses existing credentials and leaves current application access unchanged.

New dependency: a pinned, read-only container image downloader. The experiment runs after merge; registry authentication changes remain dependent on its result.

Part of #3274.
