### PR TITLE
fix(auth): classify unavailable package proof reads

### DIFF
--- a/scripts/prove-scoped-package-access/README.md
+++ b/scripts/prove-scoped-package-access/README.md
@@ -36,14 +36,16 @@ Unavailable registry reads append three diagnostic fields to the UNKNOWN result:
 
 - `registry_phase`: `token_exchange` or `manifest`.
 - `http_status`: the observed numeric status, or `0` when no HTTP response arrived.
-- `failure_class`: a fixed category such as `http_status`, `unclassified_denial`,
+- `failure_class`: a fixed category such as `http_status`, `authorization_denial`, `unclassified_denial`,
   `invalid_json`, `missing_token`, `invalid_manifest`, `digest_mismatch`,
   `timeout`, `transport`, `response_read`, or `response_size`. An invalid local
   request uses `invalid_request`; an unrecognized internal error uses
   `request_unavailable`.
 
 The status is retained when a response body cannot be read or exceeds the 4 MiB
-limit. These fields classify the failed operation; they do not establish package
+limit; a deadline while reading the body is still a `timeout`. Recognized denials
+retain their diagnostic when a baseline or postcheck makes the result UNKNOWN.
+These fields classify the failed operation; they do not establish package
 authorization. No response text, headers, endpoints, package identities, digests,
 or underlying error messages are printed. Metadata and full-download failures
 retain their fixed reason codes.

--- a/scripts/prove-scoped-package-access/README.md
+++ b/scripts/prove-scoped-package-access/README.md
@@ -32,6 +32,22 @@ The process and workflow preserve three outcomes:
 | 1 | FAIL | A valid scoped token could not read its own package, or could read the other package. |
 | 2 | UNKNOWN | Metadata, privacy, token scope, full download or availability could not be established. |
 
+Unavailable registry reads append three diagnostic fields to the UNKNOWN result:
+
+- `registry_phase`: `token_exchange` or `manifest`.
+- `http_status`: the observed numeric status, or `0` when no HTTP response arrived.
+- `failure_class`: a fixed category such as `http_status`, `unclassified_denial`,
+  `invalid_json`, `missing_token`, `invalid_manifest`, `digest_mismatch`,
+  `timeout`, `transport`, `response_read`, or `response_size`. An invalid local
+  request uses `invalid_request`; an unrecognized internal error uses
+  `request_unavailable`.
+
+The status is retained when a response body cannot be read or exceeds the 4 MiB
+limit. These fields classify the failed operation; they do not establish package
+authorization. No response text, headers, endpoints, package identities, digests,
+or underlying error messages are printed. Metadata and full-download failures
+retain their fixed reason codes.
+
 A missing image, throttling, server error, redirect or malformed response never
 counts as a successful restriction. A failed or unknown run does not authorize
 registry-authentication changes. The spike's result must be recorded before its

