### PR TITLE
feat(security): audit privileged RBAC grants

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,6 +254,8 @@ jobs:
               # kyverno-test.yaml would otherwise leave this filter false, so
               # neither kyverno test nor the shell gate would run on its own change.
               - 'tests/add-baseline-context/**'
+              - 'tests/audit-privileged-rbac/**'
+              - 'scripts/tests/test-audit-privileged-rbac.sh'
               # The declarative fixtures are the other half of that test: a PR that
               # touches only resources.yaml or kyverno-test.yaml would otherwise leave
               # the k8s filter false, so neither kyverno test nor the shell gate runs.
@@ -1007,6 +1009,8 @@ jobs:
         # required; the CLI evaluates the committed ClusterPolicy files offline.
         run: |
           kyverno test ./tests
+          shellcheck scripts/tests/test-audit-privileged-rbac.sh
+          bash scripts/tests/test-audit-privileged-rbac.sh
           shellcheck scripts/tests/test-restrict-tenant-secret-stores.sh
           bash scripts/tests/test-restrict-tenant-secret-stores.sh
           shellcheck scripts/tests/test-restrict-tenant-network-policies.sh

--- a/docs/rbac-audit.md
+++ b/docs/rbac-audit.md
@@ -1,0 +1,36 @@
+# Privileged RBAC audit
+
+The `audit-privileged-rbac` Kyverno ClusterPolicy reports Role and ClusterRole
+rules that grant wildcard administration, RBAC `bind`/`escalate`, or identity
+impersonation. Wildcard verbs, resources and API groups are evaluated as effective
+permissions, so renaming a chart's administrative role does not hide it.
+
+The policy runs in **Audit** mode. It reports privileged grants while controllers
+continue reconciling. `policies.kyverno.io/scored: "false"` records these staged
+findings as warnings in PolicyReports. It has no chart-name, namespace-label or resource-name
+exceptions. A `resourceNames` restriction is retained for review, rather than
+treated as proof that a powerful grant is safe.
+
+Impersonation is checked against its actual Kubernetes resources: users, groups
+and service accounts in the core API group, plus UIDs and user-extra subresources
+in `authentication.k8s.io`. These differ from the `roles` and `clusterroles`
+resources governing `bind` and `escalate`. Ordinary reads, non-resource health
+checks, and empty or not-yet-populated aggregated roles do not trigger findings.
+See [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/)
+and [RBAC privilege escalation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).
+
+The reports controller receives only `get`, `list` and `watch` on Roles and
+ClusterRoles. That grant is applied in the controllers layer before the policy's
+infrastructure layer. It grants no binding, escalation, impersonation or resource
+mutation. Existing Kyverno resource filters still govern background scanning.
+
+The local regression suite checks ordinary and privileged grants with the same
+Kyverno version used in CI and production. A separate application check requires
+the exact fixture census, so a policy that stops matching cannot pass merely by
+skipping every test.
+
+Promotion to **Enforce** remains tracked in #3486. It requires a fresh complete
+holder inventory, exact owner-reviewed exceptions, regression fixtures for those
+exceptions, and evidence that existing-resource reports are complete. Existing
+Kubescape scanner exceptions are not admission exceptions. Production role and
+binding inventories remain private operator evidence.

--- a/docs/rbac-audit.md
+++ b/docs/rbac-audit.md
@@ -16,6 +16,9 @@ and service accounts in the core API group, plus UIDs and user-extra subresource
 in `authentication.k8s.io`. These differ from the `roles` and `clusterroles`
 resources governing `bind` and `escalate`. Ordinary reads, non-resource health
 checks, and empty or not-yet-populated aggregated roles do not trigger findings.
