### PR TITLE
fix(security): stage source-owned Longhorn UI baseline defaults

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -165,8 +165,8 @@ runs:
     - name: 🧪 Check the Longhorn UI baseline canary
       id: longhorn_ui_baseline
       # Only arms when the desired source declares the two defaults and the
-      # live template still lacks them. Already-applied and reverted canaries
-      # do not impose these initial-rollout assumptions on unrelated deploys.
+      # live template lacks them or has no successful proof for this object.
+      # Proven and reverted canaries do not constrain unrelated deployments.
       shell: bash
       run: bash scripts/guard-longhorn-ui-baseline-context.sh before-publish
 
@@ -302,11 +302,21 @@ runs:
       run: ./scripts/wait-for-platform-flux-revision.sh "${PLATFORM_MANIFEST_DIGEST}"
 
     - name: 🧪 Verify the Longhorn UI baseline canary
+      id: verify_longhorn_ui_baseline
       if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
       # A failed after-apply proof fails this deployment. The merge queue's
       # existing unsuccessful-deploy heal restores main through this action.
       shell: bash
       run: bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile
+
+    - name: 🧾 Record the successful Longhorn UI canary proof
+      if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
+      # The JSON Patch atomically tests the final observed UID and resourceVersion;
+      # a concurrent write or replacement cannot receive an old success receipt.
+      shell: bash
+      env:
+        LONGHORN_UI_BASELINE_PROOF_PATCH: ${{ steps.verify_longhorn_ui_baseline.outputs.proof_patch }}
+      run: kubectl --context admin@prod patch deployment longhorn-ui --namespace longhorn-system --type json --patch "${LONGHORN_UI_BASELINE_PROOF_PATCH}"
 
     - name: 🛡️ Restore autoscaling once the released revision is Ready
       id: cilium_rollout_gate_release

--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -162,6 +162,14 @@ runs:
         echo "::error::Prod cluster (context admin@prod) is unreachable with the restored kubeconfig (last kubectl error: ${last_err}). KUBE_CONFIG (and likely TALOS_CONFIG) are probably stale after a cluster rebuild — refresh both and update the 'prod' environment secrets. See docs/dr/runbook.md → 'Refresh CI deploy credentials'."
         exit 1
 
+    - name: 🧪 Check the Longhorn UI baseline canary
+      id: longhorn_ui_baseline
+      # Only arms when the desired source declares the two defaults and the
+      # live template still lacks them. Already-applied and reverted canaries
+      # do not impose these initial-rollout assumptions on unrelated deploys.
+      shell: bash
+      run: bash scripts/guard-longhorn-ui-baseline-context.sh before-publish
+
     - name: 💾 Validate live persistence retirement safety
       # A commit parent is not evidence that its protection reached production:
       # two direct pushes can be waiting behind one manual dispatch. Compare the
@@ -292,6 +300,13 @@ runs:
       env:
         PLATFORM_MANIFEST_DIGEST: ${{ steps.publish_platform_manifest.outputs.digest }}
       run: ./scripts/wait-for-platform-flux-revision.sh "${PLATFORM_MANIFEST_DIGEST}"
+
+    - name: 🧪 Verify the Longhorn UI baseline canary
+      if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
+      # A failed after-apply proof fails this deployment. The merge queue's
+      # existing unsuccessful-deploy heal restores main through this action.
+      shell: bash
+      run: bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile
 
     - name: 🛡️ Restore autoscaling once the released revision is Ready
       id: cilium_rollout_gate_release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,6 +254,9 @@ jobs:
               - 'scripts/tests/test-restrict-tenant-secret-stores.sh'
               - 'scripts/tests/test-restrict-tenant-network-policies.sh'
               - 'scripts/tests/test-add-baseline-context.sh'
+              - 'scripts/tests/test-longhorn-ui-baseline-context.sh'
+              - 'scripts/tests/test-guard-longhorn-ui-baseline-context.sh'
+              - 'scripts/guard-longhorn-ui-baseline-context.sh'
               # The fixtures are the other half of that test: a PR touching only
               # resources.yaml, patched-resources.yaml, values.yaml or
               # kyverno-test.yaml would otherwise leave this filter false, so
@@ -1034,6 +1037,9 @@ jobs:
           bash scripts/tests/test-provider-drc-pod-seccomp.sh
           shellcheck scripts/tests/test-add-baseline-context.sh
           bash scripts/tests/test-add-baseline-context.sh
+          shellcheck scripts/guard-longhorn-ui-baseline-context.sh scripts/tests/test-guard-longhorn-ui-baseline-context.sh scripts/tests/test-longhorn-ui-baseline-context.sh
+          bash scripts/tests/test-guard-longhorn-ui-baseline-context.sh
+          bash scripts/tests/test-longhorn-ui-baseline-context.sh
 
       - name: 🚦 Validate default-off Cilium bandwidth manager
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -242,6 +242,12 @@ jobs:
         # the bridge safely repairs root auth so Flux can create them.
         run: ./scripts/refresh-flux-ghcr-auth.sh --allow-incomplete-fanout
 
+      - name: 🧪 Check the Longhorn UI baseline canary
+        id: longhorn_ui_baseline
+        # A fresh installation still requires stored-template proof after Flux
+        # converges. Reverted and already-applied canaries remain disarmed.
+        run: bash scripts/guard-longhorn-ui-baseline-context.sh before-publish
+
       - name: 📦 Publish evidenced manifests to GHCR
         id: publish_platform_manifest
         uses: ./.github/actions/deploy-prod/publish-platform-manifests
@@ -277,6 +283,10 @@ jobs:
               --for=condition=Ready --timeout=35m
           done
           echo "✅ All Flux Kustomizations Ready — fresh platform converged."
+
+      - name: 🧪 Verify the Longhorn UI baseline canary
+        if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
+        run: bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile
 
       - name: 🛡️ Reassert or release the Cilium rollout gate
         if: always() && steps.wait_flux.outcome == 'success'

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -245,7 +245,7 @@ jobs:
       - name: 🧪 Check the Longhorn UI baseline canary
         id: longhorn_ui_baseline
         # A fresh installation still requires stored-template proof after Flux
-        # converges. Reverted and already-applied canaries remain disarmed.
+        # converges. Reverted and successfully proven canaries remain disarmed.
         run: bash scripts/guard-longhorn-ui-baseline-context.sh before-publish
 
       - name: 📦 Publish evidenced manifests to GHCR
@@ -285,8 +285,15 @@ jobs:
           echo "✅ All Flux Kustomizations Ready — fresh platform converged."
 
       - name: 🧪 Verify the Longhorn UI baseline canary
+        id: verify_longhorn_ui_baseline
         if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
         run: bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile
