### PR TITLE
fix(render): vendor immutable controller artifacts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,12 +75,12 @@
     },
     {
       "customType": "regex",
-      "description": "Track the kubelet-serving-cert-approver version pinned in the prod controller's kustomize remote resource URL. The project ships NO Helm chart (only raw deploy/*-install.yaml manifests), so it is installed as a kustomize remote resource pinned to a release tag rather than the moving `main` branch — but the version then lives inside a raw.githubusercontent.com URL that no built-in manager (flux/kubernetes/docker) sees. This regex manager resolves it from the authoritative alex1989hu/kubelet-serving-cert-approver GitHub releases; the `v` literal sits outside the capture group and extractVersionTemplate strips the leading `v` from the `vX.Y.Z` release tags, so the resolved version matches the captured X.Y.Z while the URL keeps its `v` prefix. On a bump, re-check the standalone PDB selector still matches the upstream labels (see the kustomization comment).",
+      "description": "Track the kubelet-serving-cert-approver release in the vendored-resource updater. A version-only bump fails CI's image-version binding until the immutable source commit, SHA-256 and complete vendored resources are refreshed together. Re-check the standalone PDB selector and resource-scoped Checkov dispositions on every bump.",
       "managerFilePatterns": [
-        "/^k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization\\.ya?ml$/"
+        "/^scripts/update-vendored-operators\\.sh$/"
       ],
       "matchStrings": [
-        "kubelet-serving-cert-approver/v(?<currentValue>[0-9.]+)/deploy/"
+        "readonly cert_approver_version='(?<currentValue>[0-9.]+)'"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "alex1989hu/kubelet-serving-cert-approver",
@@ -244,11 +244,14 @@
       "addLabels": ["vendored-manifest"]
     },
     {
-      "description": "kubelet-serving-cert-approver ships only raw Kubernetes install manifests, so the custom-managed kustomize remote resource can change privileged controller/RBAC YAML in the prod infrastructure-controllers layer. Keep Renovate visibility, but require maintainer review for every release bump so the upstream manifest and local PDB selector are re-checked before deployment. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
+      "description": "kubelet-serving-cert-approver is vendored as a complete upstream manifest. Keep Renovate visibility through the updater version, but require a reviewed whole-bundle refresh with matching source commit, digest, image and PDB selector. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
       "matchPackageNames": ["alex1989hu/kubelet-serving-cert-approver"],
       "automerge": false,
       "addLabels": ["security/review-required"]
     }
   ],
