### PR TITLE
ci: guard that directly-invoked scripts are tracked executable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
     outputs:
       k8s: ${{ steps.filter.outputs.k8s }}
       bridge_validation: ${{ steps.filter.outputs.bridge_validation }}
-      exec_bit: ${{ steps.filter.outputs.exec_bit }}
       talos: ${{ steps.filter.outputs.talos }}
     steps:
       - name: 📑 Checkout
@@ -52,6 +51,27 @@ jobs:
         run: |
           shellcheck scripts/tests/test-pvc-prune-safety.sh
           bash scripts/tests/test-pvc-prune-safety.sh
+
+      - name: 🔐 Validate directly-invoked scripts are tracked executable
+        # A script a workflow runs as ./scripts/<name> must be tracked 100755, because
+        # CI clones from git and the tracked mode is what the runner gets. Caught live on
+        # #3530, where a promotion gate was committed 100644 and died "permission denied"
+        # BEFORE verifying anything — present, reviewed green, and inert. Nothing that runs
+        # could see it: shellcheck was clean, bash <file> passed, and the script own suite
+        # passed, because none of them exec the file. The class has been introduced three
+        # times, twice via an awk-into-tmp-and-mv idiom that drops the bit while leaving the
+        # content byte-correct. The guard derives the requirement from the invocation, so a
+        # script that moves behind an interpreter stops needing the bit, and finding NO
+        # direct invocation is cannot-check rather than a clean pass.
+        #
+        # Run in the shared changes job, unconditionally, for the same reason the PVC
+        # check above does: the manifest job is pull_request-only, so hosting the guard
+        # there left the merge group — the event that actually gates main — running none
+        # of it. Unconditional also removes the path filter as a way to skip the check,
+        # which is the failure mode the guard exists to catch, one level up.
+        run: |
+          bash scripts/guard-tracked-exec-bit.sh .
+          bash scripts/tests/test-guard-tracked-exec-bit.sh
 
       # The DR contract runs in its own dedicated job (below). This checks that
       # the verify block is in effect at all: it ran at spec.cluster.verify for
@@ -485,12 +505,6 @@ jobs:
               - '.github/actions/deploy-prod/**'
               - '.github/workflows/dr-rebuild.yaml'
               - '.github/workflows/ci.yaml'
-            # Any change under either root can add an invocation, remove one, or
-            # change a tracked mode, so the exec-bit guard keys on the whole surface
-            # rather than a file list that would go stale in the dangerous direction.
-            exec_bit:
-              - 'scripts/**'
-              - '.github/**'
             talos:
               - 'talos/**'
               - 'talos-local/**'
@@ -775,8 +789,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       (needs.changes.outputs.k8s == 'true' ||
-      needs.changes.outputs.bridge_validation == 'true' ||
-      needs.changes.outputs.exec_bit == 'true')
+      needs.changes.outputs.bridge_validation == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -1239,22 +1252,6 @@ jobs:
         run: |
           bash scripts/guard-gitrepository-commit-pin.sh k8s
           bash scripts/tests/test-guard-gitrepository-commit-pin.sh
-
-      - name: 🔐 Validate directly-invoked scripts are tracked executable
-        if: needs.changes.outputs.exec_bit == 'true'
-        # A script a workflow runs as ./scripts/<name> must be tracked 100755, because
-        # CI clones from git and the tracked mode is what the runner gets. Caught live on
-        # #3530, where a promotion gate was committed 100644 and died "permission denied"
-        # BEFORE verifying anything — present, reviewed green, and inert. Nothing that runs
-        # could see it: shellcheck was clean, bash <file> passed, and the script own suite
-        # passed, because none of them exec the file. The class has been introduced three
-        # times, twice via an awk-into-tmp-and-mv idiom that drops the bit while leaving the
-        # content byte-correct. The guard derives the requirement from the invocation, so a
-        # script that moves behind an interpreter stops needing the bit, and finding NO
-        # direct invocation is cannot-check rather than a clean pass.
-        run: |
-          bash scripts/guard-tracked-exec-bit.sh .
-          bash scripts/tests/test-guard-tracked-exec-bit.sh
 
       - name: 🌐 Validate no render path fetches over the network
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,8 @@ jobs:
         # of it. Unconditional also removes the path filter as a way to skip the check,
         # which is the failure mode the guard exists to catch, one level up.
         run: |
+          shellcheck scripts/guard-tracked-exec-bit.sh
+          shellcheck scripts/tests/test-guard-tracked-exec-bit.sh
           bash scripts/guard-tracked-exec-bit.sh .
           bash scripts/tests/test-guard-tracked-exec-bit.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       k8s: ${{ steps.filter.outputs.k8s }}
       bridge_validation: ${{ steps.filter.outputs.bridge_validation }}
+      exec_bit: ${{ steps.filter.outputs.exec_bit }}
       talos: ${{ steps.filter.outputs.talos }}
     steps:
       - name: 📑 Checkout
@@ -484,6 +485,12 @@ jobs:
               - '.github/actions/deploy-prod/**'
               - '.github/workflows/dr-rebuild.yaml'
               - '.github/workflows/ci.yaml'
+            # Any change under either root can add an invocation, remove one, or
+            # change a tracked mode, so the exec-bit guard keys on the whole surface
+            # rather than a file list that would go stale in the dangerous direction.
+            exec_bit:
+              - 'scripts/**'
+              - '.github/**'
             talos:
               - 'talos/**'
               - 'talos-local/**'
@@ -1231,6 +1238,22 @@ jobs:
         run: |
           bash scripts/guard-gitrepository-commit-pin.sh k8s
           bash scripts/tests/test-guard-gitrepository-commit-pin.sh
+
+      - name: 🔐 Validate directly-invoked scripts are tracked executable
+        if: needs.changes.outputs.exec_bit == 'true'
+        # A script a workflow runs as ./scripts/<name> must be tracked 100755, because
+        # CI clones from git and the tracked mode is what the runner gets. Caught live on
+        # #3530, where a promotion gate was committed 100644 and died "permission denied"
+        # BEFORE verifying anything — present, reviewed green, and inert. Nothing that runs
+        # could see it: shellcheck was clean, bash <file> passed, and the script own suite
+        # passed, because none of them exec the file. The class has been introduced three
+        # times, twice via an awk-into-tmp-and-mv idiom that drops the bit while leaving the
+        # content byte-correct. The guard derives the requirement from the invocation, so a
+        # script that moves behind an interpreter stops needing the bit, and finding NO
+        # direct invocation is cannot-check rather than a clean pass.
+        run: |
+          bash scripts/guard-tracked-exec-bit.sh .
+          bash scripts/tests/test-guard-tracked-exec-bit.sh
 
       - name: 🌐 Validate no render path fetches over the network
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -775,7 +775,8 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       (needs.changes.outputs.k8s == 'true' ||
-      needs.changes.outputs.bridge_validation == 'true')
+      needs.changes.outputs.bridge_validation == 'true' ||
+      needs.changes.outputs.exec_bit == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -79,9 +79,9 @@ status=0
 # Both roots are inventoried. `.github/scripts/` holds the CI installers, which
 # a `run:` step executes as its command and which therefore need the bit exactly
 # as much as anything under `scripts/`.
-modes="$(git ls-files -s -- 'scripts/*.sh' 'scripts/**/*.sh' '.github/scripts/*.sh' '.github/scripts/**/*.sh')"
+modes="$(git ls-files -s -- 'scripts/*.sh' 'scripts/**/*.sh' '.github/*.sh' '.github/**/*.sh')"
 if [[ -z "$modes" ]]; then
-  echo "::error::found no tracked *.sh under scripts/ or .github/scripts/; the exec-bit sweep examined nothing, so its result proves nothing"
+  echo "::error::found no tracked *.sh under scripts/ or .github/; the exec-bit sweep examined nothing, so its result proves nothing"
   exit 1
 fi
 
@@ -103,7 +103,7 @@ fi
 # accepted only where a `./` follows it.
 #
 # BSD grep has no lookbehind, so each leading delimiter is spelled as a class.
