### PR TITLE
fix(wedding-db): accept pair display name drift

### DIFF
--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -252,10 +252,10 @@ LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE;
 DO $guard$
 BEGIN
   IF EXISTS (
-    (SELECT code, name FROM ${schema}.guest_pairs EXCEPT SELECT code, name FROM guest_pairs)
+    (SELECT code FROM ${schema}.guest_pairs EXCEPT SELECT code FROM guest_pairs)
     UNION ALL
-    (SELECT code, name FROM guest_pairs EXCEPT SELECT code, name FROM ${schema}.guest_pairs)
-  ) THEN RAISE SQLSTATE 'P1001' USING MESSAGE = 'guest pair identity mismatch'; END IF;
+    (SELECT code FROM guest_pairs EXCEPT SELECT code FROM ${schema}.guest_pairs)
+  ) THEN RAISE SQLSTATE 'P1001' USING MESSAGE = 'guest pair code mismatch'; END IF;
   IF EXISTS (
     (SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered
       EXCEPT SELECT pairs.code, live.name FROM guests live JOIN guest_pairs pairs ON pairs.id=live.guest_pair_id)

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -252,6 +252,10 @@ test('merge restores pre-loss answers only where the replacement has no newer an
   assert.match(sql,/DROP SCHEMA incident_restore_34710000000_1 CASCADE/);
   assert.match(sql,/RAISE SQLSTATE 'P1001'/);
   assert.match(sql,/RAISE SQLSTATE 'P1002'/);
+  assert.match(sql,/SELECT code FROM incident_restore_34710000000_1\.guest_pairs EXCEPT SELECT code FROM guest_pairs/);
+  assert.doesNotMatch(sql,/SELECT code, name FROM (?:incident_restore_34710000000_1\.)?guest_pairs/);
+  assert.match(sql,/SELECT recovered\.pair_code, recovered\.name FROM incident_restore_34710000000_1\.guests recovered/);
+  assert.match(sql,/EXCEPT SELECT pairs\.code, live\.name FROM guests live JOIN guest_pairs pairs/);
   assert.doesNotMatch(sql,/sessions|admin_sessions/);
   assert.throws(()=>buildMergeSQL('public'),/refused/);
 });


### PR DESCRIPTION
The guarded production recovery reached the merge checkpoint in run 34728456381 and returned SQLSTATE `P1001`. The restored and live databases have the same stable guest-pair codes and the same guest identities, but a guest-pair display name changed after the database was recreated.

The recovery joins guest answers and room bookings through the stable pair code; it never uses the pair display name as a key. This change therefore compares the complete pair-code set in both directions while keeping the stricter pair-code plus guest-name guard intact before any data is written.

Validation:

- Confirmed the old assertion fails before the implementation change.
- Passed all 16 Wedding incident recovery tests after the change.
- Passed `node --check scripts/recover-wedding-db-incident.mjs` and `git diff --check`.
- Reproduced the production condition in disposable PostgreSQL 18: pair display names differed, guest identities matched, and the transaction restored one guest answer and one room booking before committing.
- Confirmed run 34728456381 cleaned up its temporary database and Flux fences and restored the Wedding app to 2/2 replicas.
