### PR TITLE
fix(wedding-db): expose safe recovery checkpoints

### DIFF
--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -34,16 +34,26 @@ const RECOVERY_RECONCILE_ANNOTATION='kustomize.toolkit.fluxcd.io/reconcile';
 const RECOVERY_OWNER_PATH='/metadata/annotations/devantler.tech~1wedding-db-recovery-owner';
 const RECOVERY_RECONCILE_PATH='/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile';
 const RECOVERY_REFUSAL_PHASES=new Set(['source-state','before-backup','restore-and-merge','after-backup','proof','cleanup']);
+const RECOVERY_REFUSAL_CHECKPOINTS=new Set([
+  'create-recovery','recovered-inventory-query','recovered-replay-time','recovered-core-inventory',
+  'live-inventory-query','live-core-inventory','core-cardinality','suspend-application',
+  'live-cluster-identity','live-primary','stage-recovered-data','application-fences',
+  'merge-recovered-data','merge-shape','merge-postcondition','drop-staging-schema',
+  'resume-application','cleanup-recovery',
+]);
 let recoveryInvocationVerified=false;
 let recoveryPhase='invocation';
+let recoveryCheckpoint;
 const check=value=>{if(!value)throw Error('refused');return value;};
 const integer=value=>{check(typeof value==='string'&&/^[1-9][0-9]*$/.test(value));return value;};
 const uid=value=>{check(typeof value==='string'&&/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/.test(value));return value;};
 const timestamp=value=>{check(typeof value==='string'&&!Number.isNaN(Date.parse(value)));return value;};
 const condition=(value,type)=>value.status?.conditions?.some(item=>item.type===type&&item.status==='True');
 
-export function recoveryRefusalMessage({verified=false,phase='invocation'}={}){
-  return verified&&RECOVERY_REFUSAL_PHASES.has(phase)?`Wedding database incident recovery refused (phase: ${phase}).\n`:'Wedding database incident recovery refused.\n';
+export function recoveryRefusalMessage({verified=false,phase='invocation',checkpoint}={}){
+  if(!verified||!RECOVERY_REFUSAL_PHASES.has(phase))return 'Wedding database incident recovery refused.\n';
+  const detail=RECOVERY_REFUSAL_CHECKPOINTS.has(checkpoint)?`; checkpoint: ${checkpoint}`:'';
+  return `Wedding database incident recovery refused (phase: ${phase}${detail}).\n`;
 }
 
 export function hasPrelossWitness(kustomization){
@@ -605,31 +615,49 @@ function run(){
   const source=sourceState();recoveryPhase='before-backup';
   const before=backup(config,'before',source);
   recoveryPhase='restore-and-merge';
-  let recovery,recoveredInventory,recovered,recoveryReplayTimestamp,liveBefore,merge,mergePrimary,error,schemaCleanupError,resumeError,cleanupError;
+  let recovery,recoveredInventory,recovered,recoveryReplayTimestamp,liveBefore,merge,mergePrimary,error,errorCheckpoint,schemaCleanupError,resumeError,cleanupError;
   try{
+    recoveryCheckpoint='create-recovery';
     recovery=createRecovery(config,source);
+    recoveryCheckpoint='recovered-inventory-query';
     recoveredInventory=inventory(recovery.primary,source.database,{requireMeaningful:true});
+    recoveryCheckpoint='recovered-replay-time';
     recoveryReplayTimestamp=validateRecoveryReplayTimestamp(recoveredInventory.value.recoveryReplayTimestamp,{replacementCreatedAt:source.replacementCreatedAt});
+    recoveryCheckpoint='recovered-core-inventory';
     recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
     const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
+    recoveryCheckpoint='live-inventory-query';
     const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
+    recoveryCheckpoint='live-core-inventory';
     liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
+    recoveryCheckpoint='core-cardinality';
     check(recovered.guestPairs===liveBefore.guestPairs&&recovered.guests===liveBefore.guests);
+    recoveryCheckpoint='suspend-application';
     suspendApplication(config);
+    recoveryCheckpoint='live-cluster-identity';
     check(object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).metadata.uid===source.currentClusterUid);
+    recoveryCheckpoint='live-primary';
     mergePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
     check(/^wedding-db-[1-9][0-9]*$/.test(mergePrimary));
+    recoveryCheckpoint='stage-recovered-data';
     const schema=loadRecovered(mergePrimary,source.database,recoveredInventory.value,config);
+    recoveryCheckpoint='application-fences';
     proveApplicationFences(config);check(list('pods','app.kubernetes.io/name=wedding-app').length===0);
+    recoveryCheckpoint='merge-recovered-data';
     const output=psql(mergePrimary,source.database,buildMergeSQL(schema));
     merge=JSON.parse(output.toString('utf8').trim());
+    recoveryCheckpoint='merge-shape';
     for(const key of ['restoredGuestAnswers','restoredRoomBookings','finalMeaningfulGuestAnswers','finalRoomBookings'])check(Number.isSafeInteger(merge[key])&&merge[key]>=0);
+    recoveryCheckpoint='merge-postcondition';
     check(merge.finalMeaningfulGuestAnswers>=recovered.meaningfulGuests&&merge.finalRoomBookings>=recovered.roomBookings);
-  }catch(candidate){error=candidate;}
+  }catch(candidate){error=candidate;errorCheckpoint=recoveryCheckpoint;}
   if(error&&mergePrimary){try{dropStagingSchema(mergePrimary,source.database,config);}catch(candidate){schemaCleanupError=candidate;}}
   try{resumeApplication(config);}catch(candidate){resumeError=candidate;}
   try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}