-readonly SCRIPT_PATH_RE='(\.github/)?scripts/[A-Za-z0-9_./-]+\.sh'
+readonly SCRIPT_PATH_RE='(\.github|scripts)/[A-Za-z0-9_./-]+\.sh'
 readonly LEADING_DELIM='(^|[[:space:]|&;("'"'"'])'
 
 scan="$(
@@ -116,7 +116,7 @@ invocations="$(
     printf '%s\n' "$scan" |
       grep -oE "${LEADING_DELIM}([A-Za-z0-9_.-]+[[:space:]]+)?\./${SCRIPT_PATH_RE}" || true
     printf '%s\n' "$scan" |
-      grep -oE "run:[[:space:]]+([A-Za-z0-9_.-]+[[:space:]]+)?(\./)?${SCRIPT_PATH_RE}" || true
+      grep -oE "run:[[:space:]]+[\"']?([A-Za-z0-9_.-]+[[:space:]]+)?(\./)?${SCRIPT_PATH_RE}" || true
     # A run block puts the command at the START of its own line. But line-leading
     # position is command position only when the PREVIOUS line did not end in a
     # backslash: a continuation line is an ARGUMENT list, and this repository has
@@ -139,7 +139,7 @@ while IFS= read -r occurrence; do
   # rather than a command, so it is stripped alongside the leading delimiters.
   prefix="$(
     printf '%s' "$occurrence" |
-      sed -E "s|(\./)?${SCRIPT_PATH_RE}\$||" |
+      sed -E "s#(\./)?${SCRIPT_PATH_RE}\$##" |
       sed -E 's|^run:||' |
       tr -d '[:space:]'
   )"
@@ -147,6 +147,10 @@ while IFS= read -r occurrence; do
     "" | "&&" | "||" | "|" | ";" | "(" | '"' | "'") ;;     # nothing in front: a direct invocation
     bash | sh | zsh | dash | ksh | source | .) continue ;; # handed to an interpreter
     sudo | exec | time | env | command | nohup | xargs) ;; # a wrapper that still execs the file
+    # A control keyword introduces a command position rather than consuming the
+    # word after it, so `if ./scripts/x.sh; then` execs the file exactly as a
+    # bare `./scripts/x.sh` does. These reached the catch-all and were discarded.
+    if | elif | while | until | then | do | else | "!" | "{") ;;
     *) continue ;;                                         # an argument to some other command, which does not exec it
   esac
 

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -105,6 +105,7 @@ fi
 # BSD grep has no lookbehind, so each leading delimiter is spelled as a class.
 readonly SCRIPT_PATH_RE='(\.github|scripts)/[A-Za-z0-9_./-]+\.sh'
 readonly LEADING_DELIM='(^|[[:space:]|&;("'"'"'])'
+readonly TOKEN_RE='[A-Za-z0-9_.=-]+'
 
 scan="$(
   grep -rhE -v '^[[:space:]]*#' --include='*.yaml' --include='*.yml' --include='*.sh' \
@@ -114,20 +115,21 @@ scan="$(
 invocations="$(
   {
     printf '%s\n' "$scan" |
-      grep -oE "${LEADING_DELIM}([A-Za-z0-9_.-]+[[:space:]]+)?\./${SCRIPT_PATH_RE}" || true
+      grep -oE "${LEADING_DELIM}(${TOKEN_RE}[[:space:]]+)*\./${SCRIPT_PATH_RE}" || true
     printf '%s\n' "$scan" |
-      grep -oE "run:[[:space:]]+[\"']?([A-Za-z0-9_.-]+[[:space:]]+)?(\./)?${SCRIPT_PATH_RE}" || true
+      grep -oE "run:[[:space:]]+[\"']?(${TOKEN_RE}[[:space:]]+)*(\./)?${SCRIPT_PATH_RE}" || true
     # A run block puts the command at the START of its own line. But line-leading
     # position is command position only when the PREVIOUS line did not end in a
     # backslash: a continuation line is an ARGUMENT list, and this repository has
     # exactly that shape, continuing a shellcheck call across several lines over
     # library files correctly tracked 100644. A stateless line-leading match
     # reports those as invocations and fails the build. awk carries that one bit
-    # of state. The pattern travels via ENVIRON because the -v option expands
-    # escape sequences in the value and would eat the backslashes.
-    GUARD_LINE_RE="^[[:space:]]*(\./)?${SCRIPT_PATH_RE}" \
-      awk '!cont && $0 ~ ENVIRON["GUARD_LINE_RE"] { print }
-           { cont = ($0 ~ /\\[[:space:]]*$/) }' <<<"$scan" || true
+    # of state and nothing else; the extraction is left to grep so the emitted
+    # occurrence STOPS at the path instead of running to the end of the line,
+    # which is what lets a trailing argument coexist with a line-leading command.
+    awk '!cont { print }
+         { cont = ($0 ~ /\\[[:space:]]*$/) }' <<<"$scan" |
+      grep -oE "^[[:space:]]*(${TOKEN_RE}[[:space:]]+)*(\./)?${SCRIPT_PATH_RE}" || true
   }
 )"
 
@@ -135,24 +137,54 @@ direct=""
 while IFS= read -r occurrence; do
   [[ -n "$occurrence" ]] || continue
 
-  # The word immediately before the path, if any. `run:` is the step keyword
-  # rather than a command, so it is stripped alongside the leading delimiters.
+  # Everything in front of the path. `run:` is the step keyword rather than a
+  # command, so it is stripped alongside the leading delimiters.
   prefix="$(
     printf '%s' "$occurrence" |
       sed -E "s#(\./)?${SCRIPT_PATH_RE}\$##" |
-      sed -E 's|^run:||' |
-      tr -d '[:space:]'
+      sed -E 's|^run:||'
   )"
