### PR TITLE
fix(ghcr): recheck controls after an own-manifest 404

### DIFF
--- a/scripts/prove-scoped-package-access/README.md
+++ b/scripts/prove-scoped-package-access/README.md
@@ -50,6 +50,15 @@ authorization. No response text, headers, endpoints, package identities, digests
 or underlying error messages are printed. Metadata and full-download failures
 retain their fixed reason codes.
 
+An own-image manifest 404 gets one bounded diagnostic comparison: re-read the
+same digest with the baseline, repeat the candidate read, re-read the baseline,
+then revalidate the candidate's exact repository scope. A stable mismatch emits
+`scoped_own_manifest_not_visible_with_live_controls`. A failed baseline, changed
+candidate response, or unverified scope keeps its specific postcheck reason.
+Every outcome on this path remains UNKNOWN. The comparison establishes observed
+visibility only; it does not explain the authorization cause, prove a full
+candidate pull, or test the cross-package boundary.
+
 A missing image, throttling, server error, redirect or malformed response never
 counts as a successful restriction. A failed or unknown run does not authorize
 registry-authentication changes. The spike's result must be recorded before its

--- a/scripts/prove-scoped-package-access/main.go
+++ b/scripts/prove-scoped-package-access/main.go
@@ -225,18 +225,46 @@ func (p proof) result(code int, reason string, diagnostics ...registryDiagnostic
 	return code
 }
 