-  if(error||schemaCleanupError||resumeError||cleanupError)throw Error('refused');
+  if(error||schemaCleanupError||resumeError||cleanupError){
+    recoveryCheckpoint=error?errorCheckpoint:schemaCleanupError?'drop-staging-schema':resumeError?'resume-application':'cleanup-recovery';
+    throw Error('refused');
+  }
   recoveryPhase='after-backup';
   const after=backup(config,'after',source);
   recoveryPhase='proof';
@@ -666,5 +694,5 @@ if(process.argv[1]===fileURLToPath(import.meta.url)){
     check(process.argv.length===2||(process.argv.length===3&&['--cleanup','--verify-source'].includes(process.argv[2])));
     const result=process.argv[2]==='--verify-source'?(verifyCandidate(),{sourceVerified:true}):process.argv[2]==='--cleanup'?runCleanup():run();
     process.stdout.write(JSON.stringify(result)+'\n');
-  }catch{process.stderr.write(recoveryRefusalMessage({verified:recoveryInvocationVerified,phase:recoveryPhase}));process.exitCode=2;}
+  }catch{process.stderr.write(recoveryRefusalMessage({verified:recoveryInvocationVerified,phase:recoveryPhase,checkpoint:recoveryCheckpoint}));process.exitCode=2;}
 }

