### PR TITLE
docs(supply-chain): state what tenant signature verification establishes

### DIFF
--- a/docs/TENANTS.md
+++ b/docs/TENANTS.md
@@ -137,13 +137,19 @@ On every `v*` tag, the tenant's `cd.yaml` calls the
 reusable workflow, which builds and pushes the image, pins its digest into
 `deploy/deployment.yaml`, pushes the manifests as an OCI artifact, and
 **cosign-signs** both (keyless, via GitHub OIDC). The platform's `OCIRepository`
-(§5) **verifies** that signature against the `publish-app.yaml` identity, so only
-artifacts produced by that trusted workflow are ever reconciled onto the cluster.
-Application tenants may advance that workflow at any immutable 40-hex commit without a
-platform-side revision update. The platform owns the trust boundary around the exact GitHub
-OIDC issuer, organization, reusable-workflow path, package source, namespace, RBAC, network
-policy, and admission policy. A tenant that needs authority outside those bounds requires a
-reviewed platform change; an ordinary release inside them does not.
+(§5) **verifies** that signature against the `publish-app.yaml` identity.
+
+That verification establishes the GitHub OIDC issuer and that the signer ran the
+`publish-app.yaml` workflow path at a 40-hex commit — the **commit shape**, not a reviewed
+revision. The verifiers in use (Flux, the `verify-app-images` admission policy, and the Talos
+pull rule) match only the certificate's issuer and subject, so a commit reference under that
+path does not prove the commit belongs to the actions repository's reviewed history.
+Application tenants may advance that workflow at any 40-hex commit without a platform-side
+revision update. Package write access, namespace, RBAC, network policy, and admission policy
+bound what a release can do; the remaining risk is accepted in
+[#3746](https://github.com/devantler-tech/platform/issues/3746). A tenant that needs authority
+outside those bounds requires a reviewed platform change; an ordinary release inside them does
+not.
 
 > Tags come from `release.yaml` → semantic-release: merge Conventional-Commit
 > PRs to `main` and a `vX.Y.Z` tag (and thus a publish) follows automatically.

--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,7 +16,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Trust immutable revisions of the platform-owned shared workflow. The tenant may
-      # release independently; platform policy, RBAC, and network boundaries govern it.
+      # Matches the issuer and the shared publish-app.yaml workflow path at a 40-hex
+      # commit: the commit shape, not a reviewed revision. Package write access,
+      # namespace, RBAC, network and admission policy bound the release; the remaining
+      # risk is accepted in devantler-tech/platform#3746.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
         subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,7 +16,9 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Trust immutable revisions of the platform-owned shared workflow. The tenant may
-      # release independently; platform policy, RBAC, and network boundaries govern it.
+      # Matches the issuer and the shared publish-app.yaml workflow path at a 40-hex
+      # commit: the commit shape, not a reviewed revision. Package write access,
+      # namespace, RBAC, network and admission policy bound the release; the remaining
+      # risk is accepted in devantler-tech/platform#3746.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
         subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@[0-9a-f]{40}$'

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -58,10 +58,12 @@ spec:
       cosign:
         keyless:
           # publish-app.yaml lives in the actions monorepo. Callers pin that
-          # reusable workflow by commit SHA, so the ref admits that form alone
-          # and rejects everything else — a mutable ref such as @main, and a
-          # release tag — the same shape as the tenants' Flux OCIRepository
-          # verify blocks (#3022). Keep this to exactly ONE identity
+          # reusable workflow by commit SHA, so the ref admits that commit shape
+          # alone and rejects everything else — a mutable ref such as @main, and
+          # a release tag — the same shape as the tenants' Flux OCIRepository
+          # verify blocks (#3022). A 40-hex ref is not proof of a reviewed
+          # revision of the actions repository; that remaining risk is
+          # accepted in #3746. Keep this to exactly ONE identity
           # entry: the IVPOL engine verifies cosign v3 bundles through
           # sigstore-go, which rejects more than one identity per verification
           # ("unsupported: multiple identities are not supported at this


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why
Our tenant guide and manifest notes describe the tenant signing check as proof that an app came from a reviewed revision of the shared publish workflow. The check cannot prove that; it only confirms the signer ran that workflow path at some commit. Readers deciding what a tenant may publish were being told more than is true.

### What
Rewords the tenant guide, both tenant source comments and the image admission policy comment to say what verification actually establishes, names the controls that limit the remaining risk, and links the decision that accepted it. Comments and docs only; no behaviour changes.

Fixes #3748

🤖 Generated with [Claude Code](https://claude.com/claude-code)