### PR TITLE
fix(storage): preserve metadata access for the CSI node plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1079,8 +1079,8 @@ jobs:
       - name: 🔐 Validate workload metadata egress isolation
         if: needs.changes.outputs.k8s == 'true'
         # Render both provider infrastructure entry points. The control must
-        # cover every workload in Hetzner/prod without selecting Talos hosts
-        # or leaking into the local Docker provider.
+        # preserve the exact CSI node exception and deny other workloads without
+        # selecting Talos hosts or leaking into the local Docker provider.
         run: |
           shellcheck scripts/tests/test-cilium-metadata-egress-policy.sh
           bash scripts/tests/test-cilium-metadata-egress-policy.sh

--- a/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
+++ b/k8s/providers/hetzner/infrastructure/cilium/cilium-clusterwide-network-policy-deny-instance-metadata-egress.yaml
@@ -2,26 +2,68 @@ apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: deny-workload-instance-metadata-egress
-spec:
-  # Cilium endpoint selectors match managed workload endpoints. Deliberately
-  # omit nodeSelector so Talos and host bootstrap traffic remain outside this
-  # policy. Crossplane keeps the same deny in its existing namespaced egress
-  # policy so that policy remains its only static egress owner.
-  endpointSelector:
-    matchExpressions:
-      - key: k8s:io.kubernetes.pod.namespace
-        operator: Exists
-      - key: k8s:io.kubernetes.pod.namespace
-        operator: NotIn
-        values:
-          - crossplane-system
-  # Cilium turns on default-deny for every direction a policy has rules in, so
-  # an egressDeny rule on its own would revoke all egress from the endpoints
-  # selected above unless some other policy allows it back. This policy is
-  # meant to subtract one destination, not to become every workload's egress
-  # allow-list, so keep default-deny off and let the deny stand on its own.
-  enableDefaultDeny:
-    egress: false
-  egressDeny:
-    - toCIDR:
-        - 169.254.169.254/32
+# The node CSI driver must read its server ID and location from Hetzner metadata
+# before it can mount volumes. Only kube-system's hcloud-csi/node identity is
+# outside this deny. A separate allow rule cannot override an egressDeny.
+#
+# Select the complement of that four-label identity: other workload namespaces,
+# OR kube-system with any of the three application labels missing or different.
+# NotIn also matches absent labels, so an incomplete identity remains protected.
+# Crossplane retains its independent metadata deny. Every branch requires a pod
+# namespace and omits nodeSelector, leaving Talos host identities untouched.
+# Keep default-deny off in EVERY branch: this control subtracts one destination,
+# and must never turn into an implicit allow-list for all other egress.
+specs:
+  - endpointSelector:
+      matchExpressions:
+        - key: k8s:io.kubernetes.pod.namespace
+          operator: Exists
+        - key: k8s:io.kubernetes.pod.namespace
+          operator: NotIn
+          values:
+            - crossplane-system
+            - kube-system
+    enableDefaultDeny:
+      egress: false
+    egressDeny:
+      - toCIDR:
+          - 169.254.169.254/32
+  - endpointSelector:
+      matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+      matchExpressions:
+        - key: k8s:app.kubernetes.io/name
+          operator: NotIn
+          values:
+            - hcloud-csi
+    enableDefaultDeny:
+      egress: false
+    egressDeny:
+      - toCIDR:
+          - 169.254.169.254/32
+  - endpointSelector:
+      matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+      matchExpressions:
+        - key: k8s:app.kubernetes.io/instance
+          operator: NotIn
+          values:
+            - hcloud-csi
+    enableDefaultDeny:
+      egress: false
+    egressDeny:
+      - toCIDR:
+          - 169.254.169.254/32
+  - endpointSelector:
+      matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+      matchExpressions:
+        - key: k8s:app.kubernetes.io/component
+          operator: NotIn
+          values:
+            - node
+    enableDefaultDeny:
+      egress: false
+    egressDeny:
+      - toCIDR:
+          - 169.254.169.254/32

--- a/scripts/tests/crossplane-egress-policy-rules.yaml
+++ b/scripts/tests/crossplane-egress-policy-rules.yaml
@@ -18,6 +18,7 @@ rules:
          object.kind == 'CiliumNetworkPolicy')) ||
       !has(object.metadata.namespace) ||
       object.metadata.namespace != 'crossplane-system' ||
