### PR TITLE
fix(wedding-db): restore data after forced recreation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,6 +239,7 @@ jobs:
           node --version
           yq --version
           node --test tests/wedding-backup-staging/*.test.mjs
+          node --test tests/wedding-db-incident-recovery/*.test.mjs
 
       - name: 🔍 Filter paths
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -20,6 +20,8 @@ jobs:
     environment: prod
     permissions:
       contents: read
+    outputs:
+      source_sha: ${{ steps.recovery_source.outputs.sha }}
     steps:
       - name: Check out the exact recovery source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,7 +30,12 @@ jobs:
           ref: main
 
       - name: Verify the exact main recovery source
-        run: node scripts/recover-wedding-db-incident.mjs --verify-source
+        id: recovery_source
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/recover-wedding-db-incident.mjs --verify-source
+          printf 'sha=%s\n' "$GITHUB_SHA" >>"$GITHUB_OUTPUT"
 
       - name: Restore production kubeconfig
         shell: bash
@@ -54,7 +61,7 @@ jobs:
   restore-application:
     name: Restore Wedding application state
     needs: recover
-    if: ${{ always() }}
+    if: ${{ always() && needs.recover.outputs.source_sha != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: prod
@@ -65,7 +72,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ needs.recover.outputs.source_sha }}
 
       - name: Verify the exact main recovery source
         run: node scripts/recover-wedding-db-incident.mjs --verify-source

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: recover
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     environment: prod
     permissions:
       contents: read

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: main
+
+      - name: Verify the exact main recovery source
+        run: node scripts/recover-wedding-db-incident.mjs --verify-source
 
       - name: Restore production kubeconfig
         shell: bash
@@ -61,6 +65,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: main
+
+      - name: Verify the exact main recovery source
+        run: node scripts/recover-wedding-db-incident.mjs --verify-source
 
       - name: Restore production kubeconfig
         shell: bash

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -16,7 +16,7 @@ jobs:
   recover:
     name: Restore pre-loss Wedding data
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     environment: prod
     permissions:
       contents: read
@@ -40,3 +40,33 @@ jobs:
 
       - name: Preserve, recover, merge, and prove Wedding data
         run: node scripts/recover-wedding-db-incident.mjs
+
+  restore-application:
+    name: Restore Wedding application state
+    needs: recover
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact recovery source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Restore production kubeconfig
+        shell: bash
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          test -n "$KUBE_CONFIG"
+          umask 077
+          mkdir -p ~/.kube
+          printf '%s' "$KUBE_CONFIG" >~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Restore only state owned by this recovery run
+        run: node scripts/recover-wedding-db-incident.mjs --cleanup

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -38,6 +38,12 @@ jobs:
           printf '%s' "$KUBE_CONFIG" >~/.kube/config
           chmod 600 ~/.kube/config
 
+      - name: Select stable production API endpoint
+        shell: bash
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: ./scripts/use-prod-stable-api-endpoint.sh
+
       - name: Preserve, recover, merge, and prove Wedding data
         run: node scripts/recover-wedding-db-incident.mjs
 
@@ -67,6 +73,12 @@ jobs:
           mkdir -p ~/.kube
           printf '%s' "$KUBE_CONFIG" >~/.kube/config
           chmod 600 ~/.kube/config
+
+      - name: Select stable production API endpoint
+        shell: bash
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: ./scripts/use-prod-stable-api-endpoint.sh
 
       - name: Restore only state owned by this recovery run
         run: node scripts/recover-wedding-db-incident.mjs --cleanup

--- a/.github/workflows/recover-wedding-db-incident.yaml
+++ b/.github/workflows/recover-wedding-db-incident.yaml
@@ -1,0 +1,42 @@
+name: Recover Wedding database incident
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+# Recovery mutates the production Wedding database. Share the deployment lock
+# so no publication or backup cutover can race the source checks or transaction.
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  recover:
+    name: Restore pre-loss Wedding data
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact recovery source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Restore production kubeconfig
+        shell: bash
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          set -euo pipefail
+          test -n "$KUBE_CONFIG"
+          umask 077
+          mkdir -p ~/.kube
+          printf '%s' "$KUBE_CONFIG" >~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Preserve, recover, merge, and prove Wedding data
+        run: node scripts/recover-wedding-db-incident.mjs

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -822,9 +822,13 @@ A deploy fails to start with one of:
 `refresh-flux-ghcr-auth.sh` fences its transaction with a `Lease` and by suspending
 the `infrastructure` and `flux-system` Kustomizations. Those fences are released
 together at exit. A hard kill releases an arbitrary prefix and leaves the rest
-held — and nothing reclaims them automatically, because Talos machine-config
-writes expose no fencing token, so a surviving process could still write after a
-timeout takeover. Recovery is deliberately a human step.
+held. Protected deploy and heal jobs run `--recover-fences`: it releases policy
+fences and then the Lease only when every holder identifies a GitHub Actions run
+attempt that is confirmed terminal, the Lease heartbeat has stopped, no node
+fence is held, and every CAS-guarded patch still matches the reported state.
+Node fences remain a manual or full-bridge recovery because Talos machine-config
+writes expose no fencing token and need the bridge's revision and scheduling
+proofs.
 
 A held policy fence is the more serious of the two: the deploy fails loudly, but
 the suspended Kustomization silently stops GitOps reconciliation for that layer
@@ -862,7 +866,11 @@ fences legitimately.
 - An identity with no run reference predates that recording, or came from a local
   run. Establish liveness another way before continuing.
 
-**3. Release.** Run the command the report printed for each dead fence. Each is
+**3. Release.** For terminal GitHub-run policy fences plus the Lease, run
+`./scripts/refresh-flux-ghcr-auth.sh --recover-fences`; it proves all holders
+before its first mutation and releases child, parent, then Lease. For a local or
+legacy holder that the API cannot prove terminal, use the commands from
+`--fences` only after establishing the process is dead. Each command is
 CAS-guarded on the holder and the resource's current state, so it fails safely if
 anything changed since the report.
 

--- a/k8s/bases/apps/wedding-app/flux-kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/flux-kustomization.yaml
@@ -15,7 +15,10 @@ spec:
   path: .
   prune: true
   wait: true
-  force: true
+  # Never let an immutable tenant-manifest change delete and recreate the
+  # stateful CNPG Cluster. Resources that genuinely require replacement must
+  # opt in individually with the Flux force annotation.
+  force: false
   # This Kustomization applies wedding-db (a CNPG `Cluster`) from the tenant's
   # own artifact, so `wait: true` health-checks it. kstatus marks a CNPG Cluster
   # NotReady for the whole of any rolling update, and CNPG rolls every instance

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -40,6 +40,13 @@ spec:
           - op: replace
             path: /spec/replicas
             value: 2
+          - op: add
+            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            value:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: kustomize-controller
+                topologyKey: kubernetes.io/hostname
       # Run kustomize-/helm-/notification-controller active/standby (HA) for
       # node-failure resilience: each binary runs --enable-leader-election and
       # holds a coordination.k8s.io Lease, so a 2nd replica is a warm standby (one
@@ -81,6 +88,13 @@ spec:
           - op: replace
             path: /spec/replicas
             value: 2
+          - op: add
+            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            value:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: helm-controller
+                topologyKey: kubernetes.io/hostname
       - target:
           kind: Deployment
           name: notification-controller
@@ -88,18 +102,25 @@ spec:
           - op: replace
             path: /spec/replicas
             value: 2
-      # Spread the four Flux controllers across worker nodes. They all carry
-      # app.kubernetes.io/part-of=flux, so a per-controller topology spread
-      # keyed on that label distributes the set (skew <= 1) — and, combined with
-      # the replicas: 2 patch above, keeps each controller's active and standby
-      # pods on different nodes instead of letting the scheduler stack them.
+          - op: add
+            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            value:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: notification-controller
+                topologyKey: kubernetes.io/hostname
+      # Spread the four Flux controllers across worker nodes. The three
+      # replicated controller patches above require each active/standby pair to
+      # use different hostnames. This additional aggregate spread distributes
+      # the whole controller set with skew <= 1.
       # On 2026-05-28 kustomize-controller landed on prod-worker-2 when that
       # node's Cilium ClusterIP datapath degraded after an OOMKill; it then
       # crash-looped on "dial tcp 10.96.0.1:443: i/o timeout" and GitOps
       # reconciliation stalled — so the fix for the underlying OOM could not be
       # applied (a deadlock GitOps cannot self-heal from). Keeping the
       # controllers spread means a single bad worker cannot decapitate
-      # reconciliation. Soft (ScheduleAnyway) so it never blocks scheduling.
+      # reconciliation. The aggregate rule is soft (ScheduleAnyway); the
+      # same-controller anti-affinity above is the required HA guarantee.
       - target:
           kind: Deployment
           labelSelector: app.kubernetes.io/part-of=flux

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -30,7 +30,6 @@ spec:
       - target:
           kind: Deployment
           name: kustomize-controller
-          namespace: flux-system
         patch: |
           - op: test
             path: /spec/template/spec/containers/0/name
@@ -65,9 +64,12 @@ spec:
       # (verified live via a forced FluxInstance reconcile). A controller must
       # also have exactly one name-targeted patch: flux-operator only applied the
       # first of two duplicate kustomize-controller targets, which silently left
-      # it at one replica. The robust fix is therefore one patch per HA controller
-      # and no source-controller replicas patch, so source-controller keeps the
-      # base manifest's single replica with zero ambiguity. (topologySpread + ndots
+      # it at one replica. Deployment patch targets must also omit `namespace`:
+      # flux-operator applies component patches before the namespace transformer,
+      # so a namespaced Deployment selector silently matches nothing. The robust
+      # fix is therefore one unnamespaced patch per HA controller and no
+      # source-controller replicas patch, so source-controller keeps the base
+      # manifest's single replica with zero ambiguity. (topologySpread + ndots
       # below still target the whole part-of=flux set by label — those don't
       # conflict and are safe at 1 replica.) flux-operator itself stays
       # single-replica: its chart exposes no replicas/leaderElection (0.50.0), so
@@ -75,7 +77,6 @@ spec:
       - target:
           kind: Deployment
           name: helm-controller
-          namespace: flux-system
         patch: |
           - op: replace
             path: /spec/replicas
@@ -83,7 +84,6 @@ spec:
       - target:
           kind: Deployment
           name: notification-controller
-          namespace: flux-system
         patch: |
           - op: replace
             path: /spec/replicas

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -41,12 +41,14 @@ spec:
             path: /spec/replicas
             value: 2
           - op: add
-            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            path: /spec/template/spec/affinity
             value:
-              - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: kustomize-controller
-                topologyKey: kubernetes.io/hostname
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app: kustomize-controller
+                    topologyKey: kubernetes.io/hostname
       # Run kustomize-/helm-/notification-controller active/standby (HA) for
       # node-failure resilience: each binary runs --enable-leader-election and
       # holds a coordination.k8s.io Lease, so a 2nd replica is a warm standby (one
@@ -89,12 +91,14 @@ spec:
             path: /spec/replicas
             value: 2
           - op: add
-            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            path: /spec/template/spec/affinity
             value:
-              - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: helm-controller
-                topologyKey: kubernetes.io/hostname
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app: helm-controller
+                    topologyKey: kubernetes.io/hostname
       - target:
           kind: Deployment
           name: notification-controller
@@ -103,12 +107,14 @@ spec:
             path: /spec/replicas
             value: 2
           - op: add
-            path: /spec/template/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution
+            path: /spec/template/spec/affinity
             value:
-              - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: notification-controller
-                topologyKey: kubernetes.io/hostname
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app: notification-controller
+                    topologyKey: kubernetes.io/hostname
       # Spread the four Flux controllers across worker nodes. The three
       # replicated controller patches above require each active/standby pair to
       # use different hostnames. This additional aggregate spread distributes

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -38,6 +38,9 @@ spec:
           - op: add
             path: /spec/template/spec/containers/0/args/-
             value: --requeue-dependency=5s
+          - op: replace
+            path: /spec/replicas
+            value: 2
       # Run kustomize-/helm-/notification-controller active/standby (HA) for
       # node-failure resilience: each binary runs --enable-leader-election and
       # holds a coordination.k8s.io Lease, so a 2nd replica is a warm standby (one
@@ -59,21 +62,16 @@ spec:
       # source-controller. That did NOT work: raw `kustomize build` honours patch
       # order and yields 1, but flux-operator resolves the overlapping label- and
       # name-targeted patches the other way, so source-controller stayed at 2
-      # (verified live via a forced FluxInstance reconcile). The robust fix is to
-      # match each HA controller BY NAME and leave source-controller matched by no
-      # replicas patch at all, so it keeps the base manifest's single replica with
-      # zero ambiguity. (topologySpread + ndots below still target the whole
-      # part-of=flux set by label — those don't conflict and are safe at 1
-      # replica.) flux-operator itself stays single-replica: its chart exposes no
-      # replicas/leaderElection (0.50.0), so it relies on reschedule.
-      - target:
-          kind: Deployment
-          name: kustomize-controller
-          namespace: flux-system
-        patch: |
-          - op: replace
-            path: /spec/replicas
-            value: 2
+      # (verified live via a forced FluxInstance reconcile). A controller must
+      # also have exactly one name-targeted patch: flux-operator only applied the
+      # first of two duplicate kustomize-controller targets, which silently left
+      # it at one replica. The robust fix is therefore one patch per HA controller
+      # and no source-controller replicas patch, so source-controller keeps the
+      # base manifest's single replica with zero ambiguity. (topologySpread + ndots
+      # below still target the whole part-of=flux set by label — those don't
+      # conflict and are safe at 1 replica.) flux-operator itself stays
+      # single-replica: its chart exposes no replicas/leaderElection (0.50.0), so
+      # it relies on reschedule.
       - target:
           kind: Deployment
           name: helm-controller

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -194,9 +194,16 @@ function schemaName(run,attempt){
   check(/^incident_restore_[1-9][0-9]*_[1-9][0-9]*$/.test(value)&&value.length<=63);return value;
 }
 
+export function buildSchemaCleanupSQL(run,attempt){
+  integer(run);integer(attempt);
+  const last=Number(attempt);check(Number.isSafeInteger(last)&&last<=100);
+  return Array.from({length:last},(_,index)=>`DROP SCHEMA IF EXISTS ${schemaName(run,String(index+1))} CASCADE;`).join('\n');
+}
+
 export function buildMergeSQL(schema){
   check(/^incident_restore_[1-9][0-9]*_[1-9][0-9]*$/.test(schema)&&schema.length<=63);
   return `BEGIN;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE;
 DO $guard$
 BEGIN
@@ -213,6 +220,10 @@ BEGIN
       EXCEPT SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered)
   ) THEN RAISE EXCEPTION 'guest identity mismatch'; END IF;
 END $guard$;
+CREATE TEMP TABLE incident_restore_counts (
+  restored_guest_answers bigint NOT NULL,
+  restored_room_bookings bigint NOT NULL
+) ON COMMIT DROP;
 WITH restored_guests AS (
   UPDATE guests live
   SET attending=recovered.attending,dietary_notes=recovered.dietary_notes,updated_at=recovered.updated_at
@@ -228,9 +239,11 @@ WITH restored_guests AS (
   ON CONFLICT (guest_pair_id) DO NOTHING
   RETURNING id
 )
+INSERT INTO incident_restore_counts (restored_guest_answers,restored_room_bookings)
+SELECT (SELECT count(*) FROM restored_guests),(SELECT count(*) FROM restored_bookings);
 SELECT json_build_object(
-  'restoredGuestAnswers',(SELECT count(*) FROM restored_guests),
-  'restoredRoomBookings',(SELECT count(*) FROM restored_bookings),
+  'restoredGuestAnswers',(SELECT restored_guest_answers FROM incident_restore_counts),
+  'restoredRoomBookings',(SELECT restored_room_bookings FROM incident_restore_counts),
   'finalMeaningfulGuestAnswers',(SELECT count(*) FROM guests WHERE attending IS NOT NULL OR dietary_notes IS NOT NULL),
   'finalRoomBookings',(SELECT count(*) FROM room_bookings)
 );
@@ -357,6 +370,10 @@ function loadRecovered(primary,database,recovered,config){
 
 function dropStagingSchema(primary,database,config){
   psql(primary,database,`DROP SCHEMA IF EXISTS ${schemaName(config.run,config.attempt)} CASCADE;`);
+}
+
+function dropRunStagingSchemas(primary,database,config){
+  psql(primary,database,buildSchemaCleanupSQL(config.run,config.attempt));
 }
 
 function fenceOwner(state,uidValue,config){
@@ -590,19 +607,23 @@ function run(){
 
 function runCleanup(){
   const config=verifyCandidate();
-  let schemaCleanupError,resumeError,cleanupError,resumed=false;
+  let schemaCleanupError,resumeError,cleanupError,resumed=false,schemaCleaned=false;
   const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   const owner=kustomization.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION];
+  if(owner)recoveryOwnerAttempt(config.run,config.attempt,owner);
+  const cleanupSchema=()=>{
+    const cluster=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER);check(cluster.metadata.uid===CURRENT_CLUSTER_UID);
+    const primary=cluster.status?.currentPrimary;check(/^wedding-db-[1-9][0-9]*$/.test(primary));
+    dropRunStagingSchemas(primary,'wedding',config);schemaCleaned=true;schemaCleanupError=undefined;
+  };
   if(owner){
-    const attempt=recoveryOwnerAttempt(config.run,config.attempt,owner);
     try{
       check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.spec?.suspend===true&&kustomization.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
-      const cluster=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER);check(cluster.metadata.uid===CURRENT_CLUSTER_UID);
-      const primary=cluster.status?.currentPrimary;check(/^wedding-db-[1-9][0-9]*$/.test(primary));
-      dropStagingSchema(primary,'wedding',{run:config.run,attempt});
+      cleanupSchema();
     }catch(candidate){schemaCleanupError=candidate;}
   }
   try{resumed=resumeApplication(config);}catch(candidate){resumeError=candidate;}
+  if(!schemaCleaned){try{cleanupSchema();}catch(candidate){schemaCleanupError=candidate;}}
   try{cleanupRecovery(config);}catch(candidate){cleanupError=candidate;}
   if(schemaCleanupError||resumeError||cleanupError)throw Error('refused');
   return {cleanup:true,resumed};

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -7,6 +7,9 @@ const NAMESPACE='wedding-app';
 const PARENT_NAMESPACE='flux-system';
 const PARENT_KUSTOMIZATION='apps';
 const PARENT_KUSTOMIZATION_UID='7a4f35ea-01c8-460e-aefe-6fdf6d10eb48';
+const FLUX_CONTROLLER='kustomize-controller';
+const FLUX_CONTROLLER_UID='48c6521a-483a-4de9-895a-bae1a61ea25e';
+const FLUX_CONTROLLER_RESTART_PATH='/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt';
 const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
 const LIVE_KUSTOMIZATION='wedding-app';
@@ -117,6 +120,18 @@ export function buildResumePatch({kustomizationUid,owner}){
     {op:'add',path:'/spec/suspend',value:false},
     {op:'remove',path:RECOVERY_OWNER_PATH},
     {op:'remove',path:RECOVERY_RECONCILE_PATH},
+  ];
+}
+
+export function buildControllerRestartPatch({resourceVersion,deploymentUid,annotationsPresent,restartToken}){
+  integer(resourceVersion);
+  check(deploymentUid===FLUX_CONTROLLER_UID&&typeof annotationsPresent==='boolean');
+  check(/^wedding-db-recovery-[1-9][0-9]*-[1-9][0-9]*$/.test(restartToken));
+  return [
+    {op:'test',path:'/metadata/resourceVersion',value:resourceVersion},
+    {op:'test',path:'/metadata/uid',value:deploymentUid},
+    ...(annotationsPresent?[]:[{op:'add',path:'/spec/template/metadata/annotations',value:{}}]),
+    {op:'add',path:FLUX_CONTROLLER_RESTART_PATH,value:restartToken},
   ];
 }
 
@@ -241,10 +256,12 @@ function optionalObject(resource,name){
   return output.length?JSON.parse(output.toString('utf8')):null;
 }
 
-function list(resource,selector){
-  const value=JSON.parse(kubectl(['--namespace',NAMESPACE,'get',resource,'--selector',selector,'--output=json','--request-timeout=20s']).toString('utf8'));
+function listAt(namespace,resource,selector){
+  const value=JSON.parse(kubectl(['--namespace',namespace,'get',resource,'--selector',selector,'--output=json','--request-timeout=20s']).toString('utf8'));
   check(typeof value?.apiVersion==='string'&&Array.isArray(value.items)&&value.items.length<=32);return value.items;
 }
+
+function list(resource,selector){return listAt(NAMESPACE,resource,selector);}
 
 function verifyCandidate(){
   check(process.env.GITHUB_REPOSITORY==='devantler-tech/platform'&&process.env.GITHUB_EVENT_NAME==='workflow_dispatch');
@@ -396,9 +413,64 @@ function proveApplicationFences(config){
   check(fenceOwner(child,LIVE_KUSTOMIZATION_UID,config)===owner);
 }
 
+function assertControllerReady(controller,{restartToken}={}){
+  check(controller.apiVersion==='apps/v1'&&controller.kind==='Deployment');
+  check(controller.metadata?.name===FLUX_CONTROLLER&&controller.metadata.namespace===PARENT_NAMESPACE);
+  check(controller.metadata.uid===FLUX_CONTROLLER_UID&&controller.metadata.creationTimestamp==='2026-05-23T00:41:46Z'&&!controller.metadata.deletionTimestamp);
+  check(typeof controller.metadata.resourceVersion==='string'&&Number.isSafeInteger(controller.metadata.generation));
+  check(controller.spec?.replicas===1&&controller.spec.selector?.matchLabels?.app===FLUX_CONTROLLER);
+  check(controller.status?.observedGeneration===controller.metadata.generation&&controller.status.updatedReplicas===1&&controller.status.readyReplicas===1&&controller.status.availableReplicas===1);
+  check(controller.spec.template?.metadata?.annotations&&typeof controller.spec.template.metadata.annotations==='object');
+  if(restartToken)check(controller.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt']===restartToken);
+}
+
+function assertReadyControllerPods(pods,expected){
+  check(pods.length===expected);
+  for(const pod of pods)check(pod.metadata?.namespace===PARENT_NAMESPACE&&!pod.metadata.deletionTimestamp&&uid(pod.metadata.uid)&&condition(pod,'Ready'));
+}
+
+function restartKustomizeController(config){
+  proveApplicationFences(config);
+  const beforeController=objectAt(PARENT_NAMESPACE,'deployments.apps',FLUX_CONTROLLER);
+  assertControllerReady(beforeController);
+  const beforePods=listAt(PARENT_NAMESPACE,'pods','app='+FLUX_CONTROLLER);
+  assertReadyControllerPods(beforePods,1);
+  const oldUids=new Set(beforePods.map(pod=>pod.metadata.uid));
+  const restartToken=`wedding-db-recovery-${integer(config.run)}-${integer(config.attempt)}`;
+  const patch=buildControllerRestartPatch({
+    resourceVersion:beforeController.metadata.resourceVersion,
+    deploymentUid:beforeController.metadata.uid,
+    annotationsPresent:typeof beforeController.spec.template.metadata.annotations==='object',
+    restartToken,
+  });
+  try{
+    kubectl(['--namespace',PARENT_NAMESPACE,'patch','deployment.apps',FLUX_CONTROLLER,'--type=json','--patch='+JSON.stringify(patch)]);
+  }catch{
+    assertControllerReady(objectAt(PARENT_NAMESPACE,'deployments.apps',FLUX_CONTROLLER),{restartToken});
+  }
+  kubectl(['--namespace',PARENT_NAMESPACE,'rollout','status','deployment.apps/'+FLUX_CONTROLLER,'--timeout=10m'],{timeout:630000});
+  const end=Date.now()+5*60*1000;
+  while(Date.now()<end){
+    proveApplicationFences(config);
+    const controller=objectAt(PARENT_NAMESPACE,'deployments.apps',FLUX_CONTROLLER);
+    const pods=listAt(PARENT_NAMESPACE,'pods','app='+FLUX_CONTROLLER);
+    const current=pods.filter(pod=>!pod.metadata?.deletionTimestamp);
+    if([...oldUids].every(oldUid=>!pods.some(pod=>pod.metadata?.uid===oldUid))){
+      assertControllerReady(controller,{restartToken});
+      assertReadyControllerPods(current,1);
+      return;
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
+  }
+  throw Error('refused');
+}
+
 function suspendApplication(config){
   acquireFence(PARENT_NAMESPACE,PARENT_KUSTOMIZATION,PARENT_KUSTOMIZATION_UID,config);
   acquireFence(NAMESPACE,LIVE_KUSTOMIZATION,LIVE_KUSTOMIZATION_UID,config);
+  // Suspension cannot cancel a reconciliation that already started. Replacing
+  // every controller process under both fences drains that cached work first.
+  restartKustomizeController(config);
   kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=0']);
   const end=Date.now()+5*60*1000;let stable=0;
   while(Date.now()<end){

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -1,0 +1,361 @@
+import {spawnSync} from 'node:child_process';
+import {lstatSync,readFileSync,realpathSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const NAMESPACE='wedding-app';
+const LIVE_CLUSTER='wedding-db';
+const LIVE_DEPLOYMENT='wedding-app';
+const LIVE_KUSTOMIZATION='wedding-app';
+const SOURCE_STORE='wedding-db';
+const SOURCE_SECRET='wedding-db-backup-r2';
+const CURRENT_CLUSTER_UID='afea05ff-7daa-4d80-99a6-f2d696cbc3f1';
+const PRELOSS_BACKUP='wedding-db-daily-20260908030000';
+const PRELOSS_BACKUP_UID='549fe940-b119-4010-bdc8-fa8e6ebc93ae';
+const PRELOSS_CLUSTER_UID='6b6d4879-e437-4ea5-a0cb-257de8edad00';
+const RECOVERY_MODE='full archive from backup 20260908T030001';
+const PROOF='wedding-db-data-recovery-proof';
+const check=value=>{if(!value)throw Error('refused');return value;};
+const integer=value=>{check(typeof value==='string'&&/^[1-9][0-9]*$/.test(value));return value;};
+const uid=value=>{check(typeof value==='string'&&/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(value));return value;};
+const timestamp=value=>{check(typeof value==='string'&&!Number.isNaN(Date.parse(value)));return value;};
+const condition=(value,type)=>value.status?.conditions?.some(item=>item.type===type&&item.status==='True');
+
+function exactObject(value,{apiVersion,kind,name}){
+  check(value?.apiVersion===apiVersion&&value.kind===kind);
+  check(value.metadata?.name===name&&value.metadata.namespace===NAMESPACE&&!value.metadata.deletionTimestamp);
+  uid(value.metadata.uid);
+}
+
+function endpointHost(endpoint){
+  return check(/^https:\/\/([0-9a-f]{32}\.r2\.cloudflarestorage\.com)$/.exec(endpoint))?.[1];
+}
+
+export function recoverySource({cluster,store,backup}){
+  exactObject(cluster,{apiVersion:'postgresql.cnpg.io/v1',kind:'Cluster',name:LIVE_CLUSTER});
+  check(cluster.metadata.uid===CURRENT_CLUSTER_UID&&cluster.metadata.creationTimestamp==='2026-09-09T01:58:14Z');
+  check(cluster.spec?.bootstrap?.initdb?.database==='wedding');
+  check(cluster.status?.phase==='Cluster in healthy state'&&cluster.status.currentPrimary&&cluster.status.readyInstances>=1);
+  check(condition(cluster,'Ready')&&condition(cluster,'ContinuousArchiving'));
+  const plugins=cluster.spec?.plugins;
+  check(Array.isArray(plugins)&&plugins.length===1);
+  check(plugins[0].name==='barman-cloud.cloudnative-pg.io'&&plugins[0].enabled===true&&plugins[0].isWALArchiver===true);
+  check(plugins[0].parameters?.barmanObjectName===SOURCE_STORE&&plugins[0].parameters.serverName==='wedding-db-20260909');
+
+  exactObject(store,{apiVersion:'barmancloud.cnpg.io/v1',kind:'ObjectStore',name:SOURCE_STORE});
+  const configuration=store.spec?.configuration;
+  check(configuration?.destinationPath==='s3://platform-backups/cnpg/wedding-db');
+  const endpoint=configuration.endpointURL;
+  endpointHost(endpoint);
+  for(const [field,key] of [['accessKeyId','ACCESS_KEY_ID'],['secretAccessKey','SECRET_ACCESS_KEY'],['region','REGION']]){
+    check(configuration.s3Credentials?.[field]?.name===SOURCE_SECRET&&configuration.s3Credentials[field].key===key);
+  }
+
+  exactObject(backup,{apiVersion:'postgresql.cnpg.io/v1',kind:'Backup',name:PRELOSS_BACKUP});
+  check(backup.metadata.uid===PRELOSS_BACKUP_UID&&backup.metadata.creationTimestamp==='2026-09-08T03:00:00Z');
+  check(backup.spec?.cluster?.name===LIVE_CLUSTER&&backup.spec.method==='plugin'&&backup.spec.pluginConfiguration?.name==='barman-cloud.cloudnative-pg.io');
+  check(backup.status?.phase==='completed'&&backup.status.backupId==='20260908T030001'&&backup.status.majorVersion===18);
+  check(backup.status.pluginMetadata?.clusterUID===PRELOSS_CLUSTER_UID&&backup.status.pluginMetadata.timeline==='162');
+  check(backup.status.startedAt&&backup.status.stoppedAt&&!backup.status.error);
+
+  const imageName=cluster.spec.imageName;
+  check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
+  check(cluster.spec.storage?.storageClass==='longhorn-wffc');
+  check(/^[1-9][0-9]*(?:Mi|Gi|Ti)$/.test(cluster.spec.storage?.size));
+  return {currentClusterUid:cluster.metadata.uid,sourceUid:store.metadata.uid,prelossBackupUid:backup.metadata.uid,database:'wedding',imageName,storageClass:'longhorn-wffc',size:cluster.spec.storage.size,endpoint,prelossBackupId:backup.status.backupId};
+}
+
+function labels(run,attempt){
+  integer(run);integer(attempt);
+  return {'app.kubernetes.io/name':'wedding-db-incident-recovery','app.kubernetes.io/managed-by':'github-actions','devantler.tech/github-run':run,'devantler.tech/github-attempt':attempt};
+}
+
+function recoveryName(run,attempt){
+  const name=`wedding-db-preloss-${integer(run)}-${integer(attempt)}`;
+  check(name.length<=63);return name;
+}
+
+export function buildRecoveryResources({run,attempt,endpoint,imageName,storageClass,prelossBackupId}){
+  check(storageClass==='longhorn-wffc');
+  check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
+  const name=recoveryName(run,attempt),owned=labels(run,attempt),hostname=endpointHost(endpoint);
+  const cluster={apiVersion:'postgresql.cnpg.io/v1',kind:'Cluster',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{
+    instances:1,imageName,enableSuperuserAccess:false,enablePDB:false,
+    storage:{size:'2Gi',storageClass},
+    resources:{requests:{cpu:'50m',memory:'256Mi'},limits:{cpu:'1',memory:'1Gi'}},
+    bootstrap:{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:check(prelossBackupId==='20260908T030001')&&prelossBackupId}}},
+    externalClusters:[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:SOURCE_STORE,serverName:'wedding-db'}}}],
+  }};
+  const policy={apiVersion:'cilium.io/v2',kind:'CiliumNetworkPolicy',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{endpointSelector:{matchLabels:{'cnpg.io/cluster':name}},egress:[
+    {toEndpoints:[{matchLabels:{'io.kubernetes.pod.namespace':'kube-system','k8s-app':'kube-dns'}}],toPorts:[{ports:[{port:'53',protocol:'UDP'},{port:'53',protocol:'TCP'}],rules:{dns:[{matchPattern:'*'}]}}]},
+    {toEntities:['kube-apiserver']},
+    {toFQDNs:[{matchName:hostname}],toPorts:[{ports:[{port:'443',protocol:'TCP'}]}]},
+  ]}};
+  return {cluster,policy};
+}
+
+export function buildBackup({run,attempt,phase}){
+  check(['before','after'].includes(phase));
+  const name=`wedding-db-incident-${phase}-${integer(run)}-${integer(attempt)}`;
+  check(name.length<=63);
+  return {apiVersion:'postgresql.cnpg.io/v1',kind:'Backup',metadata:{name,namespace:NAMESPACE,labels:labels(run,attempt)},spec:{method:'plugin',pluginConfiguration:{name:'barman-cloud.cloudnative-pg.io'},cluster:{name:LIVE_CLUSTER}}};
+}
+
+function string(value,max=1024){check(typeof value==='string'&&value.length>0&&value.length<=max&&!value.includes('\0'));return value;}
+function nullableString(value,max=1024){check(value===null||(typeof value==='string'&&value.length<=max&&!value.includes('\0')));return value;}
+function nullableBoolean(value){check(value===null||typeof value==='boolean');return value;}
+
+export function validateCoreInventory(value,{requireMeaningful=true}={}){
+  check(value&&typeof value==='object'&&!Array.isArray(value));
+  const {guestPairs,guests,roomBookings}=value;
+  check(Array.isArray(guestPairs)&&guestPairs.length>0&&guestPairs.length<=100);
+  check(Array.isArray(guests)&&guests.length>0&&guests.length<=300);
+  check(Array.isArray(roomBookings)&&roomBookings.length<=100);
+  const codes=new Set();
+  for(const pair of guestPairs){
+    check(pair&&typeof pair==='object'&&/^[A-Za-z0-9_-]{1,32}$/.test(pair.code));string(pair.name,255);timestamp(pair.createdAt);check(!codes.has(pair.code));codes.add(pair.code);
+  }
+  const guestKeys=new Set();let meaningfulGuests=0;
+  for(const guest of guests){
+    check(guest&&typeof guest==='object'&&codes.has(guest.pairCode));string(guest.name,255);nullableBoolean(guest.attending);nullableString(guest.dietaryNotes,500);timestamp(guest.updatedAt);
+    const key=guest.pairCode+'\0'+guest.name;check(!guestKeys.has(key));guestKeys.add(key);
+    if(guest.attending!==null||guest.dietaryNotes!==null)meaningfulGuests+=1;
+  }
+  const bookingCodes=new Set();
+  for(const booking of roomBookings){
+    check(booking&&typeof booking==='object'&&codes.has(booking.pairCode)&&typeof booking.requested==='boolean');nullableString(booking.notes,500);timestamp(booking.updatedAt);check(!bookingCodes.has(booking.pairCode));bookingCodes.add(booking.pairCode);
+  }
+  if(requireMeaningful)check(meaningfulGuests>0||roomBookings.length>0);
+  return {guestPairs:guestPairs.length,guests:guests.length,roomBookings:roomBookings.length,meaningfulGuests};
+}
+
+function schemaName(run,attempt){
+  const value=`incident_restore_${integer(run)}_${integer(attempt)}`;
+  check(/^incident_restore_[1-9][0-9]*_[1-9][0-9]*$/.test(value)&&value.length<=63);return value;
+}
+
+export function buildMergeSQL(schema){
+  check(/^incident_restore_[1-9][0-9]*_[1-9][0-9]*$/.test(schema)&&schema.length<=63);
+  return `BEGIN;
+LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE;
+DO $guard$
+BEGIN
+  IF EXISTS (
+    (SELECT code, name FROM ${schema}.guest_pairs EXCEPT SELECT code, name FROM guest_pairs)
+    UNION ALL
+    (SELECT code, name FROM guest_pairs EXCEPT SELECT code, name FROM ${schema}.guest_pairs)
+  ) THEN RAISE EXCEPTION 'guest pair identity mismatch'; END IF;
+  IF EXISTS (
+    (SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered
+      EXCEPT SELECT pairs.code, live.name FROM guests live JOIN guest_pairs pairs ON pairs.id=live.guest_pair_id)
+    UNION ALL
+    (SELECT pairs.code, live.name FROM guests live JOIN guest_pairs pairs ON pairs.id=live.guest_pair_id
+      EXCEPT SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered)
+  ) THEN RAISE EXCEPTION 'guest identity mismatch'; END IF;
+END $guard$;
+WITH restored_guests AS (
+  UPDATE guests live
+  SET attending=recovered.attending,dietary_notes=recovered.dietary_notes,updated_at=recovered.updated_at
+  FROM ${schema}.guests recovered JOIN guest_pairs pairs ON pairs.code=recovered.pair_code
+  WHERE live.guest_pair_id=pairs.id AND live.name=recovered.name
+    AND live.attending IS NULL AND live.dietary_notes IS NULL
+    AND (recovered.attending IS NOT NULL OR recovered.dietary_notes IS NOT NULL)
+  RETURNING live.id
+), restored_bookings AS (
+  INSERT INTO room_bookings (guest_pair_id,requested,notes,updated_at)
+  SELECT pairs.id,recovered.requested,recovered.notes,recovered.updated_at
+  FROM ${schema}.room_bookings recovered JOIN guest_pairs pairs ON pairs.code=recovered.pair_code
+  ON CONFLICT (guest_pair_id) DO NOTHING
+  RETURNING id
+)
+SELECT json_build_object(
+  'restoredGuestAnswers',(SELECT count(*) FROM restored_guests),
+  'restoredRoomBookings',(SELECT count(*) FROM restored_bookings),
+  'finalMeaningfulGuestAnswers',(SELECT count(*) FROM guests WHERE attending IS NOT NULL OR dietary_notes IS NOT NULL),
+  'finalRoomBookings',(SELECT count(*) FROM room_bookings)
+);
+DROP SCHEMA ${schema} CASCADE;
+COMMIT;`;
+}
+
+function kubectl(args,{input,timeout=30000,maxBytes=2*1024*1024}={}){
+  const result=spawnSync('kubectl',['--kubeconfig',path.join(process.env.HOME,'.kube/config'),'--context','admin@prod',...args],{input,env:{PATH:process.env.PATH,HOME:process.env.HOME},timeout,maxBuffer:maxBytes});
+  check(!result.error&&result.status===0&&result.stdout.length<=maxBytes&&result.stderr.length<=maxBytes);
+  return result.stdout;
+}
+
+function object(resource,name){
+  const value=JSON.parse(kubectl(['--namespace',NAMESPACE,'get',resource,name,'--output=json','--request-timeout=20s']).toString('utf8'));
+  check(value&&typeof value==='object'&&!Array.isArray(value));return value;
+}
+
+function optionalObject(resource,name){
+  const output=kubectl(['--namespace',NAMESPACE,'get',resource,name,'--ignore-not-found=true','--output=json','--request-timeout=20s']);
+  return output.length?JSON.parse(output.toString('utf8')):null;
+}
+
+function list(resource,selector){
+  const value=JSON.parse(kubectl(['--namespace',NAMESPACE,'get',resource,'--selector',selector,'--output=json','--request-timeout=20s']).toString('utf8'));
+  check(value?.apiVersion==='v1'&&Array.isArray(value.items)&&value.items.length<=32);return value.items;
+}
+
+function verifyCandidate(){
+  check(process.env.GITHUB_REPOSITORY==='devantler-tech/platform'&&process.env.GITHUB_EVENT_NAME==='workflow_dispatch');
+  check(process.env.GITHUB_REF==='refs/heads/main'&&process.env.GITHUB_REF_NAME==='main'&&/^[0-9a-f]{40}$/.test(process.env.GITHUB_SHA));
+  const workspace=realpathSync(process.env.GITHUB_WORKSPACE);check(workspace===process.env.GITHUB_WORKSPACE);
+  const head=spawnSync('git',['--no-replace-objects','-C',workspace,'rev-parse','HEAD'],{encoding:'utf8',env:{PATH:process.env.PATH,GIT_NO_REPLACE_OBJECTS:'1'},maxBuffer:1024});
+  check(!head.error&&head.status===0&&head.stdout===process.env.GITHUB_SHA+'\n');
+  for(const relative of ['scripts/recover-wedding-db-incident.mjs','.github/workflows/recover-wedding-db-incident.yaml','k8s/bases/apps/wedding-app/flux-kustomization.yaml']){
+    const filename=path.join(workspace,relative),stat=lstatSync(filename);check(stat.isFile()&&!stat.isSymbolicLink()&&stat.size>0&&stat.size<=524288&&realpathSync(filename)===filename);
+    const local=readFileSync(filename),source=spawnSync('git',['--no-replace-objects','-C',workspace,'show',process.env.GITHUB_SHA+':'+relative],{env:{PATH:process.env.PATH,GIT_NO_REPLACE_OBJECTS:'1'},maxBuffer:524288});
+    check(!source.error&&source.status===0&&local.equals(source.stdout));local.fill(0);source.stdout.fill(0);
+  }
+  integer(process.env.GITHUB_RUN_ID);integer(process.env.GITHUB_RUN_ATTEMPT);
+  return {run:process.env.GITHUB_RUN_ID,attempt:process.env.GITHUB_RUN_ATTEMPT};
+}
+
+function sourceState(){
+  check(kubectl(['--namespace',NAMESPACE,'get','secret',SOURCE_SECRET,'--output=name','--request-timeout=20s']).toString('utf8').trim()==='secret/'+SOURCE_SECRET);
+  check(!optionalObject('configmaps',PROOF));
+  const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  check(kustomization.spec?.force===false&&kustomization.spec.suspend!==true&&condition(kustomization,'Ready'));
+  return recoverySource({cluster:object('clusters.postgresql.cnpg.io',LIVE_CLUSTER),store:object('objectstores.barmancloud.cnpg.io',SOURCE_STORE),backup:object('backups.postgresql.cnpg.io',PRELOSS_BACKUP)});
+}
+
+function backup(config,phase,source){
+  const primary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status?.currentPrimary;check(/^wedding-db-[1-9][0-9]*$/.test(primary));
+  kubectl(['--namespace',NAMESPACE,'exec',primary,'--container=postgres','--','psql','--username=postgres','--dbname=postgres','--set=ON_ERROR_STOP=1','--tuples-only','--no-align','--command=SELECT pg_switch_wal();']);
+  const manifest=buildBackup({...config,phase});check(!optionalObject('backups.postgresql.cnpg.io',manifest.metadata.name));
+  kubectl(['create','--filename=-'],{input:Buffer.from(JSON.stringify(manifest))});
+  const end=Date.now()+30*60*1000;
+  while(Date.now()<end){
+    const value=object('backups.postgresql.cnpg.io',manifest.metadata.name);
+    if(value.status?.phase==='completed'){
+      check(value.status.pluginMetadata?.clusterUID===source.currentClusterUid&&value.status.backupId&&value.status.startedAt&&value.status.stoppedAt&&!value.status.error);
+      return {name:value.metadata.name,uid:uid(value.metadata.uid),backupId:string(value.status.backupId,64)};
+    }
+    check(!['failed','walArchivingFailing'].includes(value.status?.phase));Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,10000);
+  }
+  throw Error('refused');
+}
+
+const INVENTORY_SQL=`SELECT json_build_object(
+  'guestPairs',COALESCE((SELECT json_agg(json_build_object('code',code,'name',name,'createdAt',created_at) ORDER BY code) FROM guest_pairs),'[]'::json),
+  'guests',COALESCE((SELECT json_agg(json_build_object('pairCode',pairs.code,'name',guests.name,'attending',guests.attending,'dietaryNotes',guests.dietary_notes,'updatedAt',guests.updated_at) ORDER BY pairs.code,guests.name) FROM guests JOIN guest_pairs pairs ON pairs.id=guests.guest_pair_id),'[]'::json),
+  'roomBookings',COALESCE((SELECT json_agg(json_build_object('pairCode',pairs.code,'requested',bookings.requested,'notes',bookings.notes,'updatedAt',bookings.updated_at) ORDER BY pairs.code) FROM room_bookings bookings JOIN guest_pairs pairs ON pairs.id=bookings.guest_pair_id),'[]'::json)
+)::text;`;
+
+function inventory(primary,database,{requireMeaningful}){
+  const output=kubectl(['--namespace',NAMESPACE,'exec',primary,'--container=postgres','--','psql','--username=postgres','--dbname='+database,'--set=ON_ERROR_STOP=1','--tuples-only','--no-align','--quiet','--command='+INVENTORY_SQL],{timeout:120000,maxBytes:1024*1024});
+  return {value:JSON.parse(output.toString('utf8').trim()),summary:null,requireMeaningful};
+}
+
+function csv(value){
+  if(value===null)return '\\N';
+  const text=value instanceof Date?value.toISOString():String(value);
+  return '"'+text.replaceAll('"','""')+'"';
+}
+
+function csvRows(rows,columns){return Buffer.from(rows.map(row=>columns.map(column=>csv(row[column])).join(',')).join('\n')+'\n');}
+
+function psql(primary,database,command,{input,maxBytes=65536}={}){
+  return kubectl(['--namespace',NAMESPACE,'exec',...(input?['--stdin']:[]),primary,'--container=postgres','--','psql','--username=postgres','--dbname='+database,'--set=ON_ERROR_STOP=1','--tuples-only','--no-align','--quiet','--command='+command],{input,timeout:120000,maxBytes});
+}
+
+function loadRecovered(primary,database,recovered,config){
+  const schema=schemaName(config.run,config.attempt);
+  psql(primary,database,`CREATE SCHEMA ${schema}; CREATE TABLE ${schema}.guest_pairs(code text PRIMARY KEY,name text NOT NULL,created_at timestamptz NOT NULL); CREATE TABLE ${schema}.guests(pair_code text NOT NULL,name text NOT NULL,attending boolean,dietary_notes text,updated_at timestamptz NOT NULL,PRIMARY KEY(pair_code,name)); CREATE TABLE ${schema}.room_bookings(pair_code text PRIMARY KEY,requested boolean NOT NULL,notes text,updated_at timestamptz NOT NULL);`);
+  const loads=[
+    ['guest_pairs',['code','name','createdAt'],recovered.guestPairs],
+    ['guests',['pairCode','name','attending','dietaryNotes','updatedAt'],recovered.guests],
+    ['room_bookings',['pairCode','requested','notes','updatedAt'],recovered.roomBookings],
+  ];
+  for(const [table,columns,rows] of loads){
+    if(!rows.length)continue;
+    const sqlColumns=columns.map(column=>({pairCode:'pair_code',dietaryNotes:'dietary_notes',updatedAt:'updated_at',createdAt:'created_at'}[column]??column)).join(',');
+    psql(primary,database,`\\copy ${schema}.${table}(${sqlColumns}) FROM STDIN WITH (FORMAT csv, NULL '\\N')`,{input:csvRows(rows,columns)});
+  }
+  return schema;
+}
+
+function suspendApplication(){
+  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch={"spec":{"suspend":true}}']);
+  check(object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION).spec?.suspend===true);
+  kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=0']);
+  const end=Date.now()+5*60*1000;
+  while(Date.now()<end){
+    const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
+    if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').filter(pod=>!pod.metadata.deletionTimestamp).length===0)return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
+  }
+  throw Error('refused');
+}
+
+function resumeApplication(){
+  let failed=false;
+  try{kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=2']);}catch{failed=true;}
+  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch={"spec":{"suspend":false}}']);}catch{failed=true;}
+  try{kubectl(['--namespace',NAMESPACE,'rollout','status','deployment/'+LIVE_DEPLOYMENT,'--timeout=10m'],{timeout:630000});}catch{failed=true;}
+  check(!failed);
+}
+
+function createRecovery(config,source){
+  const resources=buildRecoveryResources({...config,...source}),name=resources.cluster.metadata.name;
+  check(!optionalObject('clusters.postgresql.cnpg.io',name)&&!optionalObject('ciliumnetworkpolicies.cilium.io',name));
+  kubectl(['create','--filename=-'],{input:Buffer.from(JSON.stringify({apiVersion:'v1',kind:'List',items:[resources.policy,resources.cluster]}))});
+  kubectl(['--namespace',NAMESPACE,'wait','cluster.postgresql.cnpg.io/'+name,'--for=condition=Ready','--timeout=30m'],{timeout:1830000});
+  const cluster=object('clusters.postgresql.cnpg.io',name);check(cluster.status?.readyInstances===1&&cluster.status.currentPrimary&&condition(cluster,'Ready'));
+  check(cluster.spec?.bootstrap?.recovery?.recoveryTarget?.backupID===source.prelossBackupId&&!cluster.spec.plugins);
+  return {name,uid:uid(cluster.metadata.uid),primary:cluster.status.currentPrimary};
+}
+
+function cleanupRecovery(config,recovery){
+  const name=recoveryName(config.run,config.attempt);check(recovery.name===name);
+  kubectl(['--namespace',NAMESPACE,'delete','cluster.postgresql.cnpg.io',name,'--wait=true','--timeout=10m'],{timeout:630000});
+  for(const claim of list('persistentvolumeclaims','cnpg.io/cluster='+name))kubectl(['--namespace',NAMESPACE,'delete','persistentvolumeclaim',claim.metadata.name,'--wait=true','--timeout=5m'],{timeout:330000});
+  kubectl(['--namespace',NAMESPACE,'delete','ciliumnetworkpolicy.cilium.io',name,'--wait=true','--timeout=2m'],{timeout:150000});
+  check(!optionalObject('clusters.postgresql.cnpg.io',name)&&list('persistentvolumeclaims','cnpg.io/cluster='+name).length===0&&!optionalObject('ciliumnetworkpolicies.cilium.io',name));
+}
+
+function recordProof({config,source,recovery,before,after,recovered,liveBefore,merge}){
+  const manifest={apiVersion:'v1',kind:'ConfigMap',metadata:{name:PROOF,namespace:NAMESPACE,labels:{'app.kubernetes.io/name':'wedding-db','app.kubernetes.io/managed-by':'github-actions'}},data:{
+    version:'1',recoveryMode:RECOVERY_MODE,replacementCreatedAt:'2026-09-09T01:58:14Z',currentClusterUid:source.currentClusterUid,prelossClusterUid:PRELOSS_CLUSTER_UID,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,
+    beforeBackupUid:before.uid,afterBackupUid:after.uid,recoveredGuests:String(recovered.guests),recoveredMeaningfulGuests:String(recovered.meaningfulGuests),recoveredRoomBookings:String(recovered.roomBookings),
+    liveBeforeMeaningfulGuests:String(liveBefore.meaningfulGuests),liveBeforeRoomBookings:String(liveBefore.roomBookings),restoredGuestAnswers:String(merge.restoredGuestAnswers),restoredRoomBookings:String(merge.restoredRoomBookings),
+    finalMeaningfulGuestAnswers:String(merge.finalMeaningfulGuestAnswers),finalRoomBookings:String(merge.finalRoomBookings),githubRun:config.run,githubAttempt:config.attempt,
+  }};
+  kubectl(['create','--filename=-'],{input:Buffer.from(JSON.stringify(manifest))});
+  exactObject(object('configmaps',PROOF),{apiVersion:'v1',kind:'ConfigMap',name:PROOF});
+}
+
+function run(){
+  const config=verifyCandidate(),source=sourceState();
+  const before=backup(config,'before',source);
+  const recovery=createRecovery(config,source);
+  const recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
+  const recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
+  const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
+  const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
+  const liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
+  check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
+  let merge,error,resumeError,suspensionAttempted=false;
+  try{
+    suspensionAttempted=true;suspendApplication();
+    check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===source.currentClusterUid);
+    const schema=loadRecovered(livePrimary,source.database,recoveredInventory.value,config);
+    const output=psql(livePrimary,source.database,buildMergeSQL(schema));
+    merge=JSON.parse(output.toString('utf8').trim());
+    for(const key of ['restoredGuestAnswers','restoredRoomBookings','finalMeaningfulGuestAnswers','finalRoomBookings'])check(Number.isSafeInteger(merge[key])&&merge[key]>=0);
+    check(merge.finalMeaningfulGuestAnswers>=recovered.meaningfulGuests&&merge.finalRoomBookings>=recovered.roomBookings);
+  }catch(candidate){error=candidate;}
+  if(suspensionAttempted){try{resumeApplication();}catch(candidate){resumeError=candidate;}}
+  if(error||resumeError)throw Error('refused');
+  const after=backup(config,'after',source);
+  recordProof({config,source,recovery,before,after,recovered,liveBefore,merge});
+  cleanupRecovery(config,recovery);
+  return {restored:true,currentClusterUid:source.currentClusterUid,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,beforeBackupUid:before.uid,afterBackupUid:after.uid,recovered,liveBefore,merge,cleanup:true};
+}
+
+if(process.argv[1]===fileURLToPath(import.meta.url)){
+  try{process.stdout.write(JSON.stringify(run())+'\n');}catch{process.stderr.write('Wedding database incident recovery refused.\n');process.exitCode=2;}
+}

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -8,6 +8,7 @@ const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
 const LIVE_KUSTOMIZATION='wedding-app';
 const SOURCE_STORE='wedding-db';
+const SOURCE_STORE_UID='9cd2ba9b-c7bf-43e2-bd2d-a5c7c139fafb';
 const SOURCE_SECRET='wedding-db-backup-r2';
 const CURRENT_CLUSTER_UID='afea05ff-7daa-4d80-99a6-f2d696cbc3f1';
 const PRELOSS_BACKUP='wedding-db-daily-20260908030000';
@@ -43,6 +44,7 @@ export function recoverySource({cluster,store,backup}){
   check(plugins[0].parameters?.barmanObjectName===SOURCE_STORE&&plugins[0].parameters.serverName==='wedding-db-20260909');
 
   exactObject(store,{apiVersion:'barmancloud.cnpg.io/v1',kind:'ObjectStore',name:SOURCE_STORE});
+  check(store.metadata.uid===SOURCE_STORE_UID&&store.metadata.creationTimestamp==='2026-06-16T20:39:55Z');
   const configuration=store.spec?.configuration;
   check(configuration?.destinationPath==='s3://platform-backups/cnpg/wedding-db');
   const endpoint=configuration.endpointURL;
@@ -310,10 +312,20 @@ function createRecovery(config,source){
 }
 
 function cleanupRecovery(config,recovery){
-  const name=recoveryName(config.run,config.attempt);check(recovery.name===name);
-  kubectl(['--namespace',NAMESPACE,'delete','cluster.postgresql.cnpg.io',name,'--wait=true','--timeout=10m'],{timeout:630000});
+  const name=recoveryName(config.run,config.attempt),owned=labels(config.run,config.attempt);
+  if(recovery)check(recovery.name===name);
+  const cluster=optionalObject('clusters.postgresql.cnpg.io',name);
+  if(cluster){
+    for(const [key,value] of Object.entries(owned))check(cluster.metadata?.labels?.[key]===value);
+    if(recovery?.uid)check(cluster.metadata.uid===recovery.uid);
+    kubectl(['--namespace',NAMESPACE,'delete','cluster.postgresql.cnpg.io',name,'--wait=true','--timeout=10m'],{timeout:630000});
+  }
   for(const claim of list('persistentvolumeclaims','cnpg.io/cluster='+name))kubectl(['--namespace',NAMESPACE,'delete','persistentvolumeclaim',claim.metadata.name,'--wait=true','--timeout=5m'],{timeout:330000});
-  kubectl(['--namespace',NAMESPACE,'delete','ciliumnetworkpolicy.cilium.io',name,'--wait=true','--timeout=2m'],{timeout:150000});
+  const policy=optionalObject('ciliumnetworkpolicies.cilium.io',name);
+  if(policy){
+    for(const [key,value] of Object.entries(owned))check(policy.metadata?.labels?.[key]===value);
+    kubectl(['--namespace',NAMESPACE,'delete','ciliumnetworkpolicy.cilium.io',name,'--wait=true','--timeout=2m'],{timeout:150000});
+  }
   check(!optionalObject('clusters.postgresql.cnpg.io',name)&&list('persistentvolumeclaims','cnpg.io/cluster='+name).length===0&&!optionalObject('ciliumnetworkpolicies.cilium.io',name));
 }
 
@@ -331,15 +343,17 @@ function recordProof({config,source,recovery,before,after,recovered,liveBefore,m
 function run(){
   const config=verifyCandidate(),source=sourceState();
   const before=backup(config,'before',source);
-  const recovery=createRecovery(config,source);
-  const recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
-  const recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
-  const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
-  const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
-  const liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
-  check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
-  let merge,error,resumeError,suspensionAttempted=false;
+  let recovery,recoveredInventory,recovered,liveBefore,merge,error,resumeError,cleanupError;
+  let recoveryAttempted=false,suspensionAttempted=false;
   try{
+    recoveryAttempted=true;
+    recovery=createRecovery(config,source);
+    recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
+    recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
+    const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
+    const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
+    liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
+    check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
     suspensionAttempted=true;suspendApplication();
     check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===source.currentClusterUid);
     const schema=loadRecovered(livePrimary,source.database,recoveredInventory.value,config);
@@ -349,10 +363,10 @@ function run(){
     check(merge.finalMeaningfulGuestAnswers>=recovered.meaningfulGuests&&merge.finalRoomBookings>=recovered.roomBookings);
   }catch(candidate){error=candidate;}
   if(suspensionAttempted){try{resumeApplication();}catch(candidate){resumeError=candidate;}}
-  if(error||resumeError)throw Error('refused');
+  if(recoveryAttempted){try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}}
+  if(error||resumeError||cleanupError)throw Error('refused');
   const after=backup(config,'after',source);
   recordProof({config,source,recovery,before,after,recovered,liveBefore,merge});
-  cleanupRecovery(config,recovery);
   return {restored:true,currentClusterUid:source.currentClusterUid,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,beforeBackupUid:before.uid,afterBackupUid:after.uid,recovered,liveBefore,merge,cleanup:true};
 }
 

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -84,6 +84,30 @@ function recoveryName(run,attempt){
 
 export function recoveryOwner(run,attempt){return integer(run)+'/'+integer(attempt);}
 
+export function buildSuspendPatch({resourceVersion,kustomizationUid,owner}){
+  integer(resourceVersion);check(kustomizationUid===LIVE_KUSTOMIZATION_UID&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
+  return [
+    {op:'test',path:'/metadata/resourceVersion',value:resourceVersion},
+    {op:'test',path:'/metadata/uid',value:kustomizationUid},
+    {op:'add',path:RECOVERY_OWNER_PATH,value:owner},
+    {op:'add',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
+    {op:'add',path:'/spec/suspend',value:true},
+  ];
+}
+
+export function buildResumePatch({kustomizationUid,owner}){
+  check(kustomizationUid===LIVE_KUSTOMIZATION_UID&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
+  return [
+    {op:'test',path:'/metadata/uid',value:kustomizationUid},
+    {op:'test',path:RECOVERY_OWNER_PATH,value:owner},
+    {op:'test',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
+    {op:'test',path:'/spec/suspend',value:true},
+    {op:'add',path:'/spec/suspend',value:false},
+    {op:'remove',path:RECOVERY_OWNER_PATH},
+    {op:'remove',path:RECOVERY_RECONCILE_PATH},
+  ];
+}
+
 export function buildRecoveryResources({run,attempt,endpoint,imageName,storageClass,prelossBackupId}){
   check(storageClass==='longhorn-wffc');
   check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
@@ -295,13 +319,7 @@ function suspendApplication(config){
   check(current.metadata.uid===LIVE_KUSTOMIZATION_UID&&typeof current.metadata.resourceVersion==='string');
   check(current.metadata.annotations&&typeof current.metadata.annotations==='object');
   check(current.spec?.suspend!==true&&!current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]);
-  const patch=[
-    {op:'test',path:'/metadata/resourceVersion',value:current.metadata.resourceVersion},
-    {op:'test',path:'/metadata/uid',value:LIVE_KUSTOMIZATION_UID},
-    {op:'add',path:RECOVERY_OWNER_PATH,value:owner},
-    {op:'add',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
-    {op:'add',path:'/spec/suspend',value:true},
-  ];
+  const patch=buildSuspendPatch({resourceVersion:current.metadata.resourceVersion,kustomizationUid:current.metadata.uid,owner});
   kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);
   const suspended=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   check(suspended.metadata.uid===LIVE_KUSTOMIZATION_UID&&suspended.spec?.suspend===true);
@@ -329,15 +347,7 @@ function resumeApplication(config){
   check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===CURRENT_CLUSTER_UID);
   let failed=false;
   try{kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=2']);}catch{failed=true;}
-  const patch=[
-    {op:'test',path:'/metadata/uid',value:LIVE_KUSTOMIZATION_UID},
-    {op:'test',path:RECOVERY_OWNER_PATH,value:owner},
-    {op:'test',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
-    {op:'test',path:'/spec/suspend',value:true},
-    {op:'add',path:'/spec/suspend',value:false},
-    {op:'remove',path:RECOVERY_OWNER_PATH},
-    {op:'remove',path:RECOVERY_RECONCILE_PATH},
-  ];
+  const patch=buildResumePatch({kustomizationUid:current.metadata.uid,owner});
   try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);}catch{failed=true;}
   try{kubectl(['--namespace',NAMESPACE,'rollout','status','deployment/'+LIVE_DEPLOYMENT,'--timeout=10m'],{timeout:630000});}catch{failed=true;}
   try{

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -7,6 +7,7 @@ const NAMESPACE='wedding-app';
 const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
 const LIVE_KUSTOMIZATION='wedding-app';
+const LIVE_KUSTOMIZATION_UID='be31651e-fe0d-4826-9ffb-d41716a66720';
 const SOURCE_STORE='wedding-db';
 const SOURCE_STORE_UID='9cd2ba9b-c7bf-43e2-bd2d-a5c7c139fafb';
 const SOURCE_SECRET='wedding-db-backup-r2';
@@ -17,6 +18,9 @@ const PRELOSS_CLUSTER_UID='6b6d4879-e437-4ea5-a0cb-257de8edad00';
 const RECOVERY_MODE='full archive from backup 20260908T030001';
 const PROOF='wedding-db-data-recovery-proof';
 const RECOVERY_OWNER_ANNOTATION='devantler.tech/wedding-db-recovery-owner';
+const RECOVERY_RECONCILE_ANNOTATION='kustomize.toolkit.fluxcd.io/reconcile';
+const RECOVERY_OWNER_PATH='/metadata/annotations/devantler.tech~1wedding-db-recovery-owner';
+const RECOVERY_RECONCILE_PATH='/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile';
 const check=value=>{if(!value)throw Error('refused');return value;};
 const integer=value=>{check(typeof value==='string'&&/^[1-9][0-9]*$/.test(value));return value;};
 const uid=value=>{check(typeof value==='string'&&/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(value));return value;};
@@ -224,6 +228,7 @@ function sourceState(){
   check(kubectl(['--namespace',NAMESPACE,'get','secret',SOURCE_SECRET,'--output=name','--request-timeout=20s']).toString('utf8').trim()==='secret/'+SOURCE_SECRET);
   check(!optionalObject('configmaps',PROOF));
   const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.metadata.creationTimestamp==='2026-05-23T01:52:44Z');
   check(kustomization.spec?.force===false&&kustomization.spec.suspend!==true&&condition(kustomization,'Ready'));
   return recoverySource({cluster:object('clusters.postgresql.cnpg.io',LIVE_CLUSTER),store:object('objectstores.barmancloud.cnpg.io',SOURCE_STORE),backup:object('backups.postgresql.cnpg.io',PRELOSS_BACKUP)});
 }
@@ -287,16 +292,29 @@ function loadRecovered(primary,database,recovered,config){
 function suspendApplication(config){
   const owner=recoveryOwner(config.run,config.attempt);
   const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-  check(current.spec?.suspend!==true&&!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]);
-  const patch={metadata:{annotations:{[RECOVERY_OWNER_ANNOTATION]:owner}},spec:{suspend:true}};
-  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch='+JSON.stringify(patch)]);
+  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID&&typeof current.metadata.resourceVersion==='string');
+  check(current.metadata.annotations&&typeof current.metadata.annotations==='object');
+  check(current.spec?.suspend!==true&&!current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]);
+  const patch=[
+    {op:'test',path:'/metadata/resourceVersion',value:current.metadata.resourceVersion},
+    {op:'test',path:'/metadata/uid',value:LIVE_KUSTOMIZATION_UID},
+    {op:'add',path:RECOVERY_OWNER_PATH,value:owner},
+    {op:'add',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
+    {op:'add',path:'/spec/suspend',value:true},
+  ];
+  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);
   const suspended=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-  check(suspended.spec?.suspend===true&&suspended.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner);
+  check(suspended.metadata.uid===LIVE_KUSTOMIZATION_UID&&suspended.spec?.suspend===true);
+  check(suspended.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&suspended.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
   kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=0']);
-  const end=Date.now()+5*60*1000;
+  const end=Date.now()+5*60*1000;let stable=0;
   while(Date.now()<end){
     const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
-    if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').filter(pod=>!pod.metadata.deletionTimestamp).length===0)return;
+    const fence=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+    check(fence.metadata.uid===LIVE_KUSTOMIZATION_UID&&fence.spec?.suspend===true);
+    check(fence.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&fence.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
+    if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').filter(pod=>!pod.metadata.deletionTimestamp).length===0)stable+=1;else stable=0;
+    if(stable>=2)return;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
   }
   throw Error('refused');
@@ -306,18 +324,28 @@ function resumeApplication(config){
   const owner=recoveryOwner(config.run,config.attempt);
   const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   if(!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION])return false;
-  check(current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]===owner);
+  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID&&current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]===owner);
+  check(current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled'&&current.spec?.suspend===true);
   check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===CURRENT_CLUSTER_UID);
   let failed=false;
   try{kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=2']);}catch{failed=true;}
-  const patch={metadata:{annotations:{[RECOVERY_OWNER_ANNOTATION]:null}},spec:{suspend:false}};
-  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch='+JSON.stringify(patch)]);}catch{failed=true;}
+  const patch=[
+    {op:'test',path:'/metadata/uid',value:LIVE_KUSTOMIZATION_UID},
+    {op:'test',path:RECOVERY_OWNER_PATH,value:owner},
+    {op:'test',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
+    {op:'test',path:'/spec/suspend',value:true},
+    {op:'add',path:'/spec/suspend',value:false},
+    {op:'remove',path:RECOVERY_OWNER_PATH},
+    {op:'remove',path:RECOVERY_RECONCILE_PATH},
+  ];
+  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);}catch{failed=true;}
   try{kubectl(['--namespace',NAMESPACE,'rollout','status','deployment/'+LIVE_DEPLOYMENT,'--timeout=10m'],{timeout:630000});}catch{failed=true;}
   try{
     const restored=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
     const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
-    check(restored.spec?.suspend===false&&!restored.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]);
-    check(deployment.spec?.replicas===2&&deployment.status?.availableReplicas===2);
+    check(restored.metadata.uid===LIVE_KUSTOMIZATION_UID&&restored.spec?.suspend===false);
+    check(!restored.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!restored.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
+    check(deployment.spec?.replicas===2&&deployment.status?.availableReplicas>=2);
   }catch{failed=true;}
   check(!failed);
   return true;

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -8,6 +8,8 @@ const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
 const LIVE_KUSTOMIZATION='wedding-app';
 const LIVE_KUSTOMIZATION_UID='be31651e-fe0d-4826-9ffb-d41716a66720';
+const LIVE_APP_POLICY_UID='60848dbb-144f-41e0-a47f-f602e8271d04';
+const LIVE_DNS_POLICY_UID='89789584-31f8-407b-99e0-b8f4f2c23c11';
 const SOURCE_STORE='wedding-db';
 const SOURCE_STORE_UID='9cd2ba9b-c7bf-43e2-bd2d-a5c7c139fafb';
 const SOURCE_SECRET='wedding-db-backup-r2';
@@ -121,7 +123,6 @@ export function buildRecoveryResources({run,attempt,endpoint,imageName,storageCl
     externalClusters:[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:SOURCE_STORE,serverName:'wedding-db'}}}],
   }};
   const policy={apiVersion:'cilium.io/v2',kind:'CiliumNetworkPolicy',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{endpointSelector:{matchLabels:{'cnpg.io/cluster':name}},egress:[
-    {toEndpoints:[{matchLabels:{'io.kubernetes.pod.namespace':'kube-system','k8s-app':'kube-dns'}}],toPorts:[{ports:[{port:'53',protocol:'UDP'},{port:'53',protocol:'TCP'}],rules:{dns:[{matchPattern:'*'}]}}]},
     {toEntities:['kube-apiserver']},
     {toFQDNs:[{matchName:hostname}],toPorts:[{ports:[{port:'443',protocol:'TCP'}]}]},
   ]}};
@@ -239,7 +240,7 @@ function verifyCandidate(){
   const workspace=realpathSync(process.env.GITHUB_WORKSPACE);check(workspace===process.env.GITHUB_WORKSPACE);
   const head=spawnSync('git',['--no-replace-objects','-C',workspace,'rev-parse','HEAD'],{encoding:'utf8',env:{PATH:process.env.PATH,GIT_NO_REPLACE_OBJECTS:'1'},maxBuffer:1024});
   check(!head.error&&head.status===0&&head.stdout===process.env.GITHUB_SHA+'\n');
-  for(const relative of ['scripts/recover-wedding-db-incident.mjs','.github/workflows/recover-wedding-db-incident.yaml','k8s/bases/apps/wedding-app/flux-kustomization.yaml']){
+  for(const relative of ['scripts/recover-wedding-db-incident.mjs','scripts/use-prod-stable-api-endpoint.sh','.github/workflows/recover-wedding-db-incident.yaml','k8s/bases/apps/wedding-app/flux-kustomization.yaml']){
     const filename=path.join(workspace,relative),stat=lstatSync(filename);check(stat.isFile()&&!stat.isSymbolicLink()&&stat.size>0&&stat.size<=524288&&realpathSync(filename)===filename);
     const local=readFileSync(filename),source=spawnSync('git',['--no-replace-objects','-C',workspace,'show',process.env.GITHUB_SHA+':'+relative],{env:{PATH:process.env.PATH,GIT_NO_REPLACE_OBJECTS:'1'},maxBuffer:524288});
     check(!source.error&&source.status===0&&local.equals(source.stdout));local.fill(0);source.stdout.fill(0);
@@ -254,6 +255,15 @@ function sourceState(){
   const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.metadata.creationTimestamp==='2026-05-23T01:52:44Z');
   check(kustomization.spec?.force===false&&kustomization.spec.suspend!==true&&condition(kustomization,'Ready'));
+  const appPolicy=object('ciliumnetworkpolicies.cilium.io','app');
+  check(appPolicy.metadata.uid===LIVE_APP_POLICY_UID&&appPolicy.metadata.creationTimestamp==='2026-06-16T18:14:37Z');
+  check(appPolicy.spec?.endpointSelector&&Object.keys(appPolicy.spec.endpointSelector).length===0);
+  check(appPolicy.spec.egress?.some(rule=>rule.toFQDNs?.some(target=>target.matchPattern==='*.r2.cloudflarestorage.com')&&rule.toPorts?.some(item=>item.ports?.some(port=>port.port==='443'&&port.protocol==='TCP'))));
+  check(appPolicy.spec.egress?.some(rule=>rule.toPorts?.some(item=>item.rules?.dns?.some(dns=>dns.matchPattern==='*'))));
+  const dnsPolicy=object('ciliumnetworkpolicies.cilium.io','allow-dns');
+  check(dnsPolicy.metadata.uid===LIVE_DNS_POLICY_UID&&dnsPolicy.metadata.creationTimestamp==='2026-05-23T01:52:43Z');
+  check(dnsPolicy.spec?.endpointSelector&&Object.keys(dnsPolicy.spec.endpointSelector).length===0);
+  check(dnsPolicy.spec.egress?.some(rule=>rule.toPorts?.some(item=>item.ports?.some(port=>port.port==='53'&&(port.protocol==='UDP'||port.protocol==='TCP')))));
   return recoverySource({cluster:object('clusters.postgresql.cnpg.io',LIVE_CLUSTER),store:object('objectstores.barmancloud.cnpg.io',SOURCE_STORE),backup:object('backups.postgresql.cnpg.io',PRELOSS_BACKUP)});
 }
 
@@ -331,7 +341,7 @@ function suspendApplication(config){
     const fence=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
     check(fence.metadata.uid===LIVE_KUSTOMIZATION_UID&&fence.spec?.suspend===true);
     check(fence.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&fence.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
-    if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').filter(pod=>!pod.metadata.deletionTimestamp).length===0)stable+=1;else stable=0;
+    if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').length===0)stable+=1;else stable=0;
     if(stable>=2)return;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
   }

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -9,6 +9,7 @@ const PARENT_KUSTOMIZATION='apps';
 const PARENT_KUSTOMIZATION_UID='7a4f35ea-01c8-460e-aefe-6fdf6d10eb48';
 const FLUX_CONTROLLER='kustomize-controller';
 const FLUX_CONTROLLER_UID='48c6521a-483a-4de9-895a-bae1a61ea25e';
+const FLUX_CONTROLLER_REPLICAS=2;
 const FLUX_CONTROLLER_RESTART_PATH='/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt';
 const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
@@ -435,8 +436,8 @@ function assertControllerReady(controller,{restartToken}={}){
   check(controller.metadata?.name===FLUX_CONTROLLER&&controller.metadata.namespace===PARENT_NAMESPACE);
   check(controller.metadata.uid===FLUX_CONTROLLER_UID&&controller.metadata.creationTimestamp==='2026-05-23T00:41:46Z'&&!controller.metadata.deletionTimestamp);
   check(typeof controller.metadata.resourceVersion==='string'&&Number.isSafeInteger(controller.metadata.generation));
-  check(controller.spec?.replicas===1&&controller.spec.selector?.matchLabels?.app===FLUX_CONTROLLER);
-  check(controller.status?.observedGeneration===controller.metadata.generation&&controller.status.updatedReplicas===1&&controller.status.readyReplicas===1&&controller.status.availableReplicas===1);
+  check(controller.spec?.replicas===FLUX_CONTROLLER_REPLICAS&&controller.spec.selector?.matchLabels?.app===FLUX_CONTROLLER);
+  check(controller.status?.observedGeneration===controller.metadata.generation&&controller.status.updatedReplicas===FLUX_CONTROLLER_REPLICAS&&controller.status.readyReplicas===FLUX_CONTROLLER_REPLICAS&&controller.status.availableReplicas===FLUX_CONTROLLER_REPLICAS);
   check(controller.spec.template?.metadata?.annotations&&typeof controller.spec.template.metadata.annotations==='object');
   if(restartToken)check(controller.spec.template.metadata.annotations['kubectl.kubernetes.io/restartedAt']===restartToken);
 }
@@ -451,7 +452,7 @@ function restartKustomizeController(config){
   const beforeController=objectAt(PARENT_NAMESPACE,'deployments.apps',FLUX_CONTROLLER);
   assertControllerReady(beforeController);
   const beforePods=listAt(PARENT_NAMESPACE,'pods','app='+FLUX_CONTROLLER);
-  assertReadyControllerPods(beforePods,1);
+  assertReadyControllerPods(beforePods,FLUX_CONTROLLER_REPLICAS);
   const oldUids=new Set(beforePods.map(pod=>pod.metadata.uid));
   const restartToken=`wedding-db-recovery-${integer(config.run)}-${integer(config.attempt)}`;
   const patch=buildControllerRestartPatch({
@@ -474,7 +475,7 @@ function restartKustomizeController(config){
     const current=pods.filter(pod=>!pod.metadata?.deletionTimestamp);
     if([...oldUids].every(oldUid=>!pods.some(pod=>pod.metadata?.uid===oldUid))){
       assertControllerReady(controller,{restartToken});
-      assertReadyControllerPods(current,1);
+      assertReadyControllerPods(current,FLUX_CONTROLLER_REPLICAS);
       return;
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -4,6 +4,9 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 const NAMESPACE='wedding-app';
+const PARENT_NAMESPACE='flux-system';
+const PARENT_KUSTOMIZATION='apps';
+const PARENT_KUSTOMIZATION_UID='7a4f35ea-01c8-460e-aefe-6fdf6d10eb48';
 const LIVE_CLUSTER='wedding-db';
 const LIVE_DEPLOYMENT='wedding-app';
 const LIVE_KUSTOMIZATION='wedding-app';
@@ -94,7 +97,7 @@ export function recoveryOwnerAttempt(run,currentAttempt,owner){
 }
 
 export function buildSuspendPatch({resourceVersion,kustomizationUid,owner}){
-  integer(resourceVersion);check(kustomizationUid===LIVE_KUSTOMIZATION_UID&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
+  integer(resourceVersion);check([LIVE_KUSTOMIZATION_UID,PARENT_KUSTOMIZATION_UID].includes(kustomizationUid)&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
   return [
     {op:'test',path:'/metadata/resourceVersion',value:resourceVersion},
     {op:'test',path:'/metadata/uid',value:kustomizationUid},
@@ -105,7 +108,7 @@ export function buildSuspendPatch({resourceVersion,kustomizationUid,owner}){
 }
 
 export function buildResumePatch({kustomizationUid,owner}){
-  check(kustomizationUid===LIVE_KUSTOMIZATION_UID&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
+  check([LIVE_KUSTOMIZATION_UID,PARENT_KUSTOMIZATION_UID].includes(kustomizationUid)&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
   return [
     {op:'test',path:'/metadata/uid',value:kustomizationUid},
     {op:'test',path:RECOVERY_OWNER_PATH,value:owner},
@@ -226,10 +229,12 @@ function kubectl(args,{input,timeout=30000,maxBytes=2*1024*1024}={}){
   return result.stdout;
 }
 
-function object(resource,name){
-  const value=JSON.parse(kubectl(['--namespace',NAMESPACE,'get',resource,name,'--output=json','--request-timeout=20s']).toString('utf8'));
+function objectAt(namespace,resource,name){
+  const value=JSON.parse(kubectl(['--namespace',namespace,'get',resource,name,'--output=json','--request-timeout=20s']).toString('utf8'));
   check(value&&typeof value==='object'&&!Array.isArray(value));return value;
 }
+
+function object(resource,name){return objectAt(NAMESPACE,resource,name);}
 
 function optionalObject(resource,name){
   const output=kubectl(['--namespace',NAMESPACE,'get',resource,name,'--ignore-not-found=true','--output=json','--request-timeout=20s']);
@@ -259,6 +264,9 @@ function verifyCandidate(){
 function sourceState(){
   check(kubectl(['--namespace',NAMESPACE,'get','secret',SOURCE_SECRET,'--output=name','--request-timeout=20s']).toString('utf8').trim()==='secret/'+SOURCE_SECRET);
   check(!optionalObject('configmaps',PROOF));
+  const parent=objectAt(PARENT_NAMESPACE,'kustomizations.kustomize.toolkit.fluxcd.io',PARENT_KUSTOMIZATION);
+  check(parent.metadata.uid===PARENT_KUSTOMIZATION_UID&&parent.metadata.creationTimestamp==='2026-05-23T00:41:58Z');
+  check(parent.spec?.suspend!==true&&condition(parent,'Ready')&&!parent.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!parent.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
   const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.metadata.creationTimestamp==='2026-05-23T01:52:44Z');
   check(kustomization.spec?.force===false&&kustomization.spec.suspend!==true&&condition(kustomization,'Ready'));
@@ -334,24 +342,68 @@ function dropStagingSchema(primary,database,config){
   psql(primary,database,`DROP SCHEMA IF EXISTS ${schemaName(config.run,config.attempt)} CASCADE;`);
 }
 
-function suspendApplication(config){
-  const owner=recoveryOwner(config.run,config.attempt);
-  const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID&&typeof current.metadata.resourceVersion==='string');
-  check(current.metadata.annotations&&typeof current.metadata.annotations==='object');
-  check(current.spec?.suspend!==true&&!current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]);
+function fenceOwner(state,uidValue,config){
+  check(state.metadata.uid===uidValue);
+  const owner=state.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION];
+  if(!owner)return null;
+  recoveryOwnerAttempt(config.run,config.attempt,owner);
+  check(state.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled'&&state.spec?.suspend===true);
+  return owner;
+}
+
+function acquireFence(namespace,name,uidValue,config){
+  const owner=recoveryOwner(config.run,config.attempt),end=Date.now()+5*60*1000;
+  let current;
+  while(Date.now()<end){
+    current=objectAt(namespace,'kustomizations.kustomize.toolkit.fluxcd.io',name);
+    check(current.metadata.uid===uidValue&&typeof current.metadata.resourceVersion==='string');
+    check(current.metadata.annotations&&typeof current.metadata.annotations==='object');
+    check(current.spec?.suspend!==true&&!current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]);
+    if(condition(current,'Ready')&&!condition(current,'Reconciling')&&current.status?.observedGeneration===current.metadata.generation)break;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
+  }
+  check(current&&Date.now()<end);
   const patch=buildSuspendPatch({resourceVersion:current.metadata.resourceVersion,kustomizationUid:current.metadata.uid,owner});
-  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);
-  const suspended=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-  check(suspended.metadata.uid===LIVE_KUSTOMIZATION_UID&&suspended.spec?.suspend===true);
-  check(suspended.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&suspended.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
+  kubectl(['--namespace',namespace,'patch','kustomization.kustomize.toolkit.fluxcd.io',name,'--type=json','--patch='+JSON.stringify(patch)]);
+  let stableResourceVersion='';
+  for(let attempt=0;attempt<3;attempt+=1){
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
+    const fenced=objectAt(namespace,'kustomizations.kustomize.toolkit.fluxcd.io',name);
+    check(fenced.metadata.uid===uidValue&&fenced.spec?.suspend===true&&!condition(fenced,'Reconciling'));
+    check(fenced.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&fenced.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
+    if(stableResourceVersion===fenced.metadata.resourceVersion)return;
+    stableResourceVersion=fenced.metadata.resourceVersion;
+  }
+  throw Error('refused');
+}
+
+function releaseFence(namespace,name,uidValue,config){
+  const current=objectAt(namespace,'kustomizations.kustomize.toolkit.fluxcd.io',name);
+  const owner=fenceOwner(current,uidValue,config);if(!owner)return false;
+  const patch=buildResumePatch({kustomizationUid:current.metadata.uid,owner});
+  kubectl(['--namespace',namespace,'patch','kustomization.kustomize.toolkit.fluxcd.io',name,'--type=json','--patch='+JSON.stringify(patch)]);
+  const released=objectAt(namespace,'kustomizations.kustomize.toolkit.fluxcd.io',name);
+  check(released.metadata.uid===uidValue&&released.spec?.suspend===false);
+  check(!released.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!released.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
+  return true;
+}
+
+function proveApplicationFences(config){
+  const owner=recoveryOwner(config.run,config.attempt);
+  const parent=objectAt(PARENT_NAMESPACE,'kustomizations.kustomize.toolkit.fluxcd.io',PARENT_KUSTOMIZATION);
+  const child=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  check(fenceOwner(parent,PARENT_KUSTOMIZATION_UID,config)===owner);
+  check(fenceOwner(child,LIVE_KUSTOMIZATION_UID,config)===owner);
+}
+
+function suspendApplication(config){
+  acquireFence(PARENT_NAMESPACE,PARENT_KUSTOMIZATION,PARENT_KUSTOMIZATION_UID,config);
+  acquireFence(NAMESPACE,LIVE_KUSTOMIZATION,LIVE_KUSTOMIZATION_UID,config);
   kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=0']);
   const end=Date.now()+5*60*1000;let stable=0;
   while(Date.now()<end){
     const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
-    const fence=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-    check(fence.metadata.uid===LIVE_KUSTOMIZATION_UID&&fence.spec?.suspend===true);
-    check(fence.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner&&fence.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
+    proveApplicationFences(config);
     if((deployment.status?.replicas??0)===0&&list('pods','app.kubernetes.io/name=wedding-app').length===0)stable+=1;else stable=0;
     if(stable>=2)return;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
@@ -360,17 +412,17 @@ function suspendApplication(config){
 }
 
 function resumeApplication(config){
-  const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
-  if(!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION])return false;
-  const owner=current.metadata.annotations[RECOVERY_OWNER_ANNOTATION];
-  recoveryOwnerAttempt(config.run,config.attempt,owner);
-  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID);
-  check(current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled'&&current.spec?.suspend===true);
+  const child=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  const parent=objectAt(PARENT_NAMESPACE,'kustomizations.kustomize.toolkit.fluxcd.io',PARENT_KUSTOMIZATION);
+  const childOwner=fenceOwner(child,LIVE_KUSTOMIZATION_UID,config);
+  const parentOwner=fenceOwner(parent,PARENT_KUSTOMIZATION_UID,config);
+  if(!childOwner&&!parentOwner)return false;
+  if(!childOwner)check(child.spec?.suspend!==true&&!child.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
   check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===CURRENT_CLUSTER_UID);
   let failed=false;
   try{kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=2']);}catch{failed=true;}
-  const patch=buildResumePatch({kustomizationUid:current.metadata.uid,owner});
-  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--type=json','--patch='+JSON.stringify(patch)]);}catch{failed=true;}
+  let childReleased=!childOwner;
+  if(childOwner){try{releaseFence(NAMESPACE,LIVE_KUSTOMIZATION,LIVE_KUSTOMIZATION_UID,config);childReleased=true;}catch{failed=true;}}
   try{kubectl(['--namespace',NAMESPACE,'rollout','status','deployment/'+LIVE_DEPLOYMENT,'--timeout=10m'],{timeout:630000});}catch{failed=true;}
   try{
     const restored=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
@@ -379,6 +431,7 @@ function resumeApplication(config){
     check(!restored.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!restored.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
     check(deployment.spec?.replicas===2&&deployment.status?.availableReplicas>=2);
   }catch{failed=true;}
+  if(parentOwner&&childReleased&&!failed){try{releaseFence(PARENT_NAMESPACE,PARENT_KUSTOMIZATION,PARENT_KUSTOMIZATION_UID,config);}catch{failed=true;}}
   check(!failed);
   return true;
 }
@@ -448,6 +501,7 @@ function run(){
     mergePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
     check(/^wedding-db-[1-9][0-9]*$/.test(mergePrimary));
     const schema=loadRecovered(mergePrimary,source.database,recoveredInventory.value,config);
+    proveApplicationFences(config);check(list('pods','app.kubernetes.io/name=wedding-app').length===0);
     const output=psql(mergePrimary,source.database,buildMergeSQL(schema));
     merge=JSON.parse(output.toString('utf8').trim());
     for(const key of ['restoredGuestAnswers','restoredRoomBookings','finalMeaningfulGuestAnswers','finalRoomBookings'])check(Number.isSafeInteger(merge[key])&&merge[key]>=0);

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -86,6 +86,13 @@ function recoveryName(run,attempt){
 
 export function recoveryOwner(run,attempt){return integer(run)+'/'+integer(attempt);}
 
+export function recoveryOwnerAttempt(run,currentAttempt,owner){
+  integer(run);integer(currentAttempt);
+  const match=new RegExp('^'+run+'/([1-9][0-9]*)$').exec(owner);
+  check(match&&BigInt(match[1])<=BigInt(currentAttempt));
+  return match[1];
+}
+
 export function buildSuspendPatch({resourceVersion,kustomizationUid,owner}){
   integer(resourceVersion);check(kustomizationUid===LIVE_KUSTOMIZATION_UID&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
   return [
@@ -231,7 +238,7 @@ function optionalObject(resource,name){
 
 function list(resource,selector){
   const value=JSON.parse(kubectl(['--namespace',NAMESPACE,'get',resource,'--selector',selector,'--output=json','--request-timeout=20s']).toString('utf8'));
-  check(value?.apiVersion==='v1'&&Array.isArray(value.items)&&value.items.length<=32);return value.items;
+  check(typeof value?.apiVersion==='string'&&Array.isArray(value.items)&&value.items.length<=32);return value.items;
 }
 
 function verifyCandidate(){
@@ -323,6 +330,10 @@ function loadRecovered(primary,database,recovered,config){
   return schema;
 }
 
+function dropStagingSchema(primary,database,config){
+  psql(primary,database,`DROP SCHEMA IF EXISTS ${schemaName(config.run,config.attempt)} CASCADE;`);
+}
+
 function suspendApplication(config){
   const owner=recoveryOwner(config.run,config.attempt);
   const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
@@ -349,10 +360,11 @@ function suspendApplication(config){
 }
 
 function resumeApplication(config){
-  const owner=recoveryOwner(config.run,config.attempt);
   const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   if(!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION])return false;
-  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID&&current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]===owner);
+  const owner=current.metadata.annotations[RECOVERY_OWNER_ANNOTATION];
+  recoveryOwnerAttempt(config.run,config.attempt,owner);
+  check(current.metadata.uid===LIVE_KUSTOMIZATION_UID);
   check(current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled'&&current.spec?.suspend===true);
   check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===CURRENT_CLUSTER_UID);
   let failed=false;
@@ -382,21 +394,30 @@ function createRecovery(config,source){
 }
 
 function cleanupRecovery(config,recovery){
-  const name=recoveryName(config.run,config.attempt),owned=labels(config.run,config.attempt);
-  if(recovery)check(recovery.name===name);
-  const cluster=optionalObject('clusters.postgresql.cnpg.io',name);
-  if(cluster){
-    for(const [key,value] of Object.entries(owned))check(cluster.metadata?.labels?.[key]===value);
-    if(recovery?.uid)check(cluster.metadata.uid===recovery.uid);
-    kubectl(['--namespace',NAMESPACE,'delete','cluster.postgresql.cnpg.io',name,'--wait=true','--timeout=10m'],{timeout:630000});
+  const attempts=new Set([config.attempt]);
+  const selector='app.kubernetes.io/name=wedding-db-incident-recovery,app.kubernetes.io/managed-by=github-actions,devantler.tech/github-run='+config.run;
+  const collect=item=>{
+    const attempt=recoveryOwnerAttempt(config.run,config.attempt,config.run+'/'+integer(item.metadata?.labels?.['devantler.tech/github-attempt']));
+    check(item.metadata?.name===recoveryName(config.run,attempt));
+    for(const [key,value] of Object.entries(labels(config.run,attempt)))check(item.metadata.labels[key]===value);
+    attempts.add(attempt);
+  };
+  const clusters=list('clusters.postgresql.cnpg.io',selector);for(const cluster of clusters)collect(cluster);
+  const policies=list('ciliumnetworkpolicies.cilium.io',selector);for(const policy of policies)collect(policy);
+  for(const claim of list('persistentvolumeclaims','cnpg.io/cluster')){
+    const clusterName=claim.metadata?.labels?.['cnpg.io/cluster'];
+    const match=new RegExp('^wedding-db-preloss-'+config.run+'-([1-9][0-9]*)$').exec(clusterName);
+    if(match)attempts.add(recoveryOwnerAttempt(config.run,config.attempt,config.run+'/'+match[1]));
   }
-  for(const claim of list('persistentvolumeclaims','cnpg.io/cluster='+name))kubectl(['--namespace',NAMESPACE,'delete','persistentvolumeclaim',claim.metadata.name,'--wait=true','--timeout=5m'],{timeout:330000});
-  const policy=optionalObject('ciliumnetworkpolicies.cilium.io',name);
-  if(policy){
-    for(const [key,value] of Object.entries(owned))check(policy.metadata?.labels?.[key]===value);
-    kubectl(['--namespace',NAMESPACE,'delete','ciliumnetworkpolicy.cilium.io',name,'--wait=true','--timeout=2m'],{timeout:150000});
-  }
-  check(!optionalObject('clusters.postgresql.cnpg.io',name)&&list('persistentvolumeclaims','cnpg.io/cluster='+name).length===0&&!optionalObject('ciliumnetworkpolicies.cilium.io',name));
+  const names=[...attempts].map(attempt=>recoveryName(config.run,attempt));
+  if(recovery){check(names.includes(recovery.name));const found=clusters.find(cluster=>cluster.metadata.name===recovery.name);if(found)check(found.metadata.uid===recovery.uid);}
+  const clusterNames=clusters.map(cluster=>cluster.metadata.name);
+  if(clusterNames.length)kubectl(['--namespace',NAMESPACE,'delete','cluster.postgresql.cnpg.io',...clusterNames,'--wait=true','--timeout=10m'],{timeout:630000});
+  const claims=list('persistentvolumeclaims','cnpg.io/cluster').filter(claim=>names.includes(claim.metadata?.labels?.['cnpg.io/cluster']));
+  if(claims.length)kubectl(['--namespace',NAMESPACE,'delete','persistentvolumeclaim',...claims.map(claim=>claim.metadata.name),'--wait=true','--timeout=10m'],{timeout:630000});
+  const policyNames=policies.map(policy=>policy.metadata.name);
+  if(policyNames.length)kubectl(['--namespace',NAMESPACE,'delete','ciliumnetworkpolicy.cilium.io',...policyNames,'--wait=true','--timeout=2m'],{timeout:150000});
+  for(const name of names)check(!optionalObject('clusters.postgresql.cnpg.io',name)&&list('persistentvolumeclaims','cnpg.io/cluster='+name).length===0&&!optionalObject('ciliumnetworkpolicies.cilium.io',name));
 }
 
 function recordProof({config,source,recovery,before,after,recovered,liveBefore,merge}){
@@ -413,7 +434,7 @@ function recordProof({config,source,recovery,before,after,recovered,liveBefore,m
 function run(){
   const config=verifyCandidate(),source=sourceState();
   const before=backup(config,'before',source);
-  let recovery,recoveredInventory,recovered,liveBefore,merge,error,resumeError,cleanupError;
+  let recovery,recoveredInventory,recovered,liveBefore,merge,mergePrimary,error,schemaCleanupError,resumeError,cleanupError;
   try{
     recovery=createRecovery(config,source);
     recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
@@ -424,7 +445,7 @@ function run(){
     check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
     suspendApplication(config);
     check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===source.currentClusterUid);
-    const mergePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
+    mergePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
     check(/^wedding-db-[1-9][0-9]*$/.test(mergePrimary));
     const schema=loadRecovered(mergePrimary,source.database,recoveredInventory.value,config);
     const output=psql(mergePrimary,source.database,buildMergeSQL(schema));
@@ -432,9 +453,10 @@ function run(){
     for(const key of ['restoredGuestAnswers','restoredRoomBookings','finalMeaningfulGuestAnswers','finalRoomBookings'])check(Number.isSafeInteger(merge[key])&&merge[key]>=0);
     check(merge.finalMeaningfulGuestAnswers>=recovered.meaningfulGuests&&merge.finalRoomBookings>=recovered.roomBookings);
   }catch(candidate){error=candidate;}
+  if(error&&mergePrimary){try{dropStagingSchema(mergePrimary,source.database,config);}catch(candidate){schemaCleanupError=candidate;}}
   try{resumeApplication(config);}catch(candidate){resumeError=candidate;}
   try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}
-  if(error||resumeError||cleanupError)throw Error('refused');
+  if(error||schemaCleanupError||resumeError||cleanupError)throw Error('refused');
   const after=backup(config,'after',source);
   recordProof({config,source,recovery,before,after,recovered,liveBefore,merge});
   return {restored:true,currentClusterUid:source.currentClusterUid,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,beforeBackupUid:before.uid,afterBackupUid:after.uid,recovered,liveBefore,merge,cleanup:true};
@@ -442,10 +464,21 @@ function run(){
 
 function runCleanup(){
   const config=verifyCandidate();
-  let resumeError,cleanupError,resumed=false;
+  let schemaCleanupError,resumeError,cleanupError,resumed=false;
+  const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  const owner=kustomization.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION];
+  if(owner){
+    const attempt=recoveryOwnerAttempt(config.run,config.attempt,owner);
+    try{
+      check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.spec?.suspend===true&&kustomization.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]==='disabled');
+      const cluster=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER);check(cluster.metadata.uid===CURRENT_CLUSTER_UID);
+      const primary=cluster.status?.currentPrimary;check(/^wedding-db-[1-9][0-9]*$/.test(primary));
+      dropStagingSchema(primary,'wedding',{run:config.run,attempt});
+    }catch(candidate){schemaCleanupError=candidate;}
+  }
   try{resumed=resumeApplication(config);}catch(candidate){resumeError=candidate;}
   try{cleanupRecovery(config);}catch(candidate){cleanupError=candidate;}
-  if(resumeError||cleanupError)throw Error('refused');
+  if(schemaCleanupError||resumeError||cleanupError)throw Error('refused');
   return {cleanup:true,resumed};
 }
 

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -16,6 +16,7 @@ const PRELOSS_BACKUP_UID='549fe940-b119-4010-bdc8-fa8e6ebc93ae';
 const PRELOSS_CLUSTER_UID='6b6d4879-e437-4ea5-a0cb-257de8edad00';
 const RECOVERY_MODE='full archive from backup 20260908T030001';
 const PROOF='wedding-db-data-recovery-proof';
+const RECOVERY_OWNER_ANNOTATION='devantler.tech/wedding-db-recovery-owner';
 const check=value=>{if(!value)throw Error('refused');return value;};
 const integer=value=>{check(typeof value==='string'&&/^[1-9][0-9]*$/.test(value));return value;};
 const uid=value=>{check(typeof value==='string'&&/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(value));return value;};
@@ -77,15 +78,18 @@ function recoveryName(run,attempt){
   check(name.length<=63);return name;
 }
 
+export function recoveryOwner(run,attempt){return integer(run)+'/'+integer(attempt);}
+
 export function buildRecoveryResources({run,attempt,endpoint,imageName,storageClass,prelossBackupId}){
   check(storageClass==='longhorn-wffc');
   check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
+  check(prelossBackupId==='20260908T030001');
   const name=recoveryName(run,attempt),owned=labels(run,attempt),hostname=endpointHost(endpoint);
   const cluster={apiVersion:'postgresql.cnpg.io/v1',kind:'Cluster',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{
     instances:1,imageName,enableSuperuserAccess:false,enablePDB:false,
     storage:{size:'2Gi',storageClass},
     resources:{requests:{cpu:'50m',memory:'256Mi'},limits:{cpu:'1',memory:'1Gi'}},
-    bootstrap:{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:check(prelossBackupId==='20260908T030001')&&prelossBackupId}}},
+    bootstrap:{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:prelossBackupId}}},
     externalClusters:[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:SOURCE_STORE,serverName:'wedding-db'}}}],
   }};
   const policy={apiVersion:'cilium.io/v2',kind:'CiliumNetworkPolicy',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{endpointSelector:{matchLabels:{'cnpg.io/cluster':name}},egress:[
@@ -280,9 +284,14 @@ function loadRecovered(primary,database,recovered,config){
   return schema;
 }
 
-function suspendApplication(){
-  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch={"spec":{"suspend":true}}']);
-  check(object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION).spec?.suspend===true);
+function suspendApplication(config){
+  const owner=recoveryOwner(config.run,config.attempt);
+  const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  check(current.spec?.suspend!==true&&!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]);
+  const patch={metadata:{annotations:{[RECOVERY_OWNER_ANNOTATION]:owner}},spec:{suspend:true}};
+  kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch='+JSON.stringify(patch)]);
+  const suspended=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  check(suspended.spec?.suspend===true&&suspended.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]===owner);
   kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=0']);
   const end=Date.now()+5*60*1000;
   while(Date.now()<end){
@@ -293,12 +302,25 @@ function suspendApplication(){
   throw Error('refused');
 }
 
-function resumeApplication(){
+function resumeApplication(config){
+  const owner=recoveryOwner(config.run,config.attempt);
+  const current=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+  if(!current.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION])return false;
+  check(current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]===owner);
+  check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===CURRENT_CLUSTER_UID);
   let failed=false;
   try{kubectl(['--namespace',NAMESPACE,'scale','deployment',LIVE_DEPLOYMENT,'--replicas=2']);}catch{failed=true;}
-  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch={"spec":{"suspend":false}}']);}catch{failed=true;}
+  const patch={metadata:{annotations:{[RECOVERY_OWNER_ANNOTATION]:null}},spec:{suspend:false}};
+  try{kubectl(['--namespace',NAMESPACE,'patch','kustomization.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION,'--field-manager=flux-client-side-apply','--type=merge','--patch='+JSON.stringify(patch)]);}catch{failed=true;}
   try{kubectl(['--namespace',NAMESPACE,'rollout','status','deployment/'+LIVE_DEPLOYMENT,'--timeout=10m'],{timeout:630000});}catch{failed=true;}
+  try{
+    const restored=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
+    const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
+    check(restored.spec?.suspend===false&&!restored.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]);
+    check(deployment.spec?.replicas===2&&deployment.status?.availableReplicas===2);
+  }catch{failed=true;}
   check(!failed);
+  return true;
 }
 
 function createRecovery(config,source){
@@ -344,9 +366,7 @@ function run(){
   const config=verifyCandidate(),source=sourceState();
   const before=backup(config,'before',source);
   let recovery,recoveredInventory,recovered,liveBefore,merge,error,resumeError,cleanupError;
-  let recoveryAttempted=false,suspensionAttempted=false;
   try{
-    recoveryAttempted=true;
     recovery=createRecovery(config,source);
     recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
     recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
@@ -354,22 +374,36 @@ function run(){
     const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
     liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
     check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
-    suspensionAttempted=true;suspendApplication();
+    suspendApplication(config);
     check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===source.currentClusterUid);
-    const schema=loadRecovered(livePrimary,source.database,recoveredInventory.value,config);
-    const output=psql(livePrimary,source.database,buildMergeSQL(schema));
+    const mergePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
+    check(/^wedding-db-[1-9][0-9]*$/.test(mergePrimary));
+    const schema=loadRecovered(mergePrimary,source.database,recoveredInventory.value,config);
+    const output=psql(mergePrimary,source.database,buildMergeSQL(schema));
     merge=JSON.parse(output.toString('utf8').trim());
     for(const key of ['restoredGuestAnswers','restoredRoomBookings','finalMeaningfulGuestAnswers','finalRoomBookings'])check(Number.isSafeInteger(merge[key])&&merge[key]>=0);
     check(merge.finalMeaningfulGuestAnswers>=recovered.meaningfulGuests&&merge.finalRoomBookings>=recovered.roomBookings);
   }catch(candidate){error=candidate;}
-  if(suspensionAttempted){try{resumeApplication();}catch(candidate){resumeError=candidate;}}
-  if(recoveryAttempted){try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}}
+  try{resumeApplication(config);}catch(candidate){resumeError=candidate;}
+  try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}
   if(error||resumeError||cleanupError)throw Error('refused');
   const after=backup(config,'after',source);
   recordProof({config,source,recovery,before,after,recovered,liveBefore,merge});
   return {restored:true,currentClusterUid:source.currentClusterUid,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,beforeBackupUid:before.uid,afterBackupUid:after.uid,recovered,liveBefore,merge,cleanup:true};
 }
 
+function runCleanup(){
+  const config=verifyCandidate();
+  let resumeError,cleanupError,resumed=false;
+  try{resumed=resumeApplication(config);}catch(candidate){resumeError=candidate;}
+  try{cleanupRecovery(config);}catch(candidate){cleanupError=candidate;}
+  if(resumeError||cleanupError)throw Error('refused');
+  return {cleanup:true,resumed};
+}
+
 if(process.argv[1]===fileURLToPath(import.meta.url)){
-  try{process.stdout.write(JSON.stringify(run())+'\n');}catch{process.stderr.write('Wedding database incident recovery refused.\n');process.exitCode=2;}
+  try{
+    check(process.argv.length===2||(process.argv.length===3&&process.argv[2]==='--cleanup'));
+    process.stdout.write(JSON.stringify(process.argv[2]==='--cleanup'?runCleanup():run())+'\n');
+  }catch{process.stderr.write('Wedding database incident recovery refused.\n');process.exitCode=2;}
 }

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -24,7 +24,10 @@ const CURRENT_CLUSTER_UID='afea05ff-7daa-4d80-99a6-f2d696cbc3f1';
 const PRELOSS_BACKUP='wedding-db-daily-20260908030000';
 const PRELOSS_BACKUP_UID='549fe940-b119-4010-bdc8-fa8e6ebc93ae';
 const PRELOSS_CLUSTER_UID='6b6d4879-e437-4ea5-a0cb-257de8edad00';
-const RECOVERY_MODE='full archive from backup 20260908T030001';
+const PRELOSS_TARGET_TIME='2026-09-09T01:57:41Z';
+const PRELOSS_TARGET_TIMELINE='162';
+const PRELOSS_RECONCILIATION_DIGEST='sha256:022128434868723705c489546f68ba344e9cbe9e5c2b930a404d8aa2122ad9c7';
+const RECOVERY_MODE='point in time 2026-09-09T01:57:41Z from backup 20260908T030001 on timeline 162';
 const PROOF='wedding-db-data-recovery-proof';
 const RECOVERY_OWNER_ANNOTATION='devantler.tech/wedding-db-recovery-owner';
 const RECOVERY_RECONCILE_ANNOTATION='kustomize.toolkit.fluxcd.io/reconcile';
@@ -73,12 +76,13 @@ export function recoverySource({cluster,store,backup}){
   check(backup.status?.phase==='completed'&&backup.status.backupId==='20260908T030001'&&backup.status.majorVersion===18);
   check(backup.status.pluginMetadata?.clusterUID===PRELOSS_CLUSTER_UID&&backup.status.pluginMetadata.timeline==='162');
   check(backup.status.startedAt&&backup.status.stoppedAt&&!backup.status.error);
+  check(Date.parse(PRELOSS_TARGET_TIME)>Date.parse(backup.status.stoppedAt)&&Date.parse(PRELOSS_TARGET_TIME)<Date.parse(cluster.metadata.creationTimestamp));
 
   const imageName=cluster.spec.imageName;
   check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
   check(cluster.spec.storage?.storageClass==='longhorn-wffc');
   check(/^[1-9][0-9]*(?:Mi|Gi|Ti)$/.test(cluster.spec.storage?.size));
-  return {currentClusterUid:cluster.metadata.uid,sourceUid:store.metadata.uid,prelossBackupUid:backup.metadata.uid,database:'wedding',imageName,storageClass:'longhorn-wffc',size:cluster.spec.storage.size,endpoint,prelossBackupId:backup.status.backupId};
+  return {currentClusterUid:cluster.metadata.uid,sourceUid:store.metadata.uid,prelossBackupUid:backup.metadata.uid,database:'wedding',imageName,storageClass:'longhorn-wffc',size:cluster.spec.storage.size,endpoint,prelossBackupId:backup.status.backupId,prelossTargetTime:PRELOSS_TARGET_TIME,prelossTargetTimeline:PRELOSS_TARGET_TIMELINE};
 }
 
 function labels(run,attempt){
@@ -136,16 +140,17 @@ export function buildControllerRestartPatch({resourceVersion,deploymentUid,annot
   ];
 }
 
-export function buildRecoveryResources({run,attempt,endpoint,imageName,storageClass,prelossBackupId}){
+export function buildRecoveryResources({run,attempt,endpoint,imageName,storageClass,prelossBackupId,prelossTargetTime,prelossTargetTimeline}){
   check(storageClass==='longhorn-wffc');
   check(typeof imageName==='string'&&/^ghcr\.io\/cloudnative-pg\/postgresql:18\.[0-9]+-[a-z0-9-]+$/.test(imageName));
   check(prelossBackupId==='20260908T030001');
+  check(prelossTargetTime===PRELOSS_TARGET_TIME&&prelossTargetTimeline===PRELOSS_TARGET_TIMELINE);
   const name=recoveryName(run,attempt),owned=labels(run,attempt),hostname=endpointHost(endpoint);
   const cluster={apiVersion:'postgresql.cnpg.io/v1',kind:'Cluster',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{
     instances:1,imageName,enableSuperuserAccess:false,enablePDB:false,
     storage:{size:'2Gi',storageClass},
     resources:{requests:{cpu:'50m',memory:'256Mi'},limits:{cpu:'1',memory:'1Gi'}},
-    bootstrap:{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:prelossBackupId}}},
+    bootstrap:{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:prelossBackupId,targetTime:prelossTargetTime,targetTLI:prelossTargetTimeline}}},
     externalClusters:[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:SOURCE_STORE,serverName:'wedding-db'}}}],
   }};
   const policy={apiVersion:'cilium.io/v2',kind:'CiliumNetworkPolicy',metadata:{name,namespace:NAMESPACE,labels:owned},spec:{endpointSelector:{matchLabels:{'cnpg.io/cluster':name}},egress:[
@@ -301,6 +306,7 @@ function sourceState(){
   const kustomization=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
   check(kustomization.metadata.uid===LIVE_KUSTOMIZATION_UID&&kustomization.metadata.creationTimestamp==='2026-05-23T01:52:44Z');
   check(kustomization.spec?.force===false&&kustomization.spec.suspend!==true&&condition(kustomization,'Ready'));
+  check(kustomization.status?.history?.some(item=>item.lastReconciled===PRELOSS_TARGET_TIME&&item.lastReconciledStatus==='ReconciliationSucceeded'&&item.digest===PRELOSS_RECONCILIATION_DIGEST&&item.metadata?.originRevision==='v1.15.11@sha1:5f0f5be0a228ee189ea3d10e4bd1b61ef0a8efe9'));
   const appPolicy=object('ciliumnetworkpolicies.cilium.io','app');
   check(appPolicy.metadata.uid===LIVE_APP_POLICY_UID&&appPolicy.metadata.creationTimestamp==='2026-06-16T18:14:37Z');
   check(appPolicy.spec?.endpointSelector&&Object.keys(appPolicy.spec.endpointSelector).length===0);
@@ -532,7 +538,8 @@ function createRecovery(config,source){
   kubectl(['create','--filename=-'],{input:Buffer.from(JSON.stringify({apiVersion:'v1',kind:'List',items:[resources.policy,resources.cluster]}))});
   kubectl(['--namespace',NAMESPACE,'wait','cluster.postgresql.cnpg.io/'+name,'--for=condition=Ready','--timeout=30m'],{timeout:1830000});
   const cluster=object('clusters.postgresql.cnpg.io',name);check(cluster.status?.readyInstances===1&&cluster.status.currentPrimary&&condition(cluster,'Ready'));
-  check(cluster.spec?.bootstrap?.recovery?.recoveryTarget?.backupID===source.prelossBackupId&&!cluster.spec.plugins);
+  const target=cluster.spec?.bootstrap?.recovery?.recoveryTarget;
+  check(target?.backupID===source.prelossBackupId&&target.targetTime===source.prelossTargetTime&&target.targetTLI===source.prelossTargetTimeline&&!target.exclusive&&!cluster.spec.plugins);
   return {name,uid:uid(cluster.metadata.uid),primary:cluster.status.currentPrimary};
 }
 
@@ -565,7 +572,7 @@ function cleanupRecovery(config,recovery){
 
 function recordProof({config,source,recovery,before,after,recovered,liveBefore,merge}){
   const manifest={apiVersion:'v1',kind:'ConfigMap',metadata:{name:PROOF,namespace:NAMESPACE,labels:{'app.kubernetes.io/name':'wedding-db','app.kubernetes.io/managed-by':'github-actions'}},data:{
-    version:'1',recoveryMode:RECOVERY_MODE,replacementCreatedAt:'2026-09-09T01:58:14Z',currentClusterUid:source.currentClusterUid,prelossClusterUid:PRELOSS_CLUSTER_UID,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,
+    version:'2',recoveryMode:RECOVERY_MODE,recoveryTargetTime:source.prelossTargetTime,recoveryTargetTimeline:source.prelossTargetTimeline,replacementCreatedAt:'2026-09-09T01:58:14Z',currentClusterUid:source.currentClusterUid,prelossClusterUid:PRELOSS_CLUSTER_UID,prelossBackupUid:source.prelossBackupUid,recoveryClusterUid:recovery.uid,
     beforeBackupUid:before.uid,afterBackupUid:after.uid,recoveredGuests:String(recovered.guests),recoveredMeaningfulGuests:String(recovered.meaningfulGuests),recoveredRoomBookings:String(recovered.roomBookings),
     liveBeforeMeaningfulGuests:String(liveBefore.meaningfulGuests),liveBeforeRoomBookings:String(liveBefore.roomBookings),restoredGuestAnswers:String(merge.restoredGuestAnswers),restoredRoomBookings:String(merge.restoredRoomBookings),
     finalMeaningfulGuestAnswers:String(merge.finalMeaningfulGuestAnswers),finalRoomBookings:String(merge.finalRoomBookings),githubRun:config.run,githubAttempt:config.attempt,
@@ -632,7 +639,8 @@ function runCleanup(){
 
 if(process.argv[1]===fileURLToPath(import.meta.url)){
   try{
-    check(process.argv.length===2||(process.argv.length===3&&process.argv[2]==='--cleanup'));
-    process.stdout.write(JSON.stringify(process.argv[2]==='--cleanup'?runCleanup():run())+'\n');
+    check(process.argv.length===2||(process.argv.length===3&&['--cleanup','--verify-source'].includes(process.argv[2])));
+    const result=process.argv[2]==='--verify-source'?(verifyCandidate(),{sourceVerified:true}):process.argv[2]==='--cleanup'?runCleanup():run();
+    process.stdout.write(JSON.stringify(result)+'\n');
   }catch{process.stderr.write('Wedding database incident recovery refused.\n');process.exitCode=2;}
 }

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -523,7 +523,7 @@ function resumeApplication(config){
   try{
     const restored=object('kustomizations.kustomize.toolkit.fluxcd.io',LIVE_KUSTOMIZATION);
     const deployment=object('deployments.apps',LIVE_DEPLOYMENT);
-    check(restored.metadata.uid===LIVE_KUSTOMIZATION_UID&&restored.spec?.suspend===false);
+    check(restored.metadata.uid===LIVE_KUSTOMIZATION_UID&&restored.spec?.suspend!==true);
     check(!restored.metadata?.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!restored.metadata?.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
     check(deployment.spec?.replicas===2&&deployment.status?.availableReplicas>=2);
   }catch{failed=true;}

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -345,20 +345,25 @@ runtime_probe_sequence=0
 runtime_probe_bootstrap_needed=0
 
 # Every fence below is released by cleanup_refresh_work in one ordered pass. A
-# hard kill leaves an arbitrary prefix released and the remainder held, and a
-# held fence is never auto-reclaimed: Talos machine-config writes expose no
-# fencing token, so a surviving process could still write after any timeout
-# takeover. Recovery is therefore deliberately human. This read-only report is
-# what makes it a procedure rather than an improvisation — it names each fence
-# still held, states whether the holder is provably dead, and prints the exact
-# CAS-guarded release. It performs no mutation by design: an operator running
-# the printed command is the explicit step the fencing model requires.
+# hard kill leaves an arbitrary prefix released and the remainder held. Policy
+# fences and the Lease can be auto-recovered only after every GitHub holder run
+# is proven terminal; node fences remain manual because Talos machine-config
+# writes expose no fencing token. This report names each fence still held,
+# states whether the holder is provably dead, and prints the exact CAS-guarded
+# release used by both the automatic and operator paths.
 # State the fence report hands to --recover-fences. Declared here, beside the
 # report that populates them, so the two cannot drift apart.
-fence_non_lease_held=0
+fence_policy_held=0
+fence_node_held=0
 fence_lease_holder=""
 fence_lease_heartbeat_live=false
 fence_lease_state_file=""
+fence_policy_child_holder=""
+fence_policy_child_uid=""
+fence_policy_child_state_file="${work_dir}/fence-policy-child-state.json"
+fence_policy_parent_holder=""
+fence_policy_parent_uid=""
+fence_policy_parent_state_file="${work_dir}/fence-policy-parent-state.json"
 
 fence_run_segment() {
   if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
@@ -486,6 +491,15 @@ report_fences_now() {
     held=$((held + 1))
     uid="$(jq -r '.metadata.uid' "${state}")"
     suspend="$(jq -r '.spec.suspend // false' "${state}")"
+    if [[ "${name}" == "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" ]]; then
+      fence_policy_child_holder="${holder}"
+      fence_policy_child_uid="${uid}"
+      cp -- "${state}" "${fence_policy_child_state_file}" || return 1
+    else
+      fence_policy_parent_holder="${holder}"
+      fence_policy_parent_uid="${uid}"
+      cp -- "${state}" "${fence_policy_parent_state_file}" || return 1
+    fi
     printf 'HELD  Kustomization flux-system/%s\n' "${name}"
     printf '    holder: %s\n' "${holder}"
     printf '    suspend=%s — Flux reconciliation of this layer is STOPPED while held.\n' \
@@ -495,6 +509,7 @@ report_fences_now() {
       "$(fence_kustomization_release_command "${name}" "${uid}" "${holder}")"
     printf '\n'
   done
+  fence_policy_held="${held}"
 
   if ! kubectl \
     --context "${KUBE_CONTEXT}" \
@@ -854,12 +869,7 @@ report_fences_now() {
         "${owner}" "${recovery}" "${uncordon}")"
     printf '\n'
   done <"${fence_report_nodes}"
-
-  # Captured BEFORE the Lease is reported, so it counts only the fences the
-  # Lease's own ordering rule says must be released first. --recover-fences
-  # refuses while this is non-zero rather than duplicating the node-journal
-  # grouping above, which is the part that is genuinely hard to get right.
-  fence_non_lease_held="${held}"
+  fence_node_held=$((held - fence_policy_held))
 
   fence_report_lease "${state}" || return 1
 
@@ -920,22 +930,26 @@ fence_run_is_terminal() {
 }
 
 recover_fences_now() {
-  local run_reference run_id run_attempt patch_file
+  local run_reference run_id run_attempt patch_file name holder uid state
 
   report_fences_now || return 1
 
   printf '\n== Automatic recovery ==\n'
 
   if [[ -z "${fence_lease_holder}" ]]; then
+    if ((fence_policy_held > 0 || fence_node_held > 0)); then
+      echo "::error::Refusing to recover non-Lease fences without the global Lease fence. Another deploy could start during recovery; inspect the report and recover manually."
+      return 1
+    fi
     printf 'No Lease fence is held; nothing to recover.\n'
     return 0
   fi
-  # The Lease is released LAST for the reason the report states: it is the global
-  # exclusion fence, so clearing it while a policy or node fence is still held
-  # lets a deploy start against a half-recovered cluster. Automation therefore
-  # refuses rather than reordering — the remaining fences need the operator.
-  if ((fence_non_lease_held > 0)); then
-    echo "::error::Refusing to recover the Lease while ${fence_non_lease_held} other fence(s) are held. Release those first, in the order the report prints."
+  # Node journals need the bridge's Talos-revision and scheduling proofs. This
+  # credential-free mode cannot safely reproduce them, so keep refusing node
+  # recovery. Policy fences have complete UID/owner/suspend state in the report
+  # and can be released with the exact same CAS patch printed for an operator.
+  if ((fence_node_held > 0)); then
+    echo "::error::Refusing automatic recovery while ${fence_node_held} node fence(s) are held. Run the bridge so bootstrap recovery can adjudicate their Talos and scheduling state."
     return 1
   fi
   # Belt and braces against a stale or cached API read: if the heartbeat is still
@@ -952,6 +966,57 @@ recover_fences_now() {
   run_id="${run_reference%% *}"
   run_attempt="${run_reference##* }"
   fence_run_is_terminal "${run_id}" "${run_attempt}" || return 1
+
+  # Prove EVERY policy holder dead before releasing the first one. This keeps a
+  # mixed live/orphaned state fully intact instead of partially unwinding it.
+  for name in "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" \
+    "${IMAGE_VERIFICATION_FLUX_PARENT_KUSTOMIZATION}"; do
+    if [[ "${name}" == "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" ]]; then
+      holder="${fence_policy_child_holder}"
+    else
+      holder="${fence_policy_parent_holder}"
+    fi
+    [[ -n "${holder}" ]] || continue
+    if ! run_reference="$(fence_holder_run_reference "${holder}")"; then
+      echo "::error::Refusing to recover Kustomization flux-system/${name}: holder '${holder}' carries no GitHub run reference."
+      return 1
+    fi
+    run_id="${run_reference%% *}"
+    run_attempt="${run_reference##* }"
+    fence_run_is_terminal "${run_id}" "${run_attempt}" || return 1
+  done
+
+  # Release in the same order as cleanup_refresh_work and the fence report:
+  # child policy handoff, parent policy handoff, then the global Lease.
+  for name in "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" \
+    "${IMAGE_VERIFICATION_FLUX_PARENT_KUSTOMIZATION}"; do
+    if [[ "${name}" == "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" ]]; then
+      holder="${fence_policy_child_holder}"
+      uid="${fence_policy_child_uid}"
+      state="${fence_policy_child_state_file}"
+    else
+      holder="${fence_policy_parent_holder}"
+      uid="${fence_policy_parent_uid}"
+      state="${fence_policy_parent_state_file}"
+    fi
+    [[ -n "${holder}" ]] || continue
+    [[ -s "${state}" && -n "${uid}" ]] || {
+      echo "::error::Refusing to recover Kustomization flux-system/${name}: its reported state was not retained."
+      return 1
+    }
+    patch_file="${work_dir}/fence-recovery-${name}-patch.json"
+    fence_kustomization_release_patch "${name}" "${uid}" "${holder}" >"${patch_file}"
+    if ! kubectl \
+      --context "${KUBE_CONTEXT}" \
+      --namespace flux-system \
+      patch "${FLUX_KUSTOMIZATION_RESOURCE}" "${name}" \
+      --type=json \
+      --patch-file "${patch_file}"; then
+      echo "::error::Recovery patch was refused for Kustomization flux-system/${name}; its UID, holder, or suspended state changed after the report. Re-run to re-evaluate."
+      return 1
+    fi
+    printf 'Released Kustomization flux-system/%s held by %s.\n' "${name}" "${holder}"
+  done
 
   # Literally the same patch the report prints for an operator — one builder, so
   # the two cannot diverge. It is built from the state the report RETAINED, never
@@ -1089,11 +1154,11 @@ fence_node_release_command() {
     "$(fence_shell_quote "${KUBE_CONTEXT}")" "${name}" "$(fence_shell_quote "${patch}")"
 }
 
-fence_kustomization_release_command() {
+fence_kustomization_release_patch() {
   local name="$1"
   local uid="$2"
   local holder="$3"
-  local owner_path patch
+  local owner_path
 
   # Only the CHILD handoff carries `reconcile: disabled` — pause_flux_policy_parent
   # writes the owner annotation and spec.suspend and nothing else. Emitting the
@@ -1102,7 +1167,7 @@ fence_kustomization_release_command() {
   # each resume_* function exactly.
   if [[ "${name}" == "${IMAGE_VERIFICATION_FLUX_KUSTOMIZATION}" ]]; then
     owner_path="${FLUX_POLICY_HANDOFF_OWNER_JSON_PATH}"
-    patch="$(jq -nc \
+    jq -nc \
       --arg uid "${uid}" \
       --arg owner_path "${owner_path}" \
       --arg reconcile_path "${FLUX_RECONCILE_JSON_PATH}" \
@@ -1114,10 +1179,10 @@ fence_kustomization_release_command() {
       {op: "add", path: "/spec/suspend", value: false},
       {op: "remove", path: $owner_path},
       {op: "remove", path: $reconcile_path}
-    ]')"
+    ]'
   else
     owner_path="${FLUX_POLICY_PARENT_OWNER_JSON_PATH}"
-    patch="$(jq -nc \
+    jq -nc \
       --arg uid "${uid}" \
       --arg owner_path "${owner_path}" \
       --arg holder "${holder}" '[
@@ -1126,8 +1191,17 @@ fence_kustomization_release_command() {
       {op: "test", path: "/spec/suspend", value: true},
       {op: "add", path: "/spec/suspend", value: false},
       {op: "remove", path: $owner_path}
-    ]')"
+    ]'
   fi
+}
+
+fence_kustomization_release_command() {
+  local name="$1"
+  local uid="$2"
+  local holder="$3"
+  local patch
+
+  patch="$(fence_kustomization_release_patch "${name}" "${uid}" "${holder}")"
   printf "kubectl --context %s -n flux-system patch %s %s --type=json -p %s" \
     "$(fence_shell_quote "${KUBE_CONTEXT}")" "${FLUX_KUSTOMIZATION_RESOURCE}" "${name}" "$(fence_shell_quote "${patch}")"
 }

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_autorecovery_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 // --recover-fences is the automated half of the fence model: it releases the
-// synchronization Lease when — and only when — the holder is PROVABLY dead.
+// policy fences and then the synchronization Lease when — and only when — every
+// holder is PROVABLY dead.
 //
 // Everything here is a statement about that proof. Expiry alone must never
 // release, because the script's own acquisition comment explains that an expired
@@ -26,6 +27,21 @@ func seedOrphanedLease(t *testing.T, f *fixture, holder string) {
 	if err := os.WriteFile(
 		filepath.Join(f.syncStateDir, "sync-lease-holder"), []byte(holder), 0o600); err != nil {
 		t.Fatalf("seed lease holder: %v", err)
+	}
+}
+
+func seedOrphanedPolicyFences(t *testing.T, f *fixture, holder string) {
+	t.Helper()
+	markers := map[string]string{
+		"flux-policy-handoff-owner":     holder,
+		"flux-policy-handoff-suspended": "",
+		"flux-policy-parent-owner":      holder,
+		"flux-policy-parent-suspended":  "",
+	}
+	for name, value := range markers {
+		if err := os.WriteFile(filepath.Join(f.syncStateDir, name), []byte(value), 0o600); err != nil {
+			t.Fatalf("seed policy fence %s: %v", name, err)
+		}
 	}
 }
 
@@ -83,36 +99,99 @@ func TestRecoverFencesRefusesWhileTheHolderRunIsNotTerminal(t *testing.T) {
 	}
 }
 
-// The Lease is the GLOBAL exclusion fence, so it is released last: clearing it
-// while a policy or node fence is still held lets a deploy start against a
-// half-recovered cluster. Automation refuses rather than reordering.
-//
-// The assertion that matters here is the third one. This refusal is reached
-// BEFORE any liveness proof is attempted, so a run that queried the API first
-// would be deciding the ordering question after paying for — and potentially
-// acting on — an answer it must not use.
-func TestRecoverFencesRefusesWhileAnotherFenceIsStillHeld(t *testing.T) {
+// A hard-killed deploy ordinarily leaves the child and parent policy fences as
+// well as the Lease. Recovery must prove every holder run is terminal before it
+// mutates anything, then release child, parent, and Lease in that order.
+func TestRecoverFencesReleasesTerminalPolicyFencesBeforeTheLease(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)
 	seedOrphanedLease(t, f, deadHolderIdentity)
+	seedOrphanedPolicyFences(t, f, deadHolderIdentity)
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{"FAKE_EXPIRED_SYNC_LEASE": "true"})
+
+	requireSuccessResult(t, result)
+	for _, marker := range []string{
+		"flux-policy-handoff-owner", "flux-policy-handoff-suspended",
+		"flux-policy-parent-owner", "flux-policy-parent-suspended",
+	} {
+		if pathExists(filepath.Join(f.syncStateDir, marker)) {
+			t.Errorf("policy fence marker %s remains after recovery", marker)
+		}
+	}
+	if holder := leaseHolderNow(t, f); holder != "" {
+		t.Errorf("lease holder = %q, want it released last", holder)
+	}
+	operations := readLines(f.operationLog)
+	child := lineIndex(t, operations, "flux-policy-resume:infrastructure")
+	parent := lineIndex(t, operations, "flux-policy-parent-resume:flux-system")
+	if child >= parent {
+		t.Errorf("policy release order = %v, want child before parent", operations)
+	}
+}
+
+// A lost policy-fence CAS must leave the parent and global Lease held. That
+// preserves exclusion for a fresh report/retry instead of exposing a partially
+// recovered control plane to another deploy.
+func TestRecoverFencesKeepsLaterFencesWhenPolicyReleaseIsRefused(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+	seedOrphanedPolicyFences(t, f, deadHolderIdentity)
 
 	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
 		map[string]string{
-			"FAKE_EXPIRED_SYNC_LEASE":        "true",
-			"FAKE_FLUX_POLICY_HANDOFF_OWNED": "true",
+			"FAKE_EXPIRED_SYNC_LEASE":               "true",
+			"FAKE_FLUX_POLICY_HANDOFF_RELEASE_FAIL": "true",
 		})
 
 	if result.exitCode == 0 {
-		t.Fatalf("recovery succeeded with another fence held; stdout = %q", result.stdout)
+		t.Fatalf("recovery succeeded after a refused child release; stdout = %q", result.stdout)
+	}
+	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
+		t.Errorf("lease holder = %q, want it retained", holder)
+	}
+	for _, marker := range []string{
+		"flux-policy-handoff-owner", "flux-policy-handoff-suspended",
+		"flux-policy-parent-owner", "flux-policy-parent-suspended",
+	} {
+		if !pathExists(filepath.Join(f.syncStateDir, marker)) {
+			t.Errorf("policy fence marker %s was removed after the refused first release", marker)
+		}
+	}
+}
+
+// Node recovery has additional Talos and scheduling proofs, so this lightweight
+// preflight must still refuse before querying liveness or releasing the Lease.
+func TestRecoverFencesRefusesWhileANodeFenceIsStillHeld(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	seedOrphanedLease(t, f, deadHolderIdentity)
+	for name, value := range map[string]string{
+		"cordon-owner-prod-worker-1": deadHolderIdentity,
+		"cordon-phase-prod-worker-1": "claimed",
+		"cordoned-prod-worker-1":     "",
+	} {
+		if err := os.WriteFile(filepath.Join(f.syncStateDir, name), []byte(value), 0o600); err != nil {
+			t.Fatalf("seed node fence %s: %v", name, err)
+		}
+	}
+
+	result := f.runHelperPreservingClusterState(validConfig(), []string{"--recover-fences"},
+		map[string]string{"FAKE_EXPIRED_SYNC_LEASE": "true"})
+
+	if result.exitCode == 0 {
+		t.Fatalf("recovery succeeded with a node fence held; stdout = %q", result.stdout)
 	}
 	if holder := leaseHolderNow(t, f); holder != deadHolderIdentity {
 		t.Errorf("lease holder = %q, want it untouched", holder)
 	}
 	if _, err := os.Stat(f.ghCalled); err == nil {
-		t.Error("liveness query was made before the ordering refusal; it should not have been")
+		t.Error("liveness query was made before the node-fence refusal")
 	}
-	if output := result.stdout + result.stderr; !strings.Contains(output, "other fence(s) are held") {
-		t.Errorf("refusal does not name the ordering rule it enforced; output = %q", output)
+	if output := result.stdout + result.stderr; !strings.Contains(output, "node fence") {
+		t.Errorf("refusal does not name the node-fence boundary; output = %q", output)
 	}
 }
 

--- a/scripts/tests/refresh-flux-ghcr-auth/fence_recovery_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fence_recovery_test.go
@@ -140,10 +140,10 @@ func TestFenceReleaseCommandsMirrorTheReleaseTheyStandInFor(t *testing.T) {
 	t.Parallel()
 	script := readRepositoryFile(t, "scripts/refresh-flux-ghcr-auth.sh")
 
-	command := functionBody(t, script, "fence_kustomization_release_command")
+	command := functionBody(t, script, "fence_kustomization_release_patch")
 	split := strings.Index(command, "\n  else\n")
 	if split < 0 {
-		t.Fatal("expected fence_kustomization_release_command to branch child vs parent")
+		t.Fatal("expected fence_kustomization_release_patch to branch child vs parent")
 	}
 	childCommand, parentCommand := command[:split], command[split:]
 

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1953,7 +1953,6 @@ const (
 // The previous aggregate remains recorded here:
 //
 //	bc95f7ee1b1d9a29819844f5dfac84f256aa4caadac8eb39b43fed59992b85ea
-
 // Moved again by the trusted tenant semantic-version rollout (#3677). Exactly
 // two existing source objects change: the ascoachingogvaner and wedding-app
 // OCIRepositories replace one fixed ref.tag with ref.semver >=1.0.0. Their
@@ -2187,7 +2186,7 @@ var expectedRenderedHashes = map[resourceIdentity]string{
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "flux-system", name: "infrastructure-controllers"}: "9d9b62d3221442d6355d16a34d31c198619fb3b3728df960fd67222a531ece7b",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "github-config", name: "github-config"}:            "8e9f72b0f4f982d050aff0b97d246c68b538cbc397cdd45d031c95cfae981e7c",
 	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "unifi", name: "unifi"}:                            "33a579299700de2467631854bac4982d3e14caa3bad8cbcd2613ac180b30af32",
-	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "wedding-app", name: "wedding-app"}:                "3710185a3d14afaeaa032447421850f6a8ab01e1ae5dbbf58819783cc61154e8",
+	{apiVersion: "kustomize.toolkit.fluxcd.io/v1", kind: "Kustomization", namespace: "wedding-app", name: "wedding-app"}:                "eb6253380641dbfac9936b4a2c938524d4f4cc9352d45ab18e8fdfd9e59bf8a8",
 }
 
 // fingerprint returns the SHA-256 identity used for byte-exact source checks.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1969,7 +1969,26 @@ const (
 // mismatch.
 //
 // Previous aggregate: 5b85be735c3d7d32e2bf6dce91c0e73435986c169234f2d72984617e9dc25a65.
-const expectedRenderedSurfaceSHA = "814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1"
+// That rollout established aggregate:
+//
+//	814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1
+//
+// Moved again by the Wedding data-loss repair after rebasing onto #3677. The
+// only additional rendered identity change is the wedding-app Kustomization's
+// global `force` value moving from true to false, plus its explanatory comment.
+// The validator reported no unapproved, missing, or duplicate identity after
+// admitting that Kustomization hash and this aggregate. This removes
+// replacement authority and adds no Role, ClusterRole, binding,
+// ServiceAccount, subject, verb, wildcard, AWS identity, or permission.
+//
+// RENDERER PROVENANCE: reproduced locally with the official kubectl v1.36.2
+// Darwin arm64 binary (SHA256
+// 4408c85c83fd3a31adaa555bdf3c7a6c81f74b19449a9060ba31ab91926f023d),
+// whose embedded Kustomize is v5.8.1, matching CI's pinned versions. Previous
+// aggregate:
+//
+//	814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1
+const expectedRenderedSurfaceSHA = "8756f2ad633f8cc0ae64c63a8e4162e0b6a8ed481f28f667736e3d1395531c6e"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -7,6 +7,7 @@ import {
   buildMergeSQL,
   buildRecoveryResources,
   buildResumePatch,
+  buildSchemaCleanupSQL,
   buildSuspendPatch,
   recoveryOwner,
   recoveryOwnerAttempt,
@@ -159,10 +160,24 @@ test('merge restores pre-loss answers only where the replacement has no newer an
   assert.match(sql,/live\.attending IS NULL AND live\.dietary_notes IS NULL/);
   assert.match(sql,/recovered\.attending IS NOT NULL OR recovered\.dietary_notes IS NOT NULL/);
   assert.match(sql,/ON CONFLICT \(guest_pair_id\) DO NOTHING/);
+  assert.match(sql,/BEGIN;\nSET TRANSACTION ISOLATION LEVEL READ COMMITTED;/);
   assert.match(sql,/LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE/);
+  assert.match(sql,/CREATE TEMP TABLE incident_restore_counts/);
+  assert.match(sql,/INSERT INTO incident_restore_counts[\s\S]*;\nSELECT json_build_object\(/);
+  assert.match(sql,/'restoredGuestAnswers',\(SELECT restored_guest_answers FROM incident_restore_counts\)/);
   assert.match(sql,/DROP SCHEMA incident_restore_34710000000_1 CASCADE/);
   assert.doesNotMatch(sql,/sessions|admin_sessions/);
   assert.throws(()=>buildMergeSQL('public'),/refused/);
+});
+
+test('cleanup retries the run-owned schema after application fences are released',async()=>{
+  assert.equal(buildSchemaCleanupSQL('34710000000','2'),'DROP SCHEMA IF EXISTS incident_restore_34710000000_1 CASCADE;\nDROP SCHEMA IF EXISTS incident_restore_34710000000_2 CASCADE;');
+  assert.throws(()=>buildSchemaCleanupSQL('34710000000','101'),/refused/);
+  const fs=await import('node:fs/promises');
+  const source=await fs.readFile(new URL('../../scripts/recover-wedding-db-incident.mjs',import.meta.url),'utf8');
+  const cleanup=source.slice(source.indexOf('function runCleanup'),source.indexOf("if(process.argv[1]"));
+  assert.match(cleanup,/if\(owner\)recoveryOwnerAttempt\(config\.run,config\.attempt,owner\)/);
+  assert.ok(cleanup.lastIndexOf('cleanupSchema()')>cleanup.indexOf('resumeApplication'));
 });
 
 test('Wedding reconciliation cannot globally force-recreate stateful data',async()=>{

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -139,6 +139,15 @@ test('both Flux fences replace every pre-suspension controller before the applic
   assert.match(source,/history\?\.some\(item=>item\.lastReconciled===PRELOSS_TARGET_TIME[\s\S]*item\.lastReconciledStatus==='ReconciliationSucceeded'/);
 });
 
+test('cleanup releases the parent after a parent-only fence acquisition',async()=>{
+  const fs=await import('node:fs/promises');
+  const source=await fs.readFile(new URL('../../scripts/recover-wedding-db-incident.mjs',import.meta.url),'utf8');
+  const resume=source.slice(source.indexOf('function resumeApplication'),source.indexOf('function createRecovery'));
+  assert.match(resume,/if\(!childOwner\)check\(child\.spec\?\.suspend!==true/);
+  assert.match(resume,/restored\.metadata\.uid===LIVE_KUSTOMIZATION_UID&&restored\.spec\?\.suspend!==true/);
+  assert.match(resume,/if\(parentOwner&&childReleased&&!failed\).*releaseFence\(PARENT_NAMESPACE/s);
+});
+
 test('current and restored backups are distinct, run-owned plugin backups',()=>{
   const before=buildBackup({run:'34710000000',attempt:'1',phase:'before'});
   const after=buildBackup({run:'34710000000',attempt:'1',phase:'after'});

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -5,6 +5,7 @@ import {
   buildBackup,
   buildMergeSQL,
   buildRecoveryResources,
+  recoveryOwner,
   recoverySource,
   validateCoreInventory,
 } from '../../scripts/recover-wedding-db-incident.mjs';
@@ -69,6 +70,11 @@ test('recovery cluster replays the complete predecessor archive from the exact b
   assert.deepEqual(policy.spec.egress.find(item=>item.toFQDNs).toFQDNs,[{matchName:'0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com'}]);
 });
 
+test('application suspension ownership is bound to one workflow attempt',()=>{
+  assert.equal(recoveryOwner('34710000000','1'),'34710000000/1');
+  assert.throws(()=>recoveryOwner('34710000000','0'),/refused/);
+});
+
 test('current and restored backups are distinct, run-owned plugin backups',()=>{
   const before=buildBackup({run:'34710000000',attempt:'1',phase:'before'});
   const after=buildBackup({run:'34710000000',attempt:'1',phase:'after'});
@@ -116,6 +122,10 @@ test('manual recovery is serialized with production deployments and discloses no
   const workflow=await fs.readFile(new URL('../../.github/workflows/recover-wedding-db-incident.yaml',import.meta.url),'utf8');
   assert.match(workflow,/workflow_dispatch:\n\npermissions: \{\}/);
   assert.match(workflow,/group: prod-deploy\n  cancel-in-progress: false\n  queue: max/);
+  assert.match(workflow,/timeout-minutes: 180/);
+  assert.match(workflow,/needs: recover\n    if: \$\{\{ always\(\) \}\}/);
+  assert.match(workflow,/timeout-minutes: 20/);
+  assert.match(workflow,/node scripts\/recover-wedding-db-incident\.mjs --cleanup/);
   assert.match(workflow,/environment: prod/);
   assert.match(workflow,/persist-credentials: false/);
   assert.doesNotMatch(workflow,/pull_request|schedule:|inputs:/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -44,6 +44,7 @@ test('source is pinned to the empty replacement and last pre-loss backup',()=>{
     currentClusterUid:CURRENT_UID,sourceUid:SOURCE_UID,prelossBackupUid:BACKUP_UID,
     database:'wedding',imageName:'ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie',storageClass:'longhorn-wffc',size:'1Gi',
     endpoint:'https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com',prelossBackupId:'20260908T030001',
+    prelossTargetTime:'2026-09-09T01:57:41Z',prelossTargetTimeline:'162',
   });
   for(const change of [
     value=>{value.cluster.metadata.uid='11111111-1111-1111-1111-111111111111';},
@@ -63,11 +64,13 @@ test('source is pinned to the empty replacement and last pre-loss backup',()=>{
   }
 });
 
-test('recovery cluster replays the complete predecessor archive from the exact base',()=>{
+test('recovery cluster reaches the witnessed pre-loss point from the exact base',()=>{
   const source=recoverySource(fixture());
   const {cluster,policy}=buildRecoveryResources({run:'34710000000',attempt:'1',...source});
   assert.equal(cluster.metadata.name,'wedding-db-preloss-34710000000-1');
-  assert.deepEqual(cluster.spec.bootstrap,{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:'20260908T030001'}}});
+  assert.deepEqual(cluster.spec.bootstrap,{recovery:{source:'wedding-db-preloss',recoveryTarget:{
+    backupID:'20260908T030001',targetTime:'2026-09-09T01:57:41Z',targetTLI:'162',
+  }}});
   assert.deepEqual(cluster.spec.externalClusters,[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:'wedding-db',serverName:'wedding-db'}}}]);
   assert.equal(cluster.spec.plugins,undefined);
   assert.equal(cluster.spec.instances,1);
@@ -132,6 +135,7 @@ test('both Flux fences replace every pre-suspension controller before the applic
   assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);
   assert.match(source,/rollout','status','deployment\.apps\/'\+FLUX_CONTROLLER/);
   assert.match(source,/every\(oldUid=>!pods\.some\(pod=>pod\.metadata\?\.uid===oldUid\)\)/);
+  assert.match(source,/history\?\.some\(item=>item\.lastReconciled===PRELOSS_TARGET_TIME[\s\S]*item\.lastReconciledStatus==='ReconciliationSucceeded'/);
 });
 
 test('current and restored backups are distinct, run-owned plugin backups',()=>{
@@ -203,6 +207,12 @@ test('manual recovery is serialized with production deployments and discloses no
   assert.equal(workflow.match(/HCLOUD_TOKEN: \$\{\{ secrets\.HCLOUD_TOKEN \}\}/g)?.length,2);
   assert.match(workflow,/environment: prod/);
   assert.match(workflow,/persist-credentials: false/);
+  assert.equal(workflow.match(/ref: main/g)?.length,2);
+  assert.equal(workflow.match(/node scripts\/recover-wedding-db-incident\.mjs --verify-source/g)?.length,2);
+  for(const job of workflow.split(/\n  [a-z-]+:\n/).slice(1)){
+    assert.ok(job.indexOf('node scripts/recover-wedding-db-incident.mjs --verify-source')<job.indexOf('KUBE_CONFIG:'));
+    assert.ok(job.indexOf('node scripts/recover-wedding-db-incident.mjs --verify-source')<job.indexOf('HCLOUD_TOKEN:'));
+  }
   assert.doesNotMatch(workflow,/pull_request|schedule:|inputs:/);
 });
 

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -8,6 +8,7 @@ import {
   buildResumePatch,
   buildSuspendPatch,
   recoveryOwner,
+  recoveryOwnerAttempt,
   recoverySource,
   validateCoreInventory,
 } from '../../scripts/recover-wedding-db-incident.mjs';
@@ -77,6 +78,9 @@ test('application suspension ownership is bound to one workflow attempt',()=>{
   const owner=recoveryOwner('34710000000','1');
   assert.equal(owner,'34710000000/1');
   assert.throws(()=>recoveryOwner('34710000000','0'),/refused/);
+  assert.equal(recoveryOwnerAttempt('34710000000','2',owner),'1');
+  assert.throws(()=>recoveryOwnerAttempt('34710000000','1','34710000000/2'),/refused/);
+  assert.throws(()=>recoveryOwnerAttempt('34710000000','2','34710000001/1'),/refused/);
   assert.deepEqual(buildSuspendPatch({resourceVersion:'279780874',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),[
     {op:'test',path:'/metadata/resourceVersion',value:'279780874'},
     {op:'test',path:'/metadata/uid',value:'be31651e-fe0d-4826-9ffb-d41716a66720'},
@@ -145,7 +149,7 @@ test('manual recovery is serialized with production deployments and discloses no
   assert.match(workflow,/group: prod-deploy\n  cancel-in-progress: false\n  queue: max/);
   assert.match(workflow,/timeout-minutes: 180/);
   assert.match(workflow,/needs: recover\n    if: \$\{\{ always\(\) \}\}/);
-  assert.match(workflow,/timeout-minutes: 20/);
+  assert.match(workflow,/timeout-minutes: 60/);
   assert.match(workflow,/node scripts\/recover-wedding-db-incident\.mjs --cleanup/);
   assert.equal(workflow.match(/run: \.\/scripts\/use-prod-stable-api-endpoint\.sh/g)?.length,2);
   assert.equal(workflow.match(/HCLOUD_TOKEN: \$\{\{ secrets\.HCLOUD_TOKEN \}\}/g)?.length,2);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {spawnSync} from 'node:child_process';
 import {
   buildBackup,
+  buildControllerRestartPatch,
   buildMergeSQL,
   buildRecoveryResources,
   buildResumePatch,
@@ -16,6 +17,7 @@ import {
 const CURRENT_UID='afea05ff-7daa-4d80-99a6-f2d696cbc3f1';
 const SOURCE_UID='9cd2ba9b-c7bf-43e2-bd2d-a5c7c139fafb';
 const BACKUP_UID='549fe940-b119-4010-bdc8-fa8e6ebc93ae';
+const CONTROLLER_UID='48c6521a-483a-4de9-895a-bae1a61ea25e';
 
 function fixture(){
   return {
@@ -99,6 +101,32 @@ test('application suspension ownership is bound to one workflow attempt',()=>{
   ]);
   assert.equal(buildSuspendPatch({resourceVersion:'279825100',kustomizationUid:'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48',owner})[1].value,'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48');
   assert.throws(()=>buildSuspendPatch({resourceVersion:'0',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),/refused/);
+});
+
+test('controller handoff restart is atomic and bound to this incident',()=>{
+  const restartToken='wedding-db-recovery-34710000000-1';
+  assert.deepEqual(buildControllerRestartPatch({resourceVersion:'279824733',deploymentUid:CONTROLLER_UID,annotationsPresent:true,restartToken}),[
+    {op:'test',path:'/metadata/resourceVersion',value:'279824733'},
+    {op:'test',path:'/metadata/uid',value:CONTROLLER_UID},
+    {op:'add',path:'/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt',value:restartToken},
+  ]);
+  assert.deepEqual(buildControllerRestartPatch({resourceVersion:'279824733',deploymentUid:CONTROLLER_UID,annotationsPresent:false,restartToken}),[
+    {op:'test',path:'/metadata/resourceVersion',value:'279824733'},
+    {op:'test',path:'/metadata/uid',value:CONTROLLER_UID},
+    {op:'add',path:'/spec/template/metadata/annotations',value:{}},
+    {op:'add',path:'/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt',value:restartToken},
+  ]);
+  assert.throws(()=>buildControllerRestartPatch({resourceVersion:'279824733',deploymentUid:CURRENT_UID,annotationsPresent:true,restartToken}),/refused/);
+  assert.throws(()=>buildControllerRestartPatch({resourceVersion:'279824733',deploymentUid:CONTROLLER_UID,annotationsPresent:true,restartToken:'manual'}),/refused/);
+});
+
+test('both Flux fences replace every pre-suspension controller before the application drains',async()=>{
+  const fs=await import('node:fs/promises');
+  const source=await fs.readFile(new URL('../../scripts/recover-wedding-db-incident.mjs',import.meta.url),'utf8');
+  const suspension=source.slice(source.indexOf('function suspendApplication'),source.indexOf('function resumeApplication'));
+  assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);
+  assert.match(source,/rollout','status','deployment\.apps\/'\+FLUX_CONTROLLER/);
+  assert.match(source,/every\(oldUid=>!pods\.some\(pod=>pod\.metadata\?\.uid===oldUid\)\)/);
 });
 
 test('current and restored backups are distinct, run-owned plugin backups',()=>{

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -5,6 +5,8 @@ import {
   buildBackup,
   buildMergeSQL,
   buildRecoveryResources,
+  buildResumePatch,
+  buildSuspendPatch,
   recoveryOwner,
   recoverySource,
   validateCoreInventory,
@@ -71,8 +73,26 @@ test('recovery cluster replays the complete predecessor archive from the exact b
 });
 
 test('application suspension ownership is bound to one workflow attempt',()=>{
-  assert.equal(recoveryOwner('34710000000','1'),'34710000000/1');
+  const owner=recoveryOwner('34710000000','1');
+  assert.equal(owner,'34710000000/1');
   assert.throws(()=>recoveryOwner('34710000000','0'),/refused/);
+  assert.deepEqual(buildSuspendPatch({resourceVersion:'279780874',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),[
+    {op:'test',path:'/metadata/resourceVersion',value:'279780874'},
+    {op:'test',path:'/metadata/uid',value:'be31651e-fe0d-4826-9ffb-d41716a66720'},
+    {op:'add',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner',value:owner},
+    {op:'add',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile',value:'disabled'},
+    {op:'add',path:'/spec/suspend',value:true},
+  ]);
+  assert.deepEqual(buildResumePatch({kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),[
+    {op:'test',path:'/metadata/uid',value:'be31651e-fe0d-4826-9ffb-d41716a66720'},
+    {op:'test',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner',value:owner},
+    {op:'test',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile',value:'disabled'},
+    {op:'test',path:'/spec/suspend',value:true},
+    {op:'add',path:'/spec/suspend',value:false},
+    {op:'remove',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner'},
+    {op:'remove',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile'},
+  ]);
+  assert.throws(()=>buildSuspendPatch({resourceVersion:'0',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),/refused/);
 });
 
 test('current and restored backups are distinct, run-owned plugin backups',()=>{

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -201,14 +201,18 @@ test('manual recovery is serialized with production deployments and discloses no
   assert.match(workflow,/workflow_dispatch:\n\npermissions: \{\}/);
   assert.match(workflow,/group: prod-deploy\n  cancel-in-progress: false\n  queue: max/);
   assert.match(workflow,/timeout-minutes: 180/);
-  assert.match(workflow,/needs: recover\n    if: \$\{\{ always\(\) \}\}/);
+  assert.match(workflow,/outputs:\n      source_sha: \$\{\{ steps\.recovery_source\.outputs\.sha \}\}/);
+  assert.match(workflow,/needs: recover\n    if: \$\{\{ always\(\) && needs\.recover\.outputs\.source_sha != '' \}\}/);
   assert.match(workflow,/timeout-minutes: 60/);
   assert.match(workflow,/node scripts\/recover-wedding-db-incident\.mjs --cleanup/);
   assert.equal(workflow.match(/run: \.\/scripts\/use-prod-stable-api-endpoint\.sh/g)?.length,2);
   assert.equal(workflow.match(/HCLOUD_TOKEN: \$\{\{ secrets\.HCLOUD_TOKEN \}\}/g)?.length,2);
   assert.match(workflow,/environment: prod/);
   assert.match(workflow,/persist-credentials: false/);
-  assert.equal(workflow.match(/ref: main/g)?.length,2);
+  assert.equal(workflow.match(/ref: main/g)?.length,1);
+  assert.match(workflow,/ref: \$\{\{ needs\.recover\.outputs\.source_sha \}\}/);
+  assert.match(workflow,/id: recovery_source/);
+  assert.match(workflow,/printf 'sha=%s\\n' "\$GITHUB_SHA" >>"\$GITHUB_OUTPUT"/);
   assert.equal(workflow.match(/node scripts\/recover-wedding-db-incident\.mjs --verify-source/g)?.length,2);
   for(const job of workflow.split(/\n  [a-z-]+:\n/).slice(1)){
     assert.ok(job.indexOf('node scripts/recover-wedding-db-incident.mjs --verify-source')<job.indexOf('KUBE_CONFIG:'));

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -97,6 +97,7 @@ test('application suspension ownership is bound to one workflow attempt',()=>{
     {op:'remove',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner'},
     {op:'remove',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile'},
   ]);
+  assert.equal(buildSuspendPatch({resourceVersion:'279825100',kustomizationUid:'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48',owner})[1].value,'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48');
   assert.throws(()=>buildSuspendPatch({resourceVersion:'0',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),/refused/);
 });
 

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -132,6 +132,11 @@ test('both Flux fences replace every pre-suspension controller before the applic
   assert.equal(instance.match(/\n          name: kustomize-controller\n/g)?.length,1);
   assert.doesNotMatch(instance,/name: (?:kustomize-controller|helm-controller|notification-controller)\n\s+namespace:/);
   assert.match(instance,/name: kustomize-controller\n        patch: \|[\s\S]*?value: --requeue-dependency=5s[\s\S]*?path: \/spec\/replicas[\s\S]*?value: 2/);
+  assert.equal(instance.match(/path: \/spec\/template\/spec\/affinity\/podAntiAffinity\/requiredDuringSchedulingIgnoredDuringExecution/g)?.length,3);
+  for(const controller of ['kustomize-controller','helm-controller','notification-controller']){
+    const patch=instance.slice(instance.indexOf(`          name: ${controller}`),instance.indexOf('\n      - target:',instance.indexOf(`          name: ${controller}`)+1));
+    assert.match(patch,new RegExp(`requiredDuringSchedulingIgnoredDuringExecution[\\s\\S]*app\\.kubernetes\\.io/name: ${controller}[\\s\\S]*topologyKey: kubernetes\\.io/hostname`));
+  }
   const suspension=source.slice(source.indexOf('function suspendApplication'),source.indexOf('function resumeApplication'));
   assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);
   assert.match(source,/rollout','status','deployment\.apps\/'\+FLUX_CONTROLLER/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -132,10 +132,10 @@ test('both Flux fences replace every pre-suspension controller before the applic
   assert.equal(instance.match(/\n          name: kustomize-controller\n/g)?.length,1);
   assert.doesNotMatch(instance,/name: (?:kustomize-controller|helm-controller|notification-controller)\n\s+namespace:/);
   assert.match(instance,/name: kustomize-controller\n        patch: \|[\s\S]*?value: --requeue-dependency=5s[\s\S]*?path: \/spec\/replicas[\s\S]*?value: 2/);
-  assert.equal(instance.match(/path: \/spec\/template\/spec\/affinity\/podAntiAffinity\/requiredDuringSchedulingIgnoredDuringExecution/g)?.length,3);
+  assert.equal(instance.match(/path: \/spec\/template\/spec\/affinity\n/g)?.length,3);
   for(const controller of ['kustomize-controller','helm-controller','notification-controller']){
     const patch=instance.slice(instance.indexOf(`          name: ${controller}`),instance.indexOf('\n      - target:',instance.indexOf(`          name: ${controller}`)+1));
-    assert.match(patch,new RegExp(`requiredDuringSchedulingIgnoredDuringExecution[\\s\\S]*app\\.kubernetes\\.io/name: ${controller}[\\s\\S]*topologyKey: kubernetes\\.io/hostname`));
+    assert.match(patch,new RegExp(`path: /spec/template/spec/affinity[\\s\\S]*requiredDuringSchedulingIgnoredDuringExecution[\\s\\S]*app: ${controller}[\\s\\S]*topologyKey: kubernetes\\.io/hostname`));
   }
   const suspension=source.slice(source.indexOf('function suspendApplication'),source.indexOf('function resumeApplication'));
   assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -124,6 +124,10 @@ test('controller handoff restart is atomic and bound to this incident',()=>{
 test('both Flux fences replace every pre-suspension controller before the application drains',async()=>{
   const fs=await import('node:fs/promises');
   const source=await fs.readFile(new URL('../../scripts/recover-wedding-db-incident.mjs',import.meta.url),'utf8');
+  const instance=await fs.readFile(new URL('../../k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml',import.meta.url),'utf8');
+  assert.match(source,/const FLUX_CONTROLLER_REPLICAS=2;/);
+  assert.equal(instance.match(/\n          name: kustomize-controller\n/g)?.length,1);
+  assert.match(instance,/name: kustomize-controller\n          namespace: flux-system\n        patch: \|[\s\S]*?value: --requeue-dependency=5s[\s\S]*?path: \/spec\/replicas[\s\S]*?value: 2/);
   const suspension=source.slice(source.indexOf('function suspendApplication'),source.indexOf('function resumeApplication'));
   assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);
   assert.match(source,/rollout','status','deployment\.apps\/'\+FLUX_CONTROLLER/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -21,7 +21,7 @@ function fixture(){
     },status:{observedGeneration:6,phase:'Cluster in healthy state',currentPrimary:'wedding-db-1',readyInstances:3,conditions:[
       {type:'Ready',status:'True'},{type:'ContinuousArchiving',status:'True'},
     ]}},
-    store:{apiVersion:'barmancloud.cnpg.io/v1',kind:'ObjectStore',metadata:{name:'wedding-db',namespace:'wedding-app',uid:SOURCE_UID},spec:{configuration:{
+    store:{apiVersion:'barmancloud.cnpg.io/v1',kind:'ObjectStore',metadata:{name:'wedding-db',namespace:'wedding-app',uid:SOURCE_UID,creationTimestamp:'2026-06-16T20:39:55Z'},spec:{configuration:{
       destinationPath:'s3://platform-backups/cnpg/wedding-db',endpointURL:'https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com',
       s3Credentials:{accessKeyId:{name:'wedding-db-backup-r2',key:'ACCESS_KEY_ID'},secretAccessKey:{name:'wedding-db-backup-r2',key:'SECRET_ACCESS_KEY'},region:{name:'wedding-db-backup-r2',key:'REGION'}},
     }}},
@@ -44,6 +44,8 @@ test('source is pinned to the empty replacement and last pre-loss backup',()=>{
     value=>{value.cluster.spec.bootstrap={recovery:{source:'old'}};},
     value=>{value.cluster.spec.plugins[0].parameters.serverName='wedding-db';},
     value=>{value.cluster.status.conditions[1].status='False';},
+    value=>{value.store.metadata.uid='33333333-3333-3333-3333-333333333333';},
+    value=>{value.store.metadata.creationTimestamp='2026-06-17T20:39:55Z';},
     value=>{value.store.spec.configuration.destinationPath='s3://other/path';},
     value=>{value.backup.metadata.uid='22222222-2222-2222-2222-222222222222';},
     value=>{value.backup.status.pluginMetadata.clusterUID=CURRENT_UID;},

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -130,7 +130,8 @@ test('both Flux fences replace every pre-suspension controller before the applic
   const instance=await fs.readFile(new URL('../../k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml',import.meta.url),'utf8');
   assert.match(source,/const FLUX_CONTROLLER_REPLICAS=2;/);
   assert.equal(instance.match(/\n          name: kustomize-controller\n/g)?.length,1);
-  assert.match(instance,/name: kustomize-controller\n          namespace: flux-system\n        patch: \|[\s\S]*?value: --requeue-dependency=5s[\s\S]*?path: \/spec\/replicas[\s\S]*?value: 2/);
+  assert.doesNotMatch(instance,/name: (?:kustomize-controller|helm-controller|notification-controller)\n\s+namespace:/);
+  assert.match(instance,/name: kustomize-controller\n        patch: \|[\s\S]*?value: --requeue-dependency=5s[\s\S]*?path: \/spec\/replicas[\s\S]*?value: 2/);
   const suspension=source.slice(source.indexOf('function suspendApplication'),source.indexOf('function resumeApplication'));
   assert.match(suspension,/acquireFence\(PARENT_NAMESPACE[\s\S]*acquireFence\(NAMESPACE[\s\S]*restartKustomizeController\(config\)[\s\S]*scale','deployment'/);
   assert.match(source,/rollout','status','deployment\.apps\/'\+FLUX_CONTROLLER/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -70,6 +70,7 @@ test('recovery cluster replays the complete predecessor archive from the exact b
   assert.equal(cluster.spec.enablePDB,false);
   assert.deepEqual(policy.spec.endpointSelector.matchLabels,{'cnpg.io/cluster':cluster.metadata.name});
   assert.deepEqual(policy.spec.egress.find(item=>item.toFQDNs).toFQDNs,[{matchName:'0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com'}]);
+  assert.equal(policy.spec.egress.some(item=>item.toEndpoints),false);
 });
 
 test('application suspension ownership is bound to one workflow attempt',()=>{
@@ -146,6 +147,8 @@ test('manual recovery is serialized with production deployments and discloses no
   assert.match(workflow,/needs: recover\n    if: \$\{\{ always\(\) \}\}/);
   assert.match(workflow,/timeout-minutes: 20/);
   assert.match(workflow,/node scripts\/recover-wedding-db-incident\.mjs --cleanup/);
+  assert.equal(workflow.match(/run: \.\/scripts\/use-prod-stable-api-endpoint\.sh/g)?.length,2);
+  assert.equal(workflow.match(/HCLOUD_TOKEN: \$\{\{ secrets\.HCLOUD_TOKEN \}\}/g)?.length,2);
   assert.match(workflow,/environment: prod/);
   assert.match(workflow,/persist-credentials: false/);
   assert.doesNotMatch(workflow,/pull_request|schedule:|inputs:/);

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {
+  buildBackup,
+  buildMergeSQL,
+  buildRecoveryResources,
+  recoverySource,
+  validateCoreInventory,
+} from '../../scripts/recover-wedding-db-incident.mjs';
+
+const CURRENT_UID='afea05ff-7daa-4d80-99a6-f2d696cbc3f1';
+const SOURCE_UID='9cd2ba9b-c7bf-43e2-bd2d-a5c7c139fafb';
+const BACKUP_UID='549fe940-b119-4010-bdc8-fa8e6ebc93ae';
+
+function fixture(){
+  return {
+    cluster:{apiVersion:'postgresql.cnpg.io/v1',kind:'Cluster',metadata:{name:'wedding-db',namespace:'wedding-app',uid:CURRENT_UID,creationTimestamp:'2026-09-09T01:58:14Z',generation:6},spec:{
+      imageName:'ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie',storage:{size:'1Gi',storageClass:'longhorn-wffc'},
+      bootstrap:{initdb:{database:'wedding'}},plugins:[{name:'barman-cloud.cloudnative-pg.io',enabled:true,isWALArchiver:true,parameters:{barmanObjectName:'wedding-db',serverName:'wedding-db-20260909'}}],
+    },status:{observedGeneration:6,phase:'Cluster in healthy state',currentPrimary:'wedding-db-1',readyInstances:3,conditions:[
+      {type:'Ready',status:'True'},{type:'ContinuousArchiving',status:'True'},
+    ]}},
+    store:{apiVersion:'barmancloud.cnpg.io/v1',kind:'ObjectStore',metadata:{name:'wedding-db',namespace:'wedding-app',uid:SOURCE_UID},spec:{configuration:{
+      destinationPath:'s3://platform-backups/cnpg/wedding-db',endpointURL:'https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com',
+      s3Credentials:{accessKeyId:{name:'wedding-db-backup-r2',key:'ACCESS_KEY_ID'},secretAccessKey:{name:'wedding-db-backup-r2',key:'SECRET_ACCESS_KEY'},region:{name:'wedding-db-backup-r2',key:'REGION'}},
+    }}},
+    backup:{apiVersion:'postgresql.cnpg.io/v1',kind:'Backup',metadata:{name:'wedding-db-daily-20260908030000',namespace:'wedding-app',uid:BACKUP_UID,creationTimestamp:'2026-09-08T03:00:00Z'},spec:{method:'plugin',pluginConfiguration:{name:'barman-cloud.cloudnative-pg.io'},cluster:{name:'wedding-db'}},status:{
+      phase:'completed',backupId:'20260908T030001',backupName:'backup-20260908030000',startedAt:'2026-09-08T03:00:01Z',stoppedAt:'2026-09-08T03:00:11Z',majorVersion:18,
+      pluginMetadata:{clusterUID:'6b6d4879-e437-4ea5-a0cb-257de8edad00',timeline:'162'},
+    }},
+  };
+}
+
+test('source is pinned to the empty replacement and last pre-loss backup',()=>{
+  assert.deepEqual(recoverySource(fixture()),{
+    currentClusterUid:CURRENT_UID,sourceUid:SOURCE_UID,prelossBackupUid:BACKUP_UID,
+    database:'wedding',imageName:'ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie',storageClass:'longhorn-wffc',size:'1Gi',
+    endpoint:'https://0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com',prelossBackupId:'20260908T030001',
+  });
+  for(const change of [
+    value=>{value.cluster.metadata.uid='11111111-1111-1111-1111-111111111111';},
+    value=>{value.cluster.metadata.creationTimestamp='2026-09-08T01:58:14Z';},
+    value=>{value.cluster.spec.bootstrap={recovery:{source:'old'}};},
+    value=>{value.cluster.spec.plugins[0].parameters.serverName='wedding-db';},
+    value=>{value.cluster.status.conditions[1].status='False';},
+    value=>{value.store.spec.configuration.destinationPath='s3://other/path';},
+    value=>{value.backup.metadata.uid='22222222-2222-2222-2222-222222222222';},
+    value=>{value.backup.status.pluginMetadata.clusterUID=CURRENT_UID;},
+    value=>{value.backup.status.phase='failed';},
+  ]){
+    const value=structuredClone(fixture());change(value);
+    assert.throws(()=>recoverySource(value),/refused/);
+  }
+});
+
+test('recovery cluster replays the complete predecessor archive from the exact base',()=>{
+  const source=recoverySource(fixture());
+  const {cluster,policy}=buildRecoveryResources({run:'34710000000',attempt:'1',...source});
+  assert.equal(cluster.metadata.name,'wedding-db-preloss-34710000000-1');
+  assert.deepEqual(cluster.spec.bootstrap,{recovery:{source:'wedding-db-preloss',recoveryTarget:{backupID:'20260908T030001'}}});
+  assert.deepEqual(cluster.spec.externalClusters,[{name:'wedding-db-preloss',plugin:{name:'barman-cloud.cloudnative-pg.io',parameters:{barmanObjectName:'wedding-db',serverName:'wedding-db'}}}]);
+  assert.equal(cluster.spec.plugins,undefined);
+  assert.equal(cluster.spec.instances,1);
+  assert.equal(cluster.spec.enablePDB,false);
+  assert.deepEqual(policy.spec.endpointSelector.matchLabels,{'cnpg.io/cluster':cluster.metadata.name});
+  assert.deepEqual(policy.spec.egress.find(item=>item.toFQDNs).toFQDNs,[{matchName:'0123456789abcdef0123456789abcdef.r2.cloudflarestorage.com'}]);
+});
+
+test('current and restored backups are distinct, run-owned plugin backups',()=>{
+  const before=buildBackup({run:'34710000000',attempt:'1',phase:'before'});
+  const after=buildBackup({run:'34710000000',attempt:'1',phase:'after'});
+  assert.equal(before.metadata.name,'wedding-db-incident-before-34710000000-1');
+  assert.equal(after.metadata.name,'wedding-db-incident-after-34710000000-1');
+  assert.notEqual(before.metadata.name,after.metadata.name);
+  for(const backup of [before,after]){
+    assert.equal(backup.spec.cluster.name,'wedding-db');
+    assert.equal(backup.spec.method,'plugin');
+    assert.equal(backup.spec.pluginConfiguration.name,'barman-cloud.cloudnative-pg.io');
+    assert.equal(backup.metadata.labels['app.kubernetes.io/managed-by'],'github-actions');
+  }
+});
+
+test('core inventory accepts only keyed, duplicate-free recovery rows',()=>{
+  const inventory={guestPairs:[{code:'PAIR01',name:'Pair',createdAt:'2026-05-01T10:00:00Z'}],guests:[{pairCode:'PAIR01',name:'Guest',attending:true,dietaryNotes:null,updatedAt:'2026-08-01T10:00:00Z'}],roomBookings:[{pairCode:'PAIR01',requested:true,notes:null,updatedAt:'2026-08-02T10:00:00Z'}]};
+  assert.deepEqual(validateCoreInventory(inventory),{guestPairs:1,guests:1,roomBookings:1,meaningfulGuests:1});
+  for(const change of [
+    value=>value.guestPairs.push(structuredClone(value.guestPairs[0])),
+    value=>{value.guests[0].pairCode='MISSING';},
+    value=>{value.guests[0].attending=null;value.guests[0].dietaryNotes=null;value.roomBookings=[];},
+    value=>value.roomBookings.push(structuredClone(value.roomBookings[0])),
+  ]){const value=structuredClone(inventory);change(value);assert.throws(()=>validateCoreInventory(value),/refused/);}
+});
+
+test('merge restores pre-loss answers only where the replacement has no newer answer',()=>{
+  const sql=buildMergeSQL('incident_restore_34710000000_1');
+  assert.match(sql,/live\.attending IS NULL AND live\.dietary_notes IS NULL/);
+  assert.match(sql,/recovered\.attending IS NOT NULL OR recovered\.dietary_notes IS NOT NULL/);
+  assert.match(sql,/ON CONFLICT \(guest_pair_id\) DO NOTHING/);
+  assert.match(sql,/LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE/);
+  assert.match(sql,/DROP SCHEMA incident_restore_34710000000_1 CASCADE/);
+  assert.doesNotMatch(sql,/sessions|admin_sessions/);
+  assert.throws(()=>buildMergeSQL('public'),/refused/);
+});
+
+test('Wedding reconciliation cannot globally force-recreate stateful data',async()=>{
+  const fs=await import('node:fs/promises');
+  const manifest=await fs.readFile(new URL('../../k8s/bases/apps/wedding-app/flux-kustomization.yaml',import.meta.url),'utf8');
+  assert.match(manifest,/\n  force: false\n/);
+});
+
+test('manual recovery is serialized with production deployments and discloses no inputs',async()=>{
+  const fs=await import('node:fs/promises');
+  const workflow=await fs.readFile(new URL('../../.github/workflows/recover-wedding-db-incident.yaml',import.meta.url),'utf8');
+  assert.match(workflow,/workflow_dispatch:\n\npermissions: \{\}/);
+  assert.match(workflow,/group: prod-deploy\n  cancel-in-progress: false\n  queue: max/);
+  assert.match(workflow,/environment: prod/);
+  assert.match(workflow,/persist-credentials: false/);
+  assert.doesNotMatch(workflow,/pull_request|schedule:|inputs:/);
+});
+
+test('an untrusted invocation refuses without data or subprocess diagnostics',()=>{
+  const script=new URL('../../scripts/recover-wedding-db-incident.mjs',import.meta.url);
+  const result=spawnSync(process.execPath,[script.pathname],{encoding:'utf8',env:{PATH:process.env.PATH},maxBuffer:4096});
+  assert.equal(result.status,2);
+  assert.equal(result.stdout,'');
+  assert.equal(result.stderr,'Wedding database incident recovery refused.\n');
+});


### PR DESCRIPTION
The Wedding PostgreSQL Cluster was recreated at 2026-09-09 01:58 UTC with `bootstrap.initdb`, which explains the missing production data. The trigger was the rollback from the 2 GiB storage declaration in Wedding release 1.15.11 to the prior 1 GiB declaration while the tenant Flux Kustomization had global force replacement enabled. The old Cluster UID and its September 8 base backup plus WAL archive are still available.

This change disables global force replacement for the Wedding tenant and adds a one-use, production-locked recovery workflow. The workflow is bound to the observed replacement Cluster UID, the predecessor Cluster UID, the exact September 8 Backup UID and Barman backup ID, the existing shared R2 ObjectStore UID, and the live namespace network-policy identities. The recovery job checks out `main` explicitly and runs the main-owned source and SHA verifier before restoring production credentials. Only after that succeeds does it export the authenticated commit to the cleanup job, which checks out the same immutable commit and repeats the verifier before loading credentials. It then selects the stable production API endpoint before its first cluster read, takes a fresh backup of the replacement database, restores the predecessor into an isolated one-instance Cluster at the witnessed pre-loss point, and validates the core guest identities before making any production change.

The point-in-time target is pinned to timeline 162 at 2026-09-09 01:57:41 UTC: the exact last successful Wedding reconciliation, 33 seconds before the replacement Cluster was created. Preflight verifies that live history witness by timestamp, digest, revision, and successful status. If the archived WAL cannot reach the target, PostgreSQL cannot complete recovery and the workflow stops before it suspends the app or merges any rows.

During the final merge, the workflow briefly suspends the Wedding Flux Kustomization and scales the app to zero. Recovered RSVP fields fill only replacement rows that are still blank; any meaningful RSVP submitted after the reset wins. Recovered room requests are inserted only when no post-reset request exists. The transaction does not restore sessions. It then resumes the app, takes a second base backup, writes a non-secret proof ConfigMap with the exact UIDs and counts, and removes the temporary recovery Cluster and PVC.

The parent `flux-system/apps` reconciliation and the Wedding child reconciliation are both quiesced and fenced by their exact live UIDs before suspension. Each fence is marked with the workflow run and attempt and excluded from reconciliation until the app is restored; both are continuously rechecked while the app drains and immediately before the merge. After both fences are held, the workflow restarts the pinned kustomize controller and proves every pre-fence controller pod has been replaced before it scales the app down. A separate `always()` job can resume only state from the same workflow run, including an earlier retry attempt, and independently removes temporary database schemas and run-owned recovery resources. If a run acquires only the parent fence, cleanup treats the child's omitted `suspend` field as unsuspended and still releases the parent. The workflow waits until terminating app pods are gone and then re-reads the CNPG primary before the merge.

The production Flux configuration split the kustomize controller changes across duplicate targets, and all three controller-replica targets incorrectly included `namespace`. Flux Operator applies component patches before it assigns the instance namespace, so those namespaced Deployment selectors matched nothing while reconciliation still reported success. This change uses one unnamespaced patch per HA controller, combines the kustomize controller operations, and installs a complete required anti-affinity object keyed to each Deployment's immutable `app` selector so active/standby pairs use different worker hostnames. Regression assertions pin the exact selector and anti-affinity shape, and the recovery refuses to start until both kustomize controller replicas are ready.

The first corrected merge-group deployment then exposed an existing orphan-recovery mismatch: the deploy and heal jobs opted into automatic fence recovery, but the helper refused whenever the canceled run had left its policy fences as well as the Lease. The helper now proves the Lease and every policy-fence holder run terminal before its first mutation, then releases the child policy fence, parent policy fence, and Lease in that order with the same CAS patches shown by the operator report. It still refuses node fences because those require the full bridge's Talos revision and scheduling proofs.

Validation:
- RED then GREEN: the incident recovery contract tests failed before each implementation slice and passed afterward.
- Combined Wedding backup and incident suite: 73 passed.
- `go test ./scripts/validate-eks-ci-role-policy` passed.
- The exact rendered authorization validator passed after rebasing onto current `main`, using the official checksum-verified kubectl 1.36.2 renderer; the authorization identity change is limited to the Wedding Kustomization moving from global force enabled to disabled.
- The same production render contains one kustomize-controller patch with both the required argument and the two-replica operation.
- `actionlint` and Node syntax validation passed.
- The complete Flux GHCR fence suite passed, including terminal-holder recovery order, live/unknown-holder refusal, node-fence refusal, and retained parent/Lease state after a forced child CAS failure.
- The generated recovery Cluster and CiliumNetworkPolicy passed client validation against the live CRD schemas.
- KSail 7.183.1 validated all 118 Kustomizations and 623 YAML files for both local and production configurations.

After this reaches `main` and the force-disable change is live, I will dispatch the recovery workflow once and verify the database proof, post-recovery backup, app health, and cleanup before closing the incident.

Refs #2867.
