### PR TITLE
fix(talos): collect unused images before storage warns

### DIFF
--- a/talos/cluster/gc-unused-images-before-pressure.yaml
+++ b/talos/cluster/gc-unused-images-before-pressure.yaml
@@ -1,0 +1,22 @@
+# Keep container image garbage collection ahead of the platform's storage
+# warning boundary.
+#
+# Kubelet defaults to collecting above 85% image-filesystem use and stopping at
+# 80%. Coroot warns at 80%, and Longhorn can stop scheduling replicas before the
+# kubelet's default trigger because both share /var on the static workers. That
+# leaves a node indefinitely warning and its Longhorn disk unschedulable while
+# months of superseded workload images remain locally cached.
+#
+# Start at 75% and reclaim to 70%. The five-point hysteresis matches kubelet's
+# default gap, while the lower boundary leaves ten percentage points before the
+# Coroot warning and room for Longhorn replica growth. This is a cluster patch,
+# so new static and autoscaled nodes inherit the same protection.
+#
+# No maximum image age is set: recently unused images remain cached while space
+# is healthy, and kubelet selects reclaim candidates only when the shared
+# filesystem crosses this capacity guard.
+machine:
+  kubelet:
+    extraConfig:
+      imageGCHighThresholdPercent: 75
+      imageGCLowThresholdPercent: 70


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

The kubelet's default image-GC trigger sits above the platform storage warning boundary, allowing superseded workload images to keep a node warning while Longhorn refuses further replica scheduling. This adds a shared Talos patch that starts image collection at 75% and reclaims to 70%, preserving kubelet's five-point hysteresis and applying the guard to existing and future nodes.

Validation:

- RED: the threshold assertion failed because no declarative patch existed.
- GREEN: the policy asserts below the warning boundary with low < high.
- Checksum-verified Talos 1.13.9 rendered and validated the complete patch stack for both control-plane and worker machine configurations.
- Both rendered roles carry the exact 75/70 settings.

Closes #3683
