### PR TITLE
fix(tenants): trust bounded release streams

### DIFF
--- a/docs/TENANTS.md
+++ b/docs/TENANTS.md
@@ -139,6 +139,11 @@ reusable workflow, which builds and pushes the image, pins its digest into
 **cosign-signs** both (keyless, via GitHub OIDC). The platform's `OCIRepository`
 (§5) **verifies** that signature against the `publish-app.yaml` identity, so only
 artifacts produced by that trusted workflow are ever reconciled onto the cluster.
+Application tenants may advance that workflow at any immutable 40-hex commit without a
+platform-side revision update. The platform owns the trust boundary around the exact GitHub
+OIDC issuer, organization, reusable-workflow path, package source, namespace, RBAC, network
+policy, and admission policy. A tenant that needs authority outside those bounds requires a
+reviewed platform change; an ordinary release inside them does not.
 
 > Tags come from `release.yaml` → semantic-release: merge Conventional-Commit
 > PRs to `main` and a `vX.Y.Z` tag (and thus a publish) follows automatically.

--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,9 +16,7 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Generated from scripts/publish-workflow-approved-revisions.tsv by
-      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
-      # signer and this consumer's current publish-workflow pin in one identity.
-      # Regeneration updates the pair and the approved set in the same PR.
+      # Trust immutable revisions of the platform-owned shared workflow. The tenant may
+      # release independently; platform policy, RBAC, and network boundaries govern it.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(625b7c0cd5ad4a04f9eb7494298c6d0fa44521ef|4f4e07a3ebf3e1161756a292966e36c91a65ee04)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,9 +16,7 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Generated from scripts/publish-workflow-approved-revisions.tsv by
-      # scripts/write-publish-workflow-matchers.sh. Accept the deployed artifact
-      # signer and this consumer's current publish-workflow pin in one identity.
-      # Regeneration updates the pair and the approved set in the same PR.
+      # Trust immutable revisions of the platform-owned shared workflow. The tenant may
+      # release independently; platform policy, RBAC, and network boundaries govern it.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(6ae5d87b342984cdaf34740e60366b9d570d8fc5|883d891a0e6a2c9420d2b60aea9d5f47c20ce803)$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/scripts/guard-publish-workflow-approved-revisions.sh
+++ b/scripts/guard-publish-workflow-approved-revisions.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # guard-publish-workflow-approved-revisions.sh — assert that each per-consumer cosign matcher
-# for the shared devantler-tech/actions publish workflows pins EXACTLY the revision pair the
-# generated approved set names for that consumer (#3551, second child of #3308).
+# for the shared devantler-tech/actions publish workflows stays inside its declared trust
+# boundary: trusted tenant release streams accept any immutable shared-workflow commit, while
+# infrastructure/configuration consumers pin exactly the generated revision pair.
 #
 # WHY A SECOND GUARD
 # guard-shared-publish-workflow-pin.sh proves every matcher pins a FIXED revision — the pattern
@@ -9,15 +10,15 @@
 # says nothing about set MEMBERSHIP: a matcher narrowed to a revision nobody approved, or a
 # regeneration that moved the set while a matcher stayed behind, passes it. This guard reads
 # scripts/publish-workflow-approved-revisions.tsv (written by
-# generate-publish-workflow-approved-revisions.sh, #3550) and checks that each consumer's
-# matcher names that consumer's pair and nothing else. An out-of-set revision is refused in
-# every mode — that is #3308's AC4.
+# generate-publish-workflow-approved-revisions.sh, #3550). Bounded consumers must name their
+# generated pair and nothing else. Trusted release streams must name the immutable commit
+# pattern and nothing broader, which preserves the issuer/workflow boundary without a release
+# approval gate.
 #
 # ENFORCEMENT
-# CI and scheduled regeneration set APPROVED_REVISIONS_ENFORCE=1, which refuses
-# the broad pattern form. Unset or 0 retains compatibility for inspection and
-# fixtures; already narrowed matchers must equal the approved pair in either mode.
-# write-publish-workflow-matchers.sh derives the four subjects from the set.
+# CI and scheduled regeneration set APPROVED_REVISIONS_ENFORCE=1, which refuses the pattern
+# form for bounded infrastructure/configuration consumers. Trusted release streams require
+# that form in every mode so tenant releases never create a platform-side repin.
 #
 # SCOPE — GENERIC SUBJECTS ARE EXCLUDED BY NAME
 # Three subjects name the shared workflows without belonging to one consumer: the Kyverno