-// run compares immutable private packages with independent baseline and anonymous controls.
-func (p proof) run(ctx context.Context) int {
-	if p.baseline.username == "" || p.baseline.password == "" || p.scoped.password == "" || p.baseline.password == p.scoped.password {
-		return p.result(2, "independent_credentials_required")
-	}
+// repositoryScopeValid decodes a fresh response on every check: missing fields
+// must never inherit the identity verified by an earlier request.
+func (p proof) repositoryScopeValid(ctx context.Context) bool {
 	var scope struct {
 		TotalCount   int `json:"total_count"`
 		Repositories []struct {
 			FullName string `json:"full_name"`
 		} `json:"repositories"`
 	}
-	if !p.metadata(ctx, "/installation/repositories?per_page=100", p.scoped.password, &scope) || scope.TotalCount != 1 || len(scope.Repositories) != 1 || scope.Repositories[0].FullName != "devantler-tech/wedding-app" {
+	return p.metadata(ctx, "/installation/repositories?per_page=100", p.scoped.password, &scope) && scope.TotalCount == 1 && len(scope.Repositories) == 1 && scope.Repositories[0].FullName == "devantler-tech/wedding-app"
+}
+
+// diagnoseOwnNotFound brackets one repeated candidate read with independent
+// exact-digest controls. A stable 404 establishes a visibility mismatch only;
+// it does not identify the authorization cause or complete either proof half.
+func (p proof) diagnoseOwnNotFound(ctx context.Context, repository, digest string, original registryRead) int {
+	baseline := p.manifest(ctx, p.baseline, repository, digest)
+	if baseline.status != http.StatusOK {
+		return p.result(2, "baseline_postcheck_unavailable", baseline.diagnostic)
+	}
+	repeated := p.manifest(ctx, p.scoped, repository, digest)
+	if repeated.diagnostic != original.diagnostic {
+		return p.result(2, "scoped_own_postcheck_changed", repeated.diagnostic)
+	}
+	baseline = p.manifest(ctx, p.baseline, repository, digest)
+	if baseline.status != http.StatusOK {
+		return p.result(2, "baseline_postcheck_unavailable", baseline.diagnostic)
+	}
+	if !p.repositoryScopeValid(ctx) {
+		return p.result(2, "token_repository_scope_postcheck_unverified")
+	}
+	return p.result(2, "scoped_own_manifest_not_visible_with_live_controls", original.diagnostic)
+}
+
+// run compares immutable private packages with independent baseline and anonymous controls.
+func (p proof) run(ctx context.Context) int {
+	if p.baseline.username == "" || p.baseline.password == "" || p.scoped.password == "" || p.baseline.password == p.scoped.password {
+		return p.result(2, "independent_credentials_required")
+	}
+	if !p.repositoryScopeValid(ctx) {
 		return p.result(2, "token_repository_scope_unverified")
 	}
 	repositories := []string{"wedding-app", "ascoachingogvaner"}
@@ -273,6 +301,9 @@ func (p proof) run(ctx context.Context) int {
 	// A successful own pull includes the image's blobs, not just its manifest.
 	ownRead := p.manifest(ctx, p.scoped, repositories[0], digests[0])
 	ownStatus := ownRead.status
+	if ownRead.diagnostic == (registryDiagnostic{phase: "manifest", status: http.StatusNotFound, class: "http_status"}) {
+		return p.diagnoseOwnNotFound(ctx, repositories[0], digests[0], ownRead)
+	}
 	if ownStatus != 200 && !denied(ownStatus) {
 		return p.result(2, "scoped_own_read_unavailable", ownRead.diagnostic)
 	}
@@ -299,9 +330,7 @@ func (p proof) run(ctx context.Context) int {
 	}
 	// Rebind the installation identity too; otherwise two denied reads from an
 	// expired token would falsely refute an otherwise usable authentication path.
-	scope.TotalCount = 0
-	scope.Repositories = nil
-	if !p.metadata(ctx, "/installation/repositories?per_page=100", p.scoped.password, &scope) || scope.TotalCount != 1 || len(scope.Repositories) != 1 || scope.Repositories[0].FullName != "devantler-tech/wedding-app" {
+	if !p.repositoryScopeValid(ctx) {
 		return p.result(2, "token_repository_scope_postcheck_unverified")
 	}
 	if denied(ownStatus) {

--- a/scripts/prove-scoped-package-access/own_not_found_test.go
+++ b/scripts/prove-scoped-package-access/own_not_found_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// An own-image 404 must not bypass the controls needed to distinguish a
+// credential-specific visibility mismatch from image loss or a stale token.
+func TestOwnNotFoundRechecksLiveControls(t *testing.T) {
+	for _, tc := range []struct {
+		fault, reason string
+	}{
+		{"stable", "scoped_own_manifest_not_visible_with_live_controls"},
+		{"baseline-missing", "baseline_postcheck_unavailable"},
+		{"baseline-disappears-after-repeat", "baseline_postcheck_unavailable"},
+		{"scope-invalid", "token_repository_scope_postcheck_unverified"},
+		{"scope-empty", "token_repository_scope_postcheck_unverified"},
+		{"scope-partial", "token_repository_scope_postcheck_unverified"},
+		{"scope-wide", "token_repository_scope_postcheck_unverified"},
+		{"scope-foreign", "token_repository_scope_postcheck_unverified"},
+		{"candidate-recovers", "scoped_own_postcheck_changed"},
+		{"candidate-denied", "scoped_own_postcheck_changed"},
+		{"candidate-unavailable", "scoped_own_postcheck_changed"},
+		{"candidate-token-missing", "scoped_own_postcheck_changed"},
+	} {
+		t.Run(tc.fault, func(t *testing.T) {
+			const manifest = `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}`
+			digest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest)))
+			var candidateReads, baselineChecks, scopeChecks int
+			var trace []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/installation/repositories":
+					if r.Header.Get("Authorization") != "Bearer scoped-secret" {
+						t.Error("scope checked with the wrong identity")
+					}
+					if candidateReads > 0 {
+						scopeChecks++
+						trace = append(trace, "scope")
+						switch tc.fault {
+						case "scope-invalid":
+							w.WriteHeader(401)
+							return
+						case "scope-empty":
+							_, _ = fmt.Fprint(w, `{}`)
+							return
+						case "scope-partial":
+							_, _ = fmt.Fprint(w, `{"total_count":1}`)
+							return
+						case "scope-wide":
+							_, _ = fmt.Fprint(w, `{"total_count":2,"repositories":[{"full_name":"devantler-tech/wedding-app"},{"full_name":"devantler-tech/ascoachingogvaner"}]}`)
+							return
+						case "scope-foreign":
+							_, _ = fmt.Fprint(w, `{"total_count":1,"repositories":[{"full_name":"devantler-tech/ascoachingogvaner"}]}`)
+							return
+						}
+					}
+					_, _ = fmt.Fprint(w, `{"total_count":1,"repositories":[{"full_name":"devantler-tech/wedding-app"}]}`)
+				case strings.HasPrefix(r.URL.Path, "/orgs/devantler-tech/packages/container/"):
+					repository := strings.TrimPrefix(r.URL.Path, "/orgs/devantler-tech/packages/container/")
+					_, _ = fmt.Fprintf(w, `{"name":%q,"package_type":"container","visibility":"private","owner":{"login":"devantler-tech"},"repository":{"full_name":%q}}`, repository, "devantler-tech/"+repository)
+				case r.URL.Path == "/token":
+					_, secret, _ := r.BasicAuth()
+					if secret == "scoped-secret" && candidateReads > 0 && tc.fault == "candidate-token-missing" {
+						w.WriteHeader(404)
+						return
+					}
+					if secret == "" {
+						w.WriteHeader(401)
+						_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED"}]}`)
+						return
+					}
+					_, _ = fmt.Fprintf(w, `{"token":%q}`, secret)
+				case strings.Contains(r.URL.Path, "/manifests/"):
+					identity := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+					if identity == "scoped-secret" {
+						if r.URL.Path != "/v2/devantler-tech/wedding-app/manifests/"+digest {
+							t.Errorf("candidate read escaped the own immutable image: %s", r.URL.Path)
+						}
+						candidateReads++
+						trace = append(trace, "candidate")
+						if candidateReads > 1 {
+							switch tc.fault {
+							case "candidate-recovers":
+								_, _ = fmt.Fprint(w, manifest)
+								return
+							case "candidate-denied":
+								w.WriteHeader(403)
+								_, _ = fmt.Fprint(w, `{"errors":[{"code":"DENIED"}]}`)
+								return
+							case "candidate-unavailable":
+								w.WriteHeader(503)
+								return
+							}
+						}
+						w.WriteHeader(404)
+						_, _ = fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"scoped-secret baseline-secret ::error::untrusted"}]}`)
+						return
+					}
+					if candidateReads > 0 {
+						baselineChecks++
+						trace = append(trace, "baseline")
+						if identity != "baseline-secret" || r.URL.Path != "/v2/devantler-tech/wedding-app/manifests/"+digest {
+							t.Error("postcheck did not use the independent baseline and exact own digest")
+						}
+						if tc.fault == "baseline-missing" || (candidateReads > 1 && tc.fault == "baseline-disappears-after-repeat") {
+							w.WriteHeader(404)
+							return
+						}
+					}
+					_, _ = fmt.Fprint(w, manifest)
+				default:
+					t.Errorf("unexpected request: %s", r.URL.Path)
+					w.WriteHeader(404)
+				}
+			}))
+			defer server.Close()
+			var output bytes.Buffer
+			p := proof{apiURL: server.URL, registryURL: server.URL, client: restrictedClient(), output: &output,
+				baseline: credential{"baseline-user", "baseline-secret"}, scoped: credential{"x-access-token", "scoped-secret"},
+				pull: func(_ context.Context, auth credential, image string) error {
+					if auth.password != "baseline-secret" || !strings.HasSuffix(image, "@"+digest) {
+						t.Error("404 path attempted an unproven candidate pull or mutable image")
+					}
+					return nil
+				}}
+			if got := p.run(context.Background()); got != 2 {
+				t.Errorf("own 404 became a conclusive verdict: %d", got)
+			}
+			if !strings.Contains(output.String(), "reason="+tc.reason) {
+				t.Errorf("missing controlled diagnosis %q: %s", tc.reason, output.String())
+			}
+			if tc.fault == "stable" {
+				if candidateReads != 2 || baselineChecks != 2 || scopeChecks != 1 || strings.Join(trace, ",") != "candidate,baseline,candidate,baseline,scope" {
+					t.Errorf("stable result lacked bounded, bracketed live controls: %v", trace)
+				}
+				if !strings.Contains(output.String(), "registry_phase=manifest http_status=404 failure_class=http_status") {
+					t.Errorf("lost original safe diagnosis: %s", output.String())
+				}
+			}
+			for _, forbidden := range []string{"secret", "::error::", server.URL} {
+				if strings.Contains(output.String(), forbidden) {
+					t.Errorf("raw data leaked in proof result: %s", output.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

An own-image manifest 404 currently stops the scoped-package experiment before it can check whether its baseline is still available. That leaves image disappearance and credential-specific visibility indistinguishable.

Recheck the same immutable image around one repeated candidate read, then verify the candidate still has exactly the intended repository scope. The result identifies stable visibility mismatches and failed controls while preserving UNKNOWN and the existing migration gate.

Fixes #3681.
Part of #3274; the experiment remains open until both authorization directions are proved.