-  case "$prefix" in
-    "" | "&&" | "||" | "|" | ";" | "(" | '"' | "'") ;;     # nothing in front: a direct invocation
-    bash | sh | zsh | dash | ksh | source | .) continue ;; # handed to an interpreter
-    sudo | exec | time | env | command | nohup | xargs) ;; # a wrapper that still execs the file
-    # A control keyword introduces a command position rather than consuming the
-    # word after it, so `if ./scripts/x.sh; then` execs the file exactly as a
-    # bare `./scripts/x.sh` does. These reached the catch-all and were discarded.
-    if | elif | while | until | then | do | else | "!" | "{") ;;
-    *) continue ;;                                         # an argument to some other command, which does not exec it
-  esac
+
+  # 🔴 EXTRACTION IS PERMISSIVE; THIS WALK IS THE WHITELIST THAT DECIDES.
+  #
+  # Enumerating admissible PREFIX SHAPES in the extraction regex instead is what
+  # produced repeated review rounds each finding one more spelling — a bare path
+  # behind two or more words (`env FOO=1 scripts/x.sh`, `FOO=1 scripts/x.sh`,
+  # `sudo -E scripts/x.sh`) escaped extraction entirely, so this classifier,
+  # which would have judged all three correctly, never ran on them. Extraction
+  # now captures however many words sit in front of the path and every decision
+  # is made here, where a form that is not provably still an exec is discarded.
+  read -ra prefix_tokens <<<"$prefix"
+  reaches_path=1
+  saw_wrapper=0
+  for token in ${prefix_tokens+"${prefix_tokens[@]}"}; do
+    case "$token" in
+      "&&" | "||" | "|" | ";" | "(" | '"' | "'") ;;               # operator: a command position follows
+      if | elif | while | until | then | do | else | "!" | "{") ;; # control keyword: likewise
+      -*)
+        # An option, admissible only as an option TO a wrapper already accepted.
+        # A bare leading `-` is the YAML sequence marker, which introduces a list
+        # entry — a path filter, not a command.
+        if ((saw_wrapper == 0)); then
+          reaches_path=0
+          break
+        fi
+        ;;
+      *=*) ;;                                                     # NAME=value: an environment assignment is transparent
+      sudo | exec | time | env | command | nohup | xargs)          # a wrapper that still execs the file
+        saw_wrapper=1
+        ;;
+      bash | sh | zsh | dash | ksh | source | .)                   # handed to an interpreter
+        reaches_path=0
+        break
+        ;;
+      *)                                                           # an argument to some other command, which does not exec it
+        reaches_path=0
+        break
+        ;;
+    esac
+  done
+  ((reaches_path == 1)) || continue
 
   path="$(printf '%s' "$occurrence" | grep -oE "(\./)?${SCRIPT_PATH_RE}" | sed 's|^\./||')"
   direct="${direct}${path}"$'\n'

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Fail when a script this repository invokes DIRECTLY is not tracked executable.
+#
+# THE RULE THIS ENFORCES: if anything under `.github/` or `scripts/` runs a script
+# as `./scripts/<name>.sh`, that path must be tracked `100755`.
+#
+# Why the tracked mode and not the file on disk. CI clones from git, so the mode
+# the runner receives is the one in the index. A local `chmod +x` that was never
+# committed leaves the working tree executable and the clone not — which is
+# precisely the broken state, and precisely the state a `test -x` check passes on.
+# This guard therefore reads `git ls-files -s` and never the filesystem.
+#
+# Why a guard rather than the one-off fix. Caught live on #3530:
+# `scripts/verify-matcher-accepts-digest.sh` was committed `100644` while a
+# composite action invoked it as `run: ./scripts/verify-matcher-accepts-digest.sh`.
+# On a Unix runner that step dies `permission denied` BEFORE the gate verifies
+# anything — a promotion gate that is present, reviewed green, and inert. Nothing
+# that runs could see it: shellcheck was clean, `bash <file>` passed, and the
+# script's own 19-assertion suite passed, because none of them `exec` the file.
+# The class has been introduced three separate times, twice via the
+# `awk … > tmp && mv` idiom, which silently drops the bit while leaving the
+# content byte-correct.
+#
+# 🔴 THE REQUIREMENT IS DERIVED FROM THE INVOCATION, NEVER FROM A LIST.
+#
+# A hard-coded list of "scripts that need the bit" goes stale in the dangerous
+# direction: a script that GAINS a direct invocation is not on the list, so the
+# one change that creates the exposure is the one the guard cannot see. Scanning
+# for the invocation shape means a script that moves to `bash scripts/...`
+# correctly stops requiring the bit, and one that moves the other way starts
+# requiring it, with no list to maintain.
+#
+# 🔴 AN INTERPRETER PREFIX IS NOT A DIRECT INVOCATION.
+#
+# an interpreter-prefixed invocation (bash, sh, source) hands
+# the file to an interpreter, which does not need the execute bit. Counting those
+# would demand the bit on library files that are correctly non-executable — a
+# false refusal on eleven files in this repository today. Only an occurrence with
+# no interpreter in front of it is a direct invocation.
+#
+# 🔴 THE FILE-TYPE FILTER IS LOAD-BEARING, NOT TIDINESS.
+#
+# Only workflow/action YAML and shell scripts are scanned, because only those
+# execute. Widening it to every file counts invocation shapes that appear inside
+# Go test fixtures and Go comments as real invocations — measured here: three
+# such paths exist in this repository today, all of them string literals in
+# `*_test.go` or a comment, none of them ever run. A guard that demanded the
+# execute bit on those would fail the build over files that do not exist.
+#
+# 🔴 A COMMENT IS NOT AN INVOCATION.
+#
+# This detector is a text scan over files that carry long explanatory comments —
+# including this one — so prose naming an invocation shape would be counted as an
+# invocation. That is not hypothetical: the first run of this guard reported a
+# violation against a path that exists only in the paragraph above. Lines whose
+# first non-whitespace character is `#` are therefore dropped before scanning,
+# which is correct for both halves: such a line is executed neither by the shell
+# nor by Actions. An inline trailing comment is not stripped, so keep any prose
+# example of an invocation on its own comment line.
+#
+# ⚠️ FINDING NO DIRECT INVOCATION AT ALL IS CANNOT-CHECK, NEVER A CLEAN PASS.
+#
+# The detector is a text scan, so a change to the invocation shape — or to this
+# script's own regex — could silently match nothing and report success over a tree
+# it never examined. An empty sweep is the shape of a broken detector far more
+# often than of a repository that stopped invoking anything, so it exits non-zero.
+
+set -euo pipefail
+
+repo_root="${1:-.}"
+cd "$repo_root"
+
+status=0
+
+# Tracked mode per path, from the INDEX. `git ls-files -s` prints
+# `<mode> <object> <stage>\t<path>`.
+modes="$(git ls-files -s -- 'scripts/*.sh' 'scripts/**/*.sh')"
+if [[ -z "$modes" ]]; then
+  echo "::error::found no tracked scripts/**/*.sh; the exec-bit sweep examined nothing, so its result proves nothing"
+  exit 1
+fi
+
+# Every `./scripts/<name>.sh` occurrence under the two roots that runs the file
+# directly. The negative lookbehind is spelled as a leading-character class
+# because BSD grep has no lookbehind: the character before the token must not be
+# part of a longer path, and the WORD before it must not be an interpreter.
+invocations="$(
+  grep -rhE -v '^[[:space:]]*#' --include='*.yaml' --include='*.yml' --include='*.sh' \
+    -r .github scripts 2>/dev/null |
+    grep -oE '(^|[[:space:]|&;(])([A-Za-z0-9_.-]+[[:space:]]+)?\./scripts/[A-Za-z0-9_./-]+\.sh' || true
+)"
+
+direct=""
+while IFS= read -r occurrence; do
+  [[ -n "$occurrence" ]] || continue
+
+  # The word immediately before the path, if any.
+  prefix="$(printf '%s' "$occurrence" | sed -E 's|\./scripts/[A-Za-z0-9_./-]+\.sh$||' | tr -d '[:space:]')"
+  case "$prefix" in
+    "" | "&&" | "||" | "|" | ";" | "(") ;;                 # nothing in front: a direct invocation
+    bash | sh | zsh | dash | ksh | source | .) continue ;; # handed to an interpreter
+    *) ;;                                                  # any other word still EXECS the file: sudo, exec, time, xargs, env
+  esac
+
+  path="$(printf '%s' "$occurrence" | grep -oE '\./scripts/[A-Za-z0-9_./-]+\.sh' | sed 's|^\./||')"
+  direct="${direct}${path}"$'\n'
+done <<EOF
+$invocations
+EOF
+
+direct="$(printf '%s' "$direct" | sort -u | grep -v '^$' || true)"
+
+if [[ -z "$direct" ]]; then
+  echo "::error::found no directly-invoked script under .github/ or scripts/; the exec-bit sweep examined nothing, so its result proves nothing"
+  exit 1
+fi
+
+checked=0
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+
+  mode="$(printf '%s\n' "$modes" | awk -v p="$path" -F'\t' '$2 == p {split($1, a, " "); print a[1]}')"
+  if [[ -z "$mode" ]]; then
+    # Not tracked, so out of scope here. This is overwhelmingly a path a test
+    # CONSTRUCTS as a string rather than one anything runs — a text scan cannot
+    # tell `printf ./scripts/fixture.sh` from an invocation, and this repository
+    # has such a test. Claiming a violation on it would fail the build over a
+    # file that does not exist. A genuinely missing script is a different and
+    # much louder failure: the very first run dies "no such file", with none of
+    # the silence that makes the exec bit worth a guard.
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  if [[ "$mode" != "100755" ]]; then
+    echo "::error file=$path::'$path' is invoked directly (./$path) but is tracked $mode, not 100755. CI clones from git, so the runner receives $mode and the step dies 'permission denied' before it checks anything. Fix with: git update-index --chmod=+x '$path'"
+    status=1
+  fi
+done <<EOF
+$direct
+EOF
+
+if ((checked == 0)); then
+  echo "::error::resolved no tracked mode for any directly-invoked script; the sweep proved nothing"
+  exit 1
+fi
+
+if ((status == 0)); then
+  echo "exec-bit guard OK; $checked directly-invoked script(s) are tracked 100755"
+fi
+
+exit "$status"

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -117,7 +117,7 @@ fi
 #
 # BSD grep has no lookbehind, so each leading delimiter is spelled as a class.
 readonly SCRIPT_PATH_RE='(\.github|scripts)/[A-Za-z0-9_./-]+\.sh'