@@ -35,20 +36,27 @@
 # SEAMS (tests substitute these; production leaves them unset)
 #   APPROVED_REVISIONS_FILE      the generated set (default scripts/publish-workflow-approved-revisions.tsv)
 #   PUBLISH_CONSUMER_ROOT        scan root for consumer manifests (default: the repository root)
-#   APPROVED_REVISIONS_ENFORCE   `1` refuses the pattern form on per-consumer subjects (default: off)
+#   APPROVED_REVISIONS_ENFORCE   `1` refuses pattern form on bounded consumers (default: off)
 set -euo pipefail
 
 GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/publish-workflow-approved-revisions.lib.sh
 source "$GUARD_DIR/publish-workflow-approved-revisions.lib.sh"
 
-# ── 3. Each registered consumer: its matcher equals its generated pair ───────────────────
+# ── 3. Each registered consumer: its matcher equals its declared boundary ────────────────
 for consumer in "${EXPECTED_CONSUMERS[@]}"; do
   record="$(lookup "$observed" "$consumer")"
   [ -n "$record" ] || refuse "no OCIRepository under $SCAN_ROOT is attributed to registered consumer $consumer; the scan, not the tree, is the likely cause"
   IFS=$'\t' read -r file workflow ref <<<"$record"
   IFS=$'\t' read -r set_workflow signer pin <<<"$(lookup "$approved" "$consumer")"
   [ "$workflow" = "$set_workflow" ] || refuse "$consumer: $file names $workflow but the approved set names $set_workflow"
+
+  if is_trusted_release_stream_consumer "$consumer"; then
+    [ "$ref" = "$PATTERN_REF" ] ||
+      refuse "$consumer: trusted release stream $file pins '@$ref'; use the immutable shared-workflow pattern '@$PATTERN_REF' so tenant releases do not require platform approval"
+    printf 'ok %s %s %s form=trusted-release-stream\n' "$consumer" "$workflow" "$file"
+    continue
+  fi
 
   if [ "$signer" = "$pin" ]; then
     accepted="$signer or ($signer)"

--- a/scripts/publish-workflow-approved-revisions.lib.sh
+++ b/scripts/publish-workflow-approved-revisions.lib.sh
@@ -24,6 +24,16 @@ readonly GENERIC_SUBJECT_FILES=(
   'talos/cluster/verify-first-party-images.yaml'
 )
 
+# Application tenants are trusted to release independently inside the platform-owned
+# boundary: exact GitHub OIDC issuer, exact shared workflow path, and an immutable 40-hex
+# workflow commit. Pinning these streams to the currently observed workflow revisions would
+# make every ordinary tenant release wait for a platform change. Infrastructure/configuration
+# consumers remain tied to their generated revision sets below.
+readonly TRUSTED_RELEASE_STREAM_CONSUMERS=(
+  'ascoachingogvaner'
+  'wedding-app'
+)
+
 readonly SUBJECT_PREFIX='^https://github\.com/devantler-tech/actions/\.github/workflows/publish-'
 # Used by both callers after the shared discovery completes.
 # shellcheck disable=SC2034
@@ -51,6 +61,14 @@ lookup() {
   # `$1 "" == k ""` forces a STRING compare: awk compares two numeric-looking strings as
   # numbers, so `100` would match a key of `1e2`.
   printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 "" == k "" { sub(/^[^\t]*\t/, ""); print; exit }'
+}
+
+is_trusted_release_stream_consumer() {
+  local candidate="$1" trusted
+  for trusted in "${TRUSTED_RELEASE_STREAM_CONSUMERS[@]}"; do
+    [ "$candidate" = "$trusted" ] && return 0
+  done
+  return 1
 }
 
 # consumer → "workflow<TAB>signer<TAB>pin"

--- a/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
+++ b/scripts/tests/test-publish-workflow-approved-revisions-guard.sh
@@ -55,7 +55,16 @@ consumer_count="$(printf '%s\n' "$consumers" | grep -c .)"
 [ "$consumer_count" -ge 2 ] || { fail "need at least two registered consumers to cross pairs, found $consumer_count"; exit 1; }
 first_consumer="$(printf '%s\n' "$consumers" | sed -n 1p | cut -f1)"
 first_workflow="$(printf '%s\n' "$consumers" | sed -n 1p | cut -f2)"
