### PR TITLE
fix(backup): stage dedicated wedding backup credentials and verification

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -10,6 +10,10 @@ description: >-
   secret is passed in as an input.
 
 inputs:
+  verify-wedding-backup-staging:
+    description: Compare the staged dedicated wedding backup credential during an opted-in manual deployment.
+    required: false
+    default: "false"
   sops-age-key:
     description: SOPS Age private key (secrets.SOPS_AGE_KEY) for decrypting SOPS-encrypted manifests.
     required: true
@@ -296,6 +300,26 @@ runs:
       env:
         PLATFORM_MANIFEST_DIGEST: ${{ steps.publish_platform_manifest.outputs.digest }}
       run: ./scripts/wait-for-platform-flux-revision.sh "${PLATFORM_MANIFEST_DIGEST}"
+
+    - name: Verify staged wedding backup credential
+      id: verify_wedding_backup_staging
+      shell: bash
+      env:
+        WEDDING_BACKUP_VERIFY: ${{ inputs.verify-wedding-backup-staging }}
+        WEDDING_BACKUP_PUBLISH_RESULT: ${{ steps.publish_platform_manifest.outcome }}
+        WEDDING_BACKUP_WAIT_RESULT: ${{ steps.wait_flux_revision.outcome }}
+        WEDDING_BACKUP_DIGEST: ${{ steps.publish_platform_manifest.outputs.digest }}
+        # Approved encrypted input and its bootstrap resource membership.
+        WEDDING_BACKUP_CIPHER_SHA256: d6bb515a499858776b042800164b8804ca1685c7f6f8e500d91eaf5e8380b906
+        WEDDING_BACKUP_BOOTSTRAP_SHA256: ce03b858d87dd669a5a67c552af6f85790f8ebb57f535c066fd3b62c60a4eda7
+      run: |
+        if [[ "${WEDDING_BACKUP_VERIFY}" == "false" || -z "${WEDDING_BACKUP_VERIFY}" ]]; then
+          exit 0
+        fi
+        WEDDING_BACKUP_KUBECTL_BIN="$(command -v kubectl)"
+        WEDDING_BACKUP_GIT_BIN="$(command -v git)"
+        export WEDDING_BACKUP_KUBECTL_BIN WEDDING_BACKUP_GIT_BIN
+        node scripts/verify-wedding-backup-staging.mjs
 
     - name: 🧪 Verify the Longhorn UI baseline canary
       id: verify_longhorn_ui_baseline

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,12 @@ name: CD
 # re-deployed what the merge queue had already shipped.)
 on:
   workflow_dispatch:
+    inputs:
+      verify-wedding-backup-staging:
+        description: Verify the staged dedicated wedding backup credential after deployment
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -312,6 +318,7 @@ jobs:
         uses: ./.github/actions/deploy-prod
         with:
           sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+          verify-wedding-backup-staging: ${{ inputs.verify-wedding-backup-staging }}
           kube-config: ${{ secrets.KUBE_CONFIG }}
           talos-config: ${{ secrets.TALOS_CONFIG }}
           ghcr-token: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,12 @@ jobs:
           shellcheck scripts/tests/test-rgd-template-static-scan-wiring.sh
           bash scripts/tests/test-rgd-template-static-scan-wiring.sh
 