-readonly LEADING_DELIM='(^|[[:space:]|&;("'"'"'])'
+readonly LEADING_DELIM='(^|[[:space:]|&;(]|(^|[[:space:]|&;(])["'"'"'])'
 readonly TOKEN_RE='[^[:space:]]+'
 
 scan="$(
@@ -125,11 +125,28 @@ scan="$(
     -r .github scripts 2>/dev/null || true
 )"
 
+# 🔴 SPLIT AT `&&` / `||` BEFORE EXTRACTING, NOT ONLY WHILE CLASSIFYING.
+#
+# Resetting the classifier at a separator fixes `echo ready && ./scripts/x.sh`,
+# where the swallowed segment is the harmless one. It does NOT fix the mirror
+# image, `./scripts/a.sh && bash ./scripts/b.sh`: `grep -o` takes the longest
+# leftmost match, so BOTH paths land in one occurrence that ends at b.sh, the
+# classifier judges it by b.sh's `bash` prefix, and a.sh — genuinely execed and
+# possibly 100644 — never becomes an occurrence of its own to judge. Splitting
+# first gives each command its own segment, so each path is extracted in its own
+# command position.
+#
+# Only whitespace-delimited `&&` and `||` are split. `;` and `|` are deliberately
+# NOT, because splitting is the FALSE-POSITIVE direction — every new segment
+# creates a fresh command position — and those two appear inside quoted strings
+# and YAML block scalars far too often to treat as separators textually.
+segmented="$(printf '%s\n' "$scan" | sed -E 's/[[:space:]]+(\&\&|\|\|)[[:space:]]+/\n/g')"
+
 invocations="$(
   {
-    printf '%s\n' "$scan" |
+    printf '%s\n' "$segmented" |
       grep -oE "${LEADING_DELIM}(${TOKEN_RE}[[:space:]]+)*\./${SCRIPT_PATH_RE}" || true
-    printf '%s\n' "$scan" |
+    printf '%s\n' "$segmented" |
       grep -oE "run:[[:space:]]+[\"']?(${TOKEN_RE}[[:space:]]+)*(\./)?${SCRIPT_PATH_RE}" || true
     # A run block puts the command at the START of its own line. But line-leading
     # position is command position only when the PREVIOUS line did not end in a
@@ -141,7 +158,7 @@ invocations="$(
     # occurrence STOPS at the path instead of running to the end of the line,
     # which is what lets a trailing argument coexist with a line-leading command.
     awk '!cont { print }
-         { cont = ($0 ~ /\\[[:space:]]*$/) }' <<<"$scan" |
+         { cont = ($0 ~ /\\[[:space:]]*$/) }' <<<"$segmented" |
       grep -oE "^[[:space:]]*(${TOKEN_RE}[[:space:]]+)*(\./)?${SCRIPT_PATH_RE}" || true
   }
 )"
@@ -172,15 +189,32 @@ while IFS= read -r occurrence; do
   saw_wrapper=0
   for token in ${prefix_tokens+"${prefix_tokens[@]}"}; do
     case "$token" in
-      "&&" | "||" | "|" | ";" | "(" | '"' | "'") ;;               # operator: a command position follows
-      if | elif | while | until | then | do | else | "!" | "{") ;; # control keyword: likewise
+      # 🔴 A SEPARATOR RESETS THE WALK; IT DOES NOT MERELY PASS.
+      #
+      # Extraction is greedy, so one occurrence can span several commands
+      # (`echo ready && ./scripts/x.sh`). Judging it by whatever came first
+      # discarded it at `echo` and never reached the `&&` proving a FRESH
+      # command position follows — the guard then reported success over a
+      # script the step genuinely execs. State is therefore per-SEGMENT:
+      # everything before the separator is spent.
+      "&&" | "||" | "|" | ";" | "(")
+        reaches_path=1
+        saw_wrapper=0
+        ;;
+      if | elif | while | until | then | do | else | "!" | "{") # control keyword: likewise
+        reaches_path=1
+        saw_wrapper=0
+        ;;
+      # A quote is TRANSPARENT — never a reset. It marks a command position in
+      # `run: "./scripts/x.sh"`, but in `foo "./scripts/x.sh"` the path is an
+      # ARGUMENT to foo, and resetting here would resurrect exactly that.
+      '"' | "'") ;;
       -*)
         # An option, admissible only as an option TO a wrapper already accepted.
         # A bare leading `-` is the YAML sequence marker, which introduces a list
         # entry — a path filter, not a command.
         if ((saw_wrapper == 0)); then
           reaches_path=0
-          break
         fi
         ;;
       *=*) ;;                                                     # NAME=value: an environment assignment is transparent
@@ -189,11 +223,9 @@ while IFS= read -r occurrence; do
         ;;
       bash | sh | zsh | dash | ksh | source | .)                   # handed to an interpreter
         reaches_path=0
-        break
         ;;
       *)                                                           # an argument to some other command, which does not exec it
         reaches_path=0
-        break
         ;;
     esac
   done

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -102,10 +102,23 @@ fi
 # front of a bare path would re-admit every quoted filter entry, so the quote is
 # accepted only where a `./` follows it.
 #
+# 🔴 TOKEN_RE MATCHES ANY WHITESPACE-DELIMITED WORD, AND THAT IS DELIBERATE.
+#
+# It spells what a prefix WORD may look like, never which prefixes are
+# admissible — that is the classifier's job. Enumerating characters here is the
+# blacklist trap the classifier comment below describes, one level up: a
+# character class that omitted `"`, `$` and braces let `FOO="${BAR}" scripts/x.sh`
+# escape extraction entirely, so the classifier — which reads `NAME=value` as a
+# transparent assignment and would have judged it correctly — never saw it.
+#
+# This does not re-admit a quoted filter entry. The risk there is a quote
+# ADJACENT to the path (`- 'scripts/x.sh'`), where no whitespace separates the
+# two, so the quote is never a word of its own and the path never starts a match.
+#
 # BSD grep has no lookbehind, so each leading delimiter is spelled as a class.
 readonly SCRIPT_PATH_RE='(\.github|scripts)/[A-Za-z0-9_./-]+\.sh'
 readonly LEADING_DELIM='(^|[[:space:]|&;("'"'"'])'
-readonly TOKEN_RE='[A-Za-z0-9_.=-]+'
+readonly TOKEN_RE='[^[:space:]]+'
 
 scan="$(
   grep -rhE -v '^[[:space:]]*#' --include='*.yaml' --include='*.yml' --include='*.sh' \

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -184,6 +184,19 @@ while IFS= read -r occurrence; do
   # which would have judged all three correctly, never ran on them. Extraction
   # now captures however many words sit in front of the path and every decision
   # is made here, where a form that is not provably still an exec is discarded.
+  # 🔴 `;` BINDS TO THE PRECEDING WORD, SO IT MUST BE TOKENISED, NOT JUST MATCHED.
+  #
+  # Bash needs no whitespace before a semicolon, so `echo ready; scripts/x.sh`
+  # yields the prefix word `ready;` — which hits the catch-all and discards the
+  # occurrence, while the `;` arm below never sees it. That is a fail-open: a
+  # directly-execed script tracked 100644 goes unchecked whenever another
+  # invocation satisfies anti-vacuity. Splitting `;` into its own word here lets
+  # the existing separator arm do its job, and does it in the CLASSIFIER rather
+  # than in extraction on purpose — a `;` inside a quoted string still only
+  # yields a stray reset within one occurrence's prefix, where the words around
+  # it are still judged, instead of manufacturing a new command position for the
+  # whole line the way an extraction split would.
+  prefix="${prefix//;/ ; }"
   read -ra prefix_tokens <<<"$prefix"
   reaches_path=1
   saw_wrapper=0