-second_consumer="$(printf '%s\n' "$consumers" | sed -n 2p | cut -f1)"
+second_consumer='aws'
+second_workflow="$(printf '%s\n' "$consumers" | awk -F'\t' -v c="$second_consumer" '$1 == c {print $2}')"
+TRUSTED_RELEASE_STREAMS='ascoachingogvaner wedding-app'
+
+is_trusted_release_stream() {
+  case " $TRUSTED_RELEASE_STREAMS " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # The artifact name is the repository name except for `.github`, which publishes as
 # `github-config` — the same table the report uses.
@@ -182,8 +191,9 @@ write_set() {
   [ -z "$extra" ] || printf '%s\n' "$extra" >>"$path"
 }
 
-# build_tree <name> <ref-form-for-all-consumers|pair> — a complete fixture: every consumer on the
-# pattern form (`pattern`) or on its own generated pair (`pair`), generics on the pattern form.
+# build_tree <name> <pattern|pair> — a complete fixture. `pair` means exact generated sets for
+# bounded consumers and the immutable commit pattern for trusted release streams. Generic
+# subjects always remain on the pattern form.
 build_tree() {
   local name="$1" form="$2" root repo workflow ref
   root="$WORK/$name"
@@ -193,7 +203,13 @@ build_tree() {
     [ -n "$repo" ] || continue
     case "$form" in
       pattern) ref="$PATTERN" ;;
-      pair) ref="($(signer_for "$repo")|$SHA_B)" ;;
+      pair)
+        if is_trusted_release_stream "$repo"; then
+          ref="$PATTERN"
+        else
+          ref="($(signer_for "$repo")|$SHA_B)"
+        fi
+        ;;
       *) printf 'build_tree: unknown form %s\n' "$form" >&2; exit 1 ;;
     esac
     write_consumer "$root" "$repo" "$workflow" "$ref"
@@ -241,7 +257,7 @@ root="$(build_tree off-pattern pattern)"
 expect_pass 'switch off: every consumer on the pattern form passes' "$root" 0
 
 root="$(build_tree off-pair pair)"
-expect_pass 'switch off: every consumer on its generated pair passes' "$root" 0
+expect_pass 'switch off: bounded consumers use generated pairs and trusted streams use the pattern' "$root" 0
 
 root="$(build_tree off-pair-reversed pair)"
 write_consumer "$root" "$first_consumer" "$first_workflow" "($SHA_B|$(signer_for "$first_consumer"))"
@@ -273,6 +289,13 @@ root="$(build_tree off-crossed pair)"
 write_consumer "$root" "$first_consumer" "$first_workflow" "($(signer_for "$second_consumer")|$SHA_B)"
 expect_refusal "switch off: another consumer's pair on $first_consumer is refused" \
   "$root" 0 "$first_consumer" "$(signer_for "$second_consumer")"
+
+# A concrete pair is still cryptographically narrow, but on a trusted tenant release stream it
+# recreates the platform approval gate this boundary is designed to remove.
+root="$(build_tree release-stream-pinned pair)"
+write_consumer "$root" 'wedding-app' 'publish-app' "($SHA_A|$SHA_B)"
+expect_refusal 'a trusted release stream pinned to a generated pair is refused' \
+  "$root" 1 'wedding-app' 'trusted release stream' "$PATTERN"
 
 root="$(build_tree off-tag pair)"
 write_consumer "$root" "$first_consumer" "$first_workflow" 'refs/tags/v.+'
@@ -323,14 +346,15 @@ expect_refusal 'signer == pin: an alternation adding a foreign revision is refus
 
 # ── switch ON: the pattern form is refused for a per-consumer subject ────────────────────────
 root="$(build_tree on-pair pair)"
-expect_pass 'switch on: every consumer on its generated pair passes' "$root" 1
+expect_pass 'switch on: bounded pairs and trusted release streams pass together' "$root" 1
 
-root="$(build_tree on-pattern pattern)"
+root="$(build_tree on-pattern pair)"
+write_consumer "$root" "$first_consumer" "$first_workflow" "$PATTERN"
 expect_refusal 'switch on: the pattern form is refused and the fix names the pair' \
   "$root" 1 'pattern form' "($(signer_for "$first_consumer")|$SHA_B)"
 
 root="$(build_tree on-one-left pair)"