--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -52,7 +52,7 @@ const condition=(value,type)=>value.status?.conditions?.some(item=>item.type===t
 
 export function recoveryRefusalMessage({verified=false,phase='invocation',checkpoint}={}){
   if(!verified||!RECOVERY_REFUSAL_PHASES.has(phase))return 'Wedding database incident recovery refused.\n';
-  const detail=RECOVERY_REFUSAL_CHECKPOINTS.has(checkpoint)?`; checkpoint: ${checkpoint}`:'';
+  const detail=phase==='restore-and-merge'&&RECOVERY_REFUSAL_CHECKPOINTS.has(checkpoint)?`; checkpoint: ${checkpoint}`:'';
   return `Wedding database incident recovery refused (phase: ${phase}${detail}).\n`;
 }
 
@@ -625,8 +625,8 @@ function run(){
     recoveryReplayTimestamp=validateRecoveryReplayTimestamp(recoveredInventory.value.recoveryReplayTimestamp,{replacementCreatedAt:source.replacementCreatedAt});
     recoveryCheckpoint='recovered-core-inventory';
     recovered=validateCoreInventory(recoveredInventory.value,{requireMeaningful:true});
-    const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
     recoveryCheckpoint='live-inventory-query';
+    const livePrimary=object('clusters.postgresql.cnpg.io',LIVE_CLUSTER).status.currentPrimary;
     const liveInventory=inventory(livePrimary,source.database,{requireMeaningful:false});
     recoveryCheckpoint='live-core-inventory';
     liveBefore=validateCoreInventory(liveInventory.value,{requireMeaningful:false});
@@ -655,10 +655,10 @@ function run(){
   try{resumeApplication(config);}catch(candidate){resumeError=candidate;}
   try{cleanupRecovery(config,recovery);}catch(candidate){cleanupError=candidate;}
   if(error||schemaCleanupError||resumeError||cleanupError){
-    recoveryCheckpoint=error?errorCheckpoint:schemaCleanupError?'drop-staging-schema':resumeError?'resume-application':'cleanup-recovery';
+    recoveryCheckpoint=schemaCleanupError?'drop-staging-schema':resumeError?'resume-application':cleanupError?'cleanup-recovery':errorCheckpoint;
     throw Error('refused');
   }
-  recoveryPhase='after-backup';
+  recoveryCheckpoint=undefined;recoveryPhase='after-backup';
   const after=backup(config,'after',source);
   recoveryPhase='proof';
   recordProof({config,source,recovery,before,after,recovered,recoveryReplayTimestamp,liveBefore,merge});

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -46,6 +46,10 @@ test('verified recovery failures disclose only allow-listed diagnostics',()=>{
     recoveryRefusalMessage({verified:true,phase:'restore-and-merge',checkpoint:'subprocess stderr'}),
     'Wedding database incident recovery refused (phase: restore-and-merge).\n',
   );
+  assert.equal(
+    recoveryRefusalMessage({verified:true,phase:'after-backup',checkpoint:'merge-postcondition'}),
+    'Wedding database incident recovery refused (phase: after-backup).\n',
+  );
   assert.equal(recoveryRefusalMessage({phase:'restore-and-merge',checkpoint:'recovered-core-inventory'}), 'Wedding database incident recovery refused.\n');
   assert.equal(recoveryRefusalMessage({verified:true,phase:'subprocess stderr'}), 'Wedding database incident recovery refused.\n');
 });

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -35,9 +35,18 @@ test('pre-loss reconciliation witness matches the live Flux history exactly',()=
   assert.equal(hasPrelossWitness({status:{history}}),false);
 });
 
-test('verified recovery failures disclose only an allow-listed phase',()=>{
+test('verified recovery failures disclose only allow-listed diagnostics',()=>{
   assert.equal(recoveryRefusalMessage(), 'Wedding database incident recovery refused.\n');
   assert.equal(recoveryRefusalMessage({verified:true,phase:'source-state'}), 'Wedding database incident recovery refused (phase: source-state).\n');
+  assert.equal(
+    recoveryRefusalMessage({verified:true,phase:'restore-and-merge',checkpoint:'recovered-core-inventory'}),
+    'Wedding database incident recovery refused (phase: restore-and-merge; checkpoint: recovered-core-inventory).\n',
+  );
+  assert.equal(
+    recoveryRefusalMessage({verified:true,phase:'restore-and-merge',checkpoint:'subprocess stderr'}),
+    'Wedding database incident recovery refused (phase: restore-and-merge).\n',
+  );
+  assert.equal(recoveryRefusalMessage({phase:'restore-and-merge',checkpoint:'recovered-core-inventory'}), 'Wedding database incident recovery refused.\n');
   assert.equal(recoveryRefusalMessage({verified:true,phase:'subprocess stderr'}), 'Wedding database incident recovery refused.\n');
 });
 


### PR DESCRIPTION
Recovery run 34722561007 restored the archived database in isolation and then refused before suspending the application, but the existing diagnostic only identified the broad restore-and-merge phase. That leaves several read-only validations indistinguishable during an active data recovery.

This change reports a fixed, allow-listed checkpoint after the workflow has verified its exact source. Untrusted invocations and arbitrary checkpoint text remain generic, and no database values or subprocess output can reach the log.

Validation:

- `node --test tests/wedding-db-incident-recovery/recovery.test.mjs`
- `node --check scripts/recover-wedding-db-incident.mjs`
- `git diff --check`
