### PR TITLE
docs(dr): explain automatic stable API endpoint selection

### DIFF
--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -588,6 +588,34 @@ two GitHub `prod` environment secrets:
 | `KUBE_CONFIG`  | `~/.kube/config`  | `ksail cluster update` drift detection (kube API)  |
 | `TALOS_CONFIG` | `~/.talos/config` | `ksail cluster update` machine-config / secret sync |
 
+### Endpoint selection during ordinary deployments
+
+The shared `deploy-prod` action runs
+[`scripts/use-prod-stable-api-endpoint.sh`](../../scripts/use-prod-stable-api-endpoint.sh)
+immediately after restoring `KUBE_CONFIG`, before its first Kubernetes API call.
+The script resolves the production floating IP through the Hetzner API, requires
+exactly one match with KSail's ownership and cluster labels, and updates only the
+restored `admin@prod` cluster's server address. Missing, ambiguous, or foreign
+floating-IP state stops deployment before a node can be rolled.
+
+A kubeconfig whose server still names a replaced control-plane node therefore
+does not need an environment-secret refresh solely to change that address. The
+deployment selects the stable address on each run, preserves the kubeconfig's
+credentials and CA, and checks `/readyz` through normal TLS validation. Check the
+`Select stable prod API endpoint` and `Verify prod cluster is reachable` steps
+when diagnosing endpoint failures.
+
+`TALOS_CONFIG` retains direct node endpoints. Do not point the Talos API at the
+Kubernetes floating IP: recovery access must remain available when etcd or the
+Kubernetes API is unhealthy.
+
+This automatic selection does not validate a control-plane failure drill by
+itself. A controlled recreate must separately demonstrate continued Kubernetes
+access without a secret refresh, with health and recovery checks recorded for
+that drill.
+
+### Credential refresh after a full rebuild
+
 After a **full rebuild** (Scenario 4) the API endpoint and Talos PKI change,
 so both secrets are stale. Symptom in CI: the
 `🩺 Verify prod cluster is reachable` preflight fails, or


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Ordinary production deployments already resolve and select the owned stable Kubernetes API endpoint before testing reachability. The recovery runbook only described rebuilding credentials, which left the obsolete credential-refresh request on #2764 and #2120 looking necessary.

Document the deployed endpoint-selection behavior, its fail-closed ownership checks, and the separate need for new credentials after a full cluster rebuild. Preserve direct node endpoints for Talos recovery and explicitly retain controlled failover validation as a separate acceptance proof.

Part of #2764. Part of #2120.

Validation: the existing stable-endpoint behavior test passes; the documentation was checked against the shared deploy action and script, and `git diff --check` passes. Current production CI run 34050865678 completed successfully; its deploy log contains the stable-endpoint confirmation and successful API reachability markers. No secret values were read or changed, and no failure drill was performed.