-write_consumer "$root" "$second_consumer" "$(printf '%s\n' "$consumers" | sed -n 2p | cut -f2)" "$PATTERN"
+write_consumer "$root" "$second_consumer" "$second_workflow" "$PATTERN"
 expect_refusal 'switch on: a single consumer left on the pattern form is refused by name' \
   "$root" 1 "$second_consumer" 'pattern form'
 
@@ -450,9 +474,9 @@ if [ -z "$enforce" ] || printf '%s\n' "$enforce" | grep -qv '^1$'; then
 fi
 [ "$failures" -eq 0 ] && pass 'wiring: ci.yaml enforces the approved set'
 
-# ── the real tree: every committed consumer uses exactly its approved pair ────────────────
+# ── the real tree: every committed consumer uses its declared boundary ───────────────────
 if out="$(APPROVED_REVISIONS_ENFORCE=1 bash "$GUARD" 2>&1)"; then
-  pass 'real tree: every per-consumer matcher uses its approved pair (enforced)'
+  pass 'real tree: every consumer matcher uses its declared boundary (enforced)'
 else
   fail 'real tree: guard refuses the committed state:'; printf '%s\n' "$out" >&2
 fi

--- a/scripts/tests/test-write-publish-workflow-matchers.sh
+++ b/scripts/tests/test-write-publish-workflow-matchers.sh
@@ -79,18 +79,31 @@ expect_atomic_refusal() {
 fixture
 if guard >"$WORK/guard.log" 2>&1; then fail 'pattern-form fixture unexpectedly passes enforcement'; fi
 grep -Fq 'pattern form' "$WORK/guard.log" || fail 'baseline refusal was not caused by the broad matcher'
-write_matchers >"$WORK/writer.log" 2>&1 || { cat "$WORK/writer.log" >&2; fail 'writer must narrow every registered consumer'; }
+write_matchers >"$WORK/writer.log" 2>&1 || { cat "$WORK/writer.log" >&2; fail 'writer must converge every registered consumer'; }
 guard >"$WORK/guard.log" 2>&1 || { cat "$WORK/guard.log" >&2; fail 'rewritten tree does not pass enforcement'; }
 [ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/github-config/oci-repository.yaml")" = \
   '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@(1111111111111111111111111111111111111111|2222222222222222222222222222222222222222)$' ] || fail 'github-config did not receive its own exact pair'
 [ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml")" = \
-  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@(3333333333333333333333333333333333333333|2222222222222222222222222222222222222222)$' ] || fail 'consumer pairs crossed'
+  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$' ] || fail 'ascoachingogvaner release stream was pinned to a workflow revision set'
 [ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/aws/oci-repository.yaml")" = \
   '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@1111111111111111111111111111111111111111$' ] || fail 'equal revisions were not deduplicated'
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml")" = \
+  '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$' ] || fail 'wedding-app release stream was pinned to a workflow revision set'
 [ "$(yq -r '.spec.interval' "$TREE/k8s/bases/apps/aws/oci-repository.yaml")" = 5m ] || fail 'unrelated YAML changed'
 grep -Fq '# Preserve this consumer comment.' "$TREE/k8s/bases/apps/aws/oci-repository.yaml" || fail 'consumer comment was lost'
 for file in "${GENERIC_FILES[@]}"; do cmp -s "$ROOT/$file" "$TREE/$file" || fail "generic subject $file changed"; done
 printf 'ok: exact consumer pairs, deduplication, unrelated fields and generic subjects\n'
+
+# Trusted application release streams advance without a platform-side signer repin. A
+# concrete revision pair on either stream reintroduces that approval gate and must fail
+# enforcement even though it still verifies the currently deployed artifact.
+SUBJECT="^https://github\\.com/devantler-tech/actions/\\.github/workflows/publish-app\\.yaml@($A|$B)\$" \
+  yq -i '.spec.verify.matchOIDCIdentity[0].subject = strenv(SUBJECT)' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml"
+if guard >"$WORK/guard.log" 2>&1; then fail 'a trusted release stream pinned to a revision pair passed enforcement'; fi
+grep -Fq 'trusted release stream' "$WORK/guard.log" || fail 'release-stream refusal did not name the boundary'
+write_matchers >"$WORK/writer.log" 2>&1 || fail 'writer did not restore the trusted release-stream boundary'
+guard >"$WORK/guard.log" 2>&1 || fail 'restored release-stream boundary did not pass enforcement'
+printf 'ok: trusted release streams refuse per-revision approval gates\n'
 
 before="$(snapshot)"
 write_matchers >"$WORK/writer.log" 2>&1
@@ -102,9 +115,13 @@ awk -F '\t' -v OFS='\t' -v pin="$D" 'NR > 1 {$6=pin} {print}' "$SET" >"$WORK/mov
 mv "$WORK/moved.tsv" "$SET"
 if guard >"$WORK/guard.log" 2>&1; then fail 'old matcher unexpectedly accepts a moved set'; fi
 grep -Fq 'not the generated pair' "$WORK/guard.log" || fail 'moved-set refusal had the wrong cause'
+ascoaching_before="$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml")"
+wedding_before="$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml")"
 write_matchers >"$WORK/writer.log" 2>&1
 guard >"$WORK/guard.log" 2>&1 || fail 'pin bump did not converge to a guard-clean tree'
