### PR TITLE
fix(ci): converge again when autoscaler churn empties the Talos target set

### DIFF
--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -341,7 +341,12 @@ stage_fanout_before_talos() {
       }
       return 0
     fi
-    if ! grep -Fxq -- processed "${talos_sync_result}"; then
+    # `deselected` means every target was proved removed before it was touched,
+    # so nothing was verified and this pass cannot authorise root cutover. It is
+    # a reason to converge again, exactly like `processed` -- not an invalid
+    # result, and not a deploy failure. Only `clean` above cuts root auth over.
+    if ! grep -Fxq -- processed "${talos_sync_result}" &&
+      ! grep -Fxq -- deselected "${talos_sync_result}"; then
       echo "::error::Talos synchronization returned an invalid convergence result; root Flux auth remains unchanged."
       return 1
     fi

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -3660,8 +3660,17 @@ sync_talos_registry_auth() {
         consecutive_clean_inventories=$((consecutive_clean_inventories + 1))
         if ((consecutive_clean_inventories >= 2)); then
           if ((deselected_any_node == 1 && processed_any_node == 0)); then
-            echo "::error::Every selected Talos target was removed before verification; refusing an empty successful rollout."
-            return 1
+            # Autoscaled nodes are removed routinely, so a target vanishing is
+            # churn rather than a failed rollout -- and each removal was proved
+            # against a fresh unambiguous inventory before it was deselected.
+            # Nothing was verified in this pass, though, so it must not stand in
+            # for the mutation-free pass root cutover requires: report it
+            # distinctly and let the caller converge again. The caller's bounded
+            # round loop still fails closed, with root auth unchanged, if the
+            # node set never settles.
+            echo "::notice::Every selected Talos target was removed before verification; converging again before any root credential change."
+            printf '%s\n' deselected >"${sync_result_file}"
+            return 0
           fi
           if ((processed_any_node == 1)); then
             printf '%s\n' processed >"${sync_result_file}"

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -282,7 +282,12 @@ func TestRemovedTargetRequiresAuthoritativeUnambiguousInventory(t *testing.T) {
 	}
 }
 
-func TestDeselectionCannotEmptyTheRequiredTargetSet(t *testing.T) {
+// Autoscaled nodes are removed routinely, so every selected target disappearing
+// is churn rather than a failed rollout: two fresh inventories have already
+// proved that no live node needs synchronization. Take another whole convergence
+// round instead of failing the queue, and cut the root credential over only once
+// a round completes having deselected nothing.
+func TestDeselectionEmptyingTheTargetSetTakesAnotherConvergenceRound(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
 	result := f.runHelper(validConfig(), nil, map[string]string{
@@ -290,11 +295,22 @@ func TestDeselectionCannotEmptyTheRequiredTargetSet(t *testing.T) {
 		"FAKE_TALOS_VERIFIED_IMAGE":        "ghcr.io/devantler-tech/ksail:v7.166.0",
 		"FAKE_NODE_REMOVED_BEFORE_PROCESS": "prod-worker-1 prod-control-plane-1",
 	})
-	requireFailureResult(t, result)
-	requireContains(t, result.stdout+result.stderr, "empty successful rollout")
+	requireSuccessResult(t, result)
+	requireContains(t, result.stdout+result.stderr, "deselected")
+	requireNotContains(t, result.stdout+result.stderr, "empty successful rollout")
 	operations := readLines(f.operationLog)
-	requireNoLine(t, operations, "root-patch")
+	// The targets vanished before any of them was touched, so nothing was mutated.
 	requireNotContains(t, strings.Join(operations, "\n"), "talos-revision:")
+	// Root auth still waits for a convergence round that deselects nothing.
+	fanoutPasses := lineIndices(operations, "variables-patch")
+	if len(fanoutPasses) < 2 {
+		t.Fatalf("fanout pass count = %d, want at least 2", len(fanoutPasses))
+	}
+	rootCutover := lineIndex(t, operations, "root-patch")
+	if fanoutPasses[1] >= rootCutover {
+		t.Errorf("root cutover did not follow a second convergence round: fanout=%d root=%d",
+			fanoutPasses[1], rootCutover)
+	}
 }
 
 func TestRemovedNodeAfterMutationStillFailsClosed(t *testing.T) {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

A merge-group deploy failed on `🚀 Deploy to Prod` and evicted `#3646` from the queue. Because that deploy runs inside the merge group, nothing could merge on `platform` while it stayed broken.

The cause was routine autoscaler churn: the one node the rollout had selected was an ephemeral autoscaler node that scaled down mid-run. The rollout then had nothing left to verify and refused to report success — so a normal cluster event became a queue-wide outage.

### What this changes

When every selected node is removed before it is touched, the rollout now takes **another full convergence round** instead of failing. If the node set settles, the deploy finishes normally; if it never settles, the existing bounded loop still fails, with the root credential untouched.

**Security floor — unchanged.** The root credential cutover still happens only after a round that verified everything it selected and deselected nothing. This pass reports a distinct result that explicitly does *not* authorise cutover, so the protection that guard exists for is intact. Each deselection also still requires the full proof it always did: an authoritative "not found", a fresh validated inventory, no live node reusing the name/UID/address, and a held lease.

**Everyday path — easier.** One autoscaler node scaling down at the wrong moment no longer blocks every merge and no longer needs a human to diagnose it.

### Validation

The existing test for this branch reproduced the production failure exactly, including its log lines. It now asserts the new behaviour — that the deploy succeeds, mutates nothing, and cuts the credential over only after a second round. Both halves of the fix were ablated individually and each one fails the test on its own. The full rollout suite and the shell safety suite pass.

Fixes #3658
