### PR TITLE
fix(kubescape): preserve profile access on upgrade

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: kubescape-operator
-      version: 1.40.3
+      version: 1.40.4
       sourceRef:
         kind: HelmRepository
         name: kubescape
@@ -46,7 +46,7 @@ spec:
     clusterName: ${cluster_name}
     capabilities:
       configurationScan: enable
-      # Chart 1.40.3 derives clusterData.continuousPostureScan from this value,
+      # Chart 1.40.4 derives clusterData.continuousPostureScan from this value,
       # and Kubescape only stores detailed WorkloadConfigurationScan results
       # when that runtime flag is true. Summaries are stored unconditionally,
       # so disabling this produces deceptively fresh summaries while detailed
@@ -90,7 +90,7 @@ spec:
       # it means "do not use the network at all", and the posture scanner needs
       # the network for one thing it cannot work without: its policy artifacts.
       #
-      # What the chart does with it (1.40.3, templates/kubescape/deployment.yaml
+      # What the chart does with it (1.40.4, templates/kubescape/deployment.yaml
       # and templates/_common.tpl):
       #   - `enable` is the ONLY thing that sets `KS_OFFLINE=true` on the
       #     scanner. With that set, the scanner does not fetch the Regolibrary
@@ -200,7 +200,7 @@ spec:
     # failure mode is a scan that aborts before persisting results. This value
     # fully replaces the chart default, so it must stay complete.
     kubescapeScheduler:
-      # Preserve the current posture window explicitly. Chart 1.40.3 hashes one
+      # Preserve the current posture window explicitly. Chart 1.40.4 hashes one
       # shared cluster seed for both scheduler defaults, so posture and
       # vulnerability scans otherwise render to the same instant and contend
       # for the storage service's single-writer SQLite database.
@@ -256,7 +256,7 @@ spec:
   # Drop all capabilities and pin a CONTAINER-level seccompProfile on the four
   # kubescape-operator Deployments. Post-rendered rather than set through
   # `values` above because the chart gives us no choice: kubescape-operator
-  # 1.40.3 exposes NO securityContext value anywhere in values.yaml (zero
+  # 1.40.4 exposes NO securityContext value anywhere in values.yaml (zero
   # occurrences), and each component's Deployment template HARDCODES the
   # container securityContext to exactly `allowPrivilegeEscalation: false`
   # + `readOnlyRootFilesystem: true` + `runAsNonRoot: true` — with no
@@ -308,3 +308,25 @@ spec:
                 path: /spec/template/spec/containers/0/securityContext/seccompProfile
                 value:
                   type: RuntimeDefault
+          # Chart 1.40.4 removes this rule from the node-agent ClusterRole, but
+          # node-agent still lists ApplicationProfiles during its storage
+          # readiness gate. Restore exactly the read-only rule from 1.40.3 so
+          # the upgrade does not expand the pre-existing platform boundary.
+          # Keep NetworkNeighborhoods paired with ApplicationProfiles because
+          # the runtime sensor reads both derived workload-profile resources.
+          - target:
+              kind: ClusterRole
+              name: ^node-agent$
+            patch: |
+              - op: add
+                path: /rules/-
+                value:
+                  apiGroups:
+                    - spdx.softwarecomposition.kubescape.io
+                  resources:
+                    - applicationprofiles
+                    - networkneighborhoods
+                  verbs:
+                    - get
+                    - list
+                    - watch