+Namespaced Roles are evaluated at their effective scope: they can bind a
+ClusterRole through a namespaced binding and impersonate service accounts, but
+cannot authorize cluster-wide user impersonation or ClusterRole escalation.
 See [Kubernetes impersonation](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/)
 and [RBAC privilege escalation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).
 

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: audit-privileged-rbac
+  annotations:
+    policies.kyverno.io/title: Audit Privileged RBAC
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/scored: "false"
+    policies.kyverno.io/subject: Role, ClusterRole
+    policies.kyverno.io/description: >-
+      Reports wildcard administration and effective bind, escalate, and
+      impersonate grants, including grants expressed through wildcard verbs.
+spec:
+  # Existing controllers require some of these grants. Audit retains the full
+  # inventory without blocking reconciliation or silently exempting chart names.
+  # Enforce requires separately reviewed, measured exceptions (platform#3486).
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: privileged-rules
+      match:
+        any:
+          - resources:
+              kinds:
+                - rbac.authorization.k8s.io/v1/Role
+                - rbac.authorization.k8s.io/v1/ClusterRole
+      validate:
+        cel:
+          expressions:
+            - expression: >-
+                !has(object.rules) || object.rules == null || object.rules.all(rule,
+                  !(has(rule.apiGroups) && has(rule.resources) && (
+                    ('*' in rule.apiGroups && '*' in rule.resources && '*' in rule.verbs) ||
+                    (('*' in rule.apiGroups || 'rbac.authorization.k8s.io' in rule.apiGroups) &&
+                     ('*' in rule.resources || 'roles' in rule.resources || 'clusterroles' in rule.resources) &&
+                     ('*' in rule.verbs || 'bind' in rule.verbs || 'escalate' in rule.verbs)) ||
+                    (('*' in rule.apiGroups || '' in rule.apiGroups) &&
+                     ('*' in rule.resources || 'users' in rule.resources ||
+                      'groups' in rule.resources || 'serviceaccounts' in rule.resources) &&
+                     ('*' in rule.verbs || 'impersonate' in rule.verbs)) ||
+                    (('*' in rule.apiGroups || 'authentication.k8s.io' in rule.apiGroups) &&
+                     rule.resources.exists(resource, resource == '*' || resource == 'uids' ||
+                       resource.startsWith('userextras/') || resource.startsWith('*/')) &&
+                     ('*' in rule.verbs || 'impersonate' in rule.verbs))
+                  )))
+              message: >-
+                Wildcard administration, RBAC bind/escalate, and identity
+                impersonation grants require review.

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml
@@ -13,8 +13,9 @@ metadata:
       Reports wildcard administration and effective bind, escalate, and
       impersonate grants, including grants expressed through wildcard verbs.
 spec:
-  # Existing controllers require some of these grants. Audit retains the full
-  # inventory without blocking reconciliation or silently exempting chart names.
+  # Existing controllers require some of these grants. Audit reports resources
+  # eligible under the existing Kyverno filters without blocking reconciliation
+  # or silently exempting chart names.
   # Enforce requires separately reviewed, measured exceptions (platform#3486).
   validationFailureAction: Audit
   background: true