--- a/scripts/prove-scoped-package-access/main.go
+++ b/scripts/prove-scoped-package-access/main.go
@@ -72,6 +72,9 @@ func (p proof) request(ctx context.Context, endpoint, authorization string) (int
 	defer func() { _ = response.Body.Close() }()
 	data, err := io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return response.StatusCode, nil, requestFailure("timeout")
+		}
 		return response.StatusCode, nil, requestFailure("response_read")
 	}
 	if len(data) > 4<<20 {
@@ -140,7 +143,8 @@ func (p proof) manifest(ctx context.Context, auth credential, repository, ref st
 		return registryRead{diagnostic: diagnostic}
 	}
 	if authorizationDenial(status, data) {
-		return registryRead{status: status}
+		diagnostic.class = "authorization_denial"
+		return registryRead{status: status, diagnostic: diagnostic}
 	}
 	if status != http.StatusOK {
 		diagnostic.class = "http_status"
@@ -171,7 +175,8 @@ func (p proof) manifest(ctx context.Context, auth credential, repository, ref st
 		return registryRead{diagnostic: diagnostic}
 	}
 	if authorizationDenial(status, data) {
-		return registryRead{status: status}
+		diagnostic.class = "authorization_denial"
+		return registryRead{status: status, diagnostic: diagnostic}
 	}
 	if status != http.StatusOK {
 		diagnostic.class = "http_status"

--- a/scripts/prove-scoped-package-access/main.go
+++ b/scripts/prove-scoped-package-access/main.go
@@ -33,12 +33,29 @@ func restrictedClient() *http.Client {
 	}}
 }
 
+// requestFailure is an internal classification; the underlying network error is discarded.
+type requestFailure string
+
+func (requestFailure) Error() string { return "registry request unavailable" }
+
+// requestFailureClass admits only the fixed categories produced by request.
+func requestFailureClass(err error) string {
+	var failure requestFailure
+	if errors.As(err, &failure) {
+		switch failure {
+		case "invalid_request", "timeout", "transport", "response_read", "response_size":
+			return string(failure)
+		}
+	}
+	return "request_unavailable"
+}
+
 // URLs and repositories are deliberately fixed in main: this credential-bearing
 // experiment is not a general registry client or an arbitrary URL fetcher.
 func (p proof) request(ctx context.Context, endpoint, authorization string) (int, []byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return 0, nil, errors.New("invalid request")
+		return 0, nil, requestFailure("invalid_request")
 	}
 	if authorization != "" {
 		req.Header.Set("Authorization", authorization)
@@ -46,13 +63,19 @@ func (p proof) request(ctx context.Context, endpoint, authorization string) (int
 	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.github+json")
 	response, err := p.client.Do(req)
 	if err != nil {
-		return 0, nil, errors.New("request unavailable")
+		if errors.Is(err, context.DeadlineExceeded) {
+			return 0, nil, requestFailure("timeout")
+		}
+		return 0, nil, requestFailure("transport")
 	}
 	// A read-only response has no pending write to commit on close.
 	defer func() { _ = response.Body.Close() }()
 	data, err := io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
-	if err != nil || len(data) > 4<<20 {
-		return 0, nil, errors.New("response unavailable or oversized")
+	if err != nil {
+		return response.StatusCode, nil, requestFailure("response_read")
+	}
+	if len(data) > 4<<20 {
+		return response.StatusCode, nil, requestFailure("response_size")
 	}
 	return response.StatusCode, data, nil
 }
@@ -89,68 +112,109 @@ func authorizationDenial(status int, data []byte) bool {
 	return true
 }
 
-// Resolve a manifest through GHCR's token exchange using a single identity. A
-// missing tag, throttling, a redirect, malformed JSON or transport failure is
-// never treated as an authorization denial.
-func (p proof) manifest(ctx context.Context, auth credential, repository, ref string) (int, string) {
+// registryDiagnostic carries only fixed classifications and an HTTP status, never server text.
+type registryDiagnostic struct {
+	phase  string
+	status int
+	class  string
+}
+
+type registryRead struct {
+	status     int
+	digest     string
+	diagnostic registryDiagnostic
+}
+
+// manifest accepts only validated manifests or classified authorization denials.
+// All other outcomes retain a safe diagnosis without changing the proof verdict.
+func (p proof) manifest(ctx context.Context, auth credential, repository, ref string) registryRead {
 	authorization := ""
 	if auth.password != "" {
 		authorization = "Basic " + base64.StdEncoding.EncodeToString([]byte(auth.username+":"+auth.password))
 	}
 	query := url.Values{"service": {"ghcr.io"}, "scope": {"repository:devantler-tech/" + repository + ":pull"}}
 	status, data, err := p.request(ctx, p.registryURL+"/token?"+query.Encode(), authorization)
+	diagnostic := registryDiagnostic{phase: "token_exchange", status: status}
 	if err != nil {
-		return 0, ""
+		diagnostic.class = requestFailureClass(err)
+		return registryRead{diagnostic: diagnostic}
 	}
 	if authorizationDenial(status, data) {
-		return status, ""
+		return registryRead{status: status}
+	}
+	if status != http.StatusOK {
+		diagnostic.class = "http_status"
+		if denied(status) {
+			diagnostic.class = "unclassified_denial"
+		}
+		return registryRead{diagnostic: diagnostic}
 	}
 	var token struct {
 		Token       string `json:"token"`
 		AccessToken string `json:"access_token"`
 	}
-	if status != 200 || json.Unmarshal(data, &token) != nil {
-		return 0, ""
+	if json.Unmarshal(data, &token) != nil {
+		diagnostic.class = "invalid_json"
+		return registryRead{diagnostic: diagnostic}
 	}
 	if token.Token == "" {
 		token.Token = token.AccessToken
 	}
 	if token.Token == "" {
-		return 0, ""
+		diagnostic.class = "missing_token"
+		return registryRead{diagnostic: diagnostic}
 	}
 	status, data, err = p.request(ctx, p.registryURL+"/v2/devantler-tech/"+repository+"/manifests/"+ref, "Bearer "+token.Token)
+	diagnostic = registryDiagnostic{phase: "manifest", status: status}
 	if err != nil {
-		return 0, ""
+		diagnostic.class = requestFailureClass(err)
+		return registryRead{diagnostic: diagnostic}
 	}
-	if denied(status) && !authorizationDenial(status, data) {
-		return 0, ""
+	if authorizationDenial(status, data) {
+		return registryRead{status: status}
 	}
-	if status != 200 {
-		return status, ""
+	if status != http.StatusOK {
+		diagnostic.class = "http_status"
+		if denied(status) {
+			diagnostic.class = "unclassified_denial"
+		}
+		return registryRead{diagnostic: diagnostic}
 	}
 	var manifest struct {
 		SchemaVersion int    `json:"schemaVersion"`
 		MediaType     string `json:"mediaType"`
 	}
-	if json.Unmarshal(data, &manifest) != nil || manifest.SchemaVersion != 2 {
-		return 0, ""
+	if json.Unmarshal(data, &manifest) != nil {
+		diagnostic.class = "invalid_json"
+		return registryRead{diagnostic: diagnostic}
+	}
+	if manifest.SchemaVersion != 2 {
+		diagnostic.class = "invalid_manifest"
+		return registryRead{diagnostic: diagnostic}
 	}
 	switch manifest.MediaType {
 	case "application/vnd.oci.image.index.v1+json", "application/vnd.oci.image.manifest.v1+json", "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.docker.distribution.manifest.v2+json":
 	default:
-		return 0, ""
+		diagnostic.class = "invalid_manifest"
+		return registryRead{diagnostic: diagnostic}
 	}
 	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 	if strings.HasPrefix(ref, "sha256:") && ref != digest {
-		return 0, ""
+		diagnostic.class = "digest_mismatch"
+		return registryRead{diagnostic: diagnostic}
 	}
-	return status, digest
+	return registryRead{status: status, digest: digest}
 }
 
-// result emits only the fixed verdict and reason; missing output cannot count as success.
-func (p proof) result(code int, reason string) int {
+// result emits fixed classifications only; missing output cannot count as success.
+func (p proof) result(code int, reason string, diagnostics ...registryDiagnostic) int {
 	verdict := []string{"PASS", "FAIL", "UNKNOWN"}[code]
-	if _, err := fmt.Fprintf(p.output, "scoped_package_proof=%s reason=%s\n", verdict, reason); err != nil {
+	line := fmt.Sprintf("scoped_package_proof=%s reason=%s", verdict, reason)
+	if code == 2 && len(diagnostics) == 1 && diagnostics[0].class != "" {
+		d := diagnostics[0]
+		line += fmt.Sprintf(" registry_phase=%s http_status=%d failure_class=%s", d.phase, d.status, d.class)
+	}
+	if _, err := fmt.Fprintln(p.output, line); err != nil {
 		return 2
 	}
 	return code
@@ -187,43 +251,46 @@ func (p proof) run(ctx context.Context) int {
 		if !p.metadata(ctx, "/orgs/devantler-tech/packages/container/"+repository, p.baseline.password, &metadata) || metadata.Name != repository || metadata.PackageType != "container" || metadata.Visibility != "private" || metadata.Owner.Login != "devantler-tech" || metadata.Repository.FullName != "devantler-tech/"+repository {
 			return p.result(2, "private_package_association_unverified")
 		}
-		status, digest := p.manifest(ctx, p.baseline, repository, "latest")
-		if status != 200 {
-			return p.result(2, "baseline_manifest_unavailable")
+		read := p.manifest(ctx, p.baseline, repository, "latest")
+		if read.status != 200 {
+			return p.result(2, "baseline_manifest_unavailable", read.diagnostic)
 		}
+		digest := read.digest
 		digests[i] = digest
-		status, _ = p.manifest(ctx, credential{}, repository, digest)
-		if !denied(status) {
-			return p.result(2, "anonymous_denial_unverified")
+		read = p.manifest(ctx, credential{}, repository, digest)
+		if !denied(read.status) {
+			return p.result(2, "anonymous_denial_unverified", read.diagnostic)
 		}
 		if p.pull(ctx, p.baseline, "ghcr.io/devantler-tech/"+repository+"@"+digest) != nil {
 			return p.result(2, "baseline_full_pull_unavailable")
 		}
 	}
 	// A successful own pull includes the image's blobs, not just its manifest.
-	ownStatus, _ := p.manifest(ctx, p.scoped, repositories[0], digests[0])
+	ownRead := p.manifest(ctx, p.scoped, repositories[0], digests[0])
+	ownStatus := ownRead.status
 	if ownStatus != 200 && !denied(ownStatus) {
-		return p.result(2, "scoped_own_read_unavailable")
+		return p.result(2, "scoped_own_read_unavailable", ownRead.diagnostic)
 	}
 	ownImage := "ghcr.io/devantler-tech/" + repositories[0] + "@" + digests[0]
 	if ownStatus == 200 && p.pull(ctx, p.scoped, ownImage) != nil {
 		return p.result(2, "scoped_own_full_pull_unavailable")
 	}
-	crossStatus, _ := p.manifest(ctx, p.scoped, repositories[1], digests[1])
+	crossRead := p.manifest(ctx, p.scoped, repositories[1], digests[1])
+	crossStatus := crossRead.status
 	if crossStatus != 200 && !denied(crossStatus) {
-		return p.result(2, "scoped_cross_read_unavailable")
+		return p.result(2, "scoped_cross_read_unavailable", crossRead.diagnostic)
 	}
 	// Repeat both baselines and the scoped positive after the negative. An expired
 	// token or registry incident during the comparison cannot pass the boundary.
 	for i, repository := range repositories {
-		status, _ := p.manifest(ctx, p.baseline, repository, digests[i])
-		if status != 200 {
-			return p.result(2, "baseline_postcheck_unavailable")
+		read := p.manifest(ctx, p.baseline, repository, digests[i])
+		if read.status != 200 {
+			return p.result(2, "baseline_postcheck_unavailable", read.diagnostic)
 		}
 	}
-	postOwnStatus, _ := p.manifest(ctx, p.scoped, repositories[0], digests[0])
-	if postOwnStatus != ownStatus {
-		return p.result(2, "scoped_own_postcheck_changed")
+	postOwnRead := p.manifest(ctx, p.scoped, repositories[0], digests[0])
+	if postOwnRead.status != ownStatus {
+		return p.result(2, "scoped_own_postcheck_changed", postOwnRead.diagnostic)
 	}
 	// Rebind the installation identity too; otherwise two denied reads from an
 	// expired token would falsely refute an otherwise usable authentication path.

--- a/scripts/prove-scoped-package-access/main_test.go
+++ b/scripts/prove-scoped-package-access/main_test.go
@@ -53,6 +53,10 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 		{"same credential is not an independent control", "same-token", 2},
 		{"invalid scoped token", "invalid-token", 2},
 		{"baseline cannot pull", "baseline-pull", 2},
+		{"baseline token authorization denied", "baseline-token-denied", 2},
+		{"baseline token denied after cross check", "baseline-token-denied-after-cross", 2},
+		{"baseline manifest authorization denied", "baseline-manifest-denied", 2},
+		{"baseline manifest denied after cross check", "baseline-manifest-denied-after-cross", 2},
 		{"own full pull fails after manifest access", "own-pull", 2},
 		{"cross 404 does not prove denial", "cross-404", 2},
 		{"cross 429 does not prove denial", "cross-429", 2},
@@ -134,6 +138,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 					_, _ = fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, name, "devantler-tech/"+linked)
 				case r.URL.Path == "/token":
 					_, secret, _ := r.BasicAuth()
+					if secret == "baseline-secret" && (tc.fault == "baseline-token-denied" || (crossed && tc.fault == "baseline-token-denied-after-cross")) {
+						w.WriteHeader(401)
+						_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"baseline-secret ::error::untrusted"}]}`)
+						return
+					}
 					if secret == "scoped-secret" {
 						switch tc.fault {
 						case "own-token-unclassified":
@@ -162,6 +171,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 				case strings.Contains(r.URL.Path, "/manifests/"):
 					credential := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 					own := strings.Contains(r.URL.Path, "/wedding-app/")
+					if credential == "baseline-secret" && (tc.fault == "baseline-manifest-denied" || (crossed && tc.fault == "baseline-manifest-denied-after-cross")) {
+						w.WriteHeader(403)
+						_, _ = fmt.Fprint(w, `{"errors":[{"code":"DENIED","message":"baseline-secret ::error::untrusted"}]}`)
+						return
+					}
 					if credential == "anonymous" && tc.fault != "public" {
 						w.WriteHeader(401)
 						_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED"}]}`)
@@ -246,15 +260,20 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 			}
 			// Losing the failed stage/status must fail these cases; raw response text cannot substitute for the classification.
 			wantDiagnostic := map[string]string{
-				"own-token-unclassified": "registry_phase=token_exchange http_status=403 failure_class=unclassified_denial",
-				"own-token-throttled":    "registry_phase=token_exchange http_status=429 failure_class=http_status",
-				"own-token-malformed":    "registry_phase=token_exchange http_status=200 failure_class=invalid_json",
-				"own-token-empty":        "registry_phase=token_exchange http_status=200 failure_class=missing_token",
-				"own-manifest-malformed": "registry_phase=manifest http_status=200 failure_class=invalid_json",
-				"cross-unclassified-403": "registry_phase=manifest http_status=403 failure_class=unclassified_denial",
-				"cross-429":              "registry_phase=manifest http_status=429 failure_class=http_status",
-				"cross-500":              "registry_phase=manifest http_status=500 failure_class=http_status",
-				"cross-404":              "registry_phase=manifest http_status=404 failure_class=http_status",
+				"baseline-token-denied":                "registry_phase=token_exchange http_status=401 failure_class=authorization_denial",
+				"baseline-token-denied-after-cross":    "registry_phase=token_exchange http_status=401 failure_class=authorization_denial",
+				"baseline-manifest-denied":             "registry_phase=manifest http_status=403 failure_class=authorization_denial",
+				"baseline-manifest-denied-after-cross": "registry_phase=manifest http_status=403 failure_class=authorization_denial",
+				"expired-after-cross":                  "registry_phase=manifest http_status=403 failure_class=authorization_denial",
+				"own-token-unclassified":               "registry_phase=token_exchange http_status=403 failure_class=unclassified_denial",
+				"own-token-throttled":                  "registry_phase=token_exchange http_status=429 failure_class=http_status",
+				"own-token-malformed":                  "registry_phase=token_exchange http_status=200 failure_class=invalid_json",
+				"own-token-empty":                      "registry_phase=token_exchange http_status=200 failure_class=missing_token",
+				"own-manifest-malformed":               "registry_phase=manifest http_status=200 failure_class=invalid_json",
+				"cross-unclassified-403":               "registry_phase=manifest http_status=403 failure_class=unclassified_denial",
+				"cross-429":                            "registry_phase=manifest http_status=429 failure_class=http_status",
+				"cross-500":                            "registry_phase=manifest http_status=500 failure_class=http_status",
+				"cross-404":                            "registry_phase=manifest http_status=404 failure_class=http_status",
 			}[tc.fault]
 			if wantDiagnostic != "" && !strings.Contains(output.String(), wantDiagnostic+"\n") {
 				t.Errorf("missing safe failure diagnosis %q in %q", wantDiagnostic, output.String())
@@ -364,9 +383,12 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
-type failingResponseBody struct{}
+type failingResponseBody struct{ err error }
 
-func (failingResponseBody) Read([]byte) (int, error) {
+func (b failingResponseBody) Read([]byte) (int, error) {
+	if b.err != nil {
+		return 0, b.err
+	}
 	return 0, errors.New("scoped-secret ::error::raw read failure")
 }
 func (failingResponseBody) Close() error { return nil }
@@ -383,6 +405,7 @@ func TestRegistryRequestFailuresKeepTheirPhaseAndSafeClass(t *testing.T) {
 			{"transport", 0, "transport"},
 			{"timeout", 0, "timeout"},
 			{"read", 200, "response_read"},
+			{"read-timeout", 200, "timeout"},
 			{"oversized", 200, "response_size"},
 		} {
 			t.Run(phase+"/"+tc.name, func(t *testing.T) {
@@ -398,6 +421,8 @@ func TestRegistryRequestFailuresKeepTheirPhaseAndSafeClass(t *testing.T) {
 						return nil, fmt.Errorf("scoped-secret: %w", context.DeadlineExceeded)
 					case "read":
 						return &http.Response{StatusCode: 200, Body: failingResponseBody{}, Header: make(http.Header)}, nil
+					case "read-timeout":
+						return &http.Response{StatusCode: 200, Body: failingResponseBody{err: fmt.Errorf("scoped-secret: %w", context.DeadlineExceeded)}, Header: make(http.Header)}, nil
 					default:
 						return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(strings.Repeat("x", (4<<20)+1))), Header: make(http.Header)}, nil
 					}

--- a/scripts/prove-scoped-package-access/main_test.go
+++ b/scripts/prove-scoped-package-access/main_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -63,6 +65,11 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 		{"empty scope postcheck cannot retain earlier fields", "empty-scope-postcheck", 2},
 		{"partial scope postcheck cannot retain earlier fields", "partial-scope-postcheck", 2},
 		{"redirect cannot receive a credential", "redirect", 2},
+		{"own token exchange unclassified forbidden", "own-token-unclassified", 2},
+		{"own token exchange throttled", "own-token-throttled", 2},
+		{"own token exchange malformed", "own-token-malformed", 2},
+		{"own token exchange missing token", "own-token-empty", 2},
+		{"own manifest response malformed", "own-manifest-malformed", 2},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var redirected, crossed bool
@@ -127,6 +134,23 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 					_, _ = fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, name, "devantler-tech/"+linked)
 				case r.URL.Path == "/token":
 					_, secret, _ := r.BasicAuth()
+					if secret == "scoped-secret" {
+						switch tc.fault {
+						case "own-token-unclassified":
+							w.WriteHeader(403)
+							_, _ = fmt.Fprint(w, "scoped-secret baseline-secret ::error::untrusted")
+							return
+						case "own-token-throttled":
+							w.WriteHeader(429)
+							return
+						case "own-token-malformed":
+							_, _ = fmt.Fprint(w, "{scoped-secret")
+							return
+						case "own-token-empty":
+							_, _ = fmt.Fprint(w, `{}`)
+							return
+						}
+					}
 					if tc.fault == "bad-token" {
 						_, _ = fmt.Fprint(w, `{broken`)
 						return
@@ -144,6 +168,10 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 						return
 					}
 					if credential == "scoped-secret" {
+						if own && tc.fault == "own-manifest-malformed" {
+							_, _ = fmt.Fprint(w, "{baseline-secret")
+							return
+						}
 						if own && (tc.fault == "own-denied" || (crossed && tc.fault == "expired-after-cross")) {
 							w.WriteHeader(403)
 							_, _ = fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
@@ -215,6 +243,24 @@ func TestProofRequiresBothDirectionsAndIndependentControls(t *testing.T) {
 			}
 			if tc.fault == "wrong-repository-token" && (len(pulls) != 0 || !strings.Contains(output.String(), "reason=token_repository_scope_unverified\n")) {
 				t.Errorf("foreign repository scope was not rejected before any pull: pulls=%d output=%s", len(pulls), output.String())
+			}
+			// Losing the failed stage/status must fail these cases; raw response text cannot substitute for the classification.
+			wantDiagnostic := map[string]string{
+				"own-token-unclassified": "registry_phase=token_exchange http_status=403 failure_class=unclassified_denial",
+				"own-token-throttled":    "registry_phase=token_exchange http_status=429 failure_class=http_status",
+				"own-token-malformed":    "registry_phase=token_exchange http_status=200 failure_class=invalid_json",
+				"own-token-empty":        "registry_phase=token_exchange http_status=200 failure_class=missing_token",
+				"own-manifest-malformed": "registry_phase=manifest http_status=200 failure_class=invalid_json",
+				"cross-unclassified-403": "registry_phase=manifest http_status=403 failure_class=unclassified_denial",
+				"cross-429":              "registry_phase=manifest http_status=429 failure_class=http_status",
+				"cross-500":              "registry_phase=manifest http_status=500 failure_class=http_status",
+				"cross-404":              "registry_phase=manifest http_status=404 failure_class=http_status",
+			}[tc.fault]
+			if wantDiagnostic != "" && !strings.Contains(output.String(), wantDiagnostic+"\n") {
+				t.Errorf("missing safe failure diagnosis %q in %q", wantDiagnostic, output.String())
+			}
+			if strings.Contains(output.String(), "::error::") || strings.Contains(output.String(), server.URL) {
+				t.Errorf("raw response or endpoint leaked: %q", output.String())
 			}
 			if strings.Contains(output.String(), "secret") {
 				t.Errorf("credential or raw error leaked: %s", output.String())
@@ -310,5 +356,66 @@ exit %d
 				t.Fatal("wrong pull identity")
 			}
 		})
+	}
+}
+
+// roundTripFunc injects transport faults below the real request and manifest logic.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type failingResponseBody struct{}
+
+func (failingResponseBody) Read([]byte) (int, error) {
+	return 0, errors.New("scoped-secret ::error::raw read failure")
+}
+func (failingResponseBody) Close() error { return nil }
+
+// TestRegistryRequestFailuresKeepTheirPhaseAndSafeClass catches discarded request
+// status/error classes without permitting network errors or response contents into output.
+func TestRegistryRequestFailuresKeepTheirPhaseAndSafeClass(t *testing.T) {
+	for _, phase := range []string{"token_exchange", "manifest"} {
+		for _, tc := range []struct {
+			name   string
+			status int
+			class  string
+		}{
+			{"transport", 0, "transport"},
+			{"timeout", 0, "timeout"},
+			{"read", 200, "response_read"},
+			{"oversized", 200, "response_size"},
+		} {
+			t.Run(phase+"/"+tc.name, func(t *testing.T) {
+				client := restrictedClient()
+				client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if phase == "manifest" && req.URL.Path == "/token" {
+						return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"token":"scoped-secret"}`)), Header: make(http.Header)}, nil
+					}
+					switch tc.name {
+					case "transport":
+						return nil, errors.New("scoped-secret ::error::raw transport failure")
+					case "timeout":
+						return nil, fmt.Errorf("scoped-secret: %w", context.DeadlineExceeded)
+					case "read":
+						return &http.Response{StatusCode: 200, Body: failingResponseBody{}, Header: make(http.Header)}, nil
+					default:
+						return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(strings.Repeat("x", (4<<20)+1))), Header: make(http.Header)}, nil
+					}
+				})
+				var out bytes.Buffer
+				p := proof{registryURL: "https://registry.invalid", client: client, output: &out}
+				read := p.manifest(context.Background(), credential{"synthetic-user", "scoped-secret"}, "synthetic-package", "latest")
+				if read.status != 0 || read.digest != "" {
+					t.Fatal("request failure became an accepted manifest or denial")
+				}
+				if got := p.result(2, "registry_read_unavailable", read.diagnostic); got != 2 {
+					t.Fatalf("exit=%d", got)
+				}
+				want := fmt.Sprintf("scoped_package_proof=UNKNOWN reason=registry_read_unavailable registry_phase=%s http_status=%d failure_class=%s\n", phase, tc.status, tc.class)
+				if out.String() != want {
+					t.Fatalf("safe classification=%q, want %q", out.String(), want)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

**Why:** An unavailable registry read left the package-access experiment without enough information to explain its result.

**What:** Report safe failure categories and status codes while preserving the experiment's authorization controls and keeping sensitive response data out of output.

Fixes #3637. Part of #2889; supports #3274.
