### PR TITLE
fix(velero): give repository maintenance explicit memory headroom

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -167,6 +167,20 @@ spec:
       # ~24x. (Applies to newly-created BackupRepositories; existing ones keep
       # their stored frequency until recreated.)
       defaultRepoMaintainFrequency: 24h
+      repositoryMaintenanceJob:
+        repositoryConfigData:
+          global:
+            # Maintenance runs in separate Jobs and does not inherit the server's
+            # resources below. Explicitly preserve its 16:1 memory headroom: the
+            # namespace's 512Mi limit OOMKills full Kopia maintenance, even when a
+            # later retry succeeds and makes BackupRepository Ready again. The
+            # ratio also survives any RequestsAndLimits VPA admission adjustment.
+            podResources:
+              cpuRequest: 15m
+              cpuLimit: 500m
+              memoryRequest: 128Mi
+              memoryLimit: 2Gi
+            keepLatestMaintenanceJobs: 3
       features: ""
 
     # Velero runs a SINGLE replica — this is correct, not a gap, and is why

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1777,7 +1777,14 @@ const (
 // seLinuxOptions. Real chart omitted/enabled/rollback renders retain all five
 // chart identities and differ only by those two operator Deployment fields.
 // Previous aggregate: a7bffd8423a99b738dd231a04b96a8e7d12b89eb2d308b26613d3004341a1c33.
-const expectedRenderedSurfaceSHA = "78ec24f102127ad42d3a005ad6fcdd4f86c4a8df3eaca7679b21aff53f0d0b35"
+// Refreshed for #3437's explicit Velero maintenance resources. Checksum-verified
+// kubectl v1.36.2 / Kustomize v5.8.1 compared all five roots against main
+// 67dc40e7: 555 documents on each side and no identity changes. Only the Velero
+// HelmRelease changes; removing configuration.repositoryMaintenanceJob restores
+// the identical parsed resource. Chart 12.1.0 renders the four resource values
+// into the existing maintenance ConfigMap, preserving three retained Jobs.
+// Previous aggregate: 78ec24f102127ad42d3a005ad6fcdd4f86c4a8df3eaca7679b21aff53f0d0b35.
+const expectedRenderedSurfaceSHA = "165ed85b44e9dd5434d606854776a38aa40e82515ffb6b767ecd77f6cfab579a"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

Velero's repository-maintenance Jobs inherit a 512Mi memory limit independently of the server's larger limit. Configure the chart's maintenance ConfigMap with explicit 128Mi requests and 2Gi limits, keeping the existing CPU settings and three retained Jobs. This gives full Kopia maintenance the same authored 16:1 memory headroom as the server.

The Jobs receive these values directly; the current auto-VPA generator targets long-lived workloads, so this fix does not rely on a VPA covering maintenance Jobs.

Validation: rendered the exact deployed Helm chart 12.1.0. Before the change the ConfigMap lacked `podResources` and the resource assertion failed; afterwards all four resource fields and retained-job count passed. Both local and production KSail 7.181.4 validations passed all 617 files. Independent review confirmed the chart and Velero 1.18 configuration keys and existing ConfigMap wiring.

The production authorization aggregate fingerprint is also refreshed for this configuration delta. Comparing all five production layers with the pinned renderer yielded 555 documents on each side: only this HelmRelease changed, and removing its maintenance configuration restored exact equality. All 83 RBAC and ServiceAccount documents and every per-object fingerprint remain unchanged. The full authorization suite passes.

After delivery, verify the live ConfigMap and a newly created maintenance Job. A successful short retry is not proof that a full maintenance operation fits the new limit. The retained OOM detection requirement in #3437 also remains separate, so this PR does not close that issue prematurely.

Refs #3437.