+
+      - name: 🧾 Record the successful Longhorn UI canary proof
+        if: steps.longhorn_ui_baseline.outputs.rollout_required == 'true'
+        env:
+          LONGHORN_UI_BASELINE_PROOF_PATCH: ${{ steps.verify_longhorn_ui_baseline.outputs.proof_patch }}
+        run: kubectl --context admin@prod patch deployment longhorn-ui --namespace longhorn-system --type json --patch "${LONGHORN_UI_BASELINE_PROOF_PATCH}"
 
       - name: 🛡️ Reassert or release the Cilium rollout gate
         if: always() && steps.wait_flux.outcome == 'success'

--- a/docs/baseline-context-rollout.md
+++ b/docs/baseline-context-rollout.md
@@ -22,10 +22,11 @@ The shared production deploy action and disaster-recovery rebuild workflow
 handle the evidence in deployment order:
 
 1. Before publication, the read-only canary guard checks whether the desired
-   source declares the defaults and the stored UI template still lacks them.
-   Only that transition arms the canary. A source rollback disarms it before
-   reading the workload; a later deployment with the defaults already present
-   does not freeze the UI's initial replica count or identity.
+   source declares the defaults and the stored UI template has both fields plus
+   a successful proof for its own UID. Fields alone never disarm verification:
+   a failed first proof or a crash before recording must retry. A source rollback
+   disarms before reading the workload; a successfully proven deployment does
+   not freeze the UI's initial replica count or identity on later chart changes.
 2. An existing canary must be Helm-owned, fully ready, non-root, have no init
    containers, and use only ephemeral volumes without an `fsGroup`. API failure is an error, never an
    empty population. A reachable API reporting an uninstalled UI allows the
@@ -35,7 +36,14 @@ handle the evidence in deployment order:
    Missing fields, unhealthy replicas, changed privilege settings or a rewriting
    owner fail the deployment. The output records the observed generation without
    emitting workload environment values or credentials.
-4. A failed merge-group deployment remains failed and the existing heal job
+4. Only after that proof succeeds, a separate workflow step records the
+   `pod-security.devantler.tech/longhorn-ui-baseline-proof` metadata annotation.
+   Its JSON Patch atomically tests the UID and resourceVersion from the final
+   observed object before recording that UID. A concurrent change or replacement
+   rejects the write; no earlier observation can certify a different object.
+   The chart does not declare this annotation. Losing the receipt safely requires
+   revalidation, and a replacement cannot inherit the prior Deployment's proof.
+5. A failed merge-group deployment remains failed and the existing heal job
    restores the current `main` revision. Removing only the two source defaults
    restores the prior rendered resources; it preserves the existing UI hardening.
    A manual CD or rebuild failure requires the normal Git revert and recovery

--- a/docs/baseline-context-rollout.md
+++ b/docs/baseline-context-rollout.md
@@ -25,8 +25,8 @@ The shared production deploy action handles the evidence in deployment order:
    Only that transition arms the canary. A source rollback disarms it before
    reading the workload; a later deployment with the defaults already present
    does not freeze the UI's initial replica count or identity.
-2. An existing canary must be Helm-owned, fully ready, non-root, and use only
-   ephemeral volumes without an `fsGroup`. API failure is an error, never an
+2. An existing canary must be Helm-owned, fully ready, non-root, have no init
+   containers, and use only ephemeral volumes without an `fsGroup`. API failure is an error, never an
    empty population. A reachable API reporting an uninstalled UI allows the
    initial installation but still requires the next step.
 3. After Flux reports the released revision Ready, the guard reads the stored
@@ -53,28 +53,18 @@ namespace. A blanket restart would roll storage managers and CSI workloads and
 can introduce an admission/reconciliation loop for operator-owned resources.
 The UI canary does not establish safety for those workloads.
 
-The next increments follow the same source-first route:
+Helm and Git templates have a source-owned route through values or exact
+post-renderers. Operator-generated templates instead depend on supported owner
+configuration and convergence: admission of a field absent from the owner's
+desired state can cause repeated writes. Storage managers, CSI components and
+operator-generated workloads are outside the UI canary's ephemeral-volume scope.
+Permission to deploy does not prove those compatibility conditions.
 
-1. Re-enumerate stored Deployments, DaemonSets, StatefulSets and CronJobs in the
-   excluded namespaces. Record each owner's source, existing security context,
-   persistent storage, rollout strategy and current readiness. Include regular
-   and init containers; distinguish a missing SELinux object from a deliberate
-   partial or empty object. Exclude stale scanner verdicts from the evidence.
-2. For a Helm- or Git-owned workload, add only the missing defaults to its
-   declared pod template, using chart values where supported and a tested exact
-   post-renderer otherwise. Review one workload's rendered delta and rollback
-   before deploying it. Chart-owned Longhorn components are separate increments
-   from the UI; no manager or CSI restart is implied by this canary.
-3. For an operator-owned workload, first establish how its reconciler builds
-   the desired template. Prefer an operator-supported source field. An admission
-   fallback needs exact owner/object scoping, a tested convergence contract and
-   its own staged preflight/after-apply gate. Keep that owner's mutation off
-   until those conditions are implemented; user permission cannot substitute
-   for them.
-4. Re-measure stored templates and runtime health after each applied increment.
-   Update C-0211 exception sizing only from the new complete measurement. The
-   original 33-workload denominator is historical, and completing the UI canary
-   does not complete platform issue #3239.
+The remaining rollout and its acceptance measurements are tracked in
+[issue #3239](https://github.com/devantler-tech/platform/issues/3239). C-0211 sizing
+depends on a complete measurement of stored controllers and every regular/init
+container, with runtime health evidence. The original 33-workload denominator is
+historical; neither this canary nor a stale scanner verdict completes that target.
 
 The existing namespace inventory test pins the default-off controller rollout.
 Its historical demand for post-rollout evidence inside the activation commit is

--- a/docs/baseline-context-rollout.md
+++ b/docs/baseline-context-rollout.md
@@ -18,7 +18,8 @@ The real pinned chart test exercises the defaults present and absent, proves
 that every other rendered resource is identical, and renders the source rollback.
 It fails if a renamed chart target causes the post-renderer to miss the UI.
 
-The shared production deploy action handles the evidence in deployment order:
+The shared production deploy action and disaster-recovery rebuild workflow
+handle the evidence in deployment order:
 
 1. Before publication, the read-only canary guard checks whether the desired
    source declares the defaults and the stored UI template still lacks them.
@@ -37,8 +38,8 @@ The shared production deploy action handles the evidence in deployment order:
 4. A failed merge-group deployment remains failed and the existing heal job
    restores the current `main` revision. Removing only the two source defaults
    restores the prior rendered resources; it preserves the existing UI hardening.
-   A manual CD failure requires the same normal Git revert and CD recovery path;
-   it does not have the merge-group heal job.
+   A manual CD or rebuild failure requires the normal Git revert and recovery
+   path; those workflows do not have the merge-group heal job.
 
 An engineer can reproduce the read-only phases with
 `bash scripts/guard-longhorn-ui-baseline-context.sh before-publish --context <read-only-context>`

--- a/docs/baseline-context-rollout.md
+++ b/docs/baseline-context-rollout.md
@@ -1,0 +1,84 @@
+# Baseline security context rollout
+
+The stored controller templates are the C-0211 measurement surface. Pod admission
+defaults do not backfill them. Source-owned template changes travel through the
+normal GitOps merge queue, which can deploy them while an engineer's interactive
+production credentials remain read-only.
+
+## Longhorn UI canary
+
+The Longhorn HelmRelease supplies `fsGroupChangePolicy: OnRootMismatch` and an
+empty container `seLinuxOptions` object through its existing `longhorn-ui`
+post-renderer. The empty object leaves SELinux/MCS label selection to the runtime.
+The UI has no `fsGroup` and uses only `emptyDir` volumes, so the ownership policy
+has no effect on mounted data. Its existing numeric identity, dropped capabilities,
+seccomp profile, replica count and volumes remain unchanged.
+
+The real pinned chart test exercises the defaults present and absent, proves
+that every other rendered resource is identical, and renders the source rollback.
+It fails if a renamed chart target causes the post-renderer to miss the UI.
+
+The shared production deploy action handles the evidence in deployment order:
+
+1. Before publication, the read-only canary guard checks whether the desired
+   source declares the defaults and the stored UI template still lacks them.
+   Only that transition arms the canary. A source rollback disarms it before
+   reading the workload; a later deployment with the defaults already present
+   does not freeze the UI's initial replica count or identity.
+2. An existing canary must be Helm-owned, fully ready, non-root, and use only
+   ephemeral volumes without an `fsGroup`. API failure is an error, never an
+   empty population. A reachable API reporting an uninstalled UI allows the
+   initial installation but still requires the next step.
+3. After Flux reports the released revision Ready, the guard reads the stored
+   defaults and complete rollout status, then watches the template for 30 seconds.
+   Missing fields, unhealthy replicas, changed privilege settings or a rewriting
+   owner fail the deployment. The output records the observed generation without
+   emitting workload environment values or credentials.
+4. A failed merge-group deployment remains failed and the existing heal job
+   restores the current `main` revision. Removing only the two source defaults
+   restores the prior rendered resources; it preserves the existing UI hardening.
+   A manual CD failure requires the same normal Git revert and CD recovery path;
+   it does not have the merge-group heal job.
+
+An engineer can reproduce the read-only phases with
+`bash scripts/guard-longhorn-ui-baseline-context.sh before-publish --context <read-only-context>`
+and `after-reconcile` after deployment. An after-apply result is recorded after
+the deploy; the activation commit does not claim evidence from a future rollout.
+
+## Remaining controller population
+
+The namespace-wide `baseline-context-controllers` admission switch remains off.
+Enabling it changes every subsequently written eligible template in that
+namespace. A blanket restart would roll storage managers and CSI workloads and
+can introduce an admission/reconciliation loop for operator-owned resources.
+The UI canary does not establish safety for those workloads.
+
+The next increments follow the same source-first route:
+
+1. Re-enumerate stored Deployments, DaemonSets, StatefulSets and CronJobs in the
+   excluded namespaces. Record each owner's source, existing security context,
+   persistent storage, rollout strategy and current readiness. Include regular
+   and init containers; distinguish a missing SELinux object from a deliberate
+   partial or empty object. Exclude stale scanner verdicts from the evidence.
+2. For a Helm- or Git-owned workload, add only the missing defaults to its
+   declared pod template, using chart values where supported and a tested exact
+   post-renderer otherwise. Review one workload's rendered delta and rollback
+   before deploying it. Chart-owned Longhorn components are separate increments
+   from the UI; no manager or CSI restart is implied by this canary.
+3. For an operator-owned workload, first establish how its reconciler builds
+   the desired template. Prefer an operator-supported source field. An admission
+   fallback needs exact owner/object scoping, a tested convergence contract and
+   its own staged preflight/after-apply gate. Keep that owner's mutation off
+   until those conditions are implemented; user permission cannot substitute
+   for them.
+4. Re-measure stored templates and runtime health after each applied increment.
+   Update C-0211 exception sizing only from the new complete measurement. The
+   original 33-workload denominator is historical, and completing the UI canary
+   does not complete platform issue #3239.
+
+The existing namespace inventory test pins the default-off controller rollout.
+Its historical demand for post-rollout evidence inside the activation commit is
+not a usable ordering for GitOps. A future namespace activation must replace
+that assumption with the enforceable preflight and after-apply sequence above,
+scoped to the owners it actually changes; changing the inventory pin alone does
+not satisfy the rollout contract.

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -199,6 +199,9 @@ spec:
                 template:
                   spec:
                     securityContext:
+                      # Source-owned C-0211 canary: the UI uses only emptyDir
+                      # volumes and sets no fsGroup, so this changes no ownership.
+                      fsGroupChangePolicy: OnRootMismatch
                       runAsNonRoot: true
                       runAsUser: 499
                       runAsGroup: 486
@@ -207,6 +210,8 @@ spec:
                     containers:
                       - name: longhorn-ui
                         securityContext:
+                          # Preserve runtime SELinux/MCS label allocation.
+                          seLinuxOptions: {}
                           runAsNonRoot: true
                           runAsUser: 499
                           runAsGroup: 486

--- a/scripts/guard-longhorn-ui-baseline-context.sh
+++ b/scripts/guard-longhorn-ui-baseline-context.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Read-only guard for the first source-owned Longhorn UI baseline rollout.
-# Already-configured workloads and a source rollback disarm the canary, so it
+# Successfully proven workloads and a source rollback disarm the canary, so it
 # does not freeze the chart's replica count or identity on future deployments.
 set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,6 +30,11 @@ read_ui() {
 has_defaults() {
   jq -e '.spec.template.spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
     ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [{}])' \
+    "${scratch}/deployment.json" >/dev/null
+}
+has_proof() {
+  jq -e '.metadata.uid != null and
+    .metadata.annotations["pod-security.devantler.tech/longhorn-ui-baseline-proof"] == .metadata.uid' \
     "${scratch}/deployment.json" >/dev/null
 }
 invariants() {
@@ -73,7 +78,7 @@ if [[ "${phase}" == before-publish ]]; then
     exit 0
   fi
   read_ui
-  if [[ -s "${scratch}/deployment.json" ]] && has_defaults; then
+  if [[ -s "${scratch}/deployment.json" ]] && has_defaults && has_proof; then
     output false
     exit 0
   fi
@@ -115,4 +120,15 @@ for ((sample = 0; sample < 3; sample++)); do
   fi
   [[ "${write_changes}" -lt 2 ]] || fail 'repeated owner writes continued during observation'
 done
+# The guard remains read-only. The deployment workflow records this receipt only
+# after proof succeeds, using tests on the exact final observed UID and version.
+# A failed proof or a crash before recording leaves the next deployment armed.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  proof_patch="$(jq -c '[
+    {op:"test",path:"/metadata/uid",value:.metadata.uid},
+    {op:"test",path:"/metadata/resourceVersion",value:.metadata.resourceVersion},
+    {op:"add",path:"/metadata/annotations/pod-security.devantler.tech~1longhorn-ui-baseline-proof",value:.metadata.uid}
+  ]' "${scratch}/deployment.json")"
+  printf 'proof_patch=%s\n' "${proof_patch}" >>"${GITHUB_OUTPUT}"
+fi
 printf 'PASS: Longhorn UI source defaults are stored, ready, and stable; generation=%s\n' "${generation}"

--- a/scripts/guard-longhorn-ui-baseline-context.sh
+++ b/scripts/guard-longhorn-ui-baseline-context.sh
@@ -47,6 +47,7 @@ invariants() {
     .spec.template.spec.securityContext.runAsUser == 499 and
     .spec.template.spec.securityContext.runAsGroup == 486 and
     .spec.template.spec.securityContext.seccompProfile.type == "RuntimeDefault" and
+    ((.spec.template.spec.initContainers // []) | length == 0) and
     ([.spec.template.spec.volumes[] | has("emptyDir")] | all) and
     ([.spec.template.spec.containers[] | .name == "longhorn-ui" and
       .securityContext.runAsNonRoot == true and .securityContext.runAsUser == 499 and

--- a/scripts/guard-longhorn-ui-baseline-context.sh
+++ b/scripts/guard-longhorn-ui-baseline-context.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Read-only guard for the first source-owned Longhorn UI baseline rollout.
+# Already-configured workloads and a source rollback disarm the canary, so it
+# does not freeze the chart's replica count or identity on future deployments.
+set -euo pipefail
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+phase="${1:-}"
+[[ $# -gt 0 ]] && shift
+context=admin@prod
+release="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context) context="${2:?context required}"; shift 2 ;;
+    --release) release="${2:?release file required}"; shift 2 ;;
+    *) printf 'Unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+case "${phase}" in before-publish|after-reconcile) ;; *) exit 2 ;; esac
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+fail() { printf '::error::Longhorn UI baseline canary: %s\n' "$1" >&2; exit 1; }
+output() {
+  printf 'rollout_required=%s\n' "$1"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then printf 'rollout_required=%s\n' "$1" >>"${GITHUB_OUTPUT}"; fi
+}
+read_ui() {
+  kubectl --context "${context}" get deployment longhorn-ui --namespace longhorn-system \
+    --ignore-not-found -o json --request-timeout=20s >"${scratch}/deployment.json" || fail 'API read failed'
+}
+has_defaults() {
+  jq -e '.spec.template.spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
+    ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [{}])' \
+    "${scratch}/deployment.json" >/dev/null
+}
+invariants() {
+  jq -e '.kind == "Deployment" and .metadata.name == "longhorn-ui" and
+    .metadata.namespace == "longhorn-system" and
+    .metadata.annotations["meta.helm.sh/release-name"] == "longhorn" and
+    .metadata.annotations["meta.helm.sh/release-namespace"] == "longhorn-system" and
+    ((.metadata.ownerReferences // []) | length == 0) and
+    .spec.replicas == 1 and .status.observedGeneration == .metadata.generation and
+    .status.replicas == 1 and .status.updatedReplicas == 1 and
+    .status.readyReplicas == 1 and .status.availableReplicas == 1 and
+    (.status.terminatingReplicas // 0) == 0 and
+    .spec.template.spec.securityContext.fsGroup == null and
+    .spec.template.spec.securityContext.runAsNonRoot == true and
+    .spec.template.spec.securityContext.runAsUser == 499 and
+    .spec.template.spec.securityContext.runAsGroup == 486 and
+    .spec.template.spec.securityContext.seccompProfile.type == "RuntimeDefault" and
+    ([.spec.template.spec.volumes[] | has("emptyDir")] | all) and
+    ([.spec.template.spec.containers[] | .name == "longhorn-ui" and
+      .securityContext.runAsNonRoot == true and .securityContext.runAsUser == 499 and
+      .securityContext.runAsGroup == 486 and .securityContext.allowPrivilegeEscalation == false and
+      (.securityContext.privileged // false) == false and
+      .securityContext.capabilities.drop == ["ALL"] and
+      .securityContext.seccompProfile.type == "RuntimeDefault"] == [true])' \
+    "${scratch}/deployment.json" >/dev/null
+}
+
+if [[ "${phase}" == before-publish ]]; then
+  # A reverted desired patch must not depend on the failed workload to recover.
+  yq -o=json '.spec.postRenderers // []' "${release}" >"${scratch}/renderers.json"
+  yq -o=json '[.[] | .kustomize.patches[] | select(.target.kind == "Deployment" and
+    .target.name == "longhorn-ui") | .patch | from_yaml]' "${scratch}/renderers.json" >"${scratch}/patches.json"
+  if ! configured="$(jq -r 'any(.[]; .spec.template.spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
+      any(.spec.template.spec.containers[]?; .name == "longhorn-ui" and .securityContext.seLinuxOptions == {}))' \
+    "${scratch}/patches.json")"; then
+    fail 'desired canary patch is malformed'
+  fi
+  if [[ "${configured}" == false ]]; then
+    output false
+    exit 0
+  fi
+  read_ui
+  if [[ -s "${scratch}/deployment.json" ]] && has_defaults; then
+    output false
+    exit 0
+  fi
+  # Reachable API + NotFound means initial installation. Post-proof is mandatory.
+  if [[ -s "${scratch}/deployment.json" ]]; then
+    invariants || fail 'existing UI is unhealthy or outside the reviewed ephemeral, non-root canary scope'
+  fi
+  output true
+  exit 0
+fi
+
+# Flux has reported the released revision Ready. Allow bounded old-pod cleanup,
+# then require consecutive stable observations of the stored, ready template.
+ready=false
+for ((attempt = 0; attempt < 12; attempt++)); do
+  read_ui
+  if [[ -s "${scratch}/deployment.json" ]] && invariants && has_defaults; then
+    ready=true
+    break
+  fi
+  sleep 5
+done
+[[ "${ready}" == true ]] || fail 'new UI defaults and a complete healthy rollout were not observed'
+generation="$(jq -r '.metadata.generation' "${scratch}/deployment.json")"
+version="$(jq -r '.metadata.resourceVersion' "${scratch}/deployment.json")"
+write_changes=0
+for ((sample = 0; sample < 3; sample++)); do
+  sleep 10
+  read_ui
+  if ! invariants || ! has_defaults; then
+    fail 'UI lost readiness or a security invariant during observation'
+  fi
+  [[ "$(jq -r '.metadata.generation' "${scratch}/deployment.json")" == "${generation}" ]] ||
+    fail 'owner rewrote the UI template during observation'
+  next_version="$(jq -r '.metadata.resourceVersion' "${scratch}/deployment.json")"
+  if [[ "${next_version}" != "${version}" ]]; then
+    write_changes=$((write_changes + 1))
+    version="${next_version}"
+  fi
+  [[ "${write_changes}" -lt 2 ]] || fail 'repeated owner writes continued during observation'
+done
+printf 'PASS: Longhorn UI source defaults are stored, ready, and stable; generation=%s\n' "${generation}"

--- a/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Check decisions against API fixtures, with kubectl as the external boundary.
+set -euo pipefail
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+mkdir "${scratch}/bin"
+cat >"${scratch}/release.yaml" <<'YAML'
+spec:
+  postRenderers:
+    - kustomize:
+        patches:
+          - target: {kind: Deployment, name: longhorn-ui}
+            patch: |
+              spec:
+                template:
+                  spec:
+                    securityContext: {fsGroupChangePolicy: OnRootMismatch}
+                    containers:
+                      - name: longhorn-ui
+                        securityContext: {seLinuxOptions: {}}
+YAML
+cat >"${scratch}/deployment.json" <<'JSON'
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"longhorn-ui","namespace":"longhorn-system","generation":7,"annotations":{"meta.helm.sh/release-name":"longhorn","meta.helm.sh/release-namespace":"longhorn-system"}},"spec":{"replicas":1,"template":{"spec":{"securityContext":{"runAsNonRoot":true,"runAsUser":499,"runAsGroup":486,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"longhorn-ui","securityContext":{"runAsNonRoot":true,"runAsUser":499,"runAsGroup":486,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}}],"volumes":[{"name":"cache","emptyDir":{}},{"name":"config","emptyDir":{}},{"name":"run","emptyDir":{}}]}}},"status":{"observedGeneration":7,"replicas":1,"updatedReplicas":1,"readyReplicas":1,"availableReplicas":1}}
+JSON
+cat >"${scratch}/bin/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FIXTURE_DIR}/calls"
+[[ "$*" == '--context fixture get deployment longhorn-ui --namespace longhorn-system --ignore-not-found -o json --request-timeout=20s' ]] || exit 99
+case "${SCENARIO}" in
+  api-error) exit 1 ;;
+  absent) exit 0 ;;
+  *) cat "${FIXTURE_DIR}/input.json" ;;
+esac
+SH
+cat >"${scratch}/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "${scratch}/bin/kubectl" "${scratch}/bin/sleep"
+export PATH="${scratch}/bin:${PATH}" FIXTURE_DIR="${scratch}"
+script="${root_dir}/scripts/guard-longhorn-ui-baseline-context.sh"
+
+check() {
+  local name="$1" phase="$2" expected="$3" scenario="$4" rc=0
+  : >"${scratch}/outputs"
+  SCENARIO="${scenario}" GITHUB_OUTPUT="${scratch}/outputs" bash "${script}" "${phase}" \
+    --context fixture --release "${scratch}/release.yaml" >"${scratch}/output" 2>&1 || rc=$?
+  if [[ "${expected}" == pass && "${rc}" -ne 0 ]] || [[ "${expected}" == fail && "${rc}" -eq 0 ]]; then
+    printf 'FAIL: %s (exit %s)\n' "${name}" "${rc}" >&2
+    cat "${scratch}/output" >&2
+    exit 1
+  fi
+}
+cp "${scratch}/deployment.json" "${scratch}/input.json"
+check 'healthy unmodified UI is an eligible canary' before-publish pass normal
+grep -qx 'rollout_required=true' "${scratch}/outputs"
+check 'API error is not absence' before-publish fail api-error
+check 'uninstalled chart can bootstrap' before-publish pass absent
+check 'post-deploy absence is failure' after-reconcile fail absent
+check 'healthy old template is not rollout evidence' after-reconcile fail normal
+
+jq '.spec.template.spec.securityContext.fsGroupChangePolicy="OnRootMismatch" |
+  .spec.template.spec.containers[0].securityContext.seLinuxOptions={}' \
+  "${scratch}/deployment.json" >"${scratch}/hardened.json"
+cp "${scratch}/hardened.json" "${scratch}/input.json"
+check 'repeated deploy accepts existing canary' before-publish pass normal
+grep -qx 'rollout_required=false' "${scratch}/outputs"
+check 'ready and stable hardened UI passes' after-reconcile pass normal
+
+for mutation in \
+  '.status.availableReplicas=0' \
+  '.status.observedGeneration=6' \
+  '.spec.template.spec.securityContext.fsGroup=1000' \
+  '.spec.template.spec.volumes[0]={name:"data",persistentVolumeClaim:{claimName:"storage"}}' \
+  '.spec.template.spec.containers[0].securityContext.privileged=true' \
+  '.spec.template.spec.containers[0].securityContext.runAsUser=0' \
+  '.metadata.ownerReferences=[{kind:"Operator",name:"rebuilding-owner"}]'; do
+  jq "${mutation}" "${scratch}/deployment.json" >"${scratch}/input.json"
+  check "invariant rejects ${mutation}" before-publish fail normal
+  jq "${mutation}" "${scratch}/hardened.json" >"${scratch}/input.json"
+  check "post-proof rejects ${mutation}" after-reconcile fail normal
+done
+
+# A post-start generation move represents an owner rewriting the template.
+cat >"${scratch}/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+jq '.metadata.generation += 1 | .status.observedGeneration += 1' "${FIXTURE_DIR}/input.json" >"${FIXTURE_DIR}/next.json"
+mv "${FIXTURE_DIR}/next.json" "${FIXTURE_DIR}/input.json"
+SH
+cp "${scratch}/hardened.json" "${scratch}/input.json"
+check 'owner rewriting during the watch fails closed' after-reconcile fail normal
+
+cat >"${scratch}/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+jq '.metadata.resourceVersion = ((.metadata.resourceVersion // "700" | tonumber) + 1 | tostring)' "${FIXTURE_DIR}/input.json" >"${FIXTURE_DIR}/next.json"
+mv "${FIXTURE_DIR}/next.json" "${FIXTURE_DIR}/input.json"
+SH
+cp "${scratch}/hardened.json" "${scratch}/input.json"
+check 'repeated writes without generation movement fail closed' after-reconcile fail normal
+
+# Source rollback must disarm before accessing the failed workload.
+printf 'spec: {}\n' >"${scratch}/release.yaml"
+check 'rollback disarms the canary before any cluster access' before-publish pass api-error
+grep -qx 'rollout_required=false' "${scratch}/outputs"
+
+# The deployed workflow must call the same real guard on each side of the
+# artifact boundary. A standalone passing checker is not an enforced rollout.
+yq -o=json '.runs.steps' "${root_dir}/.github/actions/deploy-prod/action.yml" |
+  jq -e '
+    map(.id // "") as $ids |
+    ($ids | index("longhorn_ui_baseline")) as $before |
+    ($ids | index("publish_platform_manifest")) as $publish |
+    ($ids | index("wait_flux_revision")) as $ready |
+    to_entries | map(select(.value.run == "bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile")) as $after |
+    $before != null and $publish != null and $ready != null and
+    $before < $publish and ($after | length) == 1 and $after[0].key > $ready and
+    $after[0].value.if == "steps.longhorn_ui_baseline.outputs.rollout_required == '\''true'\''"' >/dev/null
+printf 'PASS: Longhorn UI preflight, post-proof, absent/error, drift, readiness and privilege controls\n'

--- a/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
@@ -2,6 +2,7 @@
 # Check decisions against API fixtures, with kubectl as the external boundary.
 set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+real_kubectl="$(command -v kubectl)"
 scratch="$(mktemp -d)"
 trap 'rm -rf "${scratch}"' EXIT
 mkdir "${scratch}/bin"
@@ -23,6 +24,9 @@ YAML
 cat >"${scratch}/deployment.json" <<'JSON'
 {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"longhorn-ui","namespace":"longhorn-system","generation":7,"annotations":{"meta.helm.sh/release-name":"longhorn","meta.helm.sh/release-namespace":"longhorn-system"}},"spec":{"replicas":1,"template":{"spec":{"securityContext":{"runAsNonRoot":true,"runAsUser":499,"runAsGroup":486,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"longhorn-ui","securityContext":{"runAsNonRoot":true,"runAsUser":499,"runAsGroup":486,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}}],"volumes":[{"name":"cache","emptyDir":{}},{"name":"config","emptyDir":{}},{"name":"run","emptyDir":{}}]}}},"status":{"observedGeneration":7,"replicas":1,"updatedReplicas":1,"readyReplicas":1,"availableReplicas":1}}
 JSON
+jq '.metadata.uid="ui-uid" | .metadata.resourceVersion="700"' \
+  "${scratch}/deployment.json" >"${scratch}/identified.json"
+mv "${scratch}/identified.json" "${scratch}/deployment.json"
 cat >"${scratch}/bin/kubectl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -65,9 +69,37 @@ jq '.spec.template.spec.securityContext.fsGroupChangePolicy="OnRootMismatch" |
   .spec.template.spec.containers[0].securityContext.seLinuxOptions={}' \
   "${scratch}/deployment.json" >"${scratch}/hardened.json"
 cp "${scratch}/hardened.json" "${scratch}/input.json"
-check 'repeated deploy accepts existing canary' before-publish pass normal
-grep -qx 'rollout_required=false' "${scratch}/outputs"
+check 'applied fields without a successful proof must retry verification' before-publish pass normal
+grep -qx 'rollout_required=true' "${scratch}/outputs"
 check 'ready and stable hardened UI passes' after-reconcile pass normal
+proof_patch="$(sed -n 's/^proof_patch=//p' "${scratch}/outputs")"
+[[ -n "${proof_patch}" ]]
+"${real_kubectl}" patch --local --type json --patch "${proof_patch}" \
+  -f "${scratch}/input.json" -o json >"${scratch}/proven.json"
+cp "${scratch}/proven.json" "${scratch}/input.json"
+check 'successful proof disarms the same deployment' before-publish pass normal
+grep -qx 'rollout_required=false' "${scratch}/outputs"
+jq '.spec.replicas=2 | .spec.template.spec.containers[0].securityContext.runAsUser=501' \
+  "${scratch}/proven.json" >"${scratch}/input.json"
+check 'completed canary does not freeze later chart identity or replica changes' before-publish pass normal
+grep -qx 'rollout_required=false' "${scratch}/outputs"
+jq 'del(.metadata.annotations["pod-security.devantler.tech/longhorn-ui-baseline-proof"])' \
+  "${scratch}/proven.json" >"${scratch}/input.json"
+check 'lost proof safely requires revalidation' before-publish pass normal
+grep -qx 'rollout_required=true' "${scratch}/outputs"
+
+for mutation in '.metadata.uid="replacement-uid"' \
+  '.metadata.resourceVersion="701" | .spec.template.spec.containers[0].securityContext.runAsUser=500'; do
+  jq "${mutation}" "${scratch}/hardened.json" >"${scratch}/changed.json"
+  if "${real_kubectl}" patch --local --type json --patch "${proof_patch}" \
+    -f "${scratch}/changed.json" -o json >/dev/null 2>&1; then
+    printf 'FAIL: success receipt accepted a changed object: %s\n' "${mutation}" >&2
+    exit 1
+  fi
+done
+jq '.metadata.uid="replacement-uid"' "${scratch}/proven.json" >"${scratch}/input.json"
+check 'a replacement cannot inherit the prior deployment proof' before-publish pass normal
+grep -qx 'rollout_required=true' "${scratch}/outputs"
 
 for mutation in \
   '.status.availableReplicas=0' \