-  "ignorePaths": ["k8s/bases/infrastructure/cluster-policies/samples"]
+  "ignorePaths": [
+    "k8s/bases/infrastructure/cluster-policies/samples",
+    "k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/deployment.yaml"
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,10 @@ The scan is a **hard gate**: it fails the PR if the combined compliance score dr
 
 ### Updating Vendored Operator Bundles
 
-The CDI and KubeVirt operator files are pinned upstream release bundles. Refresh them only through
-[`scripts/update-vendored-operators.sh`](scripts/update-vendored-operators.sh): edit its two version
-and SHA-256 constants and run it from any directory in this repository. The updater downloads the
+The CDI, KubeVirt and kubelet-serving-cert-approver operator resources, plus the origin-ca-issuer
+CRDs, are pinned upstream artifacts. Refresh them only through
+[`scripts/update-vendored-operators.sh`](scripts/update-vendored-operators.sh): edit its corresponding
+version, source commit and SHA-256 constants and run it from any directory in this repository. The updater downloads the
 pinned release assets, reapplies the reviewed resource-scoped Checkov dispositions with the tested
 `scripts/annotate-vendored-checkov` helper, and runs Checkov before replacing either committed file.
 It requires `curl`, `go`, `sha256sum`, and the Checkov version pinned in the script on the local path.
@@ -143,6 +144,18 @@ Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the comm
 check and remains authoritative for graph findings. Before applying that file-level exclusion, the
 source validator requires every bundled workload to remain in the corresponding `cdi` or `kubevirt`
 namespace covered by those policies.
+
+Use `scripts/update-vendored-operators.sh --render-remotes` to refresh only origin-ca-issuer and
+kubelet-serving-cert-approver. Their source URLs use immutable commits and their bytes are pinned by
+SHA-256. The CRDs have no workload/RBAC Checkov dispositions: the updater requires their declared
+CRD identities and scans the secrets framework with the same canary. The cert-approver retains its
+HA deployment and has reviewed resource-scoped dispositions; its namespace is likewise protected by
+the committed Cilium policy. Its generated files contain one upstream resource each, preserving the
+original document bytes apart from the reviewed annotations. Offline CI concatenates the declared
+resource order and validates the original digest and operator image version, so manual edits or a
+Renovate version-only bump fail until the whole bundle is re-vendored. Re-check the local PDB selector
+against the upstream pod labels on a refresh. All these resources render locally without network
+access; `scripts/render-remote-resource-exceptions.tsv` has no remaining exceptions.
 
 ## Local Development Cluster
 

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-binding.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: kubelet-serving-cert-approver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: certificates:kubelet-serving-cert-approver
+subjects:
+- kind: ServiceAccount
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-certificates.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-certificates.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_156=Certificate approval is the purpose of this pinned upstream controller; signer permission is restricted to kubernetes.io/kubelet-serving."
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: certificates:kubelet-serving-cert-approver
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/kubelet-serving
+  resources:
+  - signers
+  verbs:
+  - approve

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-events.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/cluster-role-events.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: events:kubelet-serving-cert-approver
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/deployment.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/deployment.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_38=Pinned upstream certificate approver requires its service-account token; preserve the release image while the full manifest is SHA-256 verified through the vendor updater."
+    checkov.io/skip2: "CKV_K8S_43=Pinned upstream certificate approver requires its service-account token; preserve the release image while the full manifest is SHA-256 verified through the vendor updater."
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: kubelet-serving-cert-approver
+      app.kubernetes.io/name: kubelet-serving-cert-approver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: kubelet-serving-cert-approver
+        app.kubernetes.io/name: kubelet-serving-cert-approver
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+            weight: 100
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: kubelet-serving-cert-approver
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - serve
+        - --enable-leader-election
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/alex1989hu/kubelet-serving-cert-approver:0.12.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 6
+        name: cert-approver
+        ports:
+        - containerPort: 8080
+          name: health
+        - containerPort: 9090
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          initialDelaySeconds: 3
+        resources:
+          limits:
+            cpu: 250m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 18Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubelet-serving-cert-approver
+      tolerations:
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
@@ -13,11 +13,19 @@ resources:
   # active approvers. The standalone PDB (pod-disruption-budget.yaml) makes the
   # node drain-safe (maxUnavailable: 1).
   #
-  # Pinned to a release tag (not the moving `main` branch) for reproducibility:
-  # Renovate bumps the version in this URL automatically via the github-releases
-  # custom manager in .github/renovate.json (the project ships no Helm chart, only
-  # these raw install manifests, so a kustomize remote resource is the install
-  # path). On a bump, re-check the PDB selector still matches the upstream labels.
-  - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.12.0/deploy/ha-install.yaml
+  # Vendored without changing upstream document bytes apart from reviewed
+  # Checkov annotations. The updater pins an immutable source commit and SHA-256;
+  # Renovate tracks its version there. Re-vendor the whole bundle on a bump and
+  # re-check the standalone PDB selector against the upstream pod labels.
+  - namespace.yaml
+  - service-account.yaml
+  - role.yaml
+  - cluster-role-certificates.yaml
+  - cluster-role-events.yaml
+  - role-binding-events.yaml
+  - role-binding-leader-election.yaml
+  - cluster-role-binding.yaml
+  - service.yaml
+  - deployment.yaml
   - cilium-network-policy.yaml
   - pod-disruption-budget.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+  name: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role-binding-events.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role-binding-events.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_21=Pinned upstream binding permits only event creation and patching in default; the controller workload runs in its dedicated namespace."
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: events:kubelet-serving-cert-approver
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: events:kubelet-serving-cert-approver
+subjects:
+- kind: ServiceAccount
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role-binding-leader-election.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role-binding-leader-election.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: leader-election:kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election:kubelet-serving-cert-approver
+subjects:
+- kind: ServiceAccount
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/role.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: leader-election:kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/service-account.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/service-account.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/service.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/instance: kubelet-serving-cert-approver
+    app.kubernetes.io/name: kubelet-serving-cert-approver

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/custom-resource-definition-clusteroriginissuers.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/custom-resource-definition-clusteroriginissuers.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: clusteroriginissuers.cert-manager.k8s.cloudflare.com
+spec:
+  group: cert-manager.k8s.cloudflare.com
+  names:
+    kind: ClusterOriginIssuer
+    listKind: ClusterOriginIssuerList
+    plural: clusteroriginissuers
+    singular: clusteroriginissuer
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          A ClusterOriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer.
+          It is scoped to a single namespace, so it can be used only by resources in the same
+          namespace.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired state of the ClusterOriginIssuer resource.
+            properties:
+              auth:
+                description: Auth configures how to authenticate with the Cloudflare
+                  API.
+                properties:
+                  serviceKeyRef:
+                    description: |-
+                      ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
+                      Deprecated: 2026-03-19.
+                    properties:
+                      key:
+                        description: Key of the secret to select from. Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the secret in the issuer's namespace to select. If a cluster-scoped
+                          issuer, the secret is selected from the "cluster resource namespace" configured
+                          on the controller.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  tokenRef:
+                    description: TokenRef authenticates with an API Token.
+                    properties:
+                      key:
+                        description: Key of the secret to select from. Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the secret in the issuer's namespace to select. If a cluster-scoped
+                          issuer, the secret is selected from the "cluster resource namespace" configured
+                          on the controller.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [serviceKeyRef tokenRef] must
+                    be set
+                  rule: '[has(self.serviceKeyRef),has(self.tokenRef)].filter(x,x==true).size()
+                    == 1'
+              requestType:
+                description: RequestType is the signature algorithm Cloudflare should
+                  use to sign the certificate.
+                enum:
+                - OriginRSA
+                - OriginECC
+                type: string
+            required:
+            - auth
+            - requestType
+            type: object
+          status:
+            description: Status of the ClusterOriginIssuer. This is set and managed
+              automatically.
+            properties:
+              conditions:
+                description: |-
+                  List of status conditions to indicate the status of an Issuer.
+                  Known condition types are `Ready`.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/custom-resource-definition-originissuers.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/custom-resource-definition-originissuers.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: originissuers.cert-manager.k8s.cloudflare.com
+spec:
+  group: cert-manager.k8s.cloudflare.com
+  names:
+    kind: OriginIssuer
+    listKind: OriginIssuerList
+    plural: originissuers
+    singular: originissuer
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          An OriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer.
+          It is scoped to a single namespace, so it can be used only by resources in the same
+          namespace.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the OriginIssuer resource
+            properties:
+              auth:
+                description: Auth configures how to authenticate with the Cloudflare
+                  API.
+                properties:
+                  serviceKeyRef:
+                    description: |-
+                      ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
+                      Deprecated: 2026-03-19.
+                    properties:
+                      key:
+                        description: Key of the secret to select from. Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the secret in the issuer's namespace to select. If a cluster-scoped
+                          issuer, the secret is selected from the "cluster resource namespace" configured
+                          on the controller.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  tokenRef:
+                    description: TokenRef authenticates with an API Token.
+                    properties:
+                      key:
+                        description: Key of the secret to select from. Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the secret in the issuer's namespace to select. If a cluster-scoped
+                          issuer, the secret is selected from the "cluster resource namespace" configured
+                          on the controller.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [serviceKeyRef tokenRef] must
+                    be set
+                  rule: '[has(self.serviceKeyRef),has(self.tokenRef)].filter(x,x==true).size()
+                    == 1'
+              requestType:
+                description: RequestType is the signature algorithm Cloudflare should
+                  use to sign the certificate.
+                enum:
+                - OriginRSA
+                - OriginECC
+                type: string
+            required:
+            - auth
+            - requestType
+            type: object
+          status:
+            description: Status of the OriginIssuer. This is set and managed automatically.
+            properties:
+              conditions:
+                description: |-
+                  List of status conditions to indicate the status of an Issuer.
+                  Known condition types are `Ready`.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - pod-disruption-budget.yaml
-  - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
-  - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+  # Immutable source commits/digests live in scripts/update-vendored-operators.sh.
+  - custom-resource-definition-clusteroriginissuers.yaml
+  - custom-resource-definition-originissuers.yaml

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -72,6 +72,12 @@ type checkovSummary struct {
 // line numbers. A vendor refresh must therefore re-review any target change,
 // including a known check moving to a different container or field.
 var bundleTargets = map[string][]targetSpec{
+	"origin-ca-issuer": {}, // CRDs only: no workload/RBAC dispositions apply.
+	"kubelet-serving-cert-approver": {
+		{kind: "ClusterRole", name: "certificates:kubelet-serving-cert-approver", checks: []string{"CKV_K8S_156"}, reason: "Certificate approval is the purpose of this pinned upstream controller; signer permission is restricted to kubernetes.io/kubelet-serving.", resourceFingerprint: "3e3382b9d85d7f16926202613a3e6247e375a30f08eab5de4e3fa94ba235d8ce"},
+		{kind: "RoleBinding", name: "events:kubelet-serving-cert-approver", checks: []string{"CKV_K8S_21"}, reason: "Pinned upstream binding permits only event creation and patching in default; the controller workload runs in its dedicated namespace.", resourceFingerprint: "f76f09dcd9d0f3f71e2e8325d8f2fc9cb742898d637e0c539a9c284bb7d4bb5a"},
+		{kind: "Deployment", name: "kubelet-serving-cert-approver", checks: []string{"CKV_K8S_38", "CKV_K8S_43"}, reason: "Pinned upstream certificate approver requires its service-account token; preserve the release image while the full manifest is SHA-256 verified through the vendor updater.", resourceFingerprint: "e7cadbfb581bff5eedf687034a489860521ff33fb6cd647157d4fd2160353231", imageRepository: "ghcr.io/alex1989hu/kubelet-serving-cert-approver"},
+	},
 	"cdi": {
 		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason, resourceFingerprint: "df06bcec640e27ea586a8d12bffa509558eb8a244978a0de46c35743ec85341e"},
 		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "f81c6d025990a3a550fbe12e38033c8c0c4e3d4397dc14c357c7c6dc601abe07", imageRepository: "quay.io/kubevirt/cdi-operator"},
@@ -124,7 +130,7 @@ func expectedEvaluatedKeys(check string) ([]string, bool) {
 		return []string{"spec/template/spec/containers/[0]/securityContext/readOnlyRootFilesystem"}, true
 	case "CKV_K8S_43":
 		return []string{"spec/template/spec/containers/[0]/image"}, true
-	case "CKV_K8S_38", "CKV_K8S_40", "CKV_K8S_155":
+	case "CKV_K8S_21", "CKV_K8S_38", "CKV_K8S_40", "CKV_K8S_155", "CKV_K8S_156":
 		return []string{}, true
 	default:
 		return nil, false
@@ -132,7 +138,9 @@ func expectedEvaluatedKeys(check string) ([]string, bool) {
 }
 
 func main() {
-	bundle := flag.String("bundle", "", "bundle to annotate: cdi or kubevirt")
+	bundle := flag.String("bundle", "", "declared vendored bundle")
+	splitResources := flag.String("split-resources", "", "split cert-approver resources into this directory without changing bytes")
+	resourcesDir := flag.String("resources-dir", "", "read split cert-approver resources for --validate-annotated")
 	validateFindings := flag.Bool(
 		"validate-findings",
 		false,
@@ -191,6 +199,12 @@ func main() {
 	if modeCount > 1 {
 		fail("validation modes are mutually exclusive")
 	}
+	if *splitResources != "" && (modeCount != 0 || *bundle != "kubelet-serving-cert-approver") {
+		fail("--split-resources requires the cert-approver bundle and no validation mode")
+	}
+	if *resourcesDir != "" && (!*validateAnnotated || *bundle != "kubelet-serving-cert-approver") {
+		fail("--resources-dir requires the cert-approver bundle and --validate-annotated")
+	}
 	if *validateReport && *framework != "kubernetes" && *framework != "secrets" {
 		fail("--validate-report requires --framework kubernetes or --framework secrets")
 	}
@@ -208,8 +222,17 @@ func main() {
 	}
 
 	input, err := io.ReadAll(os.Stdin)
+	if *resourcesDir != "" {
+		input, err = joinCertApproverResources(*resourcesDir)
+	}
 	if err != nil {
 		fail("read bundle: %v", err)
+	}
+	if *splitResources != "" {
+		if err := splitCertApproverResources(input, *splitResources); err != nil {
+			fail("split bundle: %v", err)
+		}
+		return
 	}
 	if *validateFindings {
 		if err := validateCheckovFindings(input, targets); err != nil {
@@ -435,12 +458,18 @@ func validateSecretsCanary(report checkovReport, failedCount int) error {
 }
 
 func validateVendorSource(input []byte, bundle string) error {
+	if bundle == "origin-ca-issuer" {
+		if err := validateOriginCRD(input); err != nil {
+			return err
+		}
+	}
 	if inlineCheckovSkip.Match(input) {
 		return errors.New("source contains inline Checkov suppression")
 	}
 	protectedNamespace := map[string]string{
-		"cdi":      "cdi",
-		"kubevirt": "kubevirt",
+		"cdi":                           "cdi",
+		"kubevirt":                      "kubevirt",
+		"kubelet-serving-cert-approver": "kubelet-serving-cert-approver",
 	}[bundle]
 	decoder := yaml.NewDecoder(strings.NewReader(string(input)))
 	for documentIndex := 1; ; documentIndex++ {

--- a/scripts/annotate-vendored-checkov/render_resources.go
+++ b/scripts/annotate-vendored-checkov/render_resources.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Preserve the upstream document order so concatenation restores every byte.
+// Explicit identities prevent an upstream addition/rename from silently creating
+// an unreferenced file or overwriting a local policy/PDB during a refresh.
+var certApproverResources = []struct{ identity, file string }{
+	{"Namespace/kubelet-serving-cert-approver", "namespace.yaml"},
+	{"ServiceAccount/kubelet-serving-cert-approver", "service-account.yaml"},
+	{"Role/leader-election:kubelet-serving-cert-approver", "role.yaml"},
+	{"ClusterRole/certificates:kubelet-serving-cert-approver", "cluster-role-certificates.yaml"},
+	{"ClusterRole/events:kubelet-serving-cert-approver", "cluster-role-events.yaml"},
+	{"RoleBinding/events:kubelet-serving-cert-approver", "role-binding-events.yaml"},
+	{"RoleBinding/leader-election:kubelet-serving-cert-approver", "role-binding-leader-election.yaml"},
+	{"ClusterRoleBinding/kubelet-serving-cert-approver", "cluster-role-binding.yaml"},
+	{"Service/kubelet-serving-cert-approver", "service.yaml"},
+	{"Deployment/kubelet-serving-cert-approver", "deployment.yaml"},
+}
+
+func splitCertApproverResources(input []byte, dir string) error {
+	files := map[string][]byte{}
+	documents := splitDocuments(strings.Split(string(input), "\n"))
+	for index, lines := range documents {
+		identity, err := readIdentity(lines)
+		if err != nil {
+			return err
+		}
+		key := identity.Kind + "/" + identity.Metadata.Name
+		filename := ""
+		for _, resource := range certApproverResources {
+			if resource.identity == key {
+				filename = resource.file
+				break
+			}
+		}
+		if filename == "" {
+			return fmt.Errorf("unreviewed resource identity %s", key)
+		}
+		if _, exists := files[filename]; exists {
+			return fmt.Errorf("duplicate resource %s", key)
+		}
+		files[filename] = []byte(strings.Join(lines, "\n"))
+		// Restore the boundary newline removed by splitDocuments; the final
+		// document already retains the exact original suffix.
+		if index < len(documents)-1 {
+			files[filename] = append(files[filename], '\n')
+		}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func joinCertApproverResources(dir string) ([]byte, error) {
+	var result bytes.Buffer
+	for _, resource := range certApproverResources {
+		data, err := os.ReadFile(filepath.Join(dir, resource.file))
+		if err != nil {
+			return nil, err
+		}
+		identity, err := readIdentity(strings.Split(string(data), "\n"))
+		if err != nil {
+			return nil, err
+		}
+		if identity.Kind+"/"+identity.Metadata.Name != resource.identity {
+			return nil, fmt.Errorf("%s has wrong resource identity", resource.file)
+		}
+		result.Write(data)
+	}
+	return result.Bytes(), nil
+}
+
+func validateOriginCRD(input []byte) error {
+	decoder := yaml.NewDecoder(bytes.NewReader(input))
+	var doc manifestIdentity
+	if err := decoder.Decode(&doc); err != nil {
+		return fmt.Errorf("read CRD: %w", err)
+	}
+	if doc.Kind != "CustomResourceDefinition" || (doc.Metadata.Name != "originissuers.cert-manager.k8s.cloudflare.com" && doc.Metadata.Name != "clusteroriginissuers.cert-manager.k8s.cloudflare.com") {
+		return errors.New("source must be one of the two declared origin-ca-issuer CRDs")
+	}
+	if err := decoder.Decode(&doc); !errors.Is(err, io.EOF) {
+		return errors.New("CRD source must contain exactly one document")
+	}
+	return nil
+}

--- a/scripts/annotate-vendored-checkov/render_resources_test.go
+++ b/scripts/annotate-vendored-checkov/render_resources_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderCRDSourceRejectsWorkloads(t *testing.T) {
+	valid := "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: originissuers.cert-manager.k8s.cloudflare.com\nspec: {}\n"
+	_, stderr, err := runAnnotator(t, "origin-ca-issuer", valid, "--validate-source")
+	if err != nil {
+		t.Fatalf("declared CRD source rejected: %v: %s", err, stderr)
+	}
+	for _, invalid := range []string{"", strings.Replace(valid, "CustomResourceDefinition", "Deployment", 1), valid + "---\n" + valid} {
+		if _, _, err := runAnnotator(t, "origin-ca-issuer", invalid, "--validate-source"); err == nil {
+			t.Fatal("CRD source accepted an empty, workload, or duplicate resource")
+		}
+	}
+}
+
+func TestSplitRenderBundlePreservesEveryByteAndIdentity(t *testing.T) {
+	input := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: kubelet-serving-cert-approver\n---\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: kubelet-serving-cert-approver\n"
+	dir := t.TempDir()
+	_, stderr, err := runAnnotator(t, "kubelet-serving-cert-approver", input, "--split-resources", dir)
+	if err != nil {
+		t.Fatalf("split rejected: %v: %s", err, stderr)
+	}
+	first, err := os.ReadFile(filepath.Join(dir, "namespace.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(filepath.Join(dir, "service-account.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first)+string(second) != input {
+		t.Fatal("splitting changed upstream bytes")
+	}
+	if _, _, err := runAnnotator(t, "kubelet-serving-cert-approver", strings.Replace(input, "ServiceAccount", "Secret", 1), "--split-resources", t.TempDir()); err == nil {
+		t.Fatal("split accepted an unreviewed resource identity")
+	}
+	if _, _, err := runAnnotator(t, "kubelet-serving-cert-approver", input+"---\n"+string(first), "--split-resources", t.TempDir()); err == nil {
+		t.Fatal("split accepted duplicate resource identity")
+	}
+}
+
+func TestCommittedCertApproverRejectsChangedSourceAndVersion(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join("..", "..", "k8s", "providers", "hetzner", "infrastructure", "controllers", "kubelet-serving-cert-approver")
+	for _, resource := range certApproverResources {
+		data, err := os.ReadFile(filepath.Join(source, resource.file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, resource.file), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Published v0.12.0 source digest, independently checked before vendoring.
+	args := []string{"--validate-annotated", "--resources-dir", dir, "--source-sha256", "44d74b38379d96572c434290732092f577ee4835392b36922a72c406ee406139", "--source-version", "0.12.0"}
+	if _, stderr, err := runAnnotator(t, "kubelet-serving-cert-approver", "", args...); err != nil {
+		t.Fatalf("exact committed source rejected: %v: %s", err, stderr)
+	}
+	args[len(args)-1] = "0.13.0"
+	if _, _, err := runAnnotator(t, "kubelet-serving-cert-approver", "", args...); err == nil {
+		t.Fatal("version-only update accepted without refreshing the manifest")
+	}
+	args[len(args)-1] = "0.12.0"
+	file := filepath.Join(dir, "deployment.yaml")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, append(data, []byte("# changed outside updater\n")...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runAnnotator(t, "kubelet-serving-cert-approver", "", args...); err == nil {
+		t.Fatal("manual source rewrite accepted without a new reviewed digest")
+	}
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runAnnotator(t, "kubelet-serving-cert-approver", "", args...); err == nil {
+		t.Fatal("missing vendored workload accepted")
+	}
+}

--- a/scripts/render-remote-resource-exceptions.tsv
+++ b/scripts/render-remote-resource-exceptions.tsv
@@ -6,6 +6,3 @@
 # fails on a row whose URL is no longer referenced, so this list cannot rot.
 #
 # Columns, tab-separated:  <url>  <tracking-issue>  <reason>
-https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml	#3196	Cloudflare origin-ca-issuer CRD fetched from the moving `trunk` branch; vendoring is child (2) of #3196 and is the most urgent of the three.
-https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml	#3196	Second Cloudflare origin-ca-issuer CRD from the same moving `trunk` branch; vendored together with the row above.
-https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.12.0/deploy/ha-install.yaml	#3196	Pinned to tag v0.12.0 (no digest) and Renovate-managed; contributes ServiceAccount/ClusterRole/(Cluster)RoleBinding documents to the prod authorization surface. Vendoring is child (3) of #3196.

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -265,14 +265,14 @@ fi
 
 if [ "${mode}" = all ]; then
   prepare_bundle \
-  cdi \
-  "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml" \
-  "${cdi_sha256}"
+    cdi \
+    "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml" \
+    "${cdi_sha256}"
 
   prepare_bundle \
-  kubevirt \
-  "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml" \
-  "${kubevirt_sha256}"
+    kubevirt \
+    "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml" \
+    "${kubevirt_sha256}"
 fi
 
 prepare_render_remotes
@@ -281,11 +281,11 @@ prepare_render_remotes
 # A failed second download or scan therefore cannot leave a half-updated pair.
 if [ "${mode}" = all ]; then
   mv \
-  "${work_dir}/cdi-annotated.yaml" \
-  "${repo_root}/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml"
+    "${work_dir}/cdi-annotated.yaml" \
+    "${repo_root}/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml"
   mv \
-  "${work_dir}/kubevirt-annotated.yaml" \
-  "${repo_root}/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml"
+    "${work_dir}/kubevirt-annotated.yaml" \
+    "${repo_root}/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml"
 fi
 install_render_remotes
 validate_committed_bundles

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -12,6 +12,13 @@ readonly cdi_version='v1.65.0'
 readonly cdi_sha256='e96d59abdf358c5161cb96adcfdcc6107efc3fb608ec93ade11578c94a222015'
 readonly kubevirt_version='v1.8.0'
 readonly kubevirt_sha256='e9e92c15bca0531bf0b7db2c2dfc83b6b9bdbf1a6f3f96945f67d90d702193b5'
+# The former render-time remotes use immutable commits as well as byte digests.
+readonly origin_ca_issuer_commit='e375d9c00a66f47a15fb56457686f8629022b50d'
+readonly clusteroriginissuers_sha256='cf6af6f155cd087a1ab2a4bec68cd014f05be3cf3d0240ad331ee1fe1bec574e'
+readonly originissuers_sha256='d085e763718cf34e675b62f8394e20854237b3997f825d86556659585940b170'
+readonly cert_approver_version='0.12.0'
+readonly cert_approver_commit='b5516301e48f8e50cb18368e457779d01796119b'
+readonly cert_approver_sha256='44d74b38379d96572c434290732092f577ee4835392b36922a72c406ee406139'
 # Keep this aligned with CI_CHECKOV_VERSION in megalinter-scan-counts.sh so a
 # local vendor refresh cannot miss a rule that the non-blocking CI scan knows.
 readonly checkov_version='3.3.2'
@@ -22,6 +29,7 @@ readonly isolated_scan_skip_check='CKV2_K8S_6'
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly repo_root
+readonly render_controllers="${repo_root}/k8s/providers/hetzner/infrastructure/controllers"
 work_dir="$(mktemp -d)"
 readonly work_dir
 trap 'rm -rf "${work_dir}"' EXIT
@@ -41,7 +49,7 @@ run_checkov() {
     LC_ALL=C \
     PATH="${PATH}" \
     PYTHONUTF8=1 \
-    checkov --config-file "${checkov_config}" "$@"
+    checkov --config-file "${checkov_config}" --skip-download "$@"
 }
 
 require_tool() {
@@ -164,18 +172,82 @@ validate_committed_bundles() {
       --source-sha256 "${kubevirt_sha256}" \
       --source-version "${kubevirt_version}" \
       <k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+    go run ./scripts/annotate-vendored-checkov --bundle kubelet-serving-cert-approver \
+      --validate-annotated --source-sha256 "${cert_approver_sha256}" \
+      --source-version "${cert_approver_version}" \
+      --resources-dir "${render_controllers}/kubelet-serving-cert-approver" </dev/null
+    validate_crd "${render_controllers}/origin-ca-issuer/custom-resource-definition-clusteroriginissuers.yaml" "${clusteroriginissuers_sha256}"
+    validate_crd "${render_controllers}/origin-ca-issuer/custom-resource-definition-originissuers.yaml" "${originissuers_sha256}"
   )
 }
 
+validate_crd() {
+  local file="$1" digest="$2"
+  printf '%s  %s\n' "${digest}" "${file}" | sha256sum -c -
+  (cd "${repo_root}" && go run ./scripts/annotate-vendored-checkov \
+    --bundle origin-ca-issuer --validate-source <"${file}")
+}
+
+prepare_render_remotes() {
+  local name digest source
+  for name in clusteroriginissuers originissuers; do
+    if [ "${name}" = clusteroriginissuers ]; then
+      digest="${clusteroriginissuers_sha256}"
+    else
+      digest="${originissuers_sha256}"
+    fi
+    source="${work_dir}/${name}.yaml"
+    curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+      --retry 3 --retry-all-errors \
+      "https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/${origin_ca_issuer_commit}/deploy/crds/cert-manager.k8s.cloudflare.com_${name}.yaml" \
+      --output "${source}"
+    validate_crd "${source}" "${digest}"
+    # CRDs have no applicable Kubernetes workload/RBAC checks. Require their
+    # exact CRD identity and a real secrets-framework scan with its canary.
+    run_clean_framework_scan origin-ca-issuer source "${source}" secrets "${work_dir}/${name}-secrets.json"
+  done
+  prepare_bundle kubelet-serving-cert-approver \
+    "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/${cert_approver_commit}/deploy/ha-install.yaml" \
+    "${cert_approver_sha256}"
+  (cd "${repo_root}" && go run ./scripts/annotate-vendored-checkov \
+    --bundle kubelet-serving-cert-approver --validate-annotated \
+    --source-sha256 "${cert_approver_sha256}" --source-version "${cert_approver_version}" \
+    <"${work_dir}/kubelet-serving-cert-approver-annotated.yaml")
+  (cd "${repo_root}" && go run ./scripts/annotate-vendored-checkov \
+    --bundle kubelet-serving-cert-approver --split-resources "${work_dir}/cert-approver" \
+    <"${work_dir}/kubelet-serving-cert-approver-annotated.yaml")
+  # Prove that every expected resource exists and reconstructs the source
+  # before replacing any committed file, including on a vendor rename/removal.
+  (cd "${repo_root}" && go run ./scripts/annotate-vendored-checkov \
+    --bundle kubelet-serving-cert-approver --validate-annotated \
+    --source-sha256 "${cert_approver_sha256}" --source-version "${cert_approver_version}" \
+    --resources-dir "${work_dir}/cert-approver" </dev/null)
+}
+
+install_render_remotes() {
+  mv "${work_dir}/clusteroriginissuers.yaml" "${render_controllers}/origin-ca-issuer/custom-resource-definition-clusteroriginissuers.yaml"
+  mv "${work_dir}/originissuers.yaml" "${render_controllers}/origin-ca-issuer/custom-resource-definition-originissuers.yaml"
+  local resource
+  for resource in "${work_dir}/cert-approver/"*.yaml; do
+    mv "${resource}" "${render_controllers}/kubelet-serving-cert-approver/"
+  done
+}
+
+mode=all
 if [ "$#" -ne 0 ]; then
   if [ "$#" -eq 1 ] && [ "$1" = '--validate-committed' ]; then
     require_tool go
+    require_tool sha256sum
     validate_committed_bundles
-    printf 'Committed CDI and KubeVirt bundles match their pinned upstream digests and versions.\n'
+    printf 'All committed vendor resources match their pinned upstream digests and versions.\n'
     exit 0
   fi
-  printf 'usage: %s [--validate-committed]\n' "$0" >&2
-  exit 2
+  if [ "$#" -eq 1 ] && [ "$1" = '--render-remotes' ]; then
+    mode=render-remotes
+  else
+    printf 'usage: %s [--validate-committed|--render-remotes]\n' "$0" >&2
+    exit 2
+  fi
 fi
 
 require_tool curl
@@ -191,24 +263,31 @@ if [ "${actual_checkov_version}" != "${checkov_version}" ]; then
   exit 2
 fi
 
-prepare_bundle \
+if [ "${mode}" = all ]; then
+  prepare_bundle \
   cdi \
   "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml" \
   "${cdi_sha256}"
 
-prepare_bundle \
+  prepare_bundle \
   kubevirt \
   "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml" \
   "${kubevirt_sha256}"
+fi
+
+prepare_render_remotes
 
 # Commit both prepared outputs together only after both upstream bundles pass.
 # A failed second download or scan therefore cannot leave a half-updated pair.
-mv \
+if [ "${mode}" = all ]; then
+  mv \
   "${work_dir}/cdi-annotated.yaml" \
   "${repo_root}/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml"
-mv \
+  mv \
   "${work_dir}/kubevirt-annotated.yaml" \
   "${repo_root}/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml"
+fi
+install_render_remotes
+validate_committed_bundles
 
-printf 'Updated CDI %s and KubeVirt %s; both annotated bundles pass Checkov.\n' \
-  "${cdi_version}" "${kubevirt_version}"
+printf 'Updated %s vendored resources; digests and applicable Checkov scans passed.\n' "${mode}"

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1754,7 +1754,15 @@ const (
 // changed documents contain only the reviewed SELinux policy/template updates.
 // Removing one Namespace in a negative control reports exactly one removal.
 // Previous aggregate: 1fc28a50d08f48c8cc32eb36fe012dc1322f602282ca47b02c418376a7e6dcca.
-const expectedRenderedSurfaceSHA = "d76e357336f1c4817766463bf7990648b5c8b019939aaf680606929d51bd46b4"
+// Re-approved for #3445/#3446 using checksum-verified kubectl v1.36.2 /
+// Kustomize v5.8.1 against main 6a4ca89. All five roots retain 555 identities,
+// with no additions, removals or duplicates. Exactly three objects change:
+// cert-approver's certificates ClusterRole, default events RoleBinding and
+// Deployment gain only reviewed Checkov annotations. Removing those annotations
+// restores byte-equivalent parsed objects; no RBAC grant or workload field
+// changes. A negative control removing one identity reports exactly one removal.
+// Previous aggregate: d76e357336f1c4817766463bf7990648b5c8b019939aaf680606929d51bd46b4.
+const expectedRenderedSurfaceSHA = "ea907ed3b00ccb2086e2445e8d7ef9e1050cf0c77f4779c1f7d1b03cb8950191"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Rendering currently downloads two origin-ca-issuer CRDs from a moving branch and the cert-approver bundle from a mutable release tag. Commit the reviewed artifacts locally and extend the existing vendor updater to verify immutable source commits, SHA-256 digests and applicable Checkov scans. Offline CI validates the committed bytes, cert-approver version tracking remains active in Renovate, and the existing guard now permits zero remote render exceptions.

The cert-approver keeps its existing HA configuration. Its resources are split without reformatting upstream bytes, apart from reviewed resource-scoped Checkov annotations. The authorization fingerprint changes only for those annotations.

Validation: both KSail configurations pass (617 files each); local and production Kustomize builds pass offline; the vendor updater passes with Checkov 3.3.2; annotator and authorization tests, naming, shellcheck, and all 43 remote-guard assertions pass. New tests cover CRD identity, byte-preserving splitting, source tampering, missing resources and version-only updates. Five-root comparison with the approved renderer retains all 555 identities and changes only the stated annotations.

Fixes #3445.
Fixes #3446.
Fixes #3196.