### PR TITLE
fix(tenants): track signed release streams

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: 1.13.4
+    semver: ">=1.0.0"
   url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
   secretRef:
     name: ghcr-auth

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: 1.15.10
+    semver: ">=1.0.0"
   url: oci://ghcr.io/devantler-tech/wedding-app/manifests
   secretRef:
     name: ghcr-auth

--- a/scripts/guard-oci-repository-verify.sh
+++ b/scripts/guard-oci-repository-verify.sh
@@ -21,6 +21,10 @@
 #     reads as narrowed; alternation belongs inside the one subject regex, where the
 #     subject guards judge it.
 #   - that entry names a non-empty `issuer` and a non-empty `subject`.
+#   - the trusted Wedding and AS Coaching tenant artifacts follow the governed
+#     `>=1.0.0` semver stream. The platform owns their signer and namespace
+#     boundaries; restoring a tag or digest would reintroduce a platform PR for
+#     every tenant release and is therefore rejected by the rendered-tree guard.
 #
 # IT JUDGES THE KUSTOMIZE BUILD, NOT THE SOURCE FILES — MEASURED, NOT PREFERRED. A first
 # version scanned `k8s/**/*.yaml` with yq and was bypassed five ways in one review
@@ -82,6 +86,13 @@ readonly REQUIRED_URL_PREFIX='oci://ghcr.io/devantler-tech/'
 # the literal regex text the manifests carry (the `.` escaped), not evaluated.
 readonly REQUIRED_ISSUER='^https://token\.actions\.githubusercontent\.com$'
 readonly REQUIRED_SUBJECT_PREFIX='^https://github\.com/devantler-tech/'
+readonly REQUIRED_TENANT_STREAM_SEMVER='>=1.0.0'
+readonly WEDDING_STREAM_URL='oci://ghcr.io/devantler-tech/wedding-app/manifests'
+readonly ASCOACHING_STREAM_URL='oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests'
+# KRO preserves this placeholder in the rendered ResourceGraphDefinition; every
+# Tenant instance resolves it to its own trusted repository name at runtime.
+# shellcheck disable=SC2016
+readonly TEMPLATED_TENANT_STREAM_URL='oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests'
 # Where the cluster overlays and the Flux roots they name live (seam for the test's
 # discovery fixture; the roots are resolved relative to this directory).
 readonly K8S_DIR="${OCI_VERIFY_K8S_DIR:-$REPO_ROOT/k8s}"
@@ -218,6 +229,7 @@ fi
 # `read`'s whitespace splitting (which shifted every column right of the first empty one
 # and produced wrong-reason messages). `-` is decoded back to empty below.
 #   url  name  has_verify  provider  identities_type  identities_count  incomplete_entries
+#   issuer  subject  ref_type  ref_key_count  ref_semver
 readonly YQ_ROWS='[.. | select(type == "!!map" and .kind == "OCIRepository")]
   | .[]
   | [
@@ -230,7 +242,10 @@ readonly YQ_ROWS='[.. | select(type == "!!map" and .kind == "OCIRepository")]
       (([.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[]
           | select(((.issuer // "") == "") or ((.subject // "") == ""))] | length) | tostring),
       ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[0].issuer) // ""),
-      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[0].subject) // "")
+      ((.spec.verify.matchOIDCIdentity | select(type == "!!seq") | .[0].subject) // ""),
+      (.spec.ref | type),
+      ((((.spec.ref | select(type == "!!map") | keys | length) // 0)) | tostring),
+      ((.spec.ref | select(type == "!!map") | .semver) // "")
     ]
   | map(sub("^$", "-"))
   | join("	")'
@@ -260,10 +275,11 @@ while IFS= read -r root; do
     fail "$label: yq could not read the render, so its OCIRepositories are UNKNOWN: $(tr '\n' ' ' <"$work/rows.err")"
     continue
   fi
-  while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete issuer subject; do
+  while IFS=$'\t' read -r url name has_verify provider ids_type ids_count incomplete issuer subject ref_type ref_key_count ref_semver; do
     [ -n "$url" ] || continue
     url="$(decode "$url")"; name="$(decode "$name")"; provider="$(decode "$provider")"
     ids_type="$(decode "$ids_type")"; issuer="$(decode "$issuer")"; subject="$(decode "$subject")"
+    ref_type="$(decode "$ref_type")"; ref_semver="$(decode "$ref_semver")"
     [ -n "$url$name" ] || continue
     url="$(normalise_url "$url")"
     # The second pattern is the literal characters `${` — a Flux substitution marker,
@@ -281,6 +297,14 @@ while IFS= read -r root; do
       *) continue ;;
     esac
     in_scope=$((in_scope + 1))
+    case "$url" in
+      "$WEDDING_STREAM_URL" | "$ASCOACHING_STREAM_URL" | "$TEMPLATED_TENANT_STREAM_URL")
+        if [ "$ref_type" != "!!map" ] || [ "$ref_key_count" -ne 1 ] || [ "$ref_semver" != "$REQUIRED_TENANT_STREAM_SEMVER" ]; then
+          fail "$label: OCIRepository $name ($url) must follow the governed release stream with exactly spec.ref.semver: $REQUIRED_TENANT_STREAM_SEMVER; tag, digest, mixed and missing selectors require a platform boundary change"
+          continue
+        fi
+        ;;
+    esac
     if reason="$(exempt_reason "$url")"; then
       seen_exempt="$seen_exempt$url
 "

--- a/scripts/tests/test-guard-oci-repository-verify.sh
+++ b/scripts/tests/test-guard-oci-repository-verify.sh
@@ -119,6 +119,29 @@ assert_renders() {
 root="$(fresh_root green)"
 expect_accepted 'a verified in-scope OCIRepository with one identity is accepted' "$root"
 
+# --- GREEN: trusted tenants may follow the platform-owned release boundary ---
+root="$(fresh_root trusted-stream)"
+repo_doc wedding-app 'oci://ghcr.io/devantler-tech/wedding-app/manifests' "$(good_verify)" >"$root/wedding.yaml"; add_resource "$root" wedding.yaml
+expect_accepted 'a trusted tenant using the governed semver stream is accepted' "$root"
+
+# --- RED: trusted tenant mobility must not silently regress to platform pins ---
+root="$(fresh_root trusted-stream-tag)"
+repo_doc wedding-app 'oci://ghcr.io/devantler-tech/wedding-app/manifests' "$(good_verify)" >"$root/wedding.yaml"; add_resource "$root" wedding.yaml
+yq -i '.spec.ref = {"tag": "v1.15.11"}' "$root/wedding.yaml"
+expect_refused 'a trusted tenant fixed tag is refused by name' "$root" 'OCIRepository wedding-app (oci://ghcr.io/devantler-tech/wedding-app/manifests) must follow the governed release stream with exactly spec.ref.semver: >=1.0.0'
+
+root="$(fresh_root trusted-stream-digest)"
+repo_doc ascoachingogvaner 'oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests' "$(good_verify)" >"$root/ascoachingogvaner.yaml"; add_resource "$root" ascoachingogvaner.yaml
+yq -i '.spec.ref = {"digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' "$root/ascoachingogvaner.yaml"
+expect_refused 'a trusted tenant digest pin is refused by name' "$root" 'OCIRepository ascoachingogvaner (oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests) must follow the governed release stream with exactly spec.ref.semver: >=1.0.0'
+
+root="$(fresh_root templated-trusted-stream-tag)"
+# shellcheck disable=SC2016 # KRO placeholder is intentionally literal.
+repo_doc '${schema.spec.name}' 'oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests' "$(good_verify)" >"$root/tenant-template.yaml"; add_resource "$root" tenant-template.yaml
+yq -i '.spec.ref = {"tag": "v1.0.0"}' "$root/tenant-template.yaml"
+# shellcheck disable=SC2016 # Expected diagnostic preserves the KRO placeholder.
+expect_refused 'a templated trusted tenant fixed tag is refused by name' "$root" 'OCIRepository ${schema.spec.name} (oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests) must follow the governed release stream with exactly spec.ref.semver: >=1.0.0'
+
 # --- RED: no spec.verify at all (AC1) ---
 root="$(fresh_root noverify)"
 repo_doc bare 'oci://ghcr.io/devantler-tech/bare/manifests' '' >"$root/bare.yaml"; add_resource "$root" bare.yaml

--- a/scripts/tests/test-publish-workflow-signing-revisions.sh
+++ b/scripts/tests/test-publish-workflow-signing-revisions.sh
@@ -978,8 +978,10 @@ cat >"$origin_stub" <<STUB
 #!/usr/bin/env bash
 set -euo pipefail
 # \$1=repo \$2=workflow \$3=version. Emit the THIRD origin field, which the two-field
-# stubs above never exercise.
-if [ -n "\${3:-}" ]; then
+# stubs above never exercise. First-party tenant manifests deliberately use unbounded
+# release streams now, so choose one consumer explicitly to retain coverage of the
+# resolver's pinned-origin disclaimer without coupling this test to live ref policy.
+if [ "\$1" = '.github' ]; then
   printf '%s\t%s\t%s\n' '$SHA_A' '$SHA_A' 'pinned'
 else
   printf '%s\t%s\t%s\n' '$SHA_A' '$SHA_A' 'inferred'

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1953,7 +1953,24 @@ const (
 // The previous aggregate remains recorded here:
 //
 //	bc95f7ee1b1d9a29819844f5dfac84f256aa4caadac8eb39b43fed59992b85ea
-const expectedRenderedSurfaceSHA = "5b85be735c3d7d32e2bf6dce91c0e73435986c169234f2d72984617e9dc25a65"
+
+// Moved again by the trusted tenant semantic-version rollout (#3677). Exactly
+// two existing source objects change: the ascoachingogvaner and wedding-app
+// OCIRepositories replace one fixed ref.tag with ref.semver >=1.0.0. Their
+// Cosign verification provider, issuer and platform-bounded workflow subjects
+// remain unchanged, and the rendered guard rejects restoring a tag or digest.
+//
+// CONSERVATION, read from this validator under the SHA256-verified kubectl
+// v1.36.2 renderer: exactly this aggregate changed. It reported ZERO
+// `unapproved rendered <identity>`, ZERO `missing rendered authorization
+// resource` and ZERO `duplicate rendered`; every pinned per-resource identity
+// still passes. No Role, ClusterRole, binding, ServiceAccount, subject, verb,
+// wildcard, AWS identity or permission changes. The unresolved Flux
+// substitutions are the normal diagnostics emitted alongside an aggregate
+// mismatch.
+//
+// Previous aggregate: 5b85be735c3d7d32e2bf6dce91c0e73435986c169234f2d72984617e9dc25a65.
+const expectedRenderedSurfaceSHA = "814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
Tenant workload releases currently require a platform PR whenever Wedding App or AS Coaching publishes a new version. This makes the platform a per-release approval gate even though these tenants already publish signed artifacts and run inside platform-owned namespace, identity, network, and policy boundaries.

This change makes both tenant OCI sources follow signed stable releases with `semver: ">=1.0.0"`. It also extends the rendered-tree OCI guard so any first-party tenant `/manifests` source pinned by tag or digest fails CI; the platform's own source keeps its independent ref policy. Tenants can now release freely inside their existing capabilities, while requests for new access still require a platform boundary change.

The immediate rollout also consumes Wedding App v1.15.11, which expands its three CNPG PVCs from 1 GiB to 2 GiB and resolves devantler-tech/wedding-app#321.

Validation:
- RED: the guard accepted signed tenant manifest sources pinned by tag and digest
- GREEN: both pins are refused; signed semver tenant streams and the platform-source control pass
- `shellcheck scripts/guard-oci-repository-verify.sh scripts/tests/test-guard-oci-repository-verify.sh`
- `bash scripts/tests/test-guard-oci-repository-verify.sh`
- production render diff contains only the two OCIRepository ref-selector changes
- EKS CI authorization contract passes with every RBAC and ServiceAccount identity unchanged
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` started locally; hosted CI remains authoritative for the remote Helm-render pass
