### PR TITLE
fix(wedding-db): fence annotation-free resources

### DIFF
--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -132,11 +132,12 @@ export function recoveryOwnerAttempt(run,currentAttempt,owner){
   return match[1];
 }
 
-export function buildSuspendPatch({resourceVersion,kustomizationUid,owner}){
-  integer(resourceVersion);check([LIVE_KUSTOMIZATION_UID,PARENT_KUSTOMIZATION_UID].includes(kustomizationUid)&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
+export function buildSuspendPatch({resourceVersion,kustomizationUid,annotationsPresent,owner}){
+  integer(resourceVersion);check([LIVE_KUSTOMIZATION_UID,PARENT_KUSTOMIZATION_UID].includes(kustomizationUid)&&typeof annotationsPresent==='boolean'&&/^[1-9][0-9]*\/[1-9][0-9]*$/.test(owner));
   return [
     {op:'test',path:'/metadata/resourceVersion',value:resourceVersion},
     {op:'test',path:'/metadata/uid',value:kustomizationUid},
+    ...(annotationsPresent?[]:[{op:'add',path:'/metadata/annotations',value:{}}]),
     {op:'add',path:RECOVERY_OWNER_PATH,value:owner},
     {op:'add',path:RECOVERY_RECONCILE_PATH,value:'disabled'},
     {op:'add',path:'/spec/suspend',value:true},
@@ -427,13 +428,13 @@ function acquireFence(namespace,name,uidValue,config){
   while(Date.now()<end){
     current=objectAt(namespace,'kustomizations.kustomize.toolkit.fluxcd.io',name);
     check(current.metadata.uid===uidValue&&typeof current.metadata.resourceVersion==='string');
-    check(current.metadata.annotations&&typeof current.metadata.annotations==='object');
-    check(current.spec?.suspend!==true&&!current.metadata.annotations[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations[RECOVERY_RECONCILE_ANNOTATION]);
+    check(current.metadata.annotations===undefined||(current.metadata.annotations!==null&&typeof current.metadata.annotations==='object'&&!Array.isArray(current.metadata.annotations)));
+    check(current.spec?.suspend!==true&&!current.metadata.annotations?.[RECOVERY_OWNER_ANNOTATION]&&!current.metadata.annotations?.[RECOVERY_RECONCILE_ANNOTATION]);
     if(condition(current,'Ready')&&!condition(current,'Reconciling')&&current.status?.observedGeneration===current.metadata.generation)break;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,3000);
   }
   check(current&&Date.now()<end);
-  const patch=buildSuspendPatch({resourceVersion:current.metadata.resourceVersion,kustomizationUid:current.metadata.uid,owner});
+  const patch=buildSuspendPatch({resourceVersion:current.metadata.resourceVersion,kustomizationUid:current.metadata.uid,annotationsPresent:current.metadata.annotations!==undefined,owner});
   kubectl(['--namespace',namespace,'patch','kustomization.kustomize.toolkit.fluxcd.io',name,'--type=json','--patch='+JSON.stringify(patch)]);
   let stableResourceVersion='';
   for(let attempt=0;attempt<3;attempt+=1){

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -130,9 +130,17 @@ test('application suspension ownership is bound to one workflow attempt',()=>{
   assert.equal(recoveryOwnerAttempt('34710000000','2',owner),'1');
   assert.throws(()=>recoveryOwnerAttempt('34710000000','1','34710000000/2'),/refused/);
   assert.throws(()=>recoveryOwnerAttempt('34710000000','2','34710000001/1'),/refused/);
-  assert.deepEqual(buildSuspendPatch({resourceVersion:'279780874',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),[
+  assert.deepEqual(buildSuspendPatch({resourceVersion:'279780874',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',annotationsPresent:true,owner}),[
     {op:'test',path:'/metadata/resourceVersion',value:'279780874'},
     {op:'test',path:'/metadata/uid',value:'be31651e-fe0d-4826-9ffb-d41716a66720'},
+    {op:'add',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner',value:owner},
+    {op:'add',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile',value:'disabled'},
+    {op:'add',path:'/spec/suspend',value:true},
+  ]);
+  assert.deepEqual(buildSuspendPatch({resourceVersion:'279825100',kustomizationUid:'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48',annotationsPresent:false,owner}),[
+    {op:'test',path:'/metadata/resourceVersion',value:'279825100'},
+    {op:'test',path:'/metadata/uid',value:'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48'},
+    {op:'add',path:'/metadata/annotations',value:{}},
     {op:'add',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner',value:owner},
     {op:'add',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile',value:'disabled'},
     {op:'add',path:'/spec/suspend',value:true},
@@ -146,8 +154,7 @@ test('application suspension ownership is bound to one workflow attempt',()=>{
     {op:'remove',path:'/metadata/annotations/devantler.tech~1wedding-db-recovery-owner'},
     {op:'remove',path:'/metadata/annotations/kustomize.toolkit.fluxcd.io~1reconcile'},
   ]);
-  assert.equal(buildSuspendPatch({resourceVersion:'279825100',kustomizationUid:'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48',owner})[1].value,'7a4f35ea-01c8-460e-aefe-6fdf6d10eb48');
-  assert.throws(()=>buildSuspendPatch({resourceVersion:'0',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',owner}),/refused/);
+  assert.throws(()=>buildSuspendPatch({resourceVersion:'0',kustomizationUid:'be31651e-fe0d-4826-9ffb-d41716a66720',annotationsPresent:true,owner}),/refused/);
 });
 
 test('controller handoff restart is atomic and bound to this incident',()=>{


### PR DESCRIPTION
Recovery run 34724909168 passed archive restoration and all data inventory checks, then stopped before application suspension. The parent `apps` Kustomization has no annotations map, while the recovery fence required that map to exist before applying its ownership annotations.

This change makes the atomic JSON patch create an empty annotations map when it is absent. Existing annotation maps keep the narrower patch, and both paths remain bound to the exact resource version, UID, and workflow owner.

Validation:

- `node --test tests/wedding-db-incident-recovery/recovery.test.mjs`
- `node --check scripts/recover-wedding-db-incident.mjs`
- `git diff --check`
