### PR TITLE
fix(backup): recover the missed OpenBao snapshot after CSI repair

### DIFF
--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -189,6 +189,7 @@ patches:
   # (see the file header). Self-identifies via PersistentVolumeClaim/openbao/
   # vault-snapshots, so no explicit target is needed.
   - path: patches/store-vault-snapshots-on-hcloud.yaml
+  - path: patches/recover-vault-snapshot.yaml
   # Prod-only: add a generous memory `default` to the kube-system / kyverno
   # LimitRanges (which are CPU-only in the base). This seeds the memory limit the
   # vertical-pod-autoscalers/ VPAs scale ratio-preserving, so VPA right-sizes the memory

--- a/k8s/providers/hetzner/infrastructure/patches/recover-vault-snapshot.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/recover-vault-snapshot.yaml
@@ -1,0 +1,14 @@
+# Re-run the existing one-shot snapshot after the CSI metadata-access repair.
+# A pod-template change makes Flux replace this immutable, force-enabled Job.
+# Retaining the completed Job (no TTL) prevents repeated volume attachments;
+# the daily CronJob remains the normal backup schedule.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-snapshot-init
+  namespace: openbao
+spec:
+  template:
+    metadata:
+      annotations:
+        backup.devantler.tech/recovery-id: "2026-09-08-csi-metadata"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Today's OpenBao snapshot expired while the Hetzner CSI node driver was unavailable. The driver is now healthy after #3664, but the failed daily Job cannot retry, leaving the latest successful snapshot on September 7.

Add a production-only recovery marker to the existing `vault-snapshot-init` pod template. Its existing Flux force annotation replaces the immutable completed Job once; retaining that Job without a TTL prevents repeated mounts. The existing snapshot authentication, security context, PVC and off-cluster mirror are reused unchanged. The daily 03:30 UTC CronJob remains the normal schedule.

Validation: CI-pinned KSail 7.181.4 validated all 617 files for both local and production configurations. The rendered Job retains its 3600-second deadline, service account and no-TTL behavior, with only the recovery annotation added. Independent code review found no defect. This is an operational replay, with completion judged against live evidence rather than a new implementation test.

Before deployment, confirm there is no active snapshot Job and the execution window does not overlap the nightly schedule. After deployment, require a new snapshot on the PVC and successful off-cluster mirroring; Job completion alone is insufficient because bootstrap mode can skip the mirror when its Secret is absent.
