### PR TITLE
fix(observability): alert on failed CNPG archiving

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1174,10 +1174,11 @@ jobs:
       - name: 🩺 Validate the CNPG degraded-cluster alert
         if: needs.changes.outputs.k8s == 'true'
         # This CronJob is the only signal for a database degraded without
-        # crashlooping, and a broken check prints the same "none degraded" line
-        # as a healthy fleet. Run its real script against a stubbed API and
-        # delivery so both silent-zero guards and the credential's handling are
-        # pinned by behaviour rather than by schema.
+        # crashlooping, including a Ready cluster whose continuous WAL archive
+        # is failing. A broken check prints the same "none degraded" line as a
+        # healthy fleet. Run its real script against a stubbed API and delivery
+        # so both silent-zero guards and the credential's handling are pinned by
+        # behaviour rather than by schema.
         run: bash scripts/tests/test-cnpg-degraded-alert.sh
 
       - name: 🩺 Validate the stranded-volume-attach alert

--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -82,10 +82,12 @@ stays quiet by design, exactly as the old Alertmanager did.
   with no polling pod for the kubescape scan to flag. The four top-level
   Kustomizations (`bootstrap → infrastructure-controllers → infrastructure →
   apps`) wait on their children, so a failed controller / app / HelmRelease
-  surfaces here as its parent going NotReady. The remaining **backup-success**
-  and **cert-expiry** checks are not Flux resources, so they need a scan-safe
-  synthetic check (e.g. per-CronJob dead-man pings like the heartbeat below, tied
-  to the silent vault snapshot in #1970) and are still TODO.
+  surfaces here as its parent going NotReady. Sustained CNPG continuous-WAL
+  archival failure is covered by the degraded-cluster check below. The
+  remaining **scheduled base-backup success/staleness** and **cert-expiry**
+  checks are not Flux resources, so they need a scan-safe synthetic check (e.g.
+  per-CronJob dead-man pings like the heartbeat below, tied to the silent vault
+  snapshot in #1970) and are still TODO.
 - **Degraded CNPG clusters alert on their own, not via the merge-queue gate.**
   A database losing a replica used to reach Slack only through the gate
   described above — as a *Flux* error naming a Kustomization, 20 minutes late,
@@ -96,9 +98,14 @@ stays quiet by design, exactly as the old Alertmanager did.
   Running, never Ready, with zero restarts.
   `bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml` now
   checks every CNPG `Cluster` every 30 minutes and posts to the same Slack
-  webhook when one has been degraded past a 15-minute grace. It is deliberately
+  webhook when its replicas or configured continuous WAL archiver have been
+  degraded past a 15-minute grace. The archive branch also treats a missing
+  `ContinuousArchiving` condition as `Unknown` after the Cluster creation grace;
+  this catches a sidecar that never reports state. It is deliberately
   independent of any Flux health gate, so relaxing that gate cannot silently
-  remove this coverage.
+  remove this coverage. The archive branch was added after wedding-db remained
+  3/3 Ready while Barman rejected WAL from a replacement system ID for roughly
+  three days.
 - **A stranded volume attach alerts within about fifteen minutes.** On
   2026-07-01 one hcloud volume that stayed attached to a departed node took all
   prod delivery down for nine hours: the rescheduled `openbao-0` logged

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -1,4 +1,5 @@
-# Alerts on a CloudNativePG `Cluster` that has been degraded past a grace period.
+# Alerts on a CloudNativePG `Cluster` whose replicas or continuous WAL archive
+# have been degraded past a grace period.
 #
 # WHY THIS EXISTS AS A SEPARATE CHECK
 #
@@ -21,6 +22,13 @@
 # relaxing that gate (platform#2639 direction 1) does not silently remove the
 # only coverage this class has.
 #
+# A second silent shape was proven by the wedding-db data-loss incident on
+# 2026-09-09: a replacement Cluster reused its predecessor's Barman server name,
+# so every WAL upload was rejected while all 3/3 database instances stayed
+# Ready. CNPG reported ContinuousArchiving=False, but the replica-only predicate
+# ignored it for roughly three days. This check now treats a configured WAL
+# archiver whose condition stays non-True beyond the same grace as degradation.
+#
 # GRACE PERIOD — WHY `lastTransitionTime` IS SAFE HERE
 #
 # The grace period keys on the Ready condition's `lastTransitionTime`. That was
@@ -31,10 +39,11 @@
 # unreachable and the check a permanent no-op. Do not copy this pattern to a
 # Crossplane resource without re-measuring.)
 #
-# One rule covers both degradation shapes, because the timestamp means the right
-# thing in each: a cluster short of instances that only just became Ready is
-# still scaling up and stays quiet inside the grace; one that has been "Ready"
-# for hours while short a replica is a persistent degradation and alerts.
+# One rule covers all degradation shapes, because each condition's own
+# lastTransitionTime means the right thing: a cluster still scaling or an
+# archiver still initializing stays quiet inside the grace; either condition
+# remaining bad after that window alerts. If a configured archiver has not
+# published its condition, the Cluster creation time is the conservative clock.
 #
 # REPEATS ARE DELIBERATE. A plain webhook has no notification-controller-style
 # dedupe, so a cluster still degraded on the next tick alerts again. That is
@@ -192,12 +201,30 @@ spec:
                     .items[]
                     | . as $c
                     | (($c.status.conditions // []) | map(select(.type == "Ready")) | first) as $ready
+                    | (($c.status.conditions // []) | map(select(.type == "ContinuousArchiving")) | first) as $archive
                     | ($c.status.readyInstances // 0) as $r
                     | ($c.spec.instances // 0) as $d
-                    | select($r < $d or (($ready.status // "Unknown") != "True"))
-                    | select($ready.lastTransitionTime != null)
-                    | select(($now - ($ready.lastTransitionTime | fromdate)) >= $grace)
-                    | "• `\($c.metadata.namespace)/\($c.metadata.name)` — \($r)/\($d) instances ready, Ready=\($ready.status // "Unknown") since \($ready.lastTransitionTime)"
+                    | (([($c.spec.plugins // [])[] | select(.enabled != false and .isWALArchiver == true)] | length > 0)
+                       or ($c.spec.backup.barmanObjectStore? != null)) as $archiveConfigured
+                    | (if $ready.lastTransitionTime == null
+                       then false
+                       else (($now - ($ready.lastTransitionTime | fromdate)) >= $grace)
+                       end) as $replicaPastGrace
+                    | ($archive.lastTransitionTime // $c.metadata.creationTimestamp) as $archiveSince
+                    | (if $archiveSince == null
+                       then false
+                       else (($now - ($archiveSince | fromdate)) >= $grace)
+                       end) as $archivePastGrace
+                    | [
+                        if (($r < $d or (($ready.status // "Unknown") != "True")) and $replicaPastGrace)
+                        then "• `\($c.metadata.namespace)/\($c.metadata.name)` — \($r)/\($d) instances ready, Ready=\($ready.status // "Unknown") since \($ready.lastTransitionTime)"
+                        else empty
+                        end,
+                        if ($archiveConfigured and (($archive.status // "Unknown") != "True") and $archivePastGrace)
+                        then "• `\($c.metadata.namespace)/\($c.metadata.name)` — WAL archiving configured, ContinuousArchiving=\($archive.status // "Unknown") since \($archiveSince)"
+                        else empty
+                        end
+                      ][]
                   ' /tmp/body)
 
                   if [ -z "$degraded" ]; then
@@ -208,7 +235,7 @@ spec:
                   echo "Degraded CNPG cluster(s) detected:"
                   echo "$degraded"
 
-                  text=$(printf '*Degraded CloudNativePG cluster(s)*\n\n%s\n\n_A replica has been down longer than %ss. The primary may still be serving — check before assuming an outage. A replica that cannot self-heal needs its PVC + pod deleted so CNPG re-clones it from the primary (docs/dr/runbook.md)._' \
+                  text=$(printf '*Degraded CloudNativePG cluster(s)*\n\n%s\n\n_A replica shortage or WAL archival failure has persisted longer than %ss. The primary may still be serving. For ContinuousArchiving failures, inspect Barman object-store access and server-name isolation before trusting backups (docs/dr/runbook.md)._' \
                     "$degraded" "${GRACE_SECONDS}")
                   jq -n --arg t "$text" '{text: $t}' > /tmp/payload.json
 

--- a/scripts/tests/test-cnpg-degraded-alert.sh
+++ b/scripts/tests/test-cnpg-degraded-alert.sh
@@ -3,9 +3,10 @@
 # Contract for the cnpg-degraded-alert CronJob (#2787).
 #
 # This CronJob is the ONLY signal for a CloudNativePG cluster that is degraded
-# without crashlooping — a pod that stays Running, never Ready, with zero
-# restarts, which no Coroot inspection covers. It had no test at all, so every
-# behaviour its own manifest comment calls load-bearing was pinned by nothing.
+# without crashlooping — either a pod that stays Running but never Ready, or a
+# Ready database whose continuous WAL archive is failing. It had no test at
+# all, so every behaviour its own manifest comment calls load-bearing was
+# pinned by nothing.
 #
 # Two classes are asserted here, and they fail in opposite directions:
 #
@@ -292,6 +293,37 @@ healthy_body="$(
   }'
 )"
 readonly healthy_body
+archive_failed_body="$(
+  jq -n --arg ts "${old_stamp}" '{
+    items: [{
+      metadata: { namespace: "wedding-app", name: "wedding-db", creationTimestamp: $ts },
+      spec: {
+        instances: 3,
+        plugins: [{
+          name: "barman-cloud.cloudnative-pg.io",
+          isWALArchiver: true
+        }]
+      },
+      status: {
+        readyInstances: 3,
+        conditions: [
+          { type: "Ready", status: "True", lastTransitionTime: $ts },
+          { type: "ContinuousArchiving", status: "False", lastTransitionTime: $ts }
+        ]
+      }
+    }]
+  }'
+)"
+readonly archive_failed_body
+archive_missing_body="$(
+  jq '.items[0].status.conditions |= map(select(.type != "ContinuousArchiving"))' \
+    <<<"${archive_failed_body}"
+)"
+readonly archive_missing_body
+archive_disabled_body="$(
+  jq '.items[0].spec.plugins[0].enabled = false' <<<"${archive_failed_body}"
+)"
+readonly archive_disabled_body
 
 # Scenario 1 — degraded cluster, real webhook: exactly one delivery, and the URL
 # reaches curl through its stdin config rather than its argv.
@@ -309,6 +341,40 @@ jq -e '.text | test("umami/umami-db")' "${dir}/delivered-payload.json" >/dev/nul
 jq -e '.text | test("2/3 instances ready")' "${dir}/delivered-payload.json" >/dev/null ||
   fail "scenario 'delivers': payload does not carry the ready/desired counts"
 pass "a degraded cluster delivers exactly one alert, with the URL out of argv"
+
+# Scenario 1b — INCIDENT REGRESSION. A database can be fully Ready while every
+# WAL upload is rejected. That happened to wedding-db after its 2026-09-09
+# replacement reused the predecessor's Barman server name: all three instances
+# were healthy, so the replica-only check stayed silent for roughly three days.
+dir="$(setup_scenario archive_failed 200 "${archive_failed_body}" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'archive_failed': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "1" ] ||
+  fail "scenario 'archive_failed': expected exactly 1 delivery, got $(deliveries "${dir}")"
+jq -e '.text | test("wedding-app/wedding-db")' "${dir}/delivered-payload.json" >/dev/null ||
+  fail "scenario 'archive_failed': payload does not name the affected cluster"
+jq -e '.text | test("WAL archiving") and test("ContinuousArchiving=False")' \
+  "${dir}/delivered-payload.json" >/dev/null ||
+  fail "scenario 'archive_failed': payload does not identify the failed archival condition"
+pass "a Ready cluster with sustained WAL archival failure delivers an alert"
+
+# Scenario 1c — a configured archiver that never publishes its condition must
+# not disappear from monitoring. Use Cluster creation as the fallback grace
+# clock, then report the missing condition as Unknown.
+dir="$(setup_scenario archive_missing 200 "${archive_missing_body}" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'archive_missing': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "1" ] ||
+  fail "scenario 'archive_missing': expected exactly 1 delivery, got $(deliveries "${dir}")"
+jq -e '.text | test("ContinuousArchiving=Unknown")' "${dir}/delivered-payload.json" >/dev/null ||
+  fail "scenario 'archive_missing': payload does not identify the missing archival condition"
+pass "a configured archiver with no condition alerts after the grace period"
+
+# Scenario 1d — an explicitly disabled plugin is retained configuration, not an
+# active archiver. Its stale condition must not page until it is enabled again.
+dir="$(setup_scenario archive_disabled 200 "${archive_disabled_body}" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'archive_disabled': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'archive_disabled': an explicitly disabled archiver must not alert"
+pass "an explicitly disabled WAL archiver stays quiet"
 
 # Scenario 2 — the reserved placeholder host stays inert, so local and CI runs
 # are quiet by design without swallowing a real delivery failure.
@@ -432,6 +498,20 @@ run_scenario "${dir}" || fail "scenario 'within_grace': script exited non-zero: 
 [ "$(deliveries "${dir}")" = "0" ] ||
   fail "scenario 'within_grace': alerted on a cluster still inside its grace period"
 pass "a cluster still inside the grace period does not page"
+
+# Scenario 8b — the archive condition gets its own grace clock. A new Cluster
+# may report ContinuousArchiving=False while its sidecar starts; that ordinary
+# transition must stay quiet even though every database instance is Ready.
+dir="$(setup_scenario archive_within_grace 200 "$(
+  jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '.items[0].metadata.creationTimestamp = $ts
+     | (.items[0].status.conditions[] | select(.type == "ContinuousArchiving").lastTransitionTime) = $ts' \
+    <<<"${archive_failed_body}"
+)" "${REAL_WEBHOOK}")"
+run_scenario "${dir}" || fail "scenario 'archive_within_grace': script exited non-zero: $(cat "${dir}/stderr.log")"
+[ "$(deliveries "${dir}")" = "0" ] ||
+  fail "scenario 'archive_within_grace': alerted on an archiver still inside its grace period"
+pass "a WAL archiver still inside the grace period does not page"
 
 # ---------------------------------------------------------------------------
 # Wiring. A contract nothing runs protects nothing.


### PR DESCRIPTION
The Wedding database replacement remained 3/3 Ready while Barman rejected every WAL upload because the new PostgreSQL system ID reused its predecessor's server name. CNPG exposed `ContinuousArchiving=False`, but the existing degraded-cluster alert only checked replica readiness, so the failure stayed silent for roughly three days.

This extends the existing alert to report a configured WAL archiver whose `ContinuousArchiving` condition remains non-True beyond the 15-minute grace period. It also reports a missing condition as `Unknown` after the Cluster creation grace, accepts the plugin's default-enabled shape, and stays quiet for explicitly disabled archivers and ordinary startup transitions.

Validation:

- `bash scripts/tests/test-cnpg-degraded-alert.sh`
- `shellcheck scripts/tests/test-cnpg-degraded-alert.sh`
- `kubectl apply --dry-run=client -f k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml`
- `kubectl kustomize k8s/bases/infrastructure/controllers/coroot`
- `ksail workload validate` (118 Kustomizations and 623 YAML files)
- `ksail --config ksail.prod.yaml workload validate` (118 Kustomizations and 623 YAML files)
- `git diff --check`
