### PR TITLE
fix(ci): align Kyverno checks with the platform engine

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -144,6 +144,11 @@
   },
   "packageRules": [
     {
+      "description": "Review the Kyverno chart and CI policy engine together; chart and CLI use different version numbers, so check the chart appVersion when accepting the grouped update.",
+      "matchPackageNames": ["kyverno", "kyverno/kyverno"],
+      "groupName": "kyverno"
+    },
+    {
       "description": "flux-operator is tracked by the dedicated regex customManager above (the built-in `flux` manager stalled on it). Disable the `flux` manager for this chart so the two managers cannot open duplicate PRs if the flux manager later resumes.",
       "matchManagers": ["flux"],
       "matchPackageNames": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -144,11 +144,6 @@
   },
   "packageRules": [
     {
-      "description": "Review the Kyverno chart and CI policy engine together; chart and CLI use different version numbers, so check the chart appVersion when accepting the grouped update.",
-      "matchPackageNames": ["kyverno", "kyverno/kyverno"],
-      "groupName": "kyverno"
-    },
-    {
       "description": "flux-operator is tracked by the dedicated regex customManager above (the built-in `flux` manager stalled on it). Disable the `flux` manager for this chart so the two managers cannot open duplicate PRs if the flux manager later resumes.",
       "matchManagers": ["flux"],
       "matchPackageNames": [
@@ -253,6 +248,12 @@
       "matchPackageNames": ["alex1989hu/kubelet-serving-cert-approver"],
       "automerge": false,
       "addLabels": ["security/review-required"]
+    },
+    {
+      "description": "Review the Kyverno chart and CI policy engine together. Grouping can produce a one-sided update because their releases are independent; require the chart appVersion to match the shared CLI pin before merging. automerge:false follows the broad controller and major-update rules so they cannot bypass this comparison.",
+      "matchPackageNames": ["kyverno", "kyverno/kyverno"],
+      "groupName": "kyverno",
+      "automerge": false
     }
   ],
   "ignorePaths": [

--- a/.github/scripts/kyverno-version.sh
+++ b/.github/scripts/kyverno-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Emit the shared policy-engine pin without changing another step's environment.
+set -euo pipefail
+
+# renovate: datasource=github-releases depName=kyverno/kyverno extractVersion=^v(?<version>.+)$
+KYVERNO_VERSION="1.19.0"
+
+: "${GITHUB_OUTPUT:?GitHub Actions output file required}"
+printf 'release=v%s\n' "$KYVERNO_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,6 @@ on:
 
 permissions: {}
 
-env:
-  # renovate: datasource=github-releases depName=kyverno/kyverno extractVersion=^v(?<version>.+)$
-  KYVERNO_VERSION: "1.19.0"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -225,6 +221,7 @@ jobs:
               - 'scripts/validate-naming.py'
               - 'scripts/validate-embedded-json.py'
               - '.github/scripts/setup-ksail.sh'
+              - '.github/scripts/kyverno-version.sh'
               - 'scripts/tests/test-setup-ksail.sh'
               - '.github/scripts/setup-talosctl.sh'
               - 'scripts/tests/test-setup-talosctl.sh'
@@ -641,10 +638,14 @@ jobs:
           echo "negative control refused a wrong subject, and the positive path still verifies"
           echo "=> the check above is not vacuous"
 
+      - name: ⚖️ Read Kyverno CLI version
+        id: kyverno-version
+        run: bash .github/scripts/kyverno-version.sh
+
       - name: ⚖️ Install Kyverno CLI for package admission checks
         uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
         with:
-          release: v${{ env.KYVERNO_VERSION }}
+          release: ${{ steps.kyverno-version.outputs.release }}
 
       - name: 🔐 Verify proposed first-party Crossplane packages
         # The package image becomes the provider controller's Pod image. Check
@@ -984,13 +985,18 @@ jobs:
           shellcheck scripts/tests/test-github-config-role-activation-parity.sh
           bash scripts/tests/test-github-config-role-activation-parity.sh
 
+      - name: ⚖️ Read Kyverno CLI version
+        if: needs.changes.outputs.k8s == 'true'
+        id: kyverno-version
+        run: bash .github/scripts/kyverno-version.sh
+
       - name: ⚖️ Install Kyverno CLI
         if: needs.changes.outputs.k8s == 'true'
         # Both admission checks and policy fixtures consume the shared CLI pin.
         # Review it with the Kyverno chart's appVersion when updating the group.
         uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
         with:
-          release: v${{ env.KYVERNO_VERSION }}
+          release: ${{ steps.kyverno-version.outputs.release }}
 
       - name: 🔒 Validate Umami provisioning serialization
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+env:
+  # renovate: datasource=github-releases depName=kyverno/kyverno extractVersion=^v(?<version>.+)$
+  KYVERNO_VERSION: "1.19.0"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -640,7 +644,7 @@ jobs:
       - name: ⚖️ Install Kyverno CLI for package admission checks
         uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
         with:
-          release: v1.18.2
+          release: v${{ env.KYVERNO_VERSION }}
 
       - name: 🔐 Verify proposed first-party Crossplane packages
         # The package image becomes the provider controller's Pod image. Check
@@ -982,12 +986,11 @@ jobs:
 
       - name: ⚖️ Install Kyverno CLI
         if: needs.changes.outputs.k8s == 'true'
-        # Pinned to the version the cluster actually runs (the kyverno Helm
-        # release is v1.18.2), so a policy that passes here is evaluated by the
-        # same engine that admits it in production. Bump both together.
+        # Both admission checks and policy fixtures consume the shared CLI pin.
+        # Review it with the Kyverno chart's appVersion when updating the group.
         uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
         with:
-          release: v1.18.2
+          release: v${{ env.KYVERNO_VERSION }}
 
       - name: 🔒 Validate Umami provisioning serialization
         if: needs.changes.outputs.k8s == 'true'

--- a/docs/first-party-package-signatures.md
+++ b/docs/first-party-package-signatures.md
@@ -6,7 +6,8 @@ production Flux layers and reads `spec.package` from Crossplane `Provider`,
 `Function`, and `Configuration` resources. OCI source artifacts and third-party
 packages are outside this inventory.
 
-Run the same check locally with Go, kubectl, yq v4, jq, cosign, and Kyverno 1.18.2:
+Run the same check locally with Go, kubectl, yq v4, jq, cosign, and the Kyverno CLI
+version pinned in [the shared CI version script](../.github/scripts/kyverno-version.sh):
 
 ```sh
 bash scripts/check-first-party-package-signatures.sh
@@ -15,7 +16,7 @@ bash scripts/check-first-party-package-signatures.sh
 The script only renders files and reads the registry. It does not contact the
 cluster. For private packages, authenticate to GHCR through a Docker config that
 the credential can read; CI uses its package-read token and removes its temporary
-Docker config after the check. Kyverno 1.18.2's CLI has no Kubernetes Secret
+Docker config after the check. The CLI's offline evaluation has no Kubernetes Secret
 lister, so an ephemeral policy copy replaces its cluster pull-secret references
 with the default Docker credential provider. Image selection, signing identities,
 and validation expressions are preserved. This does not prove the live cluster's

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -481,6 +481,8 @@ assert_generated_policy_contract() {
   # Evaluate admission-time and mutate-existing rules against both the real
   # Namespace trigger and the real policy target. Every emitted form of
   # allow-crossplane must remain byte-for-byte equivalent at the spec level.
+  # Kyverno 1.19 also loads --resource inputs into its offline target store;
+  # repeating the same object as --target-resource causes a duplicate panic.
   # shellcheck disable=SC2016 # $index is a yq variable.
   CROSSPLANE_MUTATION_DIR="${mutation_dir}" yq e -N \
     -s 'strenv(CROSSPLANE_MUTATION_DIR) + "/" + ($index | tostring) + "-" + .metadata.name + ".yaml"' \
@@ -494,7 +496,6 @@ assert_generated_policy_contract() {
     kyverno apply "${mutation_dir}" \
       --resource "${controllers_dir}/crossplane/namespace.yaml" \
       --resource "${controllers_dir}/crossplane/cilium-network-policy.yaml" \
-      --target-resource "${controllers_dir}/crossplane/cilium-network-policy.yaml" \
       --output "${mutation_output_dir}" \
       --remove-color 2>&1
   )"; then


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

**Why:** Policy checks had fallen behind the engine used by the platform, reducing confidence in their results.

**What:** Bring the checks up to date, use the same version for local reproduction, and require coordinated review of future policy-engine updates.

Fixes #3631.