--- a/scripts/guard-tracked-exec-bit.sh
+++ b/scripts/guard-tracked-exec-bit.sh
@@ -75,40 +75,86 @@ status=0
 
 # Tracked mode per path, from the INDEX. `git ls-files -s` prints
 # `<mode> <object> <stage>\t<path>`.
-modes="$(git ls-files -s -- 'scripts/*.sh' 'scripts/**/*.sh')"
+#
+# Both roots are inventoried. `.github/scripts/` holds the CI installers, which
+# a `run:` step executes as its command and which therefore need the bit exactly
+# as much as anything under `scripts/`.
+modes="$(git ls-files -s -- 'scripts/*.sh' 'scripts/**/*.sh' '.github/scripts/*.sh' '.github/scripts/**/*.sh')"
 if [[ -z "$modes" ]]; then
-  echo "::error::found no tracked scripts/**/*.sh; the exec-bit sweep examined nothing, so its result proves nothing"
+  echo "::error::found no tracked *.sh under scripts/ or .github/scripts/; the exec-bit sweep examined nothing, so its result proves nothing"
   exit 1
 fi
 
-# Every `./scripts/<name>.sh` occurrence under the two roots that runs the file
-# directly. The negative lookbehind is spelled as a leading-character class
-# because BSD grep has no lookbehind: the character before the token must not be
-# part of a longer path, and the WORD before it must not be an interpreter.
-invocations="$(
+# 🔴 TWO INVOCATION SHAPES EXIST, AND ONE OF THEM CARRIES NO `./`.
+#
+# An explicitly-relative `./scripts/x.sh` can stand wherever a command can, so it
+# is matched on the character in front of it. A BARE `scripts/x.sh` cannot be
+# matched that way, because the identical text is also how a path filter entry
+# and a shellcheck argument are written; counting those would fail the build over
+# files nothing runs. `.github/scripts/kyverno-version.sh` is exactly that case —
+# it appears as a filter entry and as a `bash`-prefixed call, and is correctly
+# tracked 100644. The bare form is therefore recognised only as the command of a
+# `run:` step, which is the position that actually execs it.
+#
+# 🔴 A SHELL QUOTE IS A DELIMITER ONLY IN FRONT OF `./`.
+#
+# `run: "./scripts/x.sh"` execs the file and needs the bit. Honouring a quote in
+# front of a bare path would re-admit every quoted filter entry, so the quote is
+# accepted only where a `./` follows it.
+#
+# BSD grep has no lookbehind, so each leading delimiter is spelled as a class.
+readonly SCRIPT_PATH_RE='(\.github/)?scripts/[A-Za-z0-9_./-]+\.sh'
+readonly LEADING_DELIM='(^|[[:space:]|&;("'"'"'])'
+
+scan="$(
   grep -rhE -v '^[[:space:]]*#' --include='*.yaml' --include='*.yml' --include='*.sh' \
-    -r .github scripts 2>/dev/null |
-    grep -oE '(^|[[:space:]|&;(])([A-Za-z0-9_.-]+[[:space:]]+)?\./scripts/[A-Za-z0-9_./-]+\.sh' || true
+    -r .github scripts 2>/dev/null || true
+)"
+
+invocations="$(
+  {
+    printf '%s\n' "$scan" |
+      grep -oE "${LEADING_DELIM}([A-Za-z0-9_.-]+[[:space:]]+)?\./${SCRIPT_PATH_RE}" || true
+    printf '%s\n' "$scan" |
+      grep -oE "run:[[:space:]]+([A-Za-z0-9_.-]+[[:space:]]+)?(\./)?${SCRIPT_PATH_RE}" || true
+    # A run block puts the command at the START of its own line. But line-leading
+    # position is command position only when the PREVIOUS line did not end in a
+    # backslash: a continuation line is an ARGUMENT list, and this repository has
+    # exactly that shape, continuing a shellcheck call across several lines over
+    # library files correctly tracked 100644. A stateless line-leading match
+    # reports those as invocations and fails the build. awk carries that one bit
+    # of state. The pattern travels via ENVIRON because the -v option expands
+    # escape sequences in the value and would eat the backslashes.
+    GUARD_LINE_RE="^[[:space:]]*(\./)?${SCRIPT_PATH_RE}" \
+      awk '!cont && $0 ~ ENVIRON["GUARD_LINE_RE"] { print }
+           { cont = ($0 ~ /\\[[:space:]]*$/) }' <<<"$scan" || true
+  }
 )"
 
 direct=""
 while IFS= read -r occurrence; do
   [[ -n "$occurrence" ]] || continue
 
-  # The word immediately before the path, if any.
-  prefix="$(printf '%s' "$occurrence" | sed -E 's|\./scripts/[A-Za-z0-9_./-]+\.sh$||' | tr -d '[:space:]')"
+  # The word immediately before the path, if any. `run:` is the step keyword
+  # rather than a command, so it is stripped alongside the leading delimiters.
+  prefix="$(
+    printf '%s' "$occurrence" |
+      sed -E "s|(\./)?${SCRIPT_PATH_RE}\$||" |
+      sed -E 's|^run:||' |
+      tr -d '[:space:]'
+  )"
   case "$prefix" in
-    "" | "&&" | "||" | "|" | ";" | "(") ;;                 # nothing in front: a direct invocation
+    "" | "&&" | "||" | "|" | ";" | "(" | '"' | "'") ;;     # nothing in front: a direct invocation
     bash | sh | zsh | dash | ksh | source | .) continue ;; # handed to an interpreter
-    *) ;;                                                  # any other word still EXECS the file: sudo, exec, time, xargs, env
+    sudo | exec | time | env | command | nohup | xargs) ;; # a wrapper that still execs the file
+    *) continue ;;                                         # an argument to some other command, which does not exec it
   esac
 
-  path="$(printf '%s' "$occurrence" | grep -oE '\./scripts/[A-Za-z0-9_./-]+\.sh' | sed 's|^\./||')"
+  path="$(printf '%s' "$occurrence" | grep -oE "(\./)?${SCRIPT_PATH_RE}" | sed 's|^\./||')"
   direct="${direct}${path}"$'\n'
 done <<EOF
 $invocations
 EOF
-
 direct="$(printf '%s' "$direct" | sort -u | grep -v '^$' || true)"
 
 if [[ -z "$direct" ]]; then

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -293,6 +293,22 @@ make_trailarg_fixture() {
 }
 make_trailarg_fixture "$work/trailarg"
 expect "TRAIL run-block bare path with trailing argument is rejected" 1 "is tracked 100644, not 100755" "$work/trailarg"
+# A quoted environment assignment is still a direct exec: the shell sets the
+# variable and execs the file. The prefix classifier reads NAME=value as
+# transparent, so this case is about whether extraction hands it the occurrence
+# at all — a character-class TOKEN_RE excluding `"`, `$` and braces did not.
+# shellcheck disable=SC2016 # the literal ${BAR} is the case under test; it must not expand
+make_fixture "$work/quoted-assign" -x 'FOO="${BAR}" scripts/fixture-target.sh' anchor
+expect "QUOTED-ASSIGN quoted env assignment before a bare path is rejected" 1 \
+  "is tracked 100644, not 100755" "$work/quoted-assign"
+
+# The counterpart: the same assignment in front of an INTERPRETER is not a direct
+# exec, so widening extraction must not have made the guard accept everything.
+# shellcheck disable=SC2016 # same: the literal is the fixture
+make_fixture "$work/quoted-assign-bash" -x 'FOO="${BAR}" bash scripts/fixture-target.sh' anchor
+expect "QUOTED-ASSIGN interpreter behind a quoted assignment stays accepted" 0 \
+  "" "$work/quoted-assign-bash"
+
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -211,6 +211,88 @@ expect "CTRL  if-prefixed invocation is rejected" 1 "is tracked 100644, not 1007
 # coverage is derived from the invocation rather than pinned to a path or keyword.
 make_fixture "$work/ctrl-relaxed" -x 'if bash ./scripts/fixture-target.sh; then echo ok; fi' anchor
 expect "CTRL  if + interpreter is accepted" 0 "exec-bit guard OK" "$work/ctrl-relaxed"
