### PR TITLE
fix(metrics-server): declare baseline security defaults

### DIFF
--- a/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
@@ -19,13 +19,13 @@ spec:
   # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
   values:
     replicas: ${metrics_server_replicas:=2}
+    # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+    # fields the cluster-wide add-security-context mutation cannot supply here:
+    # that mutation rewrites the running POD, while Kubescape scores the STORED
+    # workload spec (#3239). Writing them into the chart values is the only
+    # route that moves both surfaces. They land under two different chart value
+    # keys: podSecurityContext renders pod-level, securityContext container-level.
     podSecurityContext:
-      # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
-      # fields the cluster-wide add-security-context mutation cannot supply here:
-      # that mutation rewrites the running POD, while Kubescape scores the STORED
-      # workload spec (#3239). Writing them into the chart values is the only
-      # route that moves both surfaces.
-      #
       # Inert today, which is the point: this Deployment mounts only emptyDir and
       # sets no fsGroup, so OnRootMismatch changes no ownership on any volume. It
       # is a declared default that holds if a future chart revision adds one.

--- a/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
@@ -19,6 +19,26 @@ spec:
   # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
   values:
     replicas: ${metrics_server_replicas:=2}
+    podSecurityContext:
+      # fsGroupChangePolicy and seLinuxOptions are the two non-privilege C-0211
+      # fields the cluster-wide add-security-context mutation cannot supply here:
+      # that mutation rewrites the running POD, while Kubescape scores the STORED
+      # workload spec (#3239). Writing them into the chart values is the only
+      # route that moves both surfaces.
+      #
+      # Inert today, which is the point: this Deployment mounts only emptyDir and
+      # sets no fsGroup, so OnRootMismatch changes no ownership on any volume. It
+      # is a declared default that holds if a future chart revision adds one.
+      fsGroupChangePolicy: OnRootMismatch
+    securityContext:
+      # Preserve runtime SELinux/MCS label allocation. An empty object satisfies
+      # C-0211, which accepts any non-absent seLinuxOptions, without pinning a
+      # level the node would otherwise allocate per-container (#3465).
+      #
+      # Helm merges this map into the chart's own securityContext, so the pinned
+      # user, dropped capabilities, read-only root filesystem and seccomp profile
+      # are all preserved; the rendered container gains this one field.
+      seLinuxOptions: {}
     podDisruptionBudget:
       enabled: true
       # Stays minAvailable: 1: ksail bootstrap-installs metrics-server (ksail.yaml

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1807,8 +1807,38 @@ const (
 // green — which is what re-arms the mutation controls that append an attacker
 // ClusterRoleBinding to cluster-admin, or a KRO Tenant, since every one of them
 // passes trivially while the baseline is red.
-// Previous aggregate: 165ed85b44e9dd5434d606854776a38aa40e82515ffb6b767ecd77f6cfab579a.
-const expectedRenderedSurfaceSHA = "fc59566d0ec91c68279981d90f2d14470280025b05f7f1874d9c0e56cd93574f"
+//
+// Moved again by the metrics-server baseline security defaults (#3676): the
+// chart values gain a pod-level fsGroupChangePolicy: OnRootMismatch and a
+// container-level seLinuxOptions: {}, so the rendered Deployment carries two
+// more securityContext fields.
+//
+// CONSERVATION, read off the check's own error set, which walks actual→expected
+// and expected→actual separately. The failing run reported EXACTLY ONE error
+// class — this aggregate — with ZERO `unapproved rendered <identity>`, ZERO
+// `missing rendered authorization resource` and ZERO `duplicate rendered`. So
+// membership is conserved in both directions and every pinned per-identity
+// fingerprint still passes; no subject, grant, binding or ServiceAccount moved.
+// A Deployment is not a grant-bearing kind, and the 17 `unresolved Flux
+// substitution` notes are the usual companions of a mismatch, not a second
+// finding.
+//
+// The authored delta is confined to one Deployment's securityContext. Rendering
+// the chart at its pinned 3.14.0 with and without these values differs by
+// exactly the two added fields and nothing else: the pinned runAsUser, dropped
+// capabilities, read-only root filesystem and seccomp profile are all preserved
+// by Helm's map merge, and image, volumes, replicas and the disruption budget
+// are untouched.
+//
+// RENDERER PROVENANCE, on the same terms as the entries above: measured on this
+// host's kubectl v1.36.1 with kustomize v5.8.1 through the test path, which
+// renders via renderAuthorizationLayers and so does not pass run()'s renderer
+// gate. CI's SHA256-verified kubectl v1.36.2 is what approves this constant, and
+// if it computes a different aggregate the check fails closed and reports the
+// value it computed. Restoring the superseded value fails with exactly this
+// fingerprint, so the baseline is not vacuous.
+// Previous aggregate: fc59566d0ec91c68279981d90f2d14470280025b05f7f1874d9c0e56cd93574f.
+const expectedRenderedSurfaceSHA = "1b17b64243f850afd2acc2b8af2fa5ed270e3a88d42db80437d2de40d7861a12"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Kubescape scores metrics-server as missing two baseline security declarations. The
cluster-wide mutation that normally supplies them rewrites the *running* pod, while
Kubescape reads the *stored* workload spec — so the finding persists no matter how the
cluster behaves at runtime. Declaring them in the chart values is the only route that
moves both surfaces.

### What

metrics-server now declares `fsGroupChangePolicy: OnRootMismatch` at the pod level and
an empty `seLinuxOptions` on the container. Neither changes what the workload can do:
the first is inert while the deployment mounts only `emptyDir` and sets no `fsGroup`,
and the second keeps the node's per-container SELinux label allocation rather than
pinning one. Everything that defines the runtime identity — the pinned user, dropped
capabilities, read-only root filesystem, seccomp profile, image, volumes, replica count
and disruption budget — is unchanged, which the chart render confirms field by field.

The EKS authorization aggregate moves with any rendered change and is re-approved in
this PR. Its own error set is the conservation proof in both directions: one error
class only, and zero unapproved, missing or duplicate rendered identities, so no
subject, grant, binding or ServiceAccount moved.

Fixes #3676
Part of #3239