-printf 'ok: a pin bump rewrites already narrowed matchers before enforcement\n'
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml")" = "$ascoaching_before" ] || fail 'a pin bump rewrote the ascoachingogvaner release stream'
+[ "$(yq -r '.spec.verify.matchOIDCIdentity[0].subject' "$TREE/k8s/bases/apps/wedding-app/oci-repository.yaml")" = "$wedding_before" ] || fail 'a pin bump rewrote the wedding-app release stream'
+printf 'ok: a pin bump rewrites bounded consumers and leaves trusted release streams unchanged\n'
 
 fixture
 sed '$d' "$SET" >"$WORK/incomplete.tsv"

--- a/scripts/write-publish-workflow-matchers.sh
+++ b/scripts/write-publish-workflow-matchers.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Derive per-consumer cosign subjects from the generated approved revision set.
+# Derive bounded-consumer cosign subjects from the generated approved revision set and keep
+# trusted tenant release streams on the immutable shared-workflow commit pattern.
 # Validate every input and staged result before replacing any consumer manifest.
 # Generic multi-consumer subjects remain unchanged. Unchanged output preserves bytes.
 set -euo pipefail
@@ -31,9 +32,12 @@ for consumer in "${EXPECTED_CONSUMERS[@]}"; do
     refuse "$consumer: source manifest must be a writable regular file, not a symlink"
   fi
 
-  pair="$signer"
-  [ "$signer" = "$pin" ] || pair="($signer|$pin)"
-  subject="${SUBJECT_PREFIX}${workflow#publish-}"'\.yaml@'"$pair"'$'
+  desired_ref="$PATTERN_REF"
+  if ! is_trusted_release_stream_consumer "$consumer"; then
+    desired_ref="$signer"
+    [ "$signer" = "$pin" ] || desired_ref="($signer|$pin)"
+  fi
+  subject="${SUBJECT_PREFIX}${workflow#publish-}"'\.yaml@'"$desired_ref"'$'
   mkdir -p "$STAGED/$(dirname "$file")"
   # Select the actual OCIRepository document; unrelated documents remain unchanged.
   # shellcheck disable=SC2016


### PR DESCRIPTION
The AS Coaching semver source selected a valid tenant release signed by a newer immutable revision of the platform-owned publish workflow, but the platform matcher allowed only the two revisions recorded in its generated approval set. Production reconciliation then waited 30 minutes and failed even though the release stayed inside the platform's existing tenant boundary.

This change declares AS Coaching and Wedding as trusted application release streams. Their matcher now requires the exact GitHub OIDC issuer and exact `devantler-tech/actions/.github/workflows/publish-app.yaml` path at an immutable 40-hex commit, while `.github` and AWS remain bound to their generated exact revision sets. The writer preserves that distinction, and enforcement rejects a concrete revision pair on a trusted release stream because it would recreate the per-release platform approval gate.

The platform continues to govern package source, namespace, RBAC, network, and admission-policy boundaries. A tenant release can move freely within those bounds; additional authority still requires a reviewed platform change.

Validation:
- `bash scripts/tests/test-write-publish-workflow-matchers.sh`
- `bash scripts/tests/test-publish-workflow-approved-revisions-guard.sh`
- `bash scripts/tests/test-shared-publish-workflow-pin-guard.sh`
- `bash scripts/guard-shared-publish-workflow-pin.sh`
- `shellcheck -x` on the changed matcher scripts and tests
- `go test ./scripts/validate-eks-ci-role-policy`
- real-tree matcher regeneration is a byte-identical no-op

Fixes #3699

