### PR TITLE
fix(security): supply the C-0211 baseline context to descheduler

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-release.yaml
@@ -31,6 +31,17 @@ spec:
     kind: Deployment
     deschedulingInterval: 30m
     replicas: 1
+    # C-0211 baseline context, supplied through the chart's own values because
+    # kube-system is excluded from the add-security-context mutation (#3239).
+    # Both fields are inert here and neither relaxes the chart's hardening,
+    # which the rendered output keeps verbatim: the pod has no fsGroup and its
+    # only volume is a configMap, so ownership policy governs nothing; the
+    # empty seLinuxOptions object satisfies the control while leaving SELinux
+    # type and MCS category selection to the runtime.
+    podSecurityContext:
+      fsGroupChangePolicy: OnRootMismatch
+    securityContext:
+      seLinuxOptions: {}
     deschedulerPolicy:
       # Blast-radius caps: one cycle may move at most 2 pods per node and 2 per
       # namespace, so a misjudged policy degrades slowly and visibly (evictions

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1894,7 +1894,47 @@ const (
 // The new fingerprints below were read from this validator's complete rendered
 // surface. Restoring either predecessor value makes the same focused test fail,
 // so both checks remain live.
-const expectedRenderedSurfaceSHA = "2a3498e2fdcd83a48433d7821c382fef70115fc3b87e36ac508afcac5cbdc0ef"
+//
+// Moved again by the descheduler C-0211 baseline context (#3239). The workload
+// sits in kube-system, which add-security-context excludes, so its stored
+// template is supplied through the chart's own values instead. A HelmRelease is
+// a controller-RBAC emitter, so a pure VALUES change moves this aggregate even
+// though nothing is granted.
+//
+// Rendering all five authorization roots on this branch and on main 0fd0ee0f
+// preserves the complete document identity set in both directions: 86
+// grant-bearing identities (ClusterRole, Role, ClusterRoleBinding, RoleBinding,
+// ServiceAccount) identical either way, the ClusterRole/Role rule bodies
+// identical under digest
+// 6a52babc727cc081fd2505ccf16d8617776edd2bcce6cd25aac733df9aa147e3, and 560
+// documents over 63 kinds unchanged. Four of the five roots render
+// byte-identically; infrastructure/controllers grows by 112 bytes. The complete
+// hunk list is ONE hunk of four added lines inside the descheduler HelmRelease's
+// values:
+//
+//	podSecurityContext.fsGroupChangePolicy: OnRootMismatch
+//	securityContext.seLinuxOptions: {}
+//
+// It adds no Role, ClusterRole, binding, ServiceAccount, subject, verb,
+// wildcard, AWS identity, or permission. Injecting one synthetic ClusterRole
+// into the rendered surface makes both independent extractions report the
+// difference, so the identical result above is a finding rather than a blind
+// read. A first pass of the structural extraction counted 171 per side; 85 of
+// those were document-separator artifacts rather than identities, symmetric on
+// both sides. The filtered count of 86 is the real one.
+//
+// RENDERER PROVENANCE, and unlike the #3722 entry above this one claims no local
+// reproduction: this host renders with kubectl v1.36.1 and kustomize v5.8.1,
+// which this validator REJECTS as unapproved, so no local digest was produced
+// and none could be. The value below was read from CI's own failure on run
+// 34695951314, which renders under the approved SHA256-verified toolchain. The
+// conservation evidence above is renderer-independent — it compares two trees
+// under one renderer — so it stands on its own; only the digest depends on CI.
+//
+// The previous aggregate remains recorded here:
+//
+//	2a3498e2fdcd83a48433d7821c382fef70115fc3b87e36ac508afcac5cbdc0ef
+const expectedRenderedSurfaceSHA = "64fa70ceb63e0e967b8218a55e0693f97542137b48ff463ad381afa39d796d9e"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1946,14 +1946,14 @@ const (
 // reproduction: this host renders with kubectl v1.36.1 and kustomize v5.8.1,
 // which this validator REJECTS as unapproved, so no local digest was produced
 // and none could be. The value below was read from CI's own failure on run
-// 34695951314, which renders under the approved SHA256-verified toolchain. The
+// 34698439645, which renders under the approved SHA256-verified toolchain. The
 // conservation evidence above is renderer-independent — it compares two trees
 // under one renderer — so it stands on its own; only the digest depends on CI.
 //
 // The previous aggregate remains recorded here:
 //
 //	bc95f7ee1b1d9a29819844f5dfac84f256aa4caadac8eb39b43fed59992b85ea
-const expectedRenderedSurfaceSHA = "0000000000000000000000000000000000000000000000000000000000000000"
+const expectedRenderedSurfaceSHA = "5b85be735c3d7d32e2bf6dce91c0e73435986c169234f2d72984617e9dc25a65"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Motivation

Kubescape scores the C-0211 security-context controls against each workload's **stored** controller template. `kube-system` is excluded from the cluster-wide security-context mutation because the workloads there need elevated privileges — but two of the controls it suppresses, volume-ownership policy and the SELinux options object, are not privilege settings. The descheduler has been failing both for no reason anyone chose.

### Description

Supplies the two fields through the descheduler chart's own values, which is the source-owned route the baseline rollout doc names for Helm-templated workloads. Both are inert for this workload: it has no group-ownership setting and its only volume is a configuration map, so the ownership policy governs nothing, and the empty SELinux object satisfies the control while leaving the runtime's own label selection untouched.

Rendering the real pinned chart shows the two additions are the **entire** change — every existing hardening setting on the container is preserved and the rendered resource list is identical. Removing the two values restores the previous output exactly, so the rollback is a one-line revert.

This is one workload of the remaining population; the issue stays open for the rest.

Part of #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