@@ -34,13 +35,17 @@ spec:
                   !(has(rule.apiGroups) && has(rule.resources) && (
                     ('*' in rule.apiGroups && '*' in rule.resources && '*' in rule.verbs) ||
                     (('*' in rule.apiGroups || 'rbac.authorization.k8s.io' in rule.apiGroups) &&
-                     ('*' in rule.resources || 'roles' in rule.resources || 'clusterroles' in rule.resources) &&
-                     ('*' in rule.verbs || 'bind' in rule.verbs || 'escalate' in rule.verbs)) ||
+                     ((('*' in rule.verbs || 'bind' in rule.verbs) &&
+                       ('*' in rule.resources || 'roles' in rule.resources || 'clusterroles' in rule.resources)) ||
+                      (('*' in rule.verbs || 'escalate' in rule.verbs) &&
+                       ('*' in rule.resources || 'roles' in rule.resources ||
+                        (object.kind == 'ClusterRole' && 'clusterroles' in rule.resources))))) ||
                     (('*' in rule.apiGroups || '' in rule.apiGroups) &&
-                     ('*' in rule.resources || 'users' in rule.resources ||
-                      'groups' in rule.resources || 'serviceaccounts' in rule.resources) &&
+                     ('*' in rule.resources || 'serviceaccounts' in rule.resources ||
+                      (object.kind == 'ClusterRole' && ('users' in rule.resources || 'groups' in rule.resources))) &&
                      ('*' in rule.verbs || 'impersonate' in rule.verbs)) ||
-                    (('*' in rule.apiGroups || 'authentication.k8s.io' in rule.apiGroups) &&
+                    (object.kind == 'ClusterRole' &&
+                     ('*' in rule.apiGroups || 'authentication.k8s.io' in rule.apiGroups) &&
                      rule.resources.exists(resource, resource == '*' || resource == 'uids' ||
                        resource.startsWith('userextras/') || resource.startsWith('*/')) &&
                      ('*' in rule.verbs || 'impersonate' in rule.verbs))

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - best-practices/add-resource-defaults.yaml
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml
+  - best-practices/audit-privileged-rbac.yaml
   - best-practices/disable-default-sa-automount.yaml
   - best-practices/disallow-latest-tag.yaml
   - best-practices/propagate-reloader-to-flagger-primary.yaml

--- a/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-rbac.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-rbac.yaml
@@ -1,0 +1,20 @@
+---
+# Validate-only background scans run in the reports controller. Apply this
+# read-only grant in the controllers layer before the policy in infrastructure,
+# so existing Roles and ClusterRoles are included without forbidden watch loops.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:reports-controller:read-rbac
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - role-binding.yaml
   - cluster-role-reports-controller-read-keda.yaml
   - cluster-role-read-github-teams.yaml
+  - cluster-role-read-rbac.yaml

--- a/scripts/tests/test-audit-privileged-rbac.sh
+++ b/scripts/tests/test-audit-privileged-rbac.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# A renamed/removed rule can look Excluded to kyverno test. This gate exercises
+# the actual resource census and requires non-zero, exact Audit results.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+policy="${repo_root}/k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml"
+grant="${repo_root}/k8s/bases/infrastructure/controllers/kyverno/cluster-role-read-rbac.yaml"
+result="$(mktemp)"
+trap 'rm -f "$result"' EXIT
+
+yq -e '.spec.validationFailureAction == "Audit" and .spec.background == true' "$policy" >/dev/null
+yq -e '.metadata.annotations."policies.kyverno.io/scored" == "false"' "$policy" >/dev/null
+yq -o=json "$grant" | jq -e '
+  .metadata.labels."rbac.kyverno.io/aggregate-to-reports-controller" == "true" and
+  (.rules | length) == 1 and
+  .rules[0].apiGroups == ["rbac.authorization.k8s.io"] and
+  (.rules[0].resources | sort) == ["clusterroles", "roles"] and
+  (.rules[0].verbs | sort) == ["get", "list", "watch"] and
+  (.rules[0].resourceNames // [] | length) == 0
+' >/dev/null
+
+kyverno apply "$policy" \
+  --resource "${repo_root}/tests/audit-privileged-rbac/resources.yaml" \
+  --audit-warn --warn-exit-code 0 >"$result" 2>&1
+if ! grep -Fq 'pass: 12, fail: 0, warn: 20, error: 0, skip: 0' "$result"; then
+  cat "$result"
+  echo 'RBAC Audit fixture census did not match the expected results' >&2
+  exit 1
+fi
+echo 'RBAC Audit: 12 ordinary grants pass, 20 privileged grants warn; reporting access is read-only.'

--- a/scripts/tests/test-audit-privileged-rbac.sh
+++ b/scripts/tests/test-audit-privileged-rbac.sh
@@ -23,9 +23,9 @@ yq -o=json "$grant" | jq -e '
 kyverno apply "$policy" \
   --resource "${repo_root}/tests/audit-privileged-rbac/resources.yaml" \
   --audit-warn --warn-exit-code 0 >"$result" 2>&1
-if ! grep -Fq 'pass: 12, fail: 0, warn: 20, error: 0, skip: 0' "$result"; then
+if ! grep -Fq 'pass: 15, fail: 0, warn: 21, error: 0, skip: 0' "$result"; then
   cat "$result"
   echo 'RBAC Audit fixture census did not match the expected results' >&2
   exit 1
 fi
-echo 'RBAC Audit: 12 ordinary grants pass, 20 privileged grants warn; reporting access is read-only.'
+echo 'RBAC Audit: 15 ordinary or inert grants pass, 21 privileged grants warn; reporting access is read-only.'

--- a/tests/audit-privileged-rbac/kyverno-test.yaml
+++ b/tests/audit-privileged-rbac/kyverno-test.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: audit-privileged-rbac
+policies:
+  - ../../k8s/bases/infrastructure/cluster-policies/best-practices/audit-privileged-rbac.yaml
+resources:
+  - resources.yaml
+results:
+  - policy: audit-privileged-rbac
+    rule: privileged-rules
+    kind: ClusterRole
+    result: pass
+    resources:
+      - read-only-rbac
+      - application-manager
+      - read-all
+      - inert-custom-group-verb
+      - inert-resource-verb
+      - read-users
+      - read-auth-metadata
+      - aggregate-not-yet-populated
+      - null-rules
+      - non-resource-health-reader
+  - policy: audit-privileged-rbac
+    rule: privileged-rules
+    kind: ClusterRole
+    result: fail
+    resources:
+      - triple-wildcard
+      - wildcard-with-extra-values
+      - bind-role
+      - escalate-clusterrole
+      - rbac-wildcard-verbs
+      - rbac-wildcard-resources
+      - rbac-wildcard-group
+      - impersonate-users
+      - impersonate-groups
+      - impersonate-wildcard-verbs
+      - impersonate-wildcard-group
+      - impersonate-wildcard-resources
+      - impersonate-uids
+      - impersonate-extras
+      - impersonate-extras-subresource-wildcard
+      - impersonate-auth-wildcard-verbs
+      - impersonate-auth-wildcard-resources
+      - resource-name-constrained
+  - policy: audit-privileged-rbac
+    rule: privileged-rules
+    kind: Role
+    result: pass
+    resources:
+      - sample/namespaced-reader
+      - sample/namespaced-null-rules
+  - policy: audit-privileged-rbac
+    rule: privileged-rules
+    kind: Role
+    result: fail
+    resources:
+      - sample/namespaced-wildcard
+      - sample/impersonate-serviceaccounts

--- a/tests/audit-privileged-rbac/kyverno-test.yaml
+++ b/tests/audit-privileged-rbac/kyverno-test.yaml
@@ -26,7 +26,7 @@ results:
   - policy: audit-privileged-rbac
     rule: privileged-rules
     kind: ClusterRole
-    result: fail
+    result: warn
     resources:
       - triple-wildcard
       - wildcard-with-extra-values
@@ -53,10 +53,14 @@ results:
     resources:
       - sample/namespaced-reader
       - sample/namespaced-null-rules
+      - sample/inert-namespaced-user-impersonation
+      - sample/inert-namespaced-auth-impersonation
+      - sample/inert-namespaced-clusterrole-escalation
   - policy: audit-privileged-rbac
     rule: privileged-rules
     kind: Role
-    result: fail
+    result: warn
     resources:
       - sample/namespaced-wildcard
       - sample/impersonate-serviceaccounts
+      - sample/namespaced-clusterrole-bind

--- a/tests/audit-privileged-rbac/resources.yaml
+++ b/tests/audit-privileged-rbac/resources.yaml
@@ -284,3 +284,43 @@ metadata:
 rules:
   - nonResourceURLs: ["/healthz", "/livez"]
     verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: inert-namespaced-user-impersonation
+  namespace: sample
+rules:
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: inert-namespaced-auth-impersonation
+  namespace: sample
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["uids", "userextras/scopes"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: inert-namespaced-clusterrole-escalation
+  namespace: sample
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["escalate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespaced-clusterrole-bind
+  namespace: sample
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["bind"]

--- a/tests/audit-privileged-rbac/resources.yaml
+++ b/tests/audit-privileged-rbac/resources.yaml
@@ -1,0 +1,286 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-only-rbac
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles","clusterroles"]
+    verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-manager
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-all
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespaced-reader
+  namespace: sample
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: triple-wildcard
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wildcard-with-extra-values
+rules:
+  - apiGroups: ["apps","*"]
+    resources: ["pods","*"]
+    verbs: ["get","*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespaced-wildcard
+  namespace: sample
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bind-role
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    verbs: ["bind"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: escalate-clusterrole
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["escalate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-wildcard-verbs
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-wildcard-resources
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["*"]
+    verbs: ["bind"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-wildcard-group
+rules:
+  - apiGroups: ["*"]
+    resources: ["roles"]
+    verbs: ["escalate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-users
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-groups
+rules:
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: impersonate-serviceaccounts
+  namespace: sample
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-wildcard-verbs
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-wildcard-group
+rules:
+  - apiGroups: ["*"]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-wildcard-resources
+rules:
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-uids
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["uids"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-extras
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["userextras/scopes"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-extras-subresource-wildcard
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["*/scopes"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-auth-wildcard-verbs
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["uids"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonate-auth-wildcard-resources
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["*"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: inert-custom-group-verb
+rules:
+  - apiGroups: ["example.com"]
+    resources: ["roles"]
+    verbs: ["bind"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: inert-resource-verb
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-users
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-auth-metadata
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["uids","userextras/scopes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-not-yet-populated
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.example.com/aggregate: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: resource-name-constrained
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles"]
+    verbs: ["bind"]
+    resourceNames: ["reviewed-role"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: null-rules
+rules: null
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespaced-null-rules
+  namespace: sample
+rules: null
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: non-resource-health-reader
+rules:
+  - nonResourceURLs: ["/healthz", "/livez"]
+    verbs: ["get"]


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

An installed chart can grant itself powerful permissions under an ordinary role name, leaving the current name-based check unable to identify the risk.

## What

Report these privileged grants as warnings and include existing permissions in the audit. Applications and controllers continue running while the findings are reviewed.

Blocking unsafe grants remains a separate step requiring measured exceptions and rollout evidence.

Part of #3486.
