### PR TITLE
fix(security): supply the C-0211 baseline context to snapshot-controller

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
@@ -67,3 +67,15 @@ spec:
           memory: 32Mi
         limits:
           memory: 64Mi
+      # C-0211 baseline context, supplied through the chart's own values because
+      # kube-system is excluded from the add-security-context mutation (#3239).
+      # Helm merges these maps into the chart defaults, so the rendered output
+      # keeps the existing non-root identity, dropped capabilities and read-only
+      # root filesystem verbatim. Both fields are inert here: the pod mounts no
+      # volumes and sets no fsGroup, so the ownership policy governs nothing, and
+      # the empty seLinuxOptions object leaves SELinux type and MCS category
+      # selection to the runtime.
+      podSecurityContext:
+        fsGroupChangePolicy: OnRootMismatch
+      securityContext:
+        seLinuxOptions: {}

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2025,14 +2025,15 @@ const (
 // snapshot-controller HelmRelease's controller values. Rebasing onto that
 // repair therefore leaves the conservation hunk list above unchanged.
 //
-// RENDERER PROVENANCE: PENDING CI on the merged tree. The constant below still
-// holds the previous aggregate, so CI's validator reports the merged tree's
-// aggregate as its single unapproved entry; that value replaces the constant in
-// the follow-up commit. This host's kubectl/kustomize are not approved
-// renderers, so no local digest is claimed.
+// RENDERER PROVENANCE: the value below was read from CI's own failure on job
+// 103622614274 at c61aac1e (the merge of main 8756f2ad with this context), which
+// renders under the approved SHA256-verified toolchain and reported ZERO missing
+// and ZERO duplicate rendered resources; its single unapproved entry was this
+// aggregate. This host's kubectl/kustomize are not approved renderers, so no
+// local digest is claimed.
 //
 // Previous aggregate: 8756f2ad633f8cc0ae64c63a8e4162e0b6a8ed481f28f667736e3d1395531c6e.
-const expectedRenderedSurfaceSHA = "8756f2ad633f8cc0ae64c63a8e4162e0b6a8ed481f28f667736e3d1395531c6e"
+const expectedRenderedSurfaceSHA = "525e04eedfc5e504a27b04585e25b28d42fc48db0ee9124d31b6468220bd50eb"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -1970,7 +1970,43 @@ const (
 // mismatch.
 //
 // Previous aggregate: 5b85be735c3d7d32e2bf6dce91c0e73435986c169234f2d72984617e9dc25a65.
-const expectedRenderedSurfaceSHA = "814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1"
+//
+// Moved again by the snapshot-controller C-0211 baseline context (#3239). The
+// workload sits in kube-system, which add-security-context excludes, so its
+// stored template is supplied through the chart's own values. A HelmRelease is a
+// controller-RBAC emitter, so a pure VALUES change moves this aggregate even
+// though nothing is granted.
+//
+// CONSERVATION, rendered for all five authorization roots on this branch and on
+// main 491d5ef4 under one renderer: the 86 grant-bearing identities
+// (ClusterRole, Role, ClusterRoleBinding, RoleBinding, ServiceAccount) are
+// identical in both directions, the ClusterRole/Role rule bodies are identical
+// under digest
+// 11656de3ed0f1303187fe75f1d8c8e3e1c9f7d12f95e036f91ec685990d1f2e5, and the
+// binding roleRef/subject bodies are identical under digest
+// 73436c4be4cc0e421dd50f76c945abdd945ca5b905dfcd7582a268128da1ade0. Four of the
+// five roots render byte-identically; infrastructure/controllers grows by 120
+// bytes, and its complete hunk list is ONE hunk of four added lines inside the
+// snapshot-controller HelmRelease's controller values:
+//
+//	podSecurityContext.fsGroupChangePolicy: OnRootMismatch
+//	securityContext.seLinuxOptions: {}
+//
+// It adds no Role, ClusterRole, binding, ServiceAccount, subject, verb,
+// wildcard, AWS identity, or permission. Appending one synthetic wildcard
+// ClusterRole to the branch render makes both the identity and the rule-body
+// comparisons report a difference, so the identical result is a finding rather
+// than a blind read.
+//
+// RENDERER PROVENANCE: the value below was read from CI's own failure on run
+// 34716590753 at b8ebb7db, which renders under the approved SHA256-verified
+// toolchain and reported ZERO missing and ZERO duplicate rendered resources; its
+// single unapproved entry was this aggregate. This host's kubectl/kustomize are
+// not approved renderers, so no local digest is claimed. The conservation
+// evidence above compares two trees under one renderer and stands on its own.
+//
+// Previous aggregate: 814debc4fdfaf76be14273992a9bc982fb30a548fc3fa3f55baea6213e5582a1.
+const expectedRenderedSurfaceSHA = "ce959e8ffe85ae2ea734d9c0798c2834fa29fa93c72155dae95f73ac636e489d"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why
The cluster snapshot controller is one of the remaining `kube-system` workloads whose stored template misses the C-0211 baseline context. The admission mutation deliberately skips that namespace, so the fix has to come from the workload's own source. It is the same low-risk shape as the descheduler slice (#3733): no volumes and no group ownership, so there is nothing for the new settings to change at runtime.

### What
Sets the ownership-change policy and an empty SELinux options object through the chart's own values. Rendering the pinned chart confirms that these two fields are the only change and that all existing hardening stays intact.

**Merge order:** this moves the EKS authorization fingerprint, like every HelmRelease change. The approved value is taken from CI, and it has to be re-derived after whichever of this PR or #3736 merges second (#3740). Merges on this repo are also held until the production fence in #3065 is released.

Part of #3239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