--- a/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
+++ b/scripts/tests/test-kubescape-self-hosted-scan-persistence.sh
@@ -14,6 +14,7 @@ fail() {
 
 command -v yq >/dev/null 2>&1 || fail 'yq v4 is required to inspect the Kubescape HelmRelease'
 command -v helm >/dev/null 2>&1 || fail 'helm is required to render the pinned Kubescape chart'
+command -v kubectl >/dev/null 2>&1 || fail 'kubectl is required to exercise the Flux Helm post-renderer'
 
 scanner_tag="$(yq -er '.spec.values.kubescape.image.tag | select(tag == "!!str")' "${helm_release}")" ||
   fail 'the Kubescape scanner image tag is missing or is not a string'
@@ -33,6 +34,13 @@ if ((major < 4 || (major == 4 && minor == 0 && patch < 12))); then
   fail "Kubescape scanner ${scanner_tag} predates v4.0.12 and can silently drop self-hosted posture results"
 fi
 
+# kubevuln v0.3.159 swallows an exhausted conflict retry while updating a
+# VulnerabilityManifestSummary: it logs the original AlreadyExists result and
+# returns success. kubescape/kubevuln#745 fixed both error reporting and
+# propagation, first released in v0.3.404. Chart 1.40.4 selects v0.3.430;
+# verify the rendered image below so a later chart cannot regress silently.
+readonly kubevuln_tag='v0.3.430'
+
 keep_local="$(yq -er '
   .spec.values.kubescapeScheduler.requestBody.commands[] |
   select(.CommandName == "kubescapeScan") |
@@ -51,7 +59,7 @@ readonly offline
 
 # The scanner's API-server persistence handler stores detailed
 # WorkloadConfigurationScan objects only when clusterData.continuousPostureScan
-# is true. Chart 1.40.3 derives that flag from this capability.
+# is true. Chart 1.40.4 derives that flag from this capability.
 continuous_scan="$(yq -er '.spec.values.capabilities.continuousScan' "${helm_release}")" ||
   fail 'capabilities.continuousScan is missing'
 readonly continuous_scan
@@ -85,14 +93,14 @@ readonly continuous_namespace_count
 # instant. Both scans are high-volume writers to one SQLite-backed storage API;
 # keep their authored windows separated so detailed posture writes do not lose
 # the single-writer lock to vulnerability results. These value paths and their
-# CronJob mapping were verified against immutable chart 1.40.3; fail on a chart
+# CronJob mapping were verified against immutable chart 1.40.4; fail on a chart
 # bump so the new chart must be rendered and this contract deliberately renewed.
 chart_version="$(yq -er '
   .spec.chart.spec.version |
   select(tag == "!!str" and length > 0)
 ' "${helm_release}")" || fail 'the Kubescape chart version must be an exact string'
 readonly chart_version
-[[ "${chart_version}" == "1.40.3" ]] ||
+[[ "${chart_version}" == "1.40.4" ]] ||
   fail 'the Kubescape chart changed; revalidate both rendered scheduler CronJobs before updating this guard'
 
 posture_schedule="$(yq -er '
@@ -119,7 +127,7 @@ readonly vulnerability_schedule
 # render additionally proves that the reviewed chart maps each authored value to
 # the intended CronJob. Pin the archive bytes so a republished tag fails closed.
 readonly chart_repository='https://kubescape.github.io/helm-charts/'
-readonly chart_archive_sha256='2a0ffaa69068218f03a44139ac77c81905350208413c14ba697e9514f204af07'
+readonly chart_archive_sha256='9c9dad697b13d085ed1c6cbb166d9ade239305aa2e8b5999840d455fc91a10ea'
 chart_dir="$(mktemp -d "${TMPDIR:-/tmp}/kubescape-chart.XXXXXX")" ||
   fail 'could not create a temporary directory for the Kubescape chart'
 readonly chart_dir
@@ -149,6 +157,44 @@ yq '.spec.values' "${helm_release}" >"${chart_values}"
 helm template kubescape "${chart_archive}" \
   --namespace kubescape \
   --values "${chart_values}" >"${rendered_chart}" || fail 'the pinned Kubescape chart did not render'
+
+# Chart 1.40.4 removed the node-agent's existing read-only profile rule while
+# node-agent still lists ApplicationProfiles during its storage readiness gate.
+# Exercise the platform post-renderer against a synthetic copy with that rule
+# removed so a future chart refactor cannot silently reintroduce the startup
+# failure observed during the 1.40.4 production rollout.
+readonly regressed_chart="${chart_dir}/rendered-without-node-agent-profile-read.yaml"
+yq ea '
+  (select(.kind == "ClusterRole" and .metadata.name == "node-agent").rules) |=
+    map(select(
+      (.apiGroups[0] // "") != "spdx.softwarecomposition.kubescape.io" or
+      ((.resources // []) | sort | join(",")) != "applicationprofiles,networkneighborhoods"
+    ))
+' "${rendered_chart}" >"${regressed_chart}" || fail 'could not construct the chart RBAC regression fixture'
+
+readonly postrenderer_kustomization="${chart_dir}/kustomization.yaml"
+HELM_RELEASE="${helm_release}" yq -n '
+  .apiVersion = "kustomize.config.k8s.io/v1beta1" |
+  .kind = "Kustomization" |
+  .resources = ["rendered-without-node-agent-profile-read.yaml"] |
+  .patches = (load(strenv(HELM_RELEASE)).spec.postRenderers[0].kustomize.patches // [])
+' >"${postrenderer_kustomization}" || fail 'could not construct the Flux post-renderer fixture'
+
+readonly postrendered_chart="${chart_dir}/postrendered.yaml"
+kubectl kustomize "${chart_dir}" >"${postrendered_chart}" || fail 'the Flux Helm post-renderer did not apply'
+
+node_agent_profile_reader_count="$(yq ea -er '
+  select(.kind == "ClusterRole" and .metadata.name == "node-agent") |
+  [.rules[] | select(
+    .apiGroups[0] == "spdx.softwarecomposition.kubescape.io" and
+    (.apiGroups | length) == 1 and
+    (.resources | sort | join(",")) == "applicationprofiles,networkneighborhoods" and
+    (.verbs | sort | join(",")) == "get,list,watch"
+  )] | length
+' "${postrendered_chart}")" || fail 'the post-rendered node-agent ClusterRole is missing'
+readonly node_agent_profile_reader_count
+[[ "${node_agent_profile_reader_count}" == "1" ]] ||
+  fail 'the Helm post-renderer must restore exactly the node-agent profile read rule removed by chart 1.40.4'
 
 rendered_posture_schedule="$(yq ea -er '
   select(.kind == "CronJob" and .metadata.name == "kubescape-scheduler") |
@@ -191,6 +237,17 @@ rendered_storage_image="$(yq ea -er '
 readonly rendered_storage_image
 [[ "${rendered_storage_image}" == "${storage_repository}:${storage_tag}" ]] ||
   fail 'the rendered Kubescape storage Deployment does not use the signed compatibility digest'
+
+rendered_kubevuln_image="$(yq ea -er '
+  select(.kind == "Deployment" and .metadata.name == "kubevuln") |
+  .spec.template.spec.containers[] |
+  select(.name == "kubevuln") |
+  .image |
+  select(tag == "!!str")
+' "${rendered_chart}")" || fail 'the rendered kubevuln image is missing'
+readonly rendered_kubevuln_image
+[[ "${rendered_kubevuln_image}" == "quay.io/kubescape/kubevuln:${kubevuln_tag}" ]] ||
+  fail 'the rendered kubevuln Deployment does not use the conflict-safe image'
 
 # Registry blob pulls can redirect from their API hosts to separate CDN hosts.
 # If a redirect host is blocked, kubevuln retries timeouts for hours and keeps

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1894,7 +1894,26 @@ const (
 // The new fingerprints below were read from this validator's complete rendered
 // surface. Restoring either predecessor value makes the same focused test fail,
 // so both checks remain live.
-const expectedRenderedSurfaceSHA = "2a3498e2fdcd83a48433d7821c382fef70115fc3b87e36ac508afcac5cbdc0ef"
+//
+// Moved again by the Kubescape 1.40.4 reliability repair (#3730). Exactly one
+// existing document changes: the kubescape/kubescape HelmRelease advances to
+// chart 1.40.4, which selects conflict-safe kubevuln v0.3.430, and its Helm
+// post-renderer restores the node-agent profile-reader rule that 1.40.4 removed.
+// The restored rule is byte-for-byte equivalent in authority to chart 1.40.3:
+// get/list/watch on ApplicationProfiles and NetworkNeighborhoods only.
+//
+// CONSERVATION, read from this validator under the SHA256-verified kubectl
+// v1.36.2 renderer: exactly this aggregate changed. It reported ZERO
+// `unapproved rendered <identity>`, ZERO `missing rendered authorization
+// resource` and ZERO `duplicate rendered`; every pinned per-resource identity
+// still passes. No identity, binding, ServiceAccount, write verb, wildcard,
+// AWS identity or net permission expansion is introduced. The post-renderer
+// preserves the pre-upgrade read boundary required by node-agent startup. The
+// kubescape HelmRelease's unresolved-substitution fingerprint changes with the
+// reviewed chart and patch; other substitutions are unchanged diagnostics.
+//
+// Previous aggregate: 2a3498e2fdcd83a48433d7821c382fef70115fc3b87e36ac508afcac5cbdc0ef.
+const expectedRenderedSurfaceSHA = "bc95f7ee1b1d9a29819844f5dfac84f256aa4caadac8eb39b43fed59992b85ea"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
Kubescape chart 1.40.3 runs Kubevuln v0.3.159, whose exhausted `VulnerabilityManifestSummary` conflict retries can return success while leaving stale data. Chart 1.40.4 selects conflict-safe Kubevuln v0.3.430, but its production merge-group rollout exposed a second regression: the chart removes the node-agent's existing profile-read rule while node-agent still lists ApplicationProfiles during startup, leaving the DaemonSet unready until Helm times out.

This change advances to chart 1.40.4 and restores exactly the read-only rule provided by 1.40.3: `get/list/watch` on `applicationprofiles` and `networkneighborhoods`. It adds no write verb or new identity. The behavior contract pins the immutable chart archive, verifies the rendered Kubevuln v0.3.430 image and scan schedules, removes the profile rule from a synthetic render, applies the Flux Helm post-renderer, and requires exactly the restored prior boundary.

Closes #3730.

Validation:

- `bash scripts/tests/test-kubescape-self-hosted-scan-persistence.sh`
- `shellcheck scripts/tests/test-kubescape-self-hosted-scan-persistence.sh`
- `go test ./scripts/validate-eks-ci-role-policy`
- `kubectl v1.36.2 go run ./scripts/validate-eks-ci-role-policy .`
- `kubectl v1.36.2 kustomize k8s/providers/hetzner/infrastructure`

The exact renderer reported zero unapproved identities, missing resources, or duplicates. The governed aggregate changes only for the reviewed HelmRelease chart and post-render patch; the read grant is identical to the pre-upgrade chart boundary.