+      - name: Validate dedicated wedding backup staging
+        run: |
+          node --version
+          yq --version
+          node --test tests/wedding-backup-staging/*.test.mjs
+
       - name: 🔍 Filter paths
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter

--- a/k8s/bases/apps/wedding-app/external-secret-db-backup-dedicated.yaml
+++ b/k8s/bases/apps/wedding-app/external-secret-db-backup-dedicated.yaml
@@ -1,0 +1,32 @@
+# Stage the bucket-scoped backup identity independently of the active ObjectStore.
+# The current backup credential remains available while this projection is verified.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wedding-db-backup-r2-dedicated
+  namespace: wedding-app
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: wedding-db-backup-r2-dedicated
+    creationPolicy: Owner
+    template:
+      data:
+        ACCESS_KEY_ID: "{{ .ACCESS_KEY_ID }}"
+        SECRET_ACCESS_KEY: "{{ .SECRET_ACCESS_KEY }}"
+        REGION: "auto"
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: apps/wedding-app/backup/r2
+        property: access_key_id
+    - secretKey: SECRET_ACCESS_KEY
+      remoteRef:
+        key: apps/wedding-app/backup/r2
+        property: secret_access_key

--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
   # own CiliumNetworkPolicy (networkpolicy.yaml) and namespaced SecretStore now
   # live in the tenant repo's deploy/.
   - external-secret-db-backup.yaml
+  # The dedicated identity is staged separately; ObjectStore still uses the
+  # existing projection until the new credential and destination are verified.
+  - external-secret-db-backup-dedicated.yaml
   - object-store.yaml
   - external-secret-ghcr-auth.yaml
   - namespace.yaml

--- a/k8s/bases/infrastructure/vault-seed/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-seed/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - external-secret-generated-crossview-admin-password.yaml
   - push-secret-push-crossview-admin-password.yaml
   - push-secret-seed-r2-credentials.yaml
+  - push-secret-seed-wedding-db-backup-r2.yaml
   - push-secret-seed-github-app.yaml
   - push-secret-seed-ghcr.yaml
   - push-secret-seed-dex-client-secret.yaml

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-wedding-db-backup-r2.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-wedding-db-backup-r2.yaml
@@ -1,0 +1,27 @@
+# Seed the dedicated database-backup credential from the environment's SOPS
+# bootstrap Secret. Periodic refresh restores this path after OpenBao data loss.
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: seed-wedding-db-backup-r2
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: wedding-db-backup-r2-bootstrap
+  data:
+    - match:
+        secretKey: access_key_id  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
+        remoteRef:
+          remoteKey: apps/wedding-app/backup/r2
+          property: access_key_id
+    - match:
+        secretKey: secret_access_key  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
+        remoteRef:
+          remoteKey: apps/wedding-app/backup/r2
+          property: secret_access_key

--- a/k8s/clusters/local/bootstrap/kustomization.yaml
+++ b/k8s/clusters/local/bootstrap/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ../../../providers/docker/bootstrap
   - config-map.yaml
   - secret.enc.yaml
+  - secret-wedding-db-backup-r2.enc.yaml

--- a/k8s/clusters/local/bootstrap/secret-wedding-db-backup-r2.enc.yaml
+++ b/k8s/clusters/local/bootstrap/secret-wedding-db-backup-r2.enc.yaml
@@ -1,0 +1,25 @@
+{
+	"apiVersion": "v1",
+	"kind": "Secret",
+	"metadata": {
+		"name": "wedding-db-backup-r2-bootstrap",
+		"namespace": "flux-system"
+	},
+	"type": "Opaque",
+	"stringData": {
+		"access_key_id": "ENC[AES256_GCM,data:1hEqsdVx+9kX3Xv5PBK8jSJtEVdXqTc=,iv:jyilTSNoaORS0duxP9TxtwBfg/0qyHdzP92SHx8dlrU=,tag:CILuIl0V8AvMM9DA89XApA==,type:str]",
+		"secret_access_key": "ENC[AES256_GCM,data:Tx7vsopWTsXmsfMv/4E6Ee4pKbxFuPNprc2+i3uBavt/AiiXhg==,iv:w7uyAAzIk4HXwemOg4f3EiUsi7+nFni38gcXc96mL5Y=,tag:4cd/qbuNwep5St/m73yrYw==,type:str]"
+	},
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4bTNlRi81VUhhQTd1ajRN\nMStLQU51RUVwUFlNak50RjhtOURWWkhQUlVNClRHamY3b2JxUkhEdlhVK3k0VjJ1\nUGtNeFZCRVVYNWNFRFR0M3pYQ01oNnMKLS0tIDc4cTdBc0lDM25rRGpYODV4Q3ZU\naDFTTmtLZmZ2VGwrWFlqMzZ5UjRJUkkKkCeH1KPHPuNbvsOuFB63CeyomKJ0RP99\n4P6eV6WqR8mZFvCsmpHPs+SCmcRbfkvmbk9sXJGxrmZhE8S264C2WA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq"
+			}
+		],
+		"encrypted_regex": "^(data|stringData)$",
+		"lastmodified": "2026-09-08T09:50:10Z",
+		"mac": "ENC[AES256_GCM,data:c1lxgFMTH/IeiwNebHQUpa8wB1GlGTxcAEKFapr63WcgTe9qKHdqd+u2NQt7DtViT0/sAJLe0Qi5LWzw7MRqlRAi5W07uQq5wJ0ke4bIuC0ceFOXkip4oeM0aiCL5XrWcfOPcRDvMXdoyAr5bYVOE/lX2oNKO5t5KU1kqEoG6Oo=,iv:/Tmecr2MkRG9zxbjn5hub68Fn6HVZMkL3Id9R3PNvpY=,tag:PgFgY9fC76dmZSLaA482tw==,type:str]",
+		"version": "3.13.3"
+	}
+}

--- a/k8s/clusters/prod/bootstrap/kustomization.yaml
+++ b/k8s/clusters/prod/bootstrap/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ../../../providers/hetzner/bootstrap
   - config-map.yaml
   - secret.enc.yaml
+  - secret-wedding-db-backup-r2.enc.yaml

--- a/k8s/clusters/prod/bootstrap/secret-wedding-db-backup-r2.enc.yaml
+++ b/k8s/clusters/prod/bootstrap/secret-wedding-db-backup-r2.enc.yaml
@@ -1,0 +1,25 @@
+{
+	"apiVersion": "v1",
+	"kind": "Secret",
+	"metadata": {
+		"name": "wedding-db-backup-r2-bootstrap",
+		"namespace": "flux-system"
+	},
+	"type": "Opaque",
+	"stringData": {
+		"access_key_id": "ENC[AES256_GCM,data:TCaeXHYqGfAXHaudeKByZTU7n0LEyRA9Cj7Ok46vEjA=,iv:H1t2cUsh8Ly3ENbriWx7xRHlWGE0Lwi14s65egEGbsI=,tag:bym55WvmwlcD/7LrFci6zA==,type:str]",
+		"secret_access_key": "ENC[AES256_GCM,data:V01BNq4ix3fKB/Gb2MWKirtK9GOHA6UZ2helo7AeK9xtFMCFTNjxVhoDPuq0cG1vTsbvHoimNXS15qpt+k0Gww==,iv:UptMk5HBS9uopPsTqryit4+cAWg6XPQfov7ha6pRdwA=,tag:4+0hcKGCWEDa2+q8vpTzXg==,type:str]"
+	},
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSd0pXZXpYdEdLZHcxVUp6\nRnBLRVhrWlZMMUFZY3NMT05TUmRJUG1hUXhFClc2Wnkxdk9wUFRqRWlDNWxrbUp5\na0lkdy9MMGV1U3JUVjJvbW1NUHRWOW8KLS0tIFM2Sndxck0rRGVnWlhFRTJWYWhw\nZXdxbmlPVHJYcVptTUZLRDUxUFUzTUUKqsPUUuD3CZ3rc1Cv06uHX9xtGqD/KsvI\nfCoxK0Qbc0bSzodeBmTwtJEJUuEDEQzAISLVDs3Q/mzcZdAMwA1gJw==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6"
+			}
+		],
+		"encrypted_regex": "^(data|stringData)$",
+		"lastmodified": "2026-09-08T11:08:35Z",
+		"mac": "ENC[AES256_GCM,data:TYuOu1vHF/9rIHv16BCdvkKXvQ9GZglJTnTL/j1M8WKQKk8nueZnF4KbOwg3JuGKT9yd3Lijeva/2vmnSYsgYp9O8R2ejU8MD1A0JGM9AjZQFbjXulA1OmFKOS0B+IDbnzdzaTR5DqJuKlU0QC0b7NEfzfwDtbiopjwwsvn2+2M=,iv:alyN5TrVtZaotewP1UpPuGWDxo1JKokj05XEhr2vL2s=,tag:9rPnIAjP6r8QKzk1ahAfSA==,type:str]",
+		"version": "3.13.3"
+	}
+}

--- a/scripts/verify-wedding-backup-staging.mjs
+++ b/scripts/verify-wedding-backup-staging.mjs
@@ -8,6 +8,9 @@ export async function run(env){
  try{
   if(env.WEDDING_BACKUP_VERIFY!=='true'||env.WEDDING_BACKUP_PUBLISH_RESULT!=='success'||env.WEDDING_BACKUP_WAIT_RESULT!=='success')throw Error('refused');
   const workspace=await realpath(env.GITHUB_WORKSPACE),recipeDirectory=await realpath(path.dirname(fileURLToPath(import.meta.url)));
+  // CD's default checkout publishes GITHUB_SHA. Preserve that event identity;
+  // the source guard refuses a different workflow revision instead of claiming
+  // that GITHUB_WORKFLOW_SHA was the checkout which produced the artifact.
   const options={enabled:true,sourceSha:env.GITHUB_SHA,recipeSha:env.GITHUB_WORKFLOW_SHA,digest:env.WEDDING_BACKUP_DIGEST};
   const sourceUnchanged=await createSourceGuard({workspace,recipeDirectory,sourceSha:options.sourceSha,recipeSha:options.recipeSha,cipherSha:env.WEDDING_BACKUP_CIPHER_SHA256,bootstrapSha:env.WEDDING_BACKUP_BOOTSTRAP_SHA256,git:await realpath(env.WEDDING_BACKUP_GIT_BIN)});
   const result=await verifyProjection(options,{

--- a/scripts/verify-wedding-backup-staging.mjs
+++ b/scripts/verify-wedding-backup-staging.mjs
@@ -1,0 +1,24 @@
+import {fileURLToPath} from 'node:url';
+import {realpath} from 'node:fs/promises';
+import path from 'node:path';
+import {verifyProjection} from './wedding-backup-projection.mjs';
+import {createReader,createSourceGuard} from './wedding-backup-io.mjs';
+export async function run(env){
+ if(env.WEDDING_BACKUP_VERIFY===undefined||env.WEDDING_BACKUP_VERIFY==='false')return {code:0,result:{verified:false,skipped:true}};
+ try{
+  if(env.WEDDING_BACKUP_VERIFY!=='true'||env.WEDDING_BACKUP_PUBLISH_RESULT!=='success'||env.WEDDING_BACKUP_WAIT_RESULT!=='success')throw Error('refused');
+  const workspace=await realpath(env.GITHUB_WORKSPACE),recipeDirectory=await realpath(path.dirname(fileURLToPath(import.meta.url)));
+  const options={enabled:true,sourceSha:env.GITHUB_SHA,recipeSha:env.GITHUB_WORKFLOW_SHA,digest:env.WEDDING_BACKUP_DIGEST};
+  const sourceUnchanged=await createSourceGuard({workspace,recipeDirectory,sourceSha:options.sourceSha,recipeSha:options.recipeSha,cipherSha:env.WEDDING_BACKUP_CIPHER_SHA256,bootstrapSha:env.WEDDING_BACKUP_BOOTSTRAP_SHA256,git:await realpath(env.WEDDING_BACKUP_GIT_BIN)});
+  const result=await verifyProjection(options,{
+   invocation:{repository:env.GITHUB_REPOSITORY,event:env.GITHUB_EVENT_NAME,ref:env.GITHUB_REF,sha:env.GITHUB_SHA,checkout:env.GITHUB_SHA,attempt:env.GITHUB_RUN_ATTEMPT,run:env.GITHUB_RUN_ID,workflowRef:env.GITHUB_WORKFLOW_REF,workflowSha:env.GITHUB_WORKFLOW_SHA},
+   sourceUnchanged,
+   read:createReader({kubectl:await realpath(env.WEDDING_BACKUP_KUBECTL_BIN),kubeconfig:path.join(env.HOME,'.kube/config')})
+  });
+  if(!result.verified)return {code:2,result:{verified:false}};
+  return{code:0,result:{...result,sourceSha:options.sourceSha,digest:options.digest,run:env.GITHUB_RUN_ID}};
+ }catch{return {code:2,result:{verified:false}};}
+}
+if(process.argv[1]===fileURLToPath(import.meta.url)){
+ const {code,result}=await run(process.env);process.stdout.write(JSON.stringify(result)+'\n');process.exitCode=code;
+}

--- a/scripts/wedding-backup-io.mjs
+++ b/scripts/wedding-backup-io.mjs
@@ -1,0 +1,59 @@
+import {spawn} from 'node:child_process';
+import {readFile,lstat,realpath} from 'node:fs/promises';
+import {createHash} from 'node:crypto';
+import path from 'node:path';
+import {targets} from './wedding-backup-projection.mjs';
+const check=x=>{if(!x)throw Error('refused');};
+const hash=b=>createHash('sha256').update(b).digest('hex');
+
+// Bounded stdout stays inside the caller; child diagnostics never reach a log.
+export function capture(command,args,{env,timeout=25000,maxBytes=262144}={}){
+ return new Promise((resolve,reject)=>{
+  const child=spawn(command,args,{shell:false,env,stdio:['ignore','pipe','ignore']});
+  const chunks=[];let size=0,failed=false;
+  const refuse=()=>{failed=true;child.kill('SIGKILL');};
+  const timer=setTimeout(refuse,timeout);
+  child.stdout.on('data',b=>{size+=b.length;if(size>maxBytes){b.fill(0);refuse();}else chunks.push(b);});
+  child.on('error',()=>{clearTimeout(timer);for(const b of chunks)b.fill(0);reject(Error('subprocess_refused'));});
+  child.on('close',code=>{clearTimeout(timer);const out=Buffer.concat(chunks);for(const b of chunks)b.fill(0);if(failed||code!==0){out.fill(0);reject(Error('subprocess_refused'));}else resolve(out);});
+ });
+}
+export function createReader({kubectl,kubeconfig}){
+ return async requested=>{
+  let out;
+  try{
+   const t=targets.find(x=>x.id===requested.id);check(t&&path.isAbsolute(kubectl)&&path.isAbsolute(kubeconfig));
+   check(await realpath(kubectl)===kubectl&&(await lstat(kubectl)).isFile());
+   out=await capture(kubectl,['--kubeconfig',kubeconfig,'--context','admin@prod','--namespace',t.namespace,'get',t.resource,t.name,'--output=json','--request-timeout=20s'],{env:{PATH:'/usr/bin:/bin'},maxBytes:t.kind==='Secret'?32768:262144});
+   const object=JSON.parse(out.toString('utf8'));check(object&&typeof object==='object'&&!Array.isArray(object));return object;
+  }catch{throw Error('read_refused');}finally{out?.fill(0);}
+ };
+}
+
+const cipher='k8s/clusters/prod/bootstrap/secret-wedding-db-backup-r2.enc.yaml';
+const bootstrap='k8s/clusters/prod/bootstrap/kustomization.yaml';
+const recipes=['wedding-backup-projection.mjs','wedding-backup-io.mjs','verify-wedding-backup-staging.mjs'];
+export async function createSourceGuard({workspace,recipeDirectory,sourceSha,recipeSha,cipherSha,bootstrapSha,git}){
+ return async()=>{
+  const captured=[];
+  try{
+   check([sourceSha,recipeSha].every(x=>/^[a-f0-9]{40}$/.test(x))&&[cipherSha,bootstrapSha].every(x=>/^[a-f0-9]{64}$/.test(x)));
+   // This invocation publishes the same checkout from which the helper runs.
+   // A different-source recipe needs a separately reviewed route, never inference.
+   check(sourceSha===recipeSha&&await realpath(workspace)===workspace&&await realpath(recipeDirectory)===path.join(workspace,'scripts')&&await realpath(git)===git);
+   const run=async args=>{const b=await capture(git,['--no-replace-objects','-C',workspace,...args],{env:{PATH:'/usr/bin:/bin',GIT_NO_REPLACE_OBJECTS:'1'},maxBytes:262144});captured.push(b);return b;};
+   check((await run(['rev-parse','HEAD'])).toString().trim()===sourceSha);
+   for(const relative of [cipher,bootstrap,...recipes.map(x=>'scripts/'+x)]){
+    const filename=path.join(workspace,relative),s=await lstat(filename);
+    check(s.isFile()&&!s.isSymbolicLink()&&s.size>0&&s.size<=262144&&await realpath(filename)===filename);
+    const local=await readFile(filename);captured.push(local);
+    const committed=await run(['show',sourceSha+':'+relative]);check(local.equals(committed));
+    const entry=(await run(['ls-tree',sourceSha,'--',relative])).toString();
+    const mode=entry.split(' ')[0];check(mode===(s.mode&0o111?'100755':'100644'));
+    if(relative===cipher)check(hash(local)===cipherSha);
+    if(relative===bootstrap)check(hash(local)===bootstrapSha);
+   }
+   return true;
+  }catch{return false;}finally{for(const b of captured)b.fill(0);}
+ };
+}

--- a/scripts/wedding-backup-projection.mjs
+++ b/scripts/wedding-backup-projection.mjs
@@ -1,0 +1,112 @@
+import { timingSafeEqual } from 'node:crypto';
+
+export const targets = [
+  ['source','source.toolkit.fluxcd.io/v1','OCIRepository','ocirepositories.source.toolkit.fluxcd.io','flux-system','flux-system',null],
+  ...['bootstrap','infrastructure','apps'].map(x => [x,'kustomize.toolkit.fluxcd.io/v1','Kustomization','kustomizations.kustomize.toolkit.fluxcd.io','flux-system',x,null]),
+  ['seed','external-secrets.io/v1alpha1','PushSecret','pushsecrets.external-secrets.io','flux-system','seed-wedding-db-backup-r2','infrastructure'],
+  ['projection','external-secrets.io/v1','ExternalSecret','externalsecrets.external-secrets.io','wedding-app','wedding-db-backup-r2-dedicated','apps'],
+  ['active','barmancloud.cnpg.io/v1','ObjectStore','objectstores.barmancloud.cnpg.io','wedding-app','wedding-db','apps'],
+  ['bootstrapSecret','v1','Secret','secrets','flux-system','wedding-db-backup-r2-bootstrap','bootstrap'],
+  ['projectedSecret','v1','Secret','secrets','wedding-app','wedding-db-backup-r2-dedicated',null],
+].map(([id,apiVersion,kind,resource,namespace,name,owner]) => ({id,apiVersion,kind,resource,namespace,name,owner}));
+
+const check = condition => { if (!condition) throw Error('refused'); };
+const keys = (obj, expected) => check(obj && typeof obj === 'object' && !Array.isArray(obj) && Object.keys(obj).sort().join(',') === [...expected].sort().join(','));
+const equal = (a, b) => { const x = Buffer.from(a), y = Buffer.from(b); try { return x.length === y.length && timingSafeEqual(x, y); } finally { x.fill(0); y.fill(0); } };
+function ready(obj, generation = false) {
+  check(obj.status?.conditions?.filter(x => x.type === 'Ready' && x.status === 'True').length === 1);
+  check(!obj.spec?.suspend && !obj.metadata.deletionTimestamp);
+  if (generation) check(obj.status.observedGeneration === obj.metadata.generation);
+}
+function metadata(obj, target) {
+  check(obj?.apiVersion === target.apiVersion && obj.kind === target.kind);
+  const m = obj.metadata;
+  check(m?.namespace === target.namespace && m.name === target.name && !m.deletionTimestamp);
+  check(/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(m.uid));
+  check(/^[1-9][0-9]*$/.test(m.resourceVersion));
+  // Secrets do not carry a generation; controller resources do.
+  if (target.kind !== 'Secret') check(Number.isSafeInteger(m.generation) && m.generation > 0);
+  if (target.owner) check(m.labels?.['kustomize.toolkit.fluxcd.io/name'] === target.owner && m.labels?.['kustomize.toolkit.fluxcd.io/namespace'] === 'flux-system');
+  return { namespace: target.namespace, kind: target.kind, name: target.name, uid: m.uid, resourceVersion: m.resourceVersion, ...(target.kind === 'Secret' ? {} : { generation: m.generation }) };
+}
+function decode(value, expression) {
+  check(typeof value === 'string' && value.length <= 256);
+  const bytes = Buffer.from(value, 'base64');
+  try { check(bytes.toString('base64') === value); const decoded = bytes.toString('utf8'); check(expression.test(decoded)); return decoded; }
+  finally { bytes.fill(0); }
+}
+function pair(bootstrap, projected) {
+  check(bootstrap.type === 'Opaque' && projected.type === 'Opaque');
+  check(!bootstrap.stringData && !projected.stringData);
+  keys(bootstrap.data, ['access_key_id','secret_access_key']);
+  keys(projected.data, ['ACCESS_KEY_ID','SECRET_ACCESS_KEY','REGION']);
+  const source = { access_key_id: decode(bootstrap.data.access_key_id, /^[a-f0-9]{32}$/), secret_access_key: decode(bootstrap.data.secret_access_key, /^[a-f0-9]{64}$/) };
+  const result = { access_key_id: decode(projected.data.ACCESS_KEY_ID, /^[a-f0-9]{32}$/), secret_access_key: decode(projected.data.SECRET_ACCESS_KEY, /^[a-f0-9]{64}$/) };
+  check(decode(projected.data.REGION, /^auto$/) === 'auto');
+  check(equal(source.access_key_id, result.access_key_id) && equal(source.secret_access_key, result.secret_access_key));
+  return result;
+}
+function validateControllers(d, options) {
+  ready(d.source, true);
+  check(d.source.spec.url === 'oci://ghcr.io/devantler-tech/platform/manifests' && d.source.spec.ref?.tag === 'latest' && d.source.spec.verify?.provider === 'cosign');
+  check(d.source.status.artifact?.revision === `latest@${options.digest}`);
+  check(d.source.status.conditions.filter(x => x.type === 'SourceVerified' && x.status === 'True').length === 1);
+  for (const [name, path] of Object.entries({ bootstrap: 'clusters/prod/bootstrap', infrastructure: 'providers/hetzner/infrastructure', apps: 'providers/hetzner/apps' })) {
+    const obj = d[name]; ready(obj, true);
+    check(obj.spec.sourceRef?.kind === 'OCIRepository' && obj.spec.sourceRef.name === 'flux-system' && (!obj.spec.sourceRef.namespace || obj.spec.sourceRef.namespace === 'flux-system'));
+    check(obj.spec.path === path && obj.status.lastAppliedRevision === `latest@${options.digest}`);
+  }
+  ready(d.seed); ready(d.projection);
+  const seed = d.seed.spec, projection = d.projection.spec;
+  check(seed.selector?.secret?.name === 'wedding-db-backup-r2-bootstrap' && !seed.selector.generatorRef);
+  check(seed.secretStoreRefs?.length === 1 && seed.secretStoreRefs[0].name === 'openbao' && seed.secretStoreRefs[0].kind === 'ClusterSecretStore');
+  check(seed.data?.length === 2);
+  for (const key of ['access_key_id', 'secret_access_key']) check(seed.data.filter(x => x.match?.secretKey === key && x.match.remoteRef?.remoteKey === 'apps/wedding-app/backup/r2' && x.match.remoteRef.property === key).length === 1);
+  check(!seed.template && !seed.pushSecretRef);
+  check(projection.secretStoreRef?.name === 'openbao' && projection.secretStoreRef.kind === 'ClusterSecretStore');
+  check(projection.target?.name === 'wedding-db-backup-r2-dedicated' && projection.target.creationPolicy === 'Owner');
+  keys(projection.target.template?.data, ['ACCESS_KEY_ID','SECRET_ACCESS_KEY','REGION']);
+  check(projection.target.template.data.ACCESS_KEY_ID === '{{ .ACCESS_KEY_ID }}' && projection.target.template.data.SECRET_ACCESS_KEY === '{{ .SECRET_ACCESS_KEY }}' && projection.target.template.data.REGION === 'auto');
+  check(!projection.dataFrom && !projection.target.template.templateFrom && !projection.target.template.stringData);
+  check(projection.data?.length === 2);
+  for (const [key, property] of [['ACCESS_KEY_ID','access_key_id'], ['SECRET_ACCESS_KEY','secret_access_key']]) check(projection.data.filter(x => x.secretKey === key && x.remoteRef?.key === 'apps/wedding-app/backup/r2' && x.remoteRef.property === property).length === 1);
+  const active = d.active.spec.configuration;
+  check(active?.destinationPath === 's3://platform-backups/cnpg/wedding-db');
+  for (const [key, value] of [['accessKeyId','ACCESS_KEY_ID'],['secretAccessKey','SECRET_ACCESS_KEY'],['region','REGION']]) check(active.s3Credentials?.[key]?.name === 'wedding-db-backup-r2' && active.s3Credentials[key].key === value);
+}
+async function snapshot(options, deps) {
+  const docs = {}, identities = {};
+  // Controller/source refusals happen before either Secret read.
+  for (const target of targets.filter(t => t.kind !== 'Secret')) {
+    docs[target.id] = await deps.read(target); identities[target.id] = metadata(docs[target.id], target);
+  }
+  validateControllers(docs, options);
+  for (const target of targets.filter(t => t.kind === 'Secret')) {
+    docs[target.id] = await deps.read(target); identities[target.id] = metadata(docs[target.id], target);
+  }
+  const owners = docs.projectedSecret.metadata.ownerReferences;
+  check(owners?.length === 1 && owners[0].apiVersion === 'external-secrets.io/v1' && owners[0].kind === 'ExternalSecret' && owners[0].name === 'wedding-db-backup-r2-dedicated' && owners[0].uid === docs.projection.metadata.uid && owners[0].controller === true);
+  return { identities, credential: pair(docs.bootstrapSecret, docs.projectedSecret) };
+}
+function stable(a, b) {
+  check(JSON.stringify(a.identities) === JSON.stringify(b.identities));
+  check(equal(a.credential.access_key_id, b.credential.access_key_id) && equal(a.credential.secret_access_key, b.credential.secret_access_key));
+}
+export async function verifyProjection(options, deps) {
+  if(options.enabled === undefined || options.enabled === false || options.enabled === 'false') return {verified:false, skipped:true};
+  try {
+    check(options.enabled === true || options.enabled === 'true');
+    const i = deps.invocation;
+    check(/^[a-f0-9]{40}$/.test(options.sourceSha) && /^[a-f0-9]{40}$/.test(options.recipeSha) && /^sha256:[a-f0-9]{64}$/.test(options.digest));
+    check(i.repository === 'devantler-tech/platform' && i.event === 'workflow_dispatch' && i.ref === 'refs/heads/main' && i.sha === options.recipeSha && i.checkout === options.recipeSha && i.attempt === '1' && /^[1-9][0-9]*$/.test(i.run));
+    check(i.workflowRef === 'devantler-tech/platform/.github/workflows/cd.yaml@refs/heads/main' && i.workflowSha === options.recipeSha);
+    // The trusted same-job publication adapter binds source and digest.
+    // This two-way check never decrypts source or claims plaintext-source equality.
+    const binding = { recipeSha: options.recipeSha, sourceSha: options.sourceSha, digest: options.digest };
+    check(await deps.sourceUnchanged(binding));
+    const first = await snapshot(options, deps);
+    const after = await snapshot(options, deps); stable(first, after);
+    check(await deps.sourceUnchanged(binding));
+    return { verified: true, projectionEqual: true, liveSourceStable: true };
+  } catch { return { verified: false }; }
+}

--- a/tests/wedding-backup-staging/fixtures.mjs
+++ b/tests/wedding-backup-staging/fixtures.mjs
@@ -1,0 +1,54 @@
+import { targets } from '../../scripts/wedding-backup-projection.mjs';
+export const sha = 'a'.repeat(40), digest = `sha256:${'b'.repeat(64)}`;
+export const id = 'c'.repeat(32), secret = 'd'.repeat(64);
+export const enc = s => Buffer.from(s).toString('base64');
+export const opts = { sourceSha: sha, recipeSha: sha, digest, endpoint: `https://${'e'.repeat(32)}.r2.cloudflarestorage.com` };
+export const invocation = { repository: 'devantler-tech/platform', event: 'workflow_dispatch', ref: 'refs/heads/main', sha, checkout: sha, attempt: '1', run: '12345', workflowRef:'devantler-tech/platform/.github/workflows/cd.yaml@refs/heads/main', workflowSha:sha };
+const ready = { conditions: [{ type: 'Ready', status: 'True' }], observedGeneration: 1 };
+export function fixtures() {
+  const docs = Object.fromEntries(targets.map((t, i) => [t.id, {
+    apiVersion: t.apiVersion, kind: t.kind,
+    metadata: { name: t.name, namespace: t.namespace, uid: `00000000-0000-0000-0000-${String(i+1).padStart(12, '0')}`, resourceVersion: String(i+10), generation: 1,
+      labels: { 'kustomize.toolkit.fluxcd.io/name': t.owner, 'kustomize.toolkit.fluxcd.io/namespace': 'flux-system' } },
+    spec: {}, status: structuredClone(ready)
+  }]));
+  docs.source.spec = { url: 'oci://ghcr.io/devantler-tech/platform/manifests', ref: { tag: 'latest' }, verify: { provider: 'cosign' } };
+  docs.source.status.artifact = { revision: `latest@${digest}` };
+  docs.source.status.conditions.push({ type: 'SourceVerified', status: 'True' });
+  for (const name of ['bootstrap', 'infrastructure', 'apps']) {
+    docs[name].spec = { sourceRef: { kind: 'OCIRepository', name: 'flux-system' }, path: { bootstrap: 'clusters/prod/bootstrap', infrastructure: 'providers/hetzner/infrastructure', apps: 'providers/hetzner/apps' }[name] };
+    docs[name].status.lastAppliedRevision = `latest@${digest}`;
+  }
+  docs.seed.spec = {
+    secretStoreRefs: [{ name: 'openbao', kind: 'ClusterSecretStore' }],
+    selector: { secret: { name: 'wedding-db-backup-r2-bootstrap' } },
+    data: ['access_key_id', 'secret_access_key'].map(key => ({ match: { secretKey: key, remoteRef: { remoteKey: 'apps/wedding-app/backup/r2', property: key } } }))
+  };
+  docs.projection.spec = {
+    secretStoreRef: { name: 'openbao', kind: 'ClusterSecretStore' },
+    target: { name: 'wedding-db-backup-r2-dedicated', creationPolicy: 'Owner', template: { data: { ACCESS_KEY_ID: '{{ .ACCESS_KEY_ID }}', SECRET_ACCESS_KEY: '{{ .SECRET_ACCESS_KEY }}', REGION: 'auto' } } },
+    data: [['ACCESS_KEY_ID','access_key_id'], ['SECRET_ACCESS_KEY','secret_access_key']].map(([secretKey, property]) => ({ secretKey, remoteRef: { key: 'apps/wedding-app/backup/r2', property } }))
+  };
+  docs.active.spec.configuration = {
+    destinationPath: 's3://platform-backups/cnpg/wedding-db', endpointURL: opts.endpoint,
+    s3Credentials: Object.fromEntries([['accessKeyId','ACCESS_KEY_ID'],['secretAccessKey','SECRET_ACCESS_KEY'],['region','REGION']].map(([key, value]) => [key, { name: 'wedding-db-backup-r2', key: value }]))
+  };
+  docs.bootstrapSecret.type = docs.projectedSecret.type = 'Opaque';
+  docs.bootstrapSecret.data = { access_key_id: enc(id), secret_access_key: enc(secret) };
+  docs.projectedSecret.data = { ACCESS_KEY_ID: enc(id), SECRET_ACCESS_KEY: enc(secret), REGION: enc('auto') };
+  docs.projectedSecret.metadata.ownerReferences = [{ apiVersion: 'external-secrets.io/v1', kind: 'ExternalSecret', name: 'wedding-db-backup-r2-dedicated', uid: docs.projection.metadata.uid, controller: true }];
+  return docs;
+}
+export function harness(change = () => {}, invocationPatch = {}) {
+  const docs = fixtures(); change(docs);
+  const reads = [], calls = [], receipts = [];
+  const deps = {
+    invocation: { ...invocation, ...invocationPatch },
+    read: async target => { reads.push(target.id); return structuredClone(docs[target.id]); },
+    decrypt: async () => { calls.push('decrypt'); return {access_key_id:id,secret_access_key:secret}; },
+    sourceUnchanged: async () => true,
+    probe: async () => { throw Error('S3 execution is forbidden'); },
+    record: async () => { throw Error('Private identity recording is forbidden'); }
+  };
+  return { docs, reads, calls, receipts, deps };
+}

--- a/tests/wedding-backup-staging/fixtures.mjs
+++ b/tests/wedding-backup-staging/fixtures.mjs
@@ -2,7 +2,7 @@ import { targets } from '../../scripts/wedding-backup-projection.mjs';
 export const sha = 'a'.repeat(40), digest = `sha256:${'b'.repeat(64)}`;
 export const id = 'c'.repeat(32), secret = 'd'.repeat(64);
 export const enc = s => Buffer.from(s).toString('base64');
-export const opts = { sourceSha: sha, recipeSha: sha, digest, endpoint: `https://${'e'.repeat(32)}.r2.cloudflarestorage.com` };
+export const opts = { sourceSha: 'f'.repeat(40), recipeSha: sha, digest, endpoint: `https://${'e'.repeat(32)}.r2.cloudflarestorage.com` };
 export const invocation = { repository: 'devantler-tech/platform', event: 'workflow_dispatch', ref: 'refs/heads/main', sha, checkout: sha, attempt: '1', run: '12345', workflowRef:'devantler-tech/platform/.github/workflows/cd.yaml@refs/heads/main', workflowSha:sha };
 const ready = { conditions: [{ type: 'Ready', status: 'True' }], observedGeneration: 1 };
 export function fixtures() {
@@ -41,14 +41,14 @@ export function fixtures() {
 }
 export function harness(change = () => {}, invocationPatch = {}) {
   const docs = fixtures(); change(docs);
-  const reads = [], calls = [], receipts = [];
+  const reads = [], calls = [], receipts = [], bindings = [];
   const deps = {
     invocation: { ...invocation, ...invocationPatch },
     read: async target => { reads.push(target.id); return structuredClone(docs[target.id]); },
     decrypt: async () => { calls.push('decrypt'); return {access_key_id:id,secret_access_key:secret}; },
-    sourceUnchanged: async () => true,
+    sourceUnchanged: async binding => { bindings.push(structuredClone(binding)); return true; },
     probe: async () => { throw Error('S3 execution is forbidden'); },
     record: async () => { throw Error('Private identity recording is forbidden'); }
   };
-  return { docs, reads, calls, receipts, deps };
+  return { docs, reads, calls, receipts, bindings, deps };
 }

--- a/tests/wedding-backup-staging/io.test.mjs
+++ b/tests/wedding-backup-staging/io.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {mkdtemp,writeFile,readFile,mkdir,rm,symlink,realpath} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {createHash} from 'node:crypto';
+import {execFileSync} from 'node:child_process';
+import {capture,createReader,createSourceGuard} from '../../scripts/wedding-backup-io.mjs';
+const node=process.execPath,hash=b=>createHash('sha256').update(b).digest('hex');
+async function temp(t){const p=await realpath(await mkdtemp(path.join(tmpdir(),'projection-io-')));t.after(()=>rm(p,{recursive:true,force:true}));return p;}
+test('bounded private capture returns stdout without diagnostic output',async()=>{
+ assert.equal((await capture(node,['-e','process.stderr.write("synthetic-private");process.stdout.write("okay")'],{env:{PATH:'/usr/bin:/bin'}})).toString(),'okay');
+});
+for(const [label,code,options] of [
+ ['overflow','process.stdout.write("x".repeat(9000))',{maxBytes:100}],
+ ['timeout','setTimeout(()=>{},5000)',{timeout:30}],
+ ['child error','process.stderr.write("synthetic-private");process.exit(1)',{}]
+])test(label+' returns only fixed refusal',async()=>{
+ await assert.rejects(capture(node,['-e',code],{env:{PATH:'/usr/bin:/bin'},...options}),e=>e.message==='subprocess_refused');
+});
+test('reader invokes only the selected object with an explicit context and config',async t=>{
+ const dir=await temp(t),bin=path.join(dir,'kubectl'),config=path.join(dir,'config');
+ const source=`#!${node}\nconst expected=['--kubeconfig',${JSON.stringify(config)},'--context','admin@prod','--namespace','flux-system','get','secrets','wedding-db-backup-r2-bootstrap','--output=json','--request-timeout=20s'];if(JSON.stringify(process.argv.slice(2))!==JSON.stringify(expected))process.exit(3);if(Object.keys(process.env).some(x=>!['PATH','__CF_USER_TEXT_ENCODING'].includes(x)))process.exit(4);process.stdout.write(JSON.stringify({apiVersion:'v1',kind:'Secret'}));`;
+ await writeFile(bin,source,{mode:0o700});
+ const read=createReader({kubectl:bin,kubeconfig:config});
+ assert.deepEqual(await read({id:'bootstrapSecret'}),{apiVersion:'v1',kind:'Secret'});
+ await assert.rejects(read({id:'anything-else'}),e=>e.message==='read_refused');
+});
+test('malformed or oversized object response is suppressed',async t=>{
+ const dir=await temp(t),bin=path.join(dir,'kubectl');
+ for(const code of ['process.stdout.write("synthetic-private")','process.stdout.write("x".repeat(300000))']){
+  await writeFile(bin,`#!${node}\n${code}`,{mode:0o700});
+  await assert.rejects(createReader({kubectl:bin,kubeconfig:path.join(dir,'config')})({id:'bootstrapSecret'}),e=>e.message==='read_refused');
+ }
+});
+async function sourceFixture(t){
+ const dir=await temp(t),cipher='public synthetic encrypted marker\n',bootstrap='resources:\n  - secret-wedding-db-backup-r2.enc.yaml\n';
+ const p='k8s/clusters/prod/bootstrap/';await mkdir(path.join(dir,p),{recursive:true});
+ await writeFile(path.join(dir,p,'secret-wedding-db-backup-r2.enc.yaml'),cipher);await writeFile(path.join(dir,p,'kustomization.yaml'),bootstrap);
+ await mkdir(path.join(dir,'scripts'));for(const file of ['wedding-backup-projection.mjs','wedding-backup-io.mjs','verify-wedding-backup-staging.mjs'])await writeFile(path.join(dir,'scripts',file),'// reviewed synthetic recipe\n');
+ const git=(...args)=>execFileSync('git',['-C',dir,...args],{encoding:'utf8',stdio:['ignore','pipe','pipe']}).trim();
+ git('init','-q');git('add','k8s/clusters/prod/bootstrap/secret-wedding-db-backup-r2.enc.yaml','k8s/clusters/prod/bootstrap/kustomization.yaml','scripts/wedding-backup-projection.mjs','scripts/wedding-backup-io.mjs','scripts/verify-wedding-backup-staging.mjs');git('-c','user.name=Fixture','-c','user.email=fixture@example.invalid','-c','commit.gpgsign=false','commit','-qm','fixture');
+ const sha=git('rev-parse','HEAD');return{dir,sha,git,cipherPath:path.join(dir,p,'secret-wedding-db-backup-r2.enc.yaml'),options:{workspace:dir,recipeDirectory:path.join(dir,'scripts'),sourceSha:sha,recipeSha:sha,cipherSha:hash(cipher),bootstrapSha:hash(bootstrap),git:'/usr/bin/git'}};
+}
+test('actual committed source and recipe match without a decrypt subprocess',async t=>{
+ const f=await sourceFixture(t);const guard=await createSourceGuard(f.options);assert.equal(await guard(),true);
+ await writeFile(f.cipherPath,'other encrypted bytes');assert.equal(await guard(),false);
+});
+for(const [label,change] of [
+ ['wrong cipher receipt',async f=>{f.options.cipherSha='f'.repeat(64);}],
+ ['wrong bootstrap membership receipt',async f=>{f.options.bootstrapSha='f'.repeat(64);}],
+ ['foreign recipe',async f=>{f.options.recipeSha='a'.repeat(40);}],
+ ['changed executable',async f=>{await writeFile(path.join(f.dir,'scripts/wedding-backup-projection.mjs'),'// injected\n');}],
+ ['symlinked source',async f=>{const b=await readFile(f.cipherPath);await rm(f.cipherPath);await writeFile(path.join(f.dir,'other.enc.yaml'),b);await symlink(path.join(f.dir,'other.enc.yaml'),f.cipherPath);}]
+])test(label+' fails before any runtime read',async t=>{
+ const f=await sourceFixture(t);await change(f);const guard=await createSourceGuard(f.options);assert.equal(await guard(),false);
+});

--- a/tests/wedding-backup-staging/projection.test.mjs
+++ b/tests/wedding-backup-staging/projection.test.mjs
@@ -13,6 +13,10 @@ test('true compares only the fixed dedicated pairs and returns no source-decrypt
  assert.deepEqual(result,{verified:true,projectionEqual:true,liveSourceStable:true});
  assert.equal(h.reads.filter(x=>x==='bootstrapSecret').length,2);
  assert.equal(h.reads.filter(x=>x==='projectedSecret').length,2);
+ assert.deepEqual(h.bindings,[
+  {sourceSha:'f'.repeat(40),recipeSha:'a'.repeat(40),digest:'sha256:'+'b'.repeat(64)},
+  {sourceSha:'f'.repeat(40),recipeSha:'a'.repeat(40),digest:'sha256:'+'b'.repeat(64)}
+ ]);
  assert.deepEqual(h.calls,[]);
  assert.equal(JSON.stringify(result).includes(id),false);
  assert.equal(JSON.stringify(result).includes(secret),false);

--- a/tests/wedding-backup-staging/projection.test.mjs
+++ b/tests/wedding-backup-staging/projection.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {verifyProjection} from '../../scripts/wedding-backup-projection.mjs';
+import {harness,opts,enc,id,secret} from './fixtures.mjs';
+
+for (const enabled of [undefined,false,'false']) test(`disabled ${String(enabled)} never calls a dependency`,async()=>{
+ const deps=new Proxy({}, {get(){throw Error('disabled check read a dependency');}});
+ assert.deepEqual(await verifyProjection({enabled},deps),{verified:false,skipped:true});
+});
+test('true compares only the fixed dedicated pairs and returns no source-decryption claim',async()=>{
+ const h=harness();
+ const result=await verifyProjection({...opts,enabled:true},h.deps);
+ assert.deepEqual(result,{verified:true,projectionEqual:true,liveSourceStable:true});
+ assert.equal(h.reads.filter(x=>x==='bootstrapSecret').length,2);
+ assert.equal(h.reads.filter(x=>x==='projectedSecret').length,2);
+ assert.deepEqual(h.calls,[]);
+ assert.equal(JSON.stringify(result).includes(id),false);
+ assert.equal(JSON.stringify(result).includes(secret),false);
+});
+for(const [label,change] of [
+ ['access mismatch',d=>d.projectedSecret.data.ACCESS_KEY_ID=enc('a'.repeat(32))],
+ ['secret mismatch',d=>d.projectedSecret.data.SECRET_ACCESS_KEY=enc('a'.repeat(64))],
+ ['extra field',d=>d.projectedSecret.data.EXTRA=enc('extra')],
+ ['malformed base64',d=>d.bootstrapSecret.data.access_key_id='not base64'],
+ ['wrong region',d=>d.projectedSecret.data.REGION=enc('eu-west-1')],
+ ['wrong owner',d=>d.projectedSecret.metadata.ownerReferences[0].uid='00000000-0000-0000-0000-999999999999'],
+ ['foreign source',d=>d.source.spec.url='oci://example.invalid/other'],
+ ['stale digest',d=>d.apps.status.lastAppliedRevision='latest@sha256:'+ 'f'.repeat(64)],
+ ['unverified source',d=>d.source.status.conditions.pop()],
+ ['wrong mapping',d=>d.projection.spec.data[0].remoteRef.property='secret_access_key'],
+ ['early cutover',d=>d.active.spec.configuration.destinationPath='s3://wedding-db-backups/cnpg/wedding-db'],
+ ['deleted seed',d=>d.seed.metadata.deletionTimestamp='2026-01-01T00:00:00Z']
+])test(label+' refuses without payload output',async()=>{
+ const h=harness(change);const result=await verifyProjection({...opts,enabled:'true'},h.deps);
+ assert.deepEqual(result,{verified:false});
+ assert.deepEqual(h.calls,[]);
+});
+test('controller refusal happens before either Secret read',async()=>{
+ const h=harness(d=>d.seed.status.conditions=[]);
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});
+ assert.equal(h.reads.some(x=>x.endsWith('Secret')),false);
+});
+for(const [label,change] of [
+ ['UID replacement',d=>d.bootstrapSecret.metadata.uid='00000000-0000-0000-0000-999999999999'],
+ ['resourceVersion movement',d=>d.projectedSecret.metadata.resourceVersion='999'],
+ ['generation movement',d=>{d.projection.metadata.generation=2;d.projection.status.observedGeneration=2;}],
+ ['pair replacement',d=>{d.bootstrapSecret.data.access_key_id=enc('a'.repeat(32));d.projectedSecret.data.ACCESS_KEY_ID=enc('a'.repeat(32));}]
+])test(label+' between samples refuses',async()=>{
+ const h=harness(); const read=h.deps.read; let sources=0;
+ h.deps.read=async t=>{if(t.id==='source'&&++sources===2)change(h.docs);return read(t);};
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});
+});
+for(const patch of [{event:'pull_request'},{ref:'refs/heads/other'},{attempt:'2'},{workflowSha:'f'.repeat(40)}])test('untrusted invocation refuses '+JSON.stringify(patch),async()=>{
+ const h=harness(()=>{},patch);
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});
+ assert.equal(h.reads.length,0);
+});
+test('source refusal happens before reads and source change after sampling fails',async()=>{
+ const h=harness();h.deps.sourceUnchanged=async()=>false;
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});assert.equal(h.reads.length,0);
+ let n=0;h.deps.sourceUnchanged=async()=>++n===1;
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});
+});
+test('reader diagnostics are suppressed',async()=>{
+ const h=harness();h.deps.read=async()=>{throw Error(secret);};
+ assert.deepEqual(await verifyProjection({...opts,enabled:true},h.deps),{verified:false});
+});

--- a/tests/wedding-backup-staging/runner.test.mjs
+++ b/tests/wedding-backup-staging/runner.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import {fixture} from './runtime-fixture.mjs';
+import assert from 'node:assert/strict';
+import {mkdtemp,mkdir,writeFile,readFile,copyFile,rm,realpath} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {createHash} from 'node:crypto';
+import {execFileSync,spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {run} from '../../scripts/verify-wedding-backup-staging.mjs';
+import {fixtures,sha,digest,id,secret} from './fixtures.mjs';
+const hash=x=>createHash('sha256').update(x).digest('hex'),node=process.execPath;
+const source=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'../../scripts');
+for(const flag of [undefined,'false'])test('runner omitted/false performs no setup: '+String(flag),async()=>{
+ assert.deepEqual(await run({WEDDING_BACKUP_VERIFY:flag}),{code:0,result:{verified:false,skipped:true}});
+});
+test('true refuses missing wait/publish success before setup',async()=>{
+ assert.deepEqual(await run({WEDDING_BACKUP_VERIFY:'true'}),{code:2,result:{verified:false}});
+});
+test('real one-use CLI joins same-job publication and compares only two synthetic pairs',async t=>{
+ const f=await fixture(t),entry=path.join(f.dir,'scripts/verify-wedding-backup-staging.mjs');
+ const child=spawnSync(node,[entry],{cwd:f.dir,env:f.env,encoding:'utf8',stdio:['ignore','pipe','pipe']});assert.equal(child.status,0);assert.equal(child.stderr,'');const stdout=child.stdout;
+ const result=JSON.parse(stdout);assert.deepEqual(result,{verified:true,projectionEqual:true,liveSourceStable:true,sourceSha:f.commit,digest,run:'12345'});
+ const reads=(await readFile(path.join(f.dir,'reads'),'utf8')).trim().split('\n');assert.equal(reads.length,18);assert.equal(reads.filter(x=>x.includes('/Secret/')).length,4);assert.equal(stdout.includes(id)||stdout.includes(secret),false);
+});
+for(const [label,patch] of [['failed wait',{WEDDING_BACKUP_WAIT_RESULT:'failure'}],['missing digest',{WEDDING_BACKUP_DIGEST:''}],['wrong invocation',{GITHUB_EVENT_NAME:'pull_request'}],['rerun',{GITHUB_RUN_ATTEMPT:'2'}],['wrong ciphertext',{WEDDING_BACKUP_CIPHER_SHA256:'f'.repeat(64)}]])test('real CLI '+label+' makes no API reads',async t=>{
+ const f=await fixture(t);let result;
+ try{execFileSync(node,[path.join(f.dir,'scripts/verify-wedding-backup-staging.mjs')],{cwd:f.dir,env:{...f.env,...patch},encoding:'utf8',stdio:['ignore','pipe','pipe']});assert.fail('accepted');}catch(e){assert.equal(e.status,2);assert.equal(e.stderr,'');result=e.stdout;}
+ assert.deepEqual(JSON.parse(result),{verified:false});await assert.rejects(readFile(path.join(f.dir,'reads')));
+});

--- a/tests/wedding-backup-staging/runner.test.mjs
+++ b/tests/wedding-backup-staging/runner.test.mjs
@@ -23,7 +23,7 @@ test('real one-use CLI joins same-job publication and compares only two syntheti
  const result=JSON.parse(stdout);assert.deepEqual(result,{verified:true,projectionEqual:true,liveSourceStable:true,sourceSha:f.commit,digest,run:'12345'});
  const reads=(await readFile(path.join(f.dir,'reads'),'utf8')).trim().split('\n');assert.equal(reads.length,18);assert.equal(reads.filter(x=>x.includes('/Secret/')).length,4);assert.equal(stdout.includes(id)||stdout.includes(secret),false);
 });
-for(const [label,patch] of [['failed wait',{WEDDING_BACKUP_WAIT_RESULT:'failure'}],['missing digest',{WEDDING_BACKUP_DIGEST:''}],['wrong invocation',{GITHUB_EVENT_NAME:'pull_request'}],['rerun',{GITHUB_RUN_ATTEMPT:'2'}],['wrong ciphertext',{WEDDING_BACKUP_CIPHER_SHA256:'f'.repeat(64)}]])test('real CLI '+label+' makes no API reads',async t=>{
+for(const [label,patch] of [['failed wait',{WEDDING_BACKUP_WAIT_RESULT:'failure'}],['missing digest',{WEDDING_BACKUP_DIGEST:''}],['wrong invocation',{GITHUB_EVENT_NAME:'pull_request'}],['rerun',{GITHUB_RUN_ATTEMPT:'2'}],['wrong ciphertext',{WEDDING_BACKUP_CIPHER_SHA256:'f'.repeat(64)}],['different workflow revision',{GITHUB_WORKFLOW_SHA:'f'.repeat(40)}],['different event revision',{GITHUB_SHA:'f'.repeat(40)}]])test('real CLI '+label+' makes no API reads',async t=>{
  const f=await fixture(t);let result;
  try{execFileSync(node,[path.join(f.dir,'scripts/verify-wedding-backup-staging.mjs')],{cwd:f.dir,env:{...f.env,...patch},encoding:'utf8',stdio:['ignore','pipe','pipe']});assert.fail('accepted');}catch(e){assert.equal(e.status,2);assert.equal(e.stderr,'');result=e.stdout;}
  assert.deepEqual(JSON.parse(result),{verified:false});await assert.rejects(readFile(path.join(f.dir,'reads')));

--- a/tests/wedding-backup-staging/runtime-fixture.mjs
+++ b/tests/wedding-backup-staging/runtime-fixture.mjs
@@ -1,0 +1,22 @@
+import {mkdtemp,mkdir,writeFile,copyFile,rm,realpath} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {createHash} from 'node:crypto';
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import {fixtures,digest} from './fixtures.mjs';
+const hash=x=>createHash('sha256').update(x).digest('hex'),node=process.execPath;
+const source=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'../../scripts');
+export async function fixture(t){
+ const dir=await realpath(await mkdtemp(path.join(tmpdir(),'projection-runner-')));t.after(()=>rm(dir,{recursive:true,force:true}));
+ await mkdir(path.join(dir,'scripts'));for(const name of ['wedding-backup-projection.mjs','wedding-backup-io.mjs','verify-wedding-backup-staging.mjs'])await copyFile(path.join(source,name),path.join(dir,'scripts',name));
+ const p=path.join(dir,'k8s/clusters/prod/bootstrap');await mkdir(p,{recursive:true});const cipher='public synthetic encrypted marker\n',bootstrap='resources:\n  - secret-wedding-db-backup-r2.enc.yaml\n';
+ await writeFile(path.join(p,'secret-wedding-db-backup-r2.enc.yaml'),cipher);await writeFile(path.join(p,'kustomization.yaml'),bootstrap);
+ const git=(...args)=>execFileSync('git',['-C',dir,...args],{encoding:'utf8',stdio:['ignore','pipe','pipe']}).trim();git('init','-q');git('add','scripts/wedding-backup-projection.mjs','scripts/wedding-backup-io.mjs','scripts/verify-wedding-backup-staging.mjs','k8s/clusters/prod/bootstrap/secret-wedding-db-backup-r2.enc.yaml','k8s/clusters/prod/bootstrap/kustomization.yaml');git('-c','user.name=Fixture','-c','user.email=fixture@example.invalid','-c','commit.gpgsign=false','commit','-qm','fixture');const commit=git('rev-parse','HEAD');
+ const docs=fixtures();const byName=Object.fromEntries(Object.values(docs).map(d=>[d.metadata.namespace+'/'+d.kind+'/'+d.metadata.name,d]));
+ await writeFile(path.join(dir,'objects.json'),JSON.stringify(byName));
+ const reader=path.join(dir,'kubectl');const fake=`#!${node}\nconst fs=require('node:fs');const p=${JSON.stringify(dir)};const a=process.argv.slice(2);if(a.length!==11||a[0]!=='--kubeconfig'||a[2]!=='--context'||a[3]!=='admin@prod'||a[4]!=='--namespace'||a[6]!=='get'||a[9]!=='--output=json'||a[10]!=='--request-timeout=20s')process.exit(3);if(Object.keys(process.env).some(x=>!['PATH','__CF_USER_TEXT_ENCODING'].includes(x)))process.exit(4);const objects=JSON.parse(fs.readFileSync(p+'/objects.json'));const kinds={'secrets':'Secret','ocirepositories.source.toolkit.fluxcd.io':'OCIRepository','kustomizations.kustomize.toolkit.fluxcd.io':'Kustomization','pushsecrets.external-secrets.io':'PushSecret','externalsecrets.external-secrets.io':'ExternalSecret','objectstores.barmancloud.cnpg.io':'ObjectStore'};const key=a[5]+'/'+kinds[a[7]]+'/'+a[8];if(!objects[key])process.exit(5);fs.appendFileSync(p+'/reads',key+'\\n');process.stdout.write(JSON.stringify(objects[key]));`;
+ await writeFile(reader,fake,{mode:0o700});
+ const env={PATH:'/usr/bin:/bin',HOME:dir,GITHUB_WORKSPACE:dir,GITHUB_REPOSITORY:'devantler-tech/platform',GITHUB_EVENT_NAME:'workflow_dispatch',GITHUB_REF:'refs/heads/main',GITHUB_SHA:commit,GITHUB_RUN_ID:'12345',GITHUB_RUN_ATTEMPT:'1',GITHUB_WORKFLOW_REF:'devantler-tech/platform/.github/workflows/cd.yaml@refs/heads/main',GITHUB_WORKFLOW_SHA:commit,WEDDING_BACKUP_VERIFY:'true',WEDDING_BACKUP_PUBLISH_RESULT:'success',WEDDING_BACKUP_WAIT_RESULT:'success',WEDDING_BACKUP_DIGEST:digest,WEDDING_BACKUP_CIPHER_SHA256:hash(cipher),WEDDING_BACKUP_BOOTSTRAP_SHA256:hash(bootstrap),WEDDING_BACKUP_KUBECTL_BIN:reader,WEDDING_BACKUP_GIT_BIN:'/usr/bin/git'};
+ return{dir,env,commit,docs:byName};
+}

--- a/tests/wedding-backup-staging/wiring.test.mjs
+++ b/tests/wedding-backup-staging/wiring.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {execFileSync,spawnSync} from 'node:child_process';
+import {readFile} from 'node:fs/promises';
+import path from 'node:path';
+import {fixture} from './runtime-fixture.mjs';
+const root=path.resolve(import.meta.dirname,'../..');
+const yaml=p=>JSON.parse(execFileSync('yq',['-o=json','.',path.join(root,p)],{encoding:'utf8'}));
+// Test-only resolution of scalar context references; the production proposal
+// contains no expression language beyond these direct input/step handoffs.
+function scalar(value,context){if(typeof value!=='string'||!value.startsWith('${{'))return value;const m=/^\$\{\{ ([a-zA-Z0-9_.-]+) \}\}$/.exec(value);assert.ok(m,'unsupported expression in proposed handoff');return m[1].split('.').reduce((v,k)=>v?.[k],context);}
+async function executeStep(t,flag,{wait='success',publish='success'}={}){
+ const workflow=yaml('.github/workflows/cd.yaml'),action=yaml('.github/actions/deploy-prod/action.yml');
+ const definition=workflow.on.workflow_dispatch?.inputs?.['verify-wedding-backup-staging'];assert.ok(definition,'manual opt-in input is missing');assert.equal(definition.type,'boolean');
+ const steps=workflow.jobs['deploy-prod'].steps,deploy=steps.find(s=>s.uses==='./.github/actions/deploy-prod');
+ const input=flag===undefined?definition.default:flag;
+ const resolved=scalar(deploy.with['verify-wedding-backup-staging'],{inputs:{'verify-wedding-backup-staging':input}});
+ const value=resolved===undefined?action.inputs['verify-wedding-backup-staging'].default:String(resolved);
+ const index=action.runs.steps.findIndex(s=>s.id==='verify_wedding_backup_staging');assert.ok(index>0);
+ assert.ok(action.runs.steps.slice(0,index).some(s=>s.id==='wait_flux_revision'));
+ const step=action.runs.steps[index];assert.equal(step.shell,'bash');assert.equal(step['continue-on-error'],undefined);
+ const f=await fixture(t);
+ const context={inputs:{'verify-wedding-backup-staging':value},steps:{publish_platform_manifest:{outcome:publish,outputs:{digest:f.env.WEDDING_BACKUP_DIGEST}},wait_flux_revision:{outcome:wait}}};
+ const env={...f.env,PATH:f.dir+':'+path.dirname(process.execPath)+':/usr/bin:/bin'};
+ for(const [k,v]of Object.entries(step.env))env[k]=String(scalar(v,context)??'');
+ // Only the expected source receipts are synthetic; execute the proposed shell
+// and actual helper against the disposable committed tree and bounded reader.
+ env.WEDDING_BACKUP_CIPHER_SHA256=f.env.WEDDING_BACKUP_CIPHER_SHA256;env.WEDDING_BACKUP_BOOTSTRAP_SHA256=f.env.WEDDING_BACKUP_BOOTSTRAP_SHA256;
+ const child=spawnSync('/bin/bash',['-e','-o','pipefail','-c',step.run],{cwd:f.dir,env,encoding:'utf8'});
+ let reads='';try{reads=await readFile(path.join(f.dir,'reads'),'utf8');}catch{}
+ return{child,reads};
+}
+for(const flag of [undefined,false])test('actual proposed omitted/false step does not read an object: '+String(flag),async t=>{
+ const {child,reads}=await executeStep(t,flag);assert.equal(child.status,0);assert.equal(child.stderr,'');assert.equal(reads,'');assert.equal(child.stdout,'');
+});
+test('actual proposed true step uses the publisher digest and succeeds after wait',async t=>{
+ const {child,reads}=await executeStep(t,true);assert.equal(child.status,0);assert.equal(child.stderr,'');assert.equal(JSON.parse(child.stdout).projectionEqual,true);assert.equal(reads.trim().split('\n').length,18);
+});
+for(const state of [{wait:'failure'},{publish:'failure'}])test('actual proposed true step refuses failed dependency before API reads '+JSON.stringify(state),async t=>{
+ const {child,reads}=await executeStep(t,true,state);assert.equal(child.status,2);assert.equal(child.stderr,'');assert.deepEqual(JSON.parse(child.stdout),{verified:false});assert.equal(reads,'');
+});


### PR DESCRIPTION
Stage the dedicated wedding backup credential through encrypted bootstrap Secrets, a separate OpenBao seed, and a dedicated ExternalSecret projection. The active ObjectStore, backup destination, and existing credential remain unchanged while the new projection is verified.

Add a manual CD comparison that defaults to false and uses the deployment runner's existing authority. When explicitly enabled, it binds verification to the published source and Flux revision, compares the bootstrap and projected credential pairs in memory, and refuses mismatches or changes between observations. It reports only safe results and does not decrypt the committed source or change the backup configuration. The synthetic suite runs in the existing required CI path.

Local validation completed on the combined 20-file candidate:

- All 53 synthetic tests passed, with RTK absent from the test PATH.
- Both pinned KSail validation modes passed all 619 files. Naming, authorization, actionlint, and focused workflow checks also passed.
- Full render comparison preserved every existing object and all authorization grants, adding only the three production and two local staging resources. The authorization fingerprint passed unchanged.

Hosted checks and live deployment have not run for this candidate. Live projection and any necessary reseeding verification, a separately reviewed backup cutover, and successful backup/restore validation remain required before the wider work is complete. The comparison input stays disabled on ordinary runs and can be removed after staging acceptance.

Related to #3252 and #3253; this staging change does not complete their remaining operational acceptance criteria.