+
+# MULTI-WORD PREFIX IN FRONT OF A BARE PATH: extraction used to allow at most ONE
+# word before a path, and only a `./`-prefixed path could carry more. A bare path
+# behind two or more words — an environment assignment, or a wrapper with an
+# option — therefore never reached the prefix classifier at all, and the guard
+# reported success over a 100644 file the step really does exec. Review found
+# these one spelling at a time over several rounds, which is why extraction is now
+# permissive and the classifier is the whitelist that decides.
+make_fixture "$work/envassign" -x 'env FOO=1 scripts/fixture-target.sh' anchor
+expect "PREFIX env assignment before bare path is rejected" 1 "is tracked 100644, not 100755" "$work/envassign"
+
+make_fixture "$work/bareassign" -x 'FOO=1 scripts/fixture-target.sh' anchor
+expect "PREFIX bare assignment before bare path is rejected" 1 "is tracked 100644, not 100755" "$work/bareassign"
+
+make_fixture "$work/wrapopt" -x 'sudo -E scripts/fixture-target.sh' anchor
+expect "PREFIX wrapper option before bare path is rejected" 1 "is tracked 100644, not 100755" "$work/wrapopt"
+
+# ...and the widened extraction must still RELAX. The same multi-word prefix ending
+# in an interpreter hands the file over rather than execing it. Without this the
+# three assertions above would pass just as well on a classifier that accepted
+# everything it now reaches, which would prove nothing about discrimination.
+make_fixture "$work/envinterp" -x 'env FOO=1 bash scripts/fixture-target.sh' anchor
+expect "PREFIX env assignment + interpreter is accepted" 0 "exec-bit guard OK" "$work/envinterp"
+
+# A BARE `-` IS THE YAML SEQUENCE MARKER, NOT A COMMAND: an UNQUOTED paths-filter
+# entry is a list item, and the widened extraction now reaches it where the quoted
+# form above is excluded by its quote. Only an option to a wrapper already accepted
+# may sit in front of the path; a lone `-` may not.
+make_unquoted_filter_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho lib\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'on:\n  pull_request:\n    paths:\n'
+    printf '      - scripts/fixture-target.sh\n'
+    printf 'jobs:\n  j:\n    steps:\n      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_unquoted_filter_fixture "$work/filter-unquoted"
+expect "FILTER unquoted path-filter entry is not an invocation" 0 "exec-bit guard OK" "$work/filter-unquoted"
+
+# LINE-LEADING BARE PATH WITH A TRAILING ARGUMENT: the run-block scan used to emit
+# the WHOLE line, while the prefix strip anchors the path at end-of-string. An
+# argument after the path defeated that anchor, so the prefix became the entire
+# line, hit the catch-all and was discarded — the guard skipped a script the step
+# genuinely execs. This is not hypothetical: `ci.yaml` runs
+# `scripts/update-vendored-operators.sh --validate-committed` in exactly this
+# shape, and the pre-fix guard did not check it. Extraction now stops at the path.
+# The fixture must use a run BLOCK: as a `run:` line the path is already the end
+# of the `run:` match, so the anchor holds and the case proves nothing.
+make_trailarg_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho hi\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'jobs:\n  j:\n    steps:\n      - run: |\n'
+    printf '          scripts/fixture-target.sh --some-flag\n'
+    printf '      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_trailarg_fixture "$work/trailarg"
+expect "TRAIL run-block bare path with trailing argument is rejected" 1 "is tracked 100644, not 100755" "$work/trailarg"
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -309,6 +309,88 @@ make_fixture "$work/quoted-assign-bash" -x 'FOO="${BAR}" bash scripts/fixture-ta
 expect "QUOTED-ASSIGN interpreter behind a quoted assignment stays accepted" 0 \
   "" "$work/quoted-assign-bash"
 
+
+# CHAINED COMMAND: `cmd && ./scripts/x.sh` puts a SECOND command position after the
+# separator, and the walk has to notice. Extraction is greedy, so the occurrence
+# begins at `echo`; the classifier hit that unknown token, broke immediately and
+# discarded the whole occurrence, never reaching the `&&` that proves a fresh
+# command position follows. With the anchor satisfying anti-vacuity the guard then
+# reported success over a script it genuinely execs. The walk now RESETS at a
+# separator instead of judging the occurrence by its first segment.
+make_fixture "$work/chained" -x 'echo ready && ./scripts/fixture-target.sh' anchor
+expect "CHAIN direct invocation after a command separator is rejected" 1 \
+  "is tracked 100644, not 100755" "$work/chained"
+
+# The counterpart, so the reset cannot become "accept whatever follows a
+# separator": an INTERPRETER after the separator is still not a direct exec.
+make_fixture "$work/chained-bash" -x 'echo ready && bash ./scripts/fixture-target.sh' anchor
+expect "CHAIN interpreter after a command separator stays accepted" 0 \
+  "" "$work/chained-bash"
+
+# ASSIGNMENT VALUE: `HELPER="./scripts/x.sh"` stores a path, it does not run one.
+# The opening quote is a leading delimiter, so extraction started AT the quote and
+# dropped the `HELPER=` that gives it its meaning; the classifier then saw a lone
+# `"`, read it as an operator and required an execute bit on a file that is only
+# ever handed to an interpreter. That is a false POSITIVE — it fails every PR and
+# merge-group run — so the fixture asserts the guard passes.
+make_assign_value_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho hi\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'HELPER="./scripts/fixture-target.sh"\n'
+    # shellcheck disable=SC2016 # the literal $HELPER is the fixture; it must not expand
+    printf 'bash "$HELPER"\n'
+  } > scripts/fixture-caller.sh
+  printf 'jobs:\n  j:\n    steps:\n      - run: ./scripts/fixture-anchor.sh\n' > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git update-index --chmod=+x scripts/fixture-caller.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_assign_value_fixture "$work/assign-value"
+expect "ASSIGN-VALUE a path stored in a quoted assignment is not an invocation" 0 \
+  "" "$work/assign-value"
+
+# THE MIRROR IMAGE OF CHAIN, and the reason the split had to happen in EXTRACTION
+# rather than only in the classifier. Here the swallowed segment is the one that
+# matters: `grep -o` takes the longest leftmost match, so both paths land in one
+# occurrence ending at the interpreter-invoked path, the classifier judges it by
+# that `bash` prefix, and the genuinely-execed FIRST path never becomes an
+# occurrence of its own. A classifier-only reset still reports success here.
+make_chain_first_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho a\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho b\n' > scripts/fixture-other.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'jobs:\n  j:\n    steps:\n'
+    printf '      - run: ./scripts/fixture-target.sh && bash ./scripts/fixture-other.sh\n'
+    printf '      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=-x scripts/fixture-other.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_chain_first_fixture "$work/chain-first"
+expect "CHAIN-FIRST a direct invocation BEFORE a separator is still checked" 1 \
+  "'scripts/fixture-target.sh' is invoked directly" "$work/chain-first"
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -183,6 +183,34 @@ make_filter_fixture() {
 }
 make_filter_fixture "$work/filter"
 expect "FILTER quoted path-filter entry is not an invocation" 0 "exec-bit guard OK" "$work/filter"
