### PR TITLE
fix(kubescape): preserve cleanup inventory paths

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/cron-job-hostdata-cleanup.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cron-job-hostdata-cleanup.yaml
@@ -107,7 +107,7 @@ spec:
                     exit 1
                   fi
                   for resource in $resources; do
-                    file="/tmp/${resource%%.*}.names"
+                    file="/tmp/$${resource%%.*}.names"
                     if ! kc get "$resource" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' > "$file"; then
                       echo "ERROR: failed to list $resource; refusing cleanup"
                       exit 1
@@ -118,7 +118,7 @@ spec:
                   candidates=0
                   removed=0
                   for resource in $resources; do
-                    file="/tmp/${resource%%.*}.names"
+                    file="/tmp/$${resource%%.*}.names"
                     while IFS= read -r record; do
                       [ -n "$record" ] || continue
                       if grep -Fqx "$record" /tmp/nodes; then

--- a/scripts/tests/test-kubescape-hostdata-cleanup.sh
+++ b/scripts/tests/test-kubescape-hostdata-cleanup.sh
@@ -34,7 +34,16 @@ for file in "$manifest" "$role" "$binding" "$service_account"; do
 done
 
 readonly container='.spec.jobTemplate.spec.template.spec.containers[] | select(.name == "cleanup")'
-script_body="$(yq eval -r "${container}.command[2]" "$manifest")"
+dollar='$'
+escaped_inventory_path="file=\"/tmp/${dollar}${dollar}{resource%%.*}.names\""
+readonly dollar escaped_inventory_path
+[ "$(grep -Foc "$escaped_inventory_path" "$manifest")" = '2' ] ||
+  fail 'per-resource inventory paths are not escaped from Flux post-build substitution'
+
+# Flux documents `$${var}` as the way to preserve `${var}` in an embedded
+# script. Apply that one escape transformation before executing the extracted
+# command so this test exercises the script Flux delivers to the cluster.
+script_body="$(yq eval -r "${container}.command[2]" "$manifest" | sed 's/\$\${/${/g')"
 if [ -z "$script_body" ] || [ "$script_body" = 'null' ]; then
   fail 'cleanup script is absent'
 fi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Flux post-build substitution erased the cleanup script's `${resource%%.*}` shell expression, so every host-data class shared `/tmp/.names` and the first scheduled Job exceeded its deadline. This change uses Flux's documented `$${var}` escape and makes the contract test transform the command exactly as Flux does before executing it.

Closes #3724

Validation:
- RED: the new post-build escape assertion rejected the deployed source form.
- GREEN: `bash scripts/tests/test-kubescape-hostdata-cleanup.sh`.
- `shellcheck scripts/tests/test-kubescape-hostdata-cleanup.sh`.
- `go test ./scripts/validate-eks-ci-role-policy`.
- production Kustomize render and `git diff --check`.