@@ -100,6 +132,9 @@ mv "${FIXTURE_DIR}/next.json" "${FIXTURE_DIR}/input.json"
 SH
 cp "${scratch}/hardened.json" "${scratch}/input.json"
 check 'repeated writes without generation movement fail closed' after-reconcile fail normal
+[[ ! -s "${scratch}/outputs" ]]
+check 'failed post-proof still requires verification on retry' before-publish pass normal
+grep -qx 'rollout_required=true' "${scratch}/outputs"
 
 # Source rollback must disarm before accessing the failed workload.
 printf 'spec: {}\n' >"${scratch}/release.yaml"
@@ -116,8 +151,14 @@ for workflow in .github/actions/deploy-prod/action.yml .github/workflows/dr-rebu
     ($ids | index("publish_platform_manifest")) as $publish |
     ($ids | index("wait_flux_revision")) as $ready |
     to_entries | map(select(.value.run == "bash scripts/guard-longhorn-ui-baseline-context.sh after-reconcile")) as $after |
+    map(select(.value.env.LONGHORN_UI_BASELINE_PROOF_PATCH != null)) as $record |
     $before != null and $publish != null and $ready != null and
     $before < $publish and ($after | length) == 1 and $after[0].key > $ready and
-    $after[0].value.if == "steps.longhorn_ui_baseline.outputs.rollout_required == '\''true'\''"' >/dev/null
+    $after[0].value.if == "steps.longhorn_ui_baseline.outputs.rollout_required == '\''true'\''" and
+    $after[0].value.id == "verify_longhorn_ui_baseline" and
+    ($record | length) == 1 and $record[0].key > $after[0].key and
+    $record[0].value.if == $after[0].value.if and
+    $record[0].value.env.LONGHORN_UI_BASELINE_PROOF_PATCH == "${{ steps.verify_longhorn_ui_baseline.outputs.proof_patch }}" and
+    ($record[0].value.run | contains("--patch \"${LONGHORN_UI_BASELINE_PROOF_PATCH}\""))' >/dev/null
 done
 printf 'PASS: Longhorn UI preflight, post-proof, absent/error, drift, readiness and privilege controls\n'