+
+# .GITHUB BEYOND .GITHUB/SCRIPTS: a composite action ships its own scripts, and
+# `.github/actions/<name>/check.sh` is executed by a run step exactly as an
+# installer under .github/scripts is. Inventorying only .github/scripts left that
+# path outside BOTH the mode inventory and the path regex, so the guard could not
+# find its mode and reported success over it while another invocation kept the
+# sweep non-vacuous.
+make_fixture "$work/ghany" -x '.github/actions/example/check.sh' anchor \
+  '.github/actions/example/check.sh'
+expect "GHANY .github/actions 100644 is rejected" 1 "is tracked 100644, not 100755" "$work/ghany"
+
+# QUOTED BARE PATH IN A RUN STEP: YAML strips the quotes before the shell sees the
+# value, so `run: "scripts/x.sh"` is the same command as `run: scripts/x.sh` and
+# needs the bit. The quote allowance stays scoped to `run:` — a `paths:` entry is
+# also a quoted bare path and must keep being excluded, which FILTER below pins.
+make_fixture "$work/qbare" -x '"scripts/fixture-target.sh"' anchor
+expect "QBARE quoted bare run: command is rejected" 1 "is tracked 100644, not 100755" "$work/qbare"
+
+# CONTROL KEYWORD IS NOT A CONSUMING COMMAND: `if ./scripts/x.sh; then` execs the
+# file; `if` introduces a command position rather than taking it as an argument.
+# It was landing in the catch-all beside genuine argument-takers and being skipped.
+make_fixture "$work/ctrl" -x 'if ./scripts/fixture-target.sh; then echo ok; fi' anchor
+expect "CTRL  if-prefixed invocation is rejected" 1 "is tracked 100644, not 100755" "$work/ctrl"
+
+# ...and the same three surfaces must still RELAX behind an interpreter, so the new
+# coverage is derived from the invocation rather than pinned to a path or keyword.
+make_fixture "$work/ctrl-relaxed" -x 'if bash ./scripts/fixture-target.sh; then echo ok; fi' anchor
+expect "CTRL  if + interpreter is accepted" 0 "exec-bit guard OK" "$work/ctrl-relaxed"
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -19,16 +19,20 @@ failures=0
 # Without it a fixture whose only script is interpreter-invoked has no direct
 # invocation at all, so the guard refuses on anti-vacuity and a "relaxed" case
 # would pass for the wrong reason — proving nothing about relaxation.