+      !has(object.spec) ||
       ((!has(object.spec.egress) || object.spec.egress.size() == 0) &&
        (object.kind != 'CiliumNetworkPolicy' ||
         !has(object.spec.egressDeny) ||
@@ -103,6 +104,7 @@ rules:
       !has(object.apiVersion) ||
       object.apiVersion != 'cilium.io/v2' ||
       object.kind != 'CiliumClusterwideNetworkPolicy' ||
+      !has(object.spec) ||
       ((!has(object.spec.egress) || object.spec.egress.size() == 0) &&
        (!has(object.spec.egressDeny) ||
         object.spec.egressDeny.size() == 0)) ||
@@ -127,6 +129,8 @@ rules:
       cluster-wide Cilium policy
     severity: error
 
+  # Cilium permits specs without spec. The singular-rule checks above skip
+  # absent spec fields; this rule independently inspects every specs entry.
   - name: reject-crossplane-cilium-policy-specs
     expression: >-
       !has(object.apiVersion) ||

--- a/scripts/tests/test-cilium-metadata-egress-policy.sh
+++ b/scripts/tests/test-cilium-metadata-egress-policy.sh
@@ -18,6 +18,7 @@ readonly tmp_dir
 trap 'rm -rf "${tmp_dir}"' EXIT
 readonly prod_render="${tmp_dir}/prod.yaml"
 readonly rendered_policy="${tmp_dir}/policy.yaml"
+readonly policy_json="${tmp_dir}/policy.json"
 readonly rendered_coredns_policy="${tmp_dir}/coredns-policy.yaml"
 readonly controllers_layer_render="${tmp_dir}/controllers-layer.yaml"
 readonly controllers_render="${tmp_dir}/controllers.yaml"
@@ -70,41 +71,67 @@ fi
 yq -e '.apiVersion == "cilium.io/v2" and .kind == "CiliumClusterwideNetworkPolicy"' \
   "${rendered_policy}" >/dev/null ||
   fail 'the rendered control is not a CiliumClusterwideNetworkPolicy'
-yq -e '(.spec.endpointSelector | keys | length) == 1 and
-  (.spec.endpointSelector.matchExpressions | length) == 2 and
-  ([.spec.endpointSelector.matchExpressions[] |
-    select(.key == "k8s:io.kubernetes.pod.namespace" and
-      .operator == "Exists" and
-      has("values") == false)] | length) == 1 and
-  ([.spec.endpointSelector.matchExpressions[] |
-    select(.key == "k8s:io.kubernetes.pod.namespace" and
-      .operator == "NotIn" and
-      (.values | length) == 1 and
-      .values[0] == "crossplane-system")] | length) == 1' \
-  "${rendered_policy}" >/dev/null ||
-  fail 'the cluster-wide policy must select workload namespaces, exclude reserved identities, and exclude Crossplane'
-yq -e '.spec | has("nodeSelector") == false' "${rendered_policy}" >/dev/null ||
-  fail 'the workload policy must not select Talos hosts'
-yq -e '.spec.egressDeny | length == 1' "${rendered_policy}" >/dev/null ||
-  fail 'the policy must have exactly one deny rule'
-yq -e '.spec.egressDeny[0] | (keys | length) == 1' "${rendered_policy}" >/dev/null ||
-  fail 'the deny rule must not carry additional destinations'
-yq -e '.spec.egressDeny[0] | has("toCIDR")' "${rendered_policy}" >/dev/null ||
-  fail 'the deny rule must use a CIDR destination'
-yq -e '.spec.egressDeny[0].toCIDR | length == 1' "${rendered_policy}" >/dev/null ||
-  fail 'the deny rule must contain exactly one CIDR'
-yq -e '.spec.egressDeny[0].toCIDR[0] == "169.254.169.254/32"' \
-  "${rendered_policy}" >/dev/null ||
-  fail 'the deny rule must target only the instance metadata address'
+yq -o=json '.' "${rendered_policy}" >"${policy_json}"
+# Exercise selector semantics on the rendered policy, including every missing
+# and mismatched identity label. NotIn matches a missing key; Exists does not.
+# The expected boundary is independent of how many deny rules implement it.
+jq -er '
+  def rules: if has("specs") then .specs else [.spec] end;
+  def matches($selector; $labels):
+    all(($selector.matchLabels // {} | to_entries)[];
+      $labels[.key] == .value) and
+    all(($selector.matchExpressions // [])[];
+      . as $e |
+      if .operator == "Exists" then $labels | has($e.key)
+      elif .operator == "NotIn" then
+        ($e.values | index($labels[$e.key])) == null
+      elif .operator == "In" then
+        ($e.values | index($labels[$e.key])) != null
+      else error("unsupported selector operator") end);
+  . as $policy |
+  [ ["kube-system", "tenant-example", "crossplane-system", null][] as $ns |
+    ["hcloud-csi", "other-app", null][] as $name |
+    ["hcloud-csi", "other-instance", null][] as $instance |
+    ["node", "controller", null][] as $component |
+    {
+      labels: ({
+        "k8s:io.kubernetes.pod.namespace": $ns,
+        "k8s:app.kubernetes.io/name": $name,
+        "k8s:app.kubernetes.io/instance": $instance,
+        "k8s:app.kubernetes.io/component": $component
+      } | with_entries(select(.value != null))),
+      denied: ($ns != null and $ns != "crossplane-system" and
+        ([$ns, $name, $instance, $component] !=
+          ["kube-system", "hcloud-csi", "hcloud-csi", "node"]))
+    }
+  ] as $cases |
+  [$cases[] | . as $case |
+    ($policy | rules | any(.[]; matches(.endpointSelector; $case.labels))) as $selected |
+    select($selected != .denied) | {labels, expectedDenied: .denied, selected: $selected}
+  ] as $failures |
+  if ($cases | length) != 108 then error("incomplete selector matrix")
+  elif ($failures | length) > 0 then error($failures | tojson)
+  else "PASS: all 108 metadata selector cases preserve the exact CSI node exception" end
+' "${policy_json}" || fail 'the metadata selector boundary does not match the infrastructure exception'
+
+jq -e '
+  (has("spec") != has("specs")) and
+  (
+  (if has("specs") then .specs else [.spec] end) as $rules |
+  ($rules | length) > 0 and all($rules[];
+    (keys == ["egressDeny", "enableDefaultDeny", "endpointSelector"]) and
+    .egressDeny == [{"toCIDR": ["169.254.169.254/32"]}] and
+    .enableDefaultDeny == {"egress": false})
+  )
+' "${policy_json}" >/dev/null ||
+  fail 'every metadata rule must deny only the metadata address without enabling default-deny or selecting hosts'
 
 # A policy carrying only egressDeny rules puts every selected endpoint into
 # default-deny egress: the CRD defaults enableDefaultDeny to true for each
-# direction that has rules. This policy selects every namespace except
-# crossplane-system and carries no egress allow rules, so leaving the field
+# direction that has rules. This policy carries no egress allow rules, so leaving the field
 # unset silently revokes egress from every workload that has no allow policy
 # of its own. Pin it off so the deny stays a deny.
-yq -e '.spec.enableDefaultDeny.egress == false' "${rendered_policy}" >/dev/null ||
-  fail 'the metadata deny must not put selected endpoints into default-deny egress'
+# The per-rule assertion above keeps it off in every selector branch.
 
 yq -e '(.spec.endpointSelector | keys | length) == 1 and
   (.spec.endpointSelector.matchLabels | keys | length) == 1 and
@@ -137,4 +164,4 @@ yq -e '(.spec.egressDeny | length) == 1 and
   "${crossplane_policy}" >/dev/null ||
   fail 'the existing Crossplane policy must carry the same exact metadata deny'
 
-printf 'PASS: production denies workload metadata egress without selecting Talos hosts\n'
+printf 'PASS: production preserves workload metadata isolation and the CSI node exception\n'

--- a/scripts/tests/test-crossplane-egress-policy.sh
+++ b/scripts/tests/test-crossplane-egress-policy.sh
@@ -571,12 +571,20 @@ assert_helm_rules_reject() {
   local fixture_body="$2"
   local failure_message="$3"
   local fixture_path="${test_temp_root}/${fixture_name}.yaml"
+  local expected_rule="${4:-}"
+  local validation_output
 
   printf '%s\n' "${fixture_body}" >"${fixture_path}"
-  if ksail workload validate "${fixture_path}" \
+  if validation_output="$(ksail workload validate "${fixture_path}" \
     --skip-helm-render \
-    --rules "${helm_policy_rules}" >/dev/null 2>&1; then
+    --rules "${helm_policy_rules}" 2>&1)"; then
     fail "${failure_message}"
+  fi
+  if [ -n "${expected_rule}" ] &&
+    { [[ "${validation_output}" != *"rule \"${expected_rule}\" violated"* ]] ||
+      [[ "${validation_output}" == *'rule evaluation failed:'* ]]; }; then
+    printf '%s\n' "${validation_output}" >&2
+    fail "${failure_message}: expected a policy rejection without evaluation errors"
   fi
 }
 
@@ -634,13 +642,32 @@ helm_cilium_specs_fixture=$'apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\
 assert_helm_rules_reject \
   'helm-cilium-specs' \
   "${helm_cilium_specs_fixture}" \
-  'the Helm-render guard must inspect every Cilium policy rule under specs'
+  'the Helm-render guard must inspect every Cilium policy rule under specs' \
+  'reject-crossplane-cilium-policy-specs'
+
+helm_cilium_specs_only_fixture=$'apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata:\n  name: chart-specs-only\n  namespace: crossplane-system\nspecs:\n- endpointSelector: {}\n  ingress:\n  - {}'
+assert_helm_rules_accept \
+  'helm-cilium-specs-only-ingress' \
+  "${helm_cilium_specs_only_fixture}" \
+  'the Helm-render guard must accept ingress-only specs without a singular spec'
+assert_helm_rules_reject \
+  'helm-cilium-specs-only-egress' \
+  "${helm_cilium_specs_only_fixture/ingress:/egress:}" \
+  'the Helm-render guard must reject Crossplane egress in specs without a singular spec' \
+  'reject-crossplane-cilium-policy-specs'
 
 helm_clusterwide_specs_fixture=$'apiVersion: cilium.io/v2\nkind: CiliumClusterwideNetworkPolicy\nmetadata:\n  name: chart-clusterwide-specs-deny\nspecs:\n- endpointSelector: {}\n  egressDeny:\n  - {}'
 assert_helm_rules_reject \
   'helm-clusterwide-cilium-specs' \
   "${helm_clusterwide_specs_fixture}" \
-  'the Helm-render guard must inspect every cluster-wide Cilium policy rule under specs'
+  'the Helm-render guard must inspect every cluster-wide Cilium policy rule under specs' \
+  'reject-crossplane-cilium-policy-specs'
+
+helm_unrelated_clusterwide_specs_fixture=$'apiVersion: cilium.io/v2\nkind: CiliumClusterwideNetworkPolicy\nmetadata:\n  name: chart-unrelated-specs\nspecs:\n- endpointSelector:\n    matchLabels:\n      k8s:io.kubernetes.pod.namespace: kube-system\n  egressDeny:\n  - toCIDR: [169.254.169.254/32]'
+assert_helm_rules_accept \
+  'helm-unrelated-clusterwide-specs' \
+  "${helm_unrelated_clusterwide_specs_fixture}" \
+  'the Helm-render guard must accept unrelated namespace specs without a singular spec'
 
 helm_widened_allow_policy_fixture=$'apiVersion: cilium.io/v2\nkind: CiliumNetworkPolicy\nmetadata:\n  name: allow-crossplane\n  namespace: crossplane-system\nspec:\n  endpointSelector: {}\n  egress:\n  - toEntities: [world]'
 assert_helm_rules_reject \


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

**Why:** The workload metadata deny also blocks the Hetzner node storage plugin from discovering the server information it needs to mount volumes.

**What:** Exempt only the exact infrastructure node-plugin identity while retaining metadata protection for ordinary workloads, CSI controllers, and Crossplane. Regression coverage checks namespace and identity-label mismatches, including missing labels.

Fixes #3614.