--- a/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
@@ -76,6 +76,7 @@ for mutation in \
   '.spec.template.spec.volumes[0]={name:"data",persistentVolumeClaim:{claimName:"storage"}}' \
   '.spec.template.spec.containers[0].securityContext.privileged=true' \
   '.spec.template.spec.containers[0].securityContext.runAsUser=0' \
+  '.spec.template.spec.initContainers=[{name:"unreviewed-init",securityContext:{runAsUser:0}}]' \
   '.metadata.ownerReferences=[{kind:"Operator",name:"rebuilding-owner"}]'; do
   jq "${mutation}" "${scratch}/deployment.json" >"${scratch}/input.json"
   check "invariant rejects ${mutation}" before-publish fail normal

--- a/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-guard-longhorn-ui-baseline-context.sh
@@ -108,7 +108,8 @@ grep -qx 'rollout_required=false' "${scratch}/outputs"
 
 # The deployed workflow must call the same real guard on each side of the
 # artifact boundary. A standalone passing checker is not an enforced rollout.
-yq -o=json '.runs.steps' "${root_dir}/.github/actions/deploy-prod/action.yml" |
+for workflow in .github/actions/deploy-prod/action.yml .github/workflows/dr-rebuild.yaml; do
+  yq -o=json '.runs.steps // .jobs.rebuild.steps' "${root_dir}/${workflow}" |
   jq -e '
     map(.id // "") as $ids |
     ($ids | index("longhorn_ui_baseline")) as $before |
@@ -118,4 +119,5 @@ yq -o=json '.runs.steps' "${root_dir}/.github/actions/deploy-prod/action.yml" |
     $before != null and $publish != null and $ready != null and
     $before < $publish and ($after | length) == 1 and $after[0].key > $ready and
     $after[0].value.if == "steps.longhorn_ui_baseline.outputs.rollout_required == '\''true'\''"' >/dev/null
+done
 printf 'PASS: Longhorn UI preflight, post-proof, absent/error, drift, readiness and privilege controls\n'

--- a/scripts/tests/test-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-longhorn-ui-baseline-context.sh
@@ -62,10 +62,25 @@ jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") 
   ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [{}]) and
   ([.spec.template.spec.volumes[] | has("emptyDir")] | all)] == [true]' \
   "${scratch}/on-resources.json" >/dev/null || fail 'UI canary defaults or ephemeral storage contract missing'
-jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") |
-  .spec.template.spec.securityContext.fsGroupChangePolicy == null and
-  ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [null])] == [true]' \
-  "${scratch}/off-resources.json" >/dev/null || fail 'disabled canary must omit both new defaults'
+chart_defaults_absent() {
+  jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") |
+    .spec.template.spec.securityContext.fsGroupChangePolicy == null and
+    .spec.template.spec.securityContext.seLinuxOptions == null and
+    ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [null])] == [true]' \
+    "$1" >/dev/null
+}
+chart_defaults_absent "${scratch}/off-resources.json" ||
+  fail 'chart now supplies a default or inherited SELinux options; review the canary before overriding them'
+
+# Model an upstream chart starting to supply pod options. The container's empty
+# object would shadow those options, even though normalizing the two canary
+# fields would still produce an otherwise identical render.
+jq 'map(if .kind == "Deployment" and .metadata.name == "longhorn-ui" then
+    .spec.template.spec.securityContext.seLinuxOptions = {type:"upstream_type"}
+  else . end)' "${scratch}/off-resources.json" >"${scratch}/inherited-selinux.json"
+if chart_defaults_absent "${scratch}/inherited-selinux.json"; then
+  fail 'compatibility check accepted inherited pod SELinux options that the canary would shadow'
+fi
 
 jq -S 'map(if .kind == "Deployment" and .metadata.name == "longhorn-ui" then
     del(.spec.template.spec.securityContext.fsGroupChangePolicy) |