+# `target` defaults to scripts/fixture-target.sh; pass a path under
+# .github/scripts/ to cover the CI installer surface, which is invoked as the
+# command of a run step rather than as ./scripts/<name>.
 make_fixture() {
   local dir="$1" mode="$2" invocation="$3" anchor="${4:-no}"
+  local target="${5:-scripts/fixture-target.sh}"
 
-  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows" "$dir/$(dirname "$target")"
   cd "$dir"
   git init -q .
   git config user.email t@example.com
   git config user.name t
 
-  printf '#!/usr/bin/env bash\necho hi\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho hi\n' > "$target"
   printf 'jobs:\n  j:\n    steps:\n      - run: %s\n' "$invocation" > .github/workflows/w.yaml
 
   if [[ "$anchor" == "anchor" ]]; then
@@ -37,7 +41,7 @@ make_fixture() {
   fi
 
   git add -A
-  git update-index --chmod="$mode" scripts/fixture-target.sh
+  git update-index --chmod="$mode" "$target"
   [[ "$anchor" == "anchor" ]] && git update-index --chmod=+x scripts/fixture-anchor.sh
   git -c commit.gpgsign=false commit -qm fixture
   cd - > /dev/null
@@ -84,6 +88,101 @@ expect "RELAX interpreter-invoked 100644 is accepted" 0 "exec-bit guard OK" "$wo
 make_fixture "$work/empty" -x 'echo nothing-to-see'
 expect "VACUOUS no invocation at all refuses to pass" 1 "examined nothing" "$work/empty"
 
+
+# .GITHUB/SCRIPTS COVERAGE: the CI installers live under .github/scripts and are
+# invoked as the command of a run step, with no ./ in front. That surface was
+# outside both the mode inventory and the detector, so a mode-only regression on
+# setup-ksail.sh or setup-talosctl.sh was invisible while the guard still
+# reported success over unrelated root scripts.
+make_fixture "$work/dotgithub" -x '.github/scripts/fixture-target.sh' no \
+  '.github/scripts/fixture-target.sh'
+expect "GHDIR .github/scripts 100644 is rejected" 1 "is tracked 100644, not 100755" "$work/dotgithub"
+
+# QUOTED INVOCATION: the shell execs a quoted path exactly as it execs a bare
+# one, so it needs the bit; a delimiter class that omits quotes silently skips it.
+make_fixture "$work/quoted" -x '"./scripts/fixture-target.sh"'
+expect "QUOTE quoted direct invocation is rejected" 1 "is tracked 100644, not 100755" "$work/quoted"
+
+# CONTINUATION LINE IS NOT COMMAND POSITION: recognising a run block's command by
+# line-leading position must not also claim every backslash-continued ARGUMENT.
+# This repository continues a shellcheck call over library files tracked 100644,
+# and counting those fails the build over files nothing execs. The anchor keeps
+# the sweep non-vacuous so rc=0 means "not claimed", never "nothing examined".
+make_continuation_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho lib\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'jobs:\n  j:\n    steps:\n      - run: |\n'
+    printf '          shellcheck \\\n'
+    printf '            scripts/fixture-target.sh\n'
+    printf '      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_continuation_fixture "$work/continuation"
+expect "CONT  continued argument is not an invocation" 0 "exec-bit guard OK" "$work/continuation"
+
+# RUN-BLOCK COMMAND: a multi-line run block names the command on its own line
+# with no ./ and no run: keyword on that line — the shape the talosctl installer
+# uses. Neither the delimiter pass nor the run: pass can see it.
+make_runblock_fixture() {
+  local dir="$1" mode="$2"
+  mkdir -p "$dir/scripts" "$dir/.github/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho hi\n' > .github/scripts/fixture-target.sh
+  {
+    printf 'jobs:\n  j:\n    steps:\n      - run: |\n'
+    printf '          .github/scripts/fixture-target.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod="$mode" .github/scripts/fixture-target.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_runblock_fixture "$work/runblock" -x
+expect "BLOCK run-block command 100644 is rejected" 1 "is tracked 100644, not 100755" "$work/runblock"
+make_runblock_fixture "$work/runblock-ok" +x
+expect "BLOCK run-block command 100755 is accepted" 0 "exec-bit guard OK" "$work/runblock-ok"
+
+# QUOTED PATH FILTER IS NOT AN INVOCATION: a paths-filter entry is a quoted BARE
+# path. Honouring a quote in front of a bare path would claim every such entry —
+# this repository has one on a file correctly tracked 100644 — so the quote
+# counts only in front of ./ . The anchor keeps the sweep non-vacuous.
+make_filter_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho lib\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'on:\n  pull_request:\n    paths:\n'
+    printf "      - 'scripts/fixture-target.sh'\n"
+    printf 'jobs:\n  j:\n    steps:\n      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_filter_fixture "$work/filter"
+expect "FILTER quoted path-filter entry is not an invocation" 0 "exec-bit guard OK" "$work/filter"
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -391,6 +391,48 @@ make_chain_first_fixture() {
 make_chain_first_fixture "$work/chain-first"
 expect "CHAIN-FIRST a direct invocation BEFORE a separator is still checked" 1 \
   "'scripts/fixture-target.sh' is invoked directly" "$work/chain-first"
+
+# GLUED SEMICOLON: bash needs no space before `;`, so `echo ready; scripts/x.sh`
+# yields the prefix word `ready;`. The classifier's `;` arm matches a SEPARATE
+# token only, so the word hit the catch-all and the occurrence was discarded —
+# a fail-open, since anti-vacuity was satisfied by the anchor. `;` is now split
+# into its own word before the walk.
+make_fixture "$work/semi-line" -x 'echo ready; scripts/fixture-target.sh' anchor
+expect "SEMI glued semicolon before a bare path is rejected" 1 \
+  "is tracked 100644, not 100755" "$work/semi-line"
+
+# The interpreter control, so the split cannot become "accept whatever follows a
+# semicolon".
+make_fixture "$work/semi-bash" -x 'echo ready; bash scripts/fixture-target.sh' anchor
+expect "SEMI interpreter after a glued semicolon stays accepted" 0 \
+  "" "$work/semi-bash"
+
+# The same shape inside a `run: |` block, which reaches the guard through the
+# line-leading branch rather than the `run:` branch — a separate extraction path,
+# so it needs its own fixture rather than being assumed equivalent.
+make_semi_block_fixture() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf '#!/usr/bin/env bash\necho hi\n' > scripts/fixture-target.sh
+  printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+  {
+    printf 'jobs:\n  j:\n    steps:\n      - run: |\n'
+    printf '          echo ready; scripts/fixture-target.sh\n'
+    printf '      - run: ./scripts/fixture-anchor.sh\n'
+  } > .github/workflows/w.yaml
+  git add -A
+  git update-index --chmod=-x scripts/fixture-target.sh
+  git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+make_semi_block_fixture "$work/semi-block"
+expect "SEMI glued semicolon inside a run block is rejected" 1 \
+  "is tracked 100644, not 100755" "$work/semi-block"
 if ((failures > 0)); then
   echo "::error::$failures exec-bit guard assertion(s) failed"
   exit 1

--- a/scripts/tests/test-guard-tracked-exec-bit.sh
+++ b/scripts/tests/test-guard-tracked-exec-bit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Proves guard-tracked-exec-bit.sh actually discriminates, in all four directions:
+# it FAILS on a directly-invoked script tracked 100644, PASSES once the same file
+# is tracked 100755, PASSES when the invocation moves behind an interpreter (so the
+# requirement is derived from the invocation rather than pinned to a filename), and
+# refuses to report success when it finds nothing to check.
+#
+# Each fixture is a throwaway git repository. The mode has to be set in the INDEX
+# rather than on disk, because that is the only thing the guard reads and the only
+# thing a fresh clone receives — a working-tree chmod would prove nothing.
+
+set -euo pipefail
+
+guard="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/guard-tracked-exec-bit.sh"
+failures=0
+
+# `anchor` adds a SECOND script that is directly invoked and tracked executable.
+# Without it a fixture whose only script is interpreter-invoked has no direct
+# invocation at all, so the guard refuses on anti-vacuity and a "relaxed" case
+# would pass for the wrong reason — proving nothing about relaxation.
+make_fixture() {
+  local dir="$1" mode="$2" invocation="$3" anchor="${4:-no}"
+
+  mkdir -p "$dir/scripts" "$dir/.github/workflows"
+  cd "$dir"
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+
+  printf '#!/usr/bin/env bash\necho hi\n' > scripts/fixture-target.sh
+  printf 'jobs:\n  j:\n    steps:\n      - run: %s\n' "$invocation" > .github/workflows/w.yaml
+
+  if [[ "$anchor" == "anchor" ]]; then
+    printf '#!/usr/bin/env bash\necho anchor\n' > scripts/fixture-anchor.sh
+    printf '      - run: ./scripts/fixture-anchor.sh\n' >> .github/workflows/w.yaml
+  fi
+
+  git add -A
+  git update-index --chmod="$mode" scripts/fixture-target.sh
+  [[ "$anchor" == "anchor" ]] && git update-index --chmod=+x scripts/fixture-anchor.sh
+  git -c commit.gpgsign=false commit -qm fixture
+  cd - > /dev/null
+}
+
+expect() {
+  local label="$1" want_rc="$2" want_text="$3" dir="$4"
+
+  set +e
+  output="$(bash "$guard" "$dir" 2>&1)"
+  rc=$?
+  set -e
+
+  if [[ "$rc" != "$want_rc" ]]; then
+    echo "::error::$label: rc=$rc want=$want_rc — $output"
+    failures=$((failures + 1))
+    return
+  fi
+  if [[ "$output" != *"$want_text"* ]]; then
+    echo "::error::$label: rc matched but for the wrong reason — $output"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "$label ✅"
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# RED: directly invoked, tracked non-executable.
+make_fixture "$work/red" -x './scripts/fixture-target.sh'
+expect "RED   directly-invoked 100644 is rejected" 1 "is tracked 100644, not 100755" "$work/red"
+
+# GREEN: the same invocation, with the bit tracked.
+make_fixture "$work/green" +x './scripts/fixture-target.sh'
+expect "GREEN directly-invoked 100755 is accepted" 0 "exec-bit guard OK" "$work/green"
+
+# RELAXATION: the requirement follows the invocation. The identical non-executable
+# file is fine once an interpreter runs it, so the guard is not simply always-on.
+make_fixture "$work/relaxed" -x 'bash ./scripts/fixture-target.sh' anchor
+expect "RELAX interpreter-invoked 100644 is accepted" 0 "exec-bit guard OK" "$work/relaxed"
+
+# ANTI-VACUITY: no direct invocation anywhere is cannot-check, never a clean pass.
+make_fixture "$work/empty" -x 'echo nothing-to-see'
+expect "VACUOUS no invocation at all refuses to pass" 1 "examined nothing" "$work/empty"
+
+if ((failures > 0)); then
+  echo "::error::$failures exec-bit guard assertion(s) failed"
+  exit 1
+fi
+
+echo "all exec-bit guard assertions passed"

--- a/scripts/tests/test-rgd-template-static-scan-wiring.sh
+++ b/scripts/tests/test-rgd-template-static-scan-wiring.sh
@@ -59,7 +59,7 @@ jq -e --argjson required_inputs '[
 jq -e --arg setup "$SETUP_TRIVY" --arg behavior_run "$BEHAVIORAL_RUN" '
   .jobs.validate as $gate
   | (($gate.if // "") ==
-      "github.event_name == '\''pull_request'\'' && (needs.changes.outputs.k8s == '\''true'\'' || needs.changes.outputs.bridge_validation == '\''true'\'')")
+      "github.event_name == '\''pull_request'\'' && (needs.changes.outputs.k8s == '\''true'\'' || needs.changes.outputs.bridge_validation == '\''true'\'' || needs.changes.outputs.exec_bit == '\''true'\'')")
   and (($gate["continue-on-error"] // false) == false)
   and any($gate.steps[];
       (.uses // "") == $setup and .with.version == "v0.74.0")

--- a/scripts/tests/test-rgd-template-static-scan-wiring.sh
+++ b/scripts/tests/test-rgd-template-static-scan-wiring.sh
@@ -59,7 +59,7 @@ jq -e --argjson required_inputs '[
 jq -e --arg setup "$SETUP_TRIVY" --arg behavior_run "$BEHAVIORAL_RUN" '
   .jobs.validate as $gate
   | (($gate.if // "") ==
-      "github.event_name == '\''pull_request'\'' && (needs.changes.outputs.k8s == '\''true'\'' || needs.changes.outputs.bridge_validation == '\''true'\'' || needs.changes.outputs.exec_bit == '\''true'\'')")
+      "github.event_name == '\''pull_request'\'' && (needs.changes.outputs.k8s == '\''true'\'' || needs.changes.outputs.bridge_validation == '\''true'\'')")
   and (($gate["continue-on-error"] // false) == false)
   and any($gate.steps[];
       (.uses // "") == $setup and .with.version == "v0.74.0")


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

A script that a workflow runs directly has to be marked executable in git, because CI clones the repository and gets whatever mode was committed. Nothing checked that, and when it goes wrong the step dies before it does its job — so a safety check can be present, reviewed, and quietly doing nothing.

That already happened here: a production promotion gate was committed without the mark and failed with "permission denied" before verifying anything. None of the usual checks could catch it, because none of them actually run the file. The same mistake has been made three times.

### What

Adds a check that fails the build when a directly-invoked script is missing the executable mark, naming the file and the one command that fixes it. It works out which scripts need the mark from how they are actually invoked, so a script that changes how it is called stops or starts needing it automatically — there is no list to keep up to date.

The repository is already clean today, so this is about keeping it that way rather than fixing a backlog.

Fixes #3535
