### PR TITLE
fix(wedding-db): map randomized invitation codes

### DIFF
--- a/scripts/recover-wedding-db-incident.mjs
+++ b/scripts/recover-wedding-db-incident.mjs
@@ -215,9 +215,9 @@ export function validateCoreInventory(value,{requireMeaningful=true}={}){
   check(Array.isArray(guestPairs)&&guestPairs.length>0&&guestPairs.length<=100);
   check(Array.isArray(guests)&&guests.length>0&&guests.length<=300);
   check(Array.isArray(roomBookings)&&roomBookings.length<=100);
-  const codes=new Set();
+  const codes=new Set(),pairNames=new Set();
   for(const pair of guestPairs){
-    check(pair&&typeof pair==='object'&&/^[A-Za-z0-9_-]{1,32}$/.test(pair.code));string(pair.name,255);timestamp(pair.createdAt);check(!codes.has(pair.code));codes.add(pair.code);
+    check(pair&&typeof pair==='object'&&/^[A-Za-z0-9_-]{1,32}$/.test(pair.code));string(pair.name,255);timestamp(pair.createdAt);check(!codes.has(pair.code)&&!pairNames.has(pair.name));codes.add(pair.code);pairNames.add(pair.name);
   }
   const guestKeys=new Set();let meaningfulGuests=0;
   for(const guest of guests){
@@ -252,17 +252,23 @@ LOCK TABLE guest_pairs, guests, room_bookings IN ACCESS EXCLUSIVE MODE;
 DO $guard$
 BEGIN
   IF EXISTS (
-    (SELECT code FROM ${schema}.guest_pairs EXCEPT SELECT code FROM guest_pairs)
-    UNION ALL
-    (SELECT code FROM guest_pairs EXCEPT SELECT code FROM ${schema}.guest_pairs)
-  ) THEN RAISE SQLSTATE 'P1001' USING MESSAGE = 'guest pair code mismatch'; END IF;
+    SELECT 1
+    FROM ${schema}.room_bookings recovered
+    JOIN ${schema}.guest_pairs recovered_pairs ON recovered_pairs.code=recovered.pair_code
+    LEFT JOIN guest_pairs live_pairs ON live_pairs.name=recovered_pairs.name
+    GROUP BY recovered.pair_code
+    HAVING count(live_pairs.id) <> 1
+  ) THEN RAISE SQLSTATE 'P1001' USING MESSAGE = 'room booking pair mapping mismatch'; END IF;
   IF EXISTS (
-    (SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered
-      EXCEPT SELECT pairs.code, live.name FROM guests live JOIN guest_pairs pairs ON pairs.id=live.guest_pair_id)
-    UNION ALL
-    (SELECT pairs.code, live.name FROM guests live JOIN guest_pairs pairs ON pairs.id=live.guest_pair_id
-      EXCEPT SELECT recovered.pair_code, recovered.name FROM ${schema}.guests recovered)
-  ) THEN RAISE SQLSTATE 'P1002' USING MESSAGE = 'guest identity mismatch'; END IF;
+    SELECT 1
+    FROM ${schema}.guests recovered
+    JOIN ${schema}.guest_pairs recovered_pairs ON recovered_pairs.code=recovered.pair_code
+    LEFT JOIN guest_pairs live_pairs ON live_pairs.name=recovered_pairs.name
+    LEFT JOIN guests live ON live.guest_pair_id=live_pairs.id AND live.name=recovered.name
+    WHERE recovered.attending IS NOT NULL OR recovered.dietary_notes IS NOT NULL
+    GROUP BY recovered.pair_code,recovered.name
+    HAVING count(live.id) <> 1
+  ) THEN RAISE SQLSTATE 'P1002' USING MESSAGE = 'answered guest mapping mismatch'; END IF;
 END $guard$;
 CREATE TEMP TABLE incident_restore_counts (
   restored_guest_answers bigint NOT NULL,
@@ -271,7 +277,9 @@ CREATE TEMP TABLE incident_restore_counts (
 WITH restored_guests AS (
   UPDATE guests live
   SET attending=recovered.attending,dietary_notes=recovered.dietary_notes,updated_at=recovered.updated_at
-  FROM ${schema}.guests recovered JOIN guest_pairs pairs ON pairs.code=recovered.pair_code
+  FROM ${schema}.guests recovered
+  JOIN ${schema}.guest_pairs recovered_pairs ON recovered_pairs.code=recovered.pair_code
+  JOIN guest_pairs pairs ON pairs.name=recovered_pairs.name
   WHERE live.guest_pair_id=pairs.id AND live.name=recovered.name
     AND live.attending IS NULL AND live.dietary_notes IS NULL
     AND (recovered.attending IS NOT NULL OR recovered.dietary_notes IS NOT NULL)
@@ -279,7 +287,9 @@ WITH restored_guests AS (
 ), restored_bookings AS (
   INSERT INTO room_bookings (guest_pair_id,requested,notes,updated_at)
   SELECT pairs.id,recovered.requested,recovered.notes,recovered.updated_at
-  FROM ${schema}.room_bookings recovered JOIN guest_pairs pairs ON pairs.code=recovered.pair_code
+  FROM ${schema}.room_bookings recovered
+  JOIN ${schema}.guest_pairs recovered_pairs ON recovered_pairs.code=recovered.pair_code
+  JOIN guest_pairs pairs ON pairs.name=recovered_pairs.name
   ON CONFLICT (guest_pair_id) DO NOTHING
   RETURNING id
 )

--- a/tests/wedding-db-incident-recovery/recovery.test.mjs
+++ b/tests/wedding-db-incident-recovery/recovery.test.mjs
@@ -233,6 +233,7 @@ test('core inventory accepts only keyed, duplicate-free recovery rows',()=>{
   assert.deepEqual(validateCoreInventory(inventory),{guestPairs:1,guests:1,roomBookings:1,meaningfulGuests:1});
   for(const change of [
     value=>value.guestPairs.push(structuredClone(value.guestPairs[0])),
+    value=>value.guestPairs.push({...structuredClone(value.guestPairs[0]),code:'PAIR02'}),
     value=>{value.guests[0].pairCode='MISSING';},
     value=>{value.guests[0].attending=null;value.guests[0].dietaryNotes=null;value.roomBookings=[];},
     value=>value.roomBookings.push(structuredClone(value.roomBookings[0])),
@@ -252,10 +253,14 @@ test('merge restores pre-loss answers only where the replacement has no newer an
   assert.match(sql,/DROP SCHEMA incident_restore_34710000000_1 CASCADE/);
   assert.match(sql,/RAISE SQLSTATE 'P1001'/);
   assert.match(sql,/RAISE SQLSTATE 'P1002'/);
-  assert.match(sql,/SELECT code FROM incident_restore_34710000000_1\.guest_pairs EXCEPT SELECT code FROM guest_pairs/);
-  assert.doesNotMatch(sql,/SELECT code, name FROM (?:incident_restore_34710000000_1\.)?guest_pairs/);
-  assert.match(sql,/SELECT recovered\.pair_code, recovered\.name FROM incident_restore_34710000000_1\.guests recovered/);
-  assert.match(sql,/EXCEPT SELECT pairs\.code, live\.name FROM guests live JOIN guest_pairs pairs/);
+  assert.doesNotMatch(sql,/EXCEPT SELECT code/);
+  assert.match(sql,/LEFT JOIN guest_pairs live_pairs ON live_pairs\.name=recovered_pairs\.name/);
+  assert.match(sql,/HAVING count\(live_pairs\.id\) <> 1/);
+  assert.match(sql,/LEFT JOIN guests live ON live\.guest_pair_id=live_pairs\.id AND live\.name=recovered\.name/);
+  assert.match(sql,/WHERE recovered\.attending IS NOT NULL OR recovered\.dietary_notes IS NOT NULL\n    GROUP BY/);
+  assert.match(sql,/HAVING count\(live\.id\) <> 1/);
+  assert.match(sql,/JOIN incident_restore_34710000000_1\.guest_pairs recovered_pairs ON recovered_pairs\.code=recovered\.pair_code\n  JOIN guest_pairs pairs ON pairs\.name=recovered_pairs\.name/);
+  assert.doesNotMatch(sql,/JOIN guest_pairs pairs ON pairs\.code=recovered\.pair_code/);
   assert.doesNotMatch(sql,/sessions|admin_sessions/);
   assert.throws(()=>buildMergeSQL('public'),/refused/);
 });


### PR DESCRIPTION
Production recovery run 34730164625 still returned `P1001` after comparing guest-pair codes. The Wedding app generates a fresh random invitation code for every pair when it seeds an empty database, so the recreated database is expected to have different codes from the archived database.

This change keeps each code scoped to its own database. It resolves recovered answers and bookings through the archived pair name and then finds the current pair with that name. Before writing anything, it requires every answered guest and every booking to resolve to exactly one current target. Guest answers also require the guest name to match. Retired, unanswered seed entries are ignored, and current answers or bookings are still never overwritten.

Validation:

- Confirmed the new inventory and mapping assertions fail before the implementation change.
- Passed all 16 Wedding incident recovery tests after the change.
- Passed `node --check scripts/recover-wedding-db-incident.mjs` and `git diff --check`.
- Checked all six revisions of the Wedding seed list: pair names are unique at every revision, while the historical and current lists differ by one retired entry.
- Reproduced the recovery in disposable PostgreSQL 18 with different old and current codes; one answer and one booking were restored and committed.
- Reproduced a retired unanswered pair; it was ignored while valid data was restored.
- Reproduced missing guest and booking targets; both transactions refused before writes through the expected `P1002` and `P1001` guards.
- Confirmed run 34730164625 rolled back its transaction, removed temporary resources and Flux fences, and restored the Wedding app to 2/2 replicas.
