### PR TITLE
fix(coroot): suppress verified kubelet probe noise

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -398,6 +398,7 @@ jobs:
               - 'scripts/tests/crossplane-egress-policy-rules.yaml'
               - 'scripts/tests/test-cnpg-degraded-alert.sh'
               - 'scripts/tests/test-stranded-volume-attach-alert.sh'
+              - 'scripts/tests/test-coroot-alert-autosuppressor.sh'
               # The Job manifest, the Secret it imports and this test are one
               # contract: the credential is only out of the environment while all
               # three agree.
@@ -1186,6 +1187,13 @@ jobs:
         # shape against a stubbed API and delivery, so the fire, each quiet
         # verdict and both silent-zero guards are pinned by behaviour.
         run: bash scripts/tests/test-stranded-volume-attach-alert.sh
+
+      - name: 🔕 Validate narrow Coroot alert suppressions
+        if: needs.changes.outputs.k8s == 'true'
+        # The kubelet alert fingerprint is shared across every failed upstream.
+        # Exercise the rendered script so the two known static-pod probe series
+        # suppress, while one additional active upstream keeps the alert visible.
+        run: bash scripts/tests/test-coroot-alert-autosuppressor.sh
 
       - name: 🔑 Validate the MinIO bucket Job's credential handling
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml
@@ -44,9 +44,19 @@
 #      host extension is fixable via a manifest, and a genuine storage fault would
 #      still surface via Longhorn volume health and the instance-manager apps' own
 #      SLOs, so this host-app connectivity signal is the least-actionable place to
-#      lose. Scoped to rule_id + the single app id. NB the sibling
-#      `_:Unknown:kubelet` raises the same rule; it is intentionally NOT suppressed
-#      here until its specific failed upstreams are separately verified benign.
+#      lose. Scoped to rule_id + the single app id.
+#
+#   3. kubelet-static-pod-probes - the sibling `network-tcp-connections` warning
+#      on `_:Unknown:kubelet`, but ONLY while its complete active-upstream set is
+#      kube-scheduler + kube-controller-manager. These are the kubelet's HTTPS
+#      health probes against the Talos static pods: three schedulers each have a
+#      10s liveness and readiness probe (0.6/s total), and three controller
+#      managers each have a 10s liveness probe (0.3/s total). All six pods stay
+#      Ready while Coroot classifies the short probe connections as failures.
+#      SAFETY: the alert detail is read before suppression and every chart series
+#      with a positive sample must be one of those exact two names. Any new active
+#      upstream keeps the alert visible, even though Coroot reuses the same alert
+#      fingerprint for all kubelet TCP failures.
 #
 # PROD-ONLY: Coroot alerting (the Slack webhook) is wired only in the hetzner
 # overlay, so this lives here, not in the base.
@@ -154,6 +164,26 @@ spec:
                                and (.application_id | endswith(":_:Unknown:extensions")))
                       | .id'); do
                     ids="$ids $id"; echo "match extensions-host-failed-conns: $id"
+                  done
+
+                  # Exemption 3 - kubelet health probes to the static scheduler
+                  # and controller-manager pods. Refuse the exemption if ANY
+                  # other upstream has a positive sample in the failed-TCP chart.
+                  for id in $(printf '%s' "$ALERTS" | jq -r '.data.alerts[]
+                      | select(.suppressed==false and .resolved_at==null and .rule_id=="network-tcp-connections"
+                               and (.application_id | endswith(":_:Unknown:kubelet")))
+                      | .id'); do
+                    active=$(curl $RETRY "$BASE/api/project/$PID/alerts/$id" | jq -c '
+                      [.data.widgets[]? | .chart?
+                       | select(.title=="Failed TCP connections, per second")
+                       | .series[]?
+                       | select(.data | any(.[]?; type=="number" and . > 0))
+                       | .name] | unique | sort')
+                    if [ "$active" = '["→kube-controller-manager","→kube-scheduler"]' ]; then
+                      ids="$ids $id"; echo "match kubelet-static-pod-probes: $id"
+                    else
+                      echo "keep kubelet TCP alert visible; active upstreams: $active"
+                    fi
                   done
 
                   n=$(echo $ids | wc -w)

--- a/scripts/tests/test-coroot-alert-autosuppressor.sh
+++ b/scripts/tests/test-coroot-alert-autosuppressor.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Behaviour contract for Coroot's declarative alert auto-suppressor.
+#
+# Coroot attributes the kubelet's localhost health probes for the three static
+# kube-schedulers and controller managers as failed outbound TCP connections.
+# The live signal is deterministic: scheduler liveness + readiness yields
+# 0.6/s, while controller-manager liveness yields 0.3/s. Suppression is safe
+# only while those are the complete set of active upstream series. A third
+# active upstream must keep the alert visible.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly manifest="${root_dir}/k8s/providers/hetzner/infrastructure/coroot/cron-job-alert-autosuppressor.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok — %s\n' "$1"
+}
+
+for tool in yq jq; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    printf '::error::%s is required to run this contract test.\n' "${tool}" >&2
+    exit 64
+  }
+done
+
+[ -f "${manifest}" ] || fail "manifest not found: ${manifest}"
+script_body="$(yq eval '.spec.jobTemplate.spec.template.spec.containers[0].command[2]' "${manifest}")"
+[ -n "${script_body}" ] && [ "${script_body}" != "null" ] ||
+  fail "could not extract the autosuppressor script"
+
+work_root="$(mktemp -d /tmp/tmp.XXXXXXXXXX)"
+trap 'rm -rf "${work_root}"' EXIT
+
+setup_scenario() {
+  local name="$1" extra_upstream="$2"
+  local dir="${work_root}/${name}"
+  mkdir -p "${dir}/bin"
+
+  cat >"${dir}/user.json" <<'JSON'
+{"data":{"projects":[{"id":"95rsc5yp","name":"platform"}]}}
+JSON
+  cat >"${dir}/alerts.json" <<'JSON'
+{"data":{"alerts":[{"id":"kubelet-probe-noise","suppressed":false,"resolved_at":null,"rule_id":"network-tcp-connections","application_id":"95rsc5yp:_:Unknown:kubelet"}]}}
+JSON
+
+  jq -cn --argjson extra "${extra_upstream}" '
+    {data:{widgets:[{chart:{title:"Failed TCP connections, per second",series:(
+      [
+        {name:"→kube-scheduler",data:[0.6,0.6]},
+        {name:"→kube-controller-manager",data:[0.3,0.3]},
+        {name:"→coredns",data:[0,0]}
+      ] + (if $extra then [{name:"→external:443",data:[0,0.1]}] else [] end)
+    )}}]}}' >"${dir}/detail-kubelet-probe-noise.json"
+
+  cat >"${dir}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+dir="${SCENARIO_DIR}"
+url=""
+payload=""
+prev=""
+for arg in "$@"; do
+  [ "${prev}" = "-d" ] && payload="${arg}"
+  case "${arg}" in http://*) url="${arg}" ;; esac
+  prev="${arg}"
+done
+case "${url}" in
+  */api/user) cat "${dir}/user.json" ;;
+  *'/alerts?limit=500') cat "${dir}/alerts.json" ;;
+  */alerts/suppress)
+    printf '%s' "${payload}" >"${dir}/suppressed.json"
+    ;;
+  */alerts/*)
+    id="${url##*/}"
+    cat "${dir}/detail-${id}.json"
+    ;;
+  *)
+    printf 'unstubbed curl URL: %s\n' "${url}" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "${dir}/bin/curl"
+  printf '%s' "${dir}"
+}
+
+run_scenario() {
+  local dir="$1"
+  SCENARIO_DIR="${dir}" PATH="${dir}/bin:${PATH}" /bin/sh -c "${script_body}"
+}
+
+exact_dir="$(setup_scenario exact false)"
+run_scenario "${exact_dir}" >/dev/null
+[ -f "${exact_dir}/suppressed.json" ] ||
+  fail "the exact kubelet health-probe series were not suppressed"
+jq -e '.ids == ["kubelet-probe-noise"]' "${exact_dir}/suppressed.json" >/dev/null ||
+  fail "the exact scenario suppressed the wrong alert set"
+pass "exact kubelet scheduler/controller-manager probe noise is suppressed"
+
+extra_dir="$(setup_scenario extra true)"
+run_scenario "${extra_dir}" >/dev/null
+[ ! -e "${extra_dir}/suppressed.json" ] ||
+  fail "a kubelet alert with an additional active upstream was suppressed"
+pass "an additional active upstream keeps the kubelet alert visible"
+


### PR DESCRIPTION
Coroot classifies the kubelet's localhost HTTPS health probes to the Talos scheduler and controller-manager static pods as failed TCP traffic. The resulting warning stays firing even while all six control-plane pods are Ready, obscuring network failures that need operator attention.

This change teaches the existing declarative autosuppressor to read the alert detail and suppress the warning only when the complete active-upstream set is exactly `kube-scheduler` and `kube-controller-manager`. Any additional upstream with a positive sample keeps the alert visible. A behavior test runs the rendered Job script against both cases.

Closes #3728.

Validation:

- `bash scripts/tests/test-coroot-alert-autosuppressor.sh`
- `shellcheck scripts/tests/test-coroot-alert-autosuppressor.sh`
- `actionlint .github/workflows/ci.yaml`
- `kubectl v1.36.2 kustomize k8s/providers/hetzner/infrastructure`
- `go test ./scripts/validate-eks-ci-role-policy`
- `kubectl v1.36.2 go run ./scripts/validate-eks-ci-role-policy .`

The authorization contract remains unchanged.