--- a/scripts/tests/test-longhorn-ui-baseline-context.sh
+++ b/scripts/tests/test-longhorn-ui-baseline-context.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Render the pinned chart through the real Flux post-renderers. The canary must
+# change only the UI security defaults, and removing them must restore the chart.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+release_dir="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/longhorn"
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+for tool in kubectl helm yq jq; do
+  command -v "${tool}" >/dev/null || fail "${tool} is required"
+done
+
+kubectl kustomize "${release_dir}" | yq -o=json \
+  'select(.kind == "HelmRelease" and .metadata.name == "longhorn")' >"${scratch}/on.json"
+yq -o=json '.data' "${root_dir}/k8s/clusters/prod/bootstrap/config-map.yaml" >"${scratch}/variables.json"
+jq --slurpfile variables "${scratch}/variables.json" '.spec.values | walk(
+  if type == "string" and test("^\\$\\{[a-z_]+:=[0-9]+\\}$") then
+    capture("^\\$\\{(?<name>[a-z_]+):=(?<fallback>[0-9]+)\\}$") |
+    ($variables[0][.name] // .fallback) | tonumber
+  else . end)' "${scratch}/on.json" >"${scratch}/values.json"
+chart_name="$(jq -r '.spec.chart.spec.chart' "${scratch}/on.json")"
+chart_version="$(jq -r '.spec.chart.spec.version' "${scratch}/on.json")"
+chart_repo="$(yq -r '.spec.url' "${release_dir}/helm-repository.yaml")"
+helm pull "${chart_name}" --repo "${chart_repo}" --version "${chart_version}" --destination "${scratch}"
+helm template longhorn "${scratch}/${chart_name}-${chart_version}.tgz" \
+  --namespace longhorn-system --values "${scratch}/values.json" >"${scratch}/chart.yaml"
+
+# Remove only the canary defaults from the source-owned UI patch. This is the
+# rollback proposed for a failing canary, and leaves its existing hardening intact.
+yq -o=json '(.spec.postRenderers[].kustomize.patches[] |
+  select(.target.kind == "Deployment" and .target.name == "longhorn-ui").patch) |=
+  (from_yaml | del(.spec.template.spec.securityContext.fsGroupChangePolicy) |
+   del(.spec.template.spec.containers[].securityContext.seLinuxOptions) | to_yaml)' \
+  "${scratch}/on.json" >"${scratch}/off.json"
+
+render() {
+  local mode="$1" index count
+  mkdir "${scratch}/${mode}"
+  cp "${scratch}/chart.yaml" "${scratch}/${mode}/resources.yaml"
+  count="$(jq '.spec.postRenderers | length' "${scratch}/${mode}.json")"
+  for ((index = 0; index < count; index++)); do
+    jq --argjson index "${index}" '{apiVersion: "kustomize.config.k8s.io/v1beta1",
+      kind: "Kustomization", resources: ["resources.yaml"]} +
+      .spec.postRenderers[$index].kustomize' "${scratch}/${mode}.json" >"${scratch}/${mode}/kustomization.yaml"
+    kubectl kustomize "${scratch}/${mode}" >"${scratch}/${mode}/next.yaml"
+    mv "${scratch}/${mode}/next.yaml" "${scratch}/${mode}/resources.yaml"
+  done
+  yq ea -o=json '[.]' "${scratch}/${mode}/resources.yaml" |
+    jq -S 'sort_by([.apiVersion,.kind,.metadata.namespace,.metadata.name])' >"${scratch}/${mode}-resources.json"
+}
+render off
+render on
+
+# A target rename or a patch that Helm never applies must fail here, instead of
+# passing because Kustomize tolerates unmatched patch targets.
+jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") |
+  .spec.template.spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
+  .spec.template.spec.securityContext.fsGroup == null and
+  ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [{}]) and
+  ([.spec.template.spec.volumes[] | has("emptyDir")] | all)] == [true]' \
+  "${scratch}/on-resources.json" >/dev/null || fail 'UI canary defaults or ephemeral storage contract missing'
+jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") |
+  .spec.template.spec.securityContext.fsGroupChangePolicy == null and
+  ([.spec.template.spec.containers[] | .securityContext.seLinuxOptions] == [null])] == [true]' \
+  "${scratch}/off-resources.json" >/dev/null || fail 'disabled canary must omit both new defaults'
+
+jq -S 'map(if .kind == "Deployment" and .metadata.name == "longhorn-ui" then
+    del(.spec.template.spec.securityContext.fsGroupChangePolicy) |
+    del(.spec.template.spec.containers[].securityContext.seLinuxOptions)
+  else . end)' "${scratch}/on-resources.json" >"${scratch}/normalized.json"
+cmp "${scratch}/off-resources.json" "${scratch}/normalized.json" ||
+  fail 'canary changes resources beyond the two UI defaults, including storage controllers or existing hardening'
+
+cp "${scratch}/off.json" "${scratch}/rollback.json"
+render rollback
+cmp "${scratch}/off-resources.json" "${scratch}/rollback-resources.json" || fail 'rollback must restore all rendered resources exactly'
+
+# Prove the positive assertion rejects the unchanged release; a test which only
+# compared normalized output would incorrectly accept an entirely absent patch.
+if jq -e '[.[] | select(.kind == "Deployment" and .metadata.name == "longhorn-ui") |
+  .spec.template.spec.securityContext.fsGroupChangePolicy] == ["OnRootMismatch"]' \
+  "${scratch}/off-resources.json" >/dev/null; then
+  fail 'negative control accepted a release without the canary'
+fi
+
+printf 'PASS: exact Longhorn chart changes only the two UI defaults; disabled state and rollback preserve every resource\n'

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1762,7 +1762,15 @@ const (
 // restores byte-equivalent parsed objects; no RBAC grant or workload field
 // changes. A negative control removing one identity reports exactly one removal.
 // Previous aggregate: d76e357336f1c4817766463bf7990648b5c8b019939aaf680606929d51bd46b4.
-const expectedRenderedSurfaceSHA = "ea907ed3b00ccb2086e2445e8d7ef9e1050cf0c77f4779c1f7d1b03cb8950191"
+// Refreshed for #3239's source-owned Longhorn UI canary. Pinned kubectl v1.36.2
+// rendered all five roots on main 45841c15 and this tree: 555 identities each,
+// zero additions or removals, and all 83 RBAC/ServiceAccount documents unchanged.
+// Only longhorn-system/longhorn changes, adding fsGroupChangePolicy and empty
+// seLinuxOptions to the existing UI patch. The real chart regression proves the
+// entire rendered release differs only by those two fields on longhorn-ui;
+// manager, CSI, storage objects, identity, capabilities and seccomp are unchanged.
+// Previous aggregate: ea907ed3b00ccb2086e2445e8d7ef9e1050cf0c77f4779c1f7d1b03cb8950191.
+const expectedRenderedSurfaceSHA = "a7bffd8423a99b738dd231a04b96a8e7d12b89eb2d308b26613d3004341a1c33"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Longhorn's stored UI controller template still lacks the two C-0211 baseline fields. Supply `fsGroupChangePolicy: OnRootMismatch` and empty container `seLinuxOptions` through its existing exact UI post-renderer. The chart does not expose these fields as values. The UI has no `fsGroup` and uses only `emptyDir` volumes, so this preserves runtime ownership, UID/group, capabilities, seccomp, storage controllers and grants.

The shared production deploy action and disaster-recovery rebuild check the healthy UI before publishing and require stored-field, rollout-readiness and stability proof after Flux reconciles. A separate workflow step records success only after that proof, atomically testing the final observed Deployment UID and resourceVersion. Fields without a matching receipt remain subject to verification on retry; completed canaries and source rollback do not freeze unrelated later deployments. The guard itself remains read-only. API errors, unsafe storage/privilege changes, absent post-deploy resources and owner rewrite loops fail the deployment. A failed merge-group deploy retains the existing main-revision heal path.

Validation:

- Real pinned chart: RED without the defaults, GREEN with them; every other rendered resource is identical, and removing the fields restores the release exactly.
- Guard fixtures cover failure/crash/retry, receipt loss, UID replacement, concurrent updates before recording, later completed-canary changes, readiness, API failure versus NotFound, owner drift and recovery. Real local JSON Patch execution rejects stale receipts, and workflow-boundary checks cover both production paths.
- Chart compatibility rejects inherited pod SELinux options that an empty container override would shadow; its negative control fails when that assertion is removed.
- Existing baseline mutation test and ShellCheck pass.
- Both local and production KSail validation pass (118 kustomizations, 605 files each).
- Rebased on #3635. The required authorization regression passes; the source comparison confirms the two UI defaults are the only workload changes and no permission grant is altered.
- Read-only live preflight passes; production deployment and after-apply proof remain pending.

Part of #3239. This is one UI canary, not the full historical 33-workload target. The namespace-wide controller switch stays off, the C-0211 residual is unchanged until remeasurement, and the rollout guide gives the source-first route for the remaining chart- and operator-owned workloads. The previous requirement to place future rollout evidence inside an activation commit is bypassed by source-owned templates with enforced deployment-order proof, not by weakening its namespace gate.
