### PR TITLE
fix(supply-chain): pin the cert-approver image by digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -244,8 +244,8 @@
       "addLabels": ["vendored-manifest"]
     },
     {
-      "description": "kubelet-serving-cert-approver is vendored as a complete upstream manifest. Keep Renovate visibility through the updater version, but require a reviewed whole-bundle refresh with matching source commit, digest, image and PDB selector. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
-      "matchPackageNames": ["alex1989hu/kubelet-serving-cert-approver"],
+      "description": "kubelet-serving-cert-approver is vendored as a complete upstream manifest. Keep Renovate visibility through the updater version, but require a reviewed whole-bundle refresh with matching source commit, digest, image and PDB selector. The ghcr.io name covers the kustomization images: pin (tag + digest): a tag or digest update there fails CI's image-pin guard until the updater's version and cert_approver_image_digest move with it. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
+      "matchPackageNames": ["alex1989hu/kubelet-serving-cert-approver", "ghcr.io/alex1989hu/kubelet-serving-cert-approver"],
       "automerge": false,
       "addLabels": ["security/review-required"]
     },

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,6 +336,10 @@ jobs:
               # contract for the vendored CDI/KubeVirt manifests.
               - 'scripts/annotate-vendored-checkov/**'
               - 'scripts/update-vendored-operators.sh'
+              # The cert-approver image-pin guard reads the updater's constants,
+              # so both halves re-run when either changes.
+              - 'scripts/guard-cert-approver-image-pin.sh'
+              - 'scripts/tests/test-guard-cert-approver-image-pin.sh'
               # The Trivy dispositions and the local CI-equivalent scan are one
               # contract: a path-scoped ignore is inert unless both callers load it.
               - '.mega-linter.yml'
@@ -897,8 +901,11 @@ jobs:
         # vendor rename must fail offline.
         run: |
           bash -n scripts/update-vendored-operators.sh
-          shellcheck scripts/update-vendored-operators.sh
+          shellcheck scripts/update-vendored-operators.sh \
+            scripts/guard-cert-approver-image-pin.sh \
+            scripts/tests/test-guard-cert-approver-image-pin.sh
           go test ./scripts/annotate-vendored-checkov
+          bash scripts/tests/test-guard-cert-approver-image-pin.sh
           scripts/update-vendored-operators.sh --validate-committed
 
       - name: 🔎 Validate Trivy ignore-file wiring

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,14 @@ Renovate version-only bump fail until the whole bundle is re-vendored. Re-check 
 against the upstream pod labels on a refresh. All these resources render locally without network
 access; `scripts/render-remote-resource-exceptions.tsv` has no remaining exceptions.
 
+The cert-approver image is also pinned by **digest**, in its `kustomization.yaml` `images:` entry
+rather than in the vendored bytes, because an upstream tag can move (#3515). The entry's tag and
+digest must equal the updater's `cert_approver_version` and `cert_approver_image_digest`:
+`scripts/guard-cert-approver-image-pin.sh` enforces that inside `--validate-committed`, and
+`--render-remotes` re-resolves the tag from the registry and refuses to refresh until the constant
+matches. On a bump, review the image the new tag points at, then update the version, the digest
+constant and the `images:` entry together.
+
 ## Local Development Cluster
 
 **Primary method (requires KSail + Docker):**

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
@@ -29,3 +29,13 @@ resources:
   - deployment.yaml
   - cilium-network-policy.yaml
   - pod-disruption-budget.yaml
+# Pin the operator image by digest here, not in the vendored deployment.yaml: those bytes must stay
+# upstream's, and upstream v0.11.1 showed they can name a moving tag with imagePullPolicy: Always
+# (#3515). Renders as `:<newTag>@<digest>`, so the kubelet pulls this digest whatever the tag points
+# at. The tag and digest must equal the updater's cert_approver_version and cert_approver_image_digest;
+# scripts/guard-cert-approver-image-pin.sh enforces that in CI, and the updater re-resolves the digest
+# from the registry on every refresh.
+images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.12.0
+    digest: sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45

--- a/scripts/guard-cert-approver-image-pin.sh
+++ b/scripts/guard-cert-approver-image-pin.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Fail when the kubelet-serving-cert-approver image is not pinned, in the Kustomization that deploys
+# it, to the exact tag AND digest the vendor updater records (#3515).
+#
+# WHY THE PIN LIVES IN THE KUSTOMIZATION. The vendored `deployment.yaml` must stay the upstream bytes:
+# CI binds its SHA-256 and its `image:` tag to the updater's constants, and Renovate ignores the file.
+# Upstream v0.11.1 showed those bytes can name a MOVING tag (`:main`) with `imagePullPolicy: Always`,
+# so vendoring alone cannot keep production on reviewed code. A Kustomize `images:` override adds the
+# digest without touching the vendored bytes, and the kubelet then pulls exactly that digest whatever
+# the tag points at.
+#
+# WHY THE TAG IS CHECKED TOO. Kustomize renders `name:<newTag>@<digest>`, and the kubelet ignores the
+# tag once a digest is present. A refresh that bumps the tag but forgets the digest would render the
+# NEW version while production keeps running the OLD image — a silent skew. Requiring the tag to equal
+# the updater's version forces every bump through this pin.
+#
+# Exit codes:
+#   0  exactly one entry, pinned to the expected tag and digest
+#   1  the pin is missing, duplicated, renamed, or names a different tag or digest
+#   2  cannot check: bad usage, missing file, missing yq, unparseable YAML, or malformed expected values
+
+set -uo pipefail
+
+readonly image='ghcr.io/alex1989hu/kubelet-serving-cert-approver'
+
+die() {
+  printf 'guard-cert-approver-image-pin: %s\n' "$*" >&2
+  exit 2
+}
+
+defect() {
+  printf 'guard-cert-approver-image-pin: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$#" -eq 3 ] || die "usage: $0 <kustomization.yaml> <expected-version> <expected-digest>"
+file="$1"
+version="$2"
+digest="$3"
+[ -f "$file" ] || die "kustomization '$file' does not exist"
+command -v yq >/dev/null 2>&1 || die "yq is required but not installed"
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "expected version '$version' is not X.Y.Z"
+[[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "expected digest '$digest' is not sha256:<64 lowercase hex>"
+
+# Every read checks its own exit status: a parse failure must be exit 2, never an empty selection
+# that reads as "no pin" (exit 1) or, worse, as a match.
+select_expr='(.images // [])[] | select(.name == strenv(IMAGE))'
+
+if ! count="$(IMAGE="$image" yq "[${select_expr}] | length" "$file" 2>&1)"; then
+  die "cannot parse '$file': $count"
+fi
+[[ "$count" =~ ^[0-9]+$ ]] || die "unexpected entry count '$count' from '$file'"
+[ "$count" -eq 1 ] || defect "expected exactly one images: entry for $image in $file, found $count"
+
+field() { # <yq-path>
+  IMAGE="$image" yq "${select_expr} | $1 // \"\"" "$file" 2>&1
+}
+
+new_name="$(field .newName)" || die "cannot read newName from '$file': $new_name"
+new_tag="$(field .newTag)" || die "cannot read newTag from '$file': $new_tag"
+entry_digest="$(field .digest)" || die "cannot read digest from '$file': $entry_digest"
+
+[ -z "$new_name" ] || defect "the entry sets newName '$new_name', which replaces the image this digest was reviewed for"
+[ "$new_tag" = "$version" ] || defect "the entry's newTag is '${new_tag:-<unset>}', but the updater's version is '$version'"
+[ "$entry_digest" = "$digest" ] || defect "the entry's digest is '${entry_digest:-<unset>}', but the updater records '$digest'"
+
+printf 'guard-cert-approver-image-pin: %s pinned to %s@%s\n' "$image" "$version" "$digest"

--- a/scripts/tests/test-guard-cert-approver-image-pin.sh
+++ b/scripts/tests/test-guard-cert-approver-image-pin.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Pins the cert-approver image-pin guard's verdict in all THREE directions (#3515).
+#
+#   exit 0  exactly one images: entry, pinned to the updater's tag and digest
+#   exit 1  the pin is missing, duplicated, renamed, or names another tag/digest
+#   exit 2  the guard could not check
+#
+# The first case runs the guard against the REAL committed kustomization with the updater's own
+# constants, so a revert of either half of the pin fails here. Every other case is a fixture that
+# isolates one condition, so an assertion can only be satisfied by the case it belongs to.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+guard="$repo_root/scripts/guard-cert-approver-image-pin.sh"
+updater="$repo_root/scripts/update-vendored-operators.sh"
+committed="$repo_root/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+failures=0
+assertions=0
+
+run_guard() { # <file> <version> <digest>
+  if GUARD_OUT="$("$guard" "$@" 2>&1)"; then
+    GUARD_RC=0
+  else
+    GUARD_RC=$?
+  fi
+}
+
+assert_rc() { # <label> <expected-rc>
+  assertions=$((assertions + 1))
+  if [ "$2" = "$GUARD_RC" ]; then
+    printf '  ok   %s (exit %s)\n' "$1" "$GUARD_RC"
+  else
+    printf '  FAIL %s: expected exit %s, got %s\n' "$1" "$2" "$GUARD_RC"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() { # <label> <needle>
+  assertions=$((assertions + 1))
+  # A here-string, not a pipe: under pipefail an early `grep -q` match SIGPIPEs the writer and
+  # inverts the verdict.
+  if grep -qF -- "$2" <<<"$GUARD_OUT"; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: output did not contain %s\n' "$1" "$2"
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/       | /'
+    failures=$((failures + 1))
+  fi
+}
+
+constant() { # <name> -> the value of `readonly <name>='…'` in the updater
+  sed -n "s/^readonly $1='\\(.*\\)'\$/\\1/p" "$updater"
+}
+
+version="$(constant cert_approver_version)"
+digest="$(constant cert_approver_image_digest)"
+other_digest='sha256:0000000000000000000000000000000000000000000000000000000000000000'
+
+echo "== the updater records both halves of the pin =="
+assertions=$((assertions + 1))
+if [ -n "$version" ] && [ -n "$digest" ]; then
+  printf '  ok   updater declares cert_approver_version (%s) and cert_approver_image_digest (%s)\n' "$version" "$digest"
+else
+  printf '  FAIL updater must declare cert_approver_version and cert_approver_image_digest (got version=%s digest=%s)\n' "${version:-<empty>}" "${digest:-<empty>}"
+  failures=$((failures + 1))
+  # Without the constants the committed case below cannot assert anything meaningful.
+  version="${version:-0.0.0}"
+  digest="${digest:-$other_digest}"
+fi
+
+echo "== the committed kustomization is pinned to the updater's tag and digest =="
+run_guard "$committed" "$version" "$digest"
+assert_rc "committed kustomization" 0
+
+fixture() { # <name> <images-block> -> echoes the file path
+  local f="$scratch/$1.yaml"
+  printf '%s\n' 'apiVersion: kustomize.config.k8s.io/v1beta1' 'kind: Kustomization' 'resources:' '  - deployment.yaml' >"$f"
+  [ -z "$2" ] || printf '%s\n' "$2" >>"$f"
+  printf '%s' "$f"
+}
+
+good='images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.12.0
+    digest: sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45'
+fixture_version='0.12.0'
+fixture_digest='sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45'
+
+echo "== case: pinned fixture is accepted =="
+run_guard "$(fixture pinned "$good")" "$fixture_version" "$fixture_digest"
+assert_rc "pinned fixture" 0
+
+echo "== case: no images block =="
+run_guard "$(fixture none "")" "$fixture_version" "$fixture_digest"
+assert_rc "missing images block" 1
+assert_contains "names the missing entry" "found 0"
+
+echo "== case: only an unrelated image is pinned =="
+run_guard "$(fixture unrelated 'images:
+  - name: ghcr.io/example/other
+    newTag: 0.12.0
+    digest: sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45')" "$fixture_version" "$fixture_digest"
+assert_rc "unrelated image only" 1
+
+echo "== case: tag differs from the updater's version =="
+run_guard "$(fixture tag 'images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.11.1
+    digest: sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45')" "$fixture_version" "$fixture_digest"
+assert_rc "stale tag" 1
+assert_contains "names the tag mismatch" "newTag is '0.11.1'"
+
+echo "== case: digest missing =="
+run_guard "$(fixture nodigest 'images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.12.0')" "$fixture_version" "$fixture_digest"
+assert_rc "missing digest" 1
+assert_contains "names the unset digest" "digest is '<unset>'"
+
+echo "== case: digest differs from the updater's =="
+run_guard "$(fixture digest "images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.12.0
+    digest: $other_digest")" "$fixture_version" "$fixture_digest"
+assert_rc "different digest" 1
+
+echo "== case: newName replaces the reviewed image =="
+run_guard "$(fixture newname 'images:
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newName: ghcr.io/example/fork
+    newTag: 0.12.0
+    digest: sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45')" "$fixture_version" "$fixture_digest"
+assert_rc "newName set" 1
+
+echo "== case: the entry is duplicated =="
+run_guard "$(fixture duplicate "$good
+  - name: ghcr.io/alex1989hu/kubelet-serving-cert-approver
+    newTag: 0.12.0
+    digest: $other_digest")" "$fixture_version" "$fixture_digest"
+assert_rc "duplicated entry" 1
+assert_contains "names the duplicate" "found 2"
+
+echo "== case: cannot check =="
+run_guard "$scratch/does-not-exist.yaml" "$fixture_version" "$fixture_digest"
+assert_rc "missing file" 2
+printf '%s\n' 'images: [unterminated' >"$scratch/broken.yaml"
+run_guard "$scratch/broken.yaml" "$fixture_version" "$fixture_digest"
+assert_rc "unparseable YAML" 2
+run_guard "$(fixture malformed "$good")" "$fixture_version" "sha256:not-hex"
+assert_rc "malformed expected digest" 2
+run_guard "$(fixture usage "$good")" "$fixture_version"
+assert_rc "bad usage" 2
+
+printf '\n%d assertion(s), %d failure(s)\n' "$assertions" "$failures"
+[ "$failures" -eq 0 ]

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -19,6 +19,10 @@ readonly originissuers_sha256='d085e763718cf34e675b62f8394e20854237b3997f825d865
 readonly cert_approver_version='0.12.0'
 readonly cert_approver_commit='b5516301e48f8e50cb18368e457779d01796119b'
 readonly cert_approver_sha256='44d74b38379d96572c434290732092f577ee4835392b36922a72c406ee406139'
+# The digest the cert-approver kustomization pins its image to (#3515). The vendored bytes name only a
+# tag, and a tag can move; this is what production actually pulls. --render-remotes re-resolves the tag
+# from the registry and refuses to refresh while this constant disagrees with it.
+readonly cert_approver_image_digest='sha256:534e40a0050c34bda2a7bae53aa9c11133704f23dc83fee14f3b45b0f1eabe45'
 # Keep this aligned with CI_CHECKOV_VERSION in megalinter-scan-counts.sh so a
 # local vendor refresh cannot miss a rule that the non-blocking CI scan knows.
 readonly checkov_version='3.3.2'
@@ -176,6 +180,9 @@ validate_committed_bundles() {
       --validate-annotated --source-sha256 "${cert_approver_sha256}" \
       --source-version "${cert_approver_version}" \
       --resources-dir "${render_controllers}/kubelet-serving-cert-approver" </dev/null
+    scripts/guard-cert-approver-image-pin.sh \
+      "${render_controllers}/kubelet-serving-cert-approver/kustomization.yaml" \
+      "${cert_approver_version}" "${cert_approver_image_digest}"
     validate_crd "${render_controllers}/origin-ca-issuer/custom-resource-definition-clusteroriginissuers.yaml" "${clusteroriginissuers_sha256}"
     validate_crd "${render_controllers}/origin-ca-issuer/custom-resource-definition-originissuers.yaml" "${originissuers_sha256}"
   )
@@ -188,8 +195,34 @@ validate_crd() {
     --bundle origin-ca-issuer --validate-source <"${file}")
 }
 
+# Resolve what the pinned cert-approver tag points at in the registry NOW, and refuse to refresh when
+# it differs from cert_approver_image_digest. A refresh is the moment a new tag is adopted, so this is
+# where a tag that moved, or a version bump without its digest, must stop and name the digest to review.
+verify_cert_approver_image_digest() {
+  local token resolved
+  token="$(curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+    "https://ghcr.io/token?scope=repository:alex1989hu/kubelet-serving-cert-approver:pull&service=ghcr.io" |
+    sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  if [ -z "${token}" ]; then
+    printf 'could not obtain a ghcr.io pull token for the cert-approver image\n' >&2
+    exit 1
+  fi
+  resolved="$(curl --proto '=https' --tlsv1.2 --fail --silent --show-error --head \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/alex1989hu/kubelet-serving-cert-approver/manifests/${cert_approver_version}" |
+    tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest: *//p')"
+  if [ "${resolved}" != "${cert_approver_image_digest}" ]; then
+    printf 'ghcr.io/alex1989hu/kubelet-serving-cert-approver:%s resolves to %s, but cert_approver_image_digest is %s.\n' \
+      "${cert_approver_version}" "${resolved:-<nothing>}" "${cert_approver_image_digest}" >&2
+    printf 'Review that image, then record its digest here and in the kustomization images: pin.\n' >&2
+    exit 1
+  fi
+}
+
 prepare_render_remotes() {
   local name digest source
+  verify_cert_approver_image_digest
   for name in clusteroriginissuers originissuers; do
     if [ "${name}" = clusteroriginissuers ]; then
       digest="${clusteroriginissuers_sha256}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why
The kubelet-serving-cert-approver controller signs the cluster's kubelet serving certificates, yet it runs an image referenced only by a tag and re-pulled on every restart. Upstream has already shipped a release whose manifest pointed that tag at a moving branch. Vendoring the manifest locked the files we deploy, but not the code they pull. So an upstream tag change could reach production with no review.

### What
Production now pulls one exact, reviewed image for this controller, whatever the tag later points at. The recorded image fingerprint lives next to the vendored version, and CI fails if the two ever drift apart. That includes a future version bump that forgets to update the fingerprint. Refreshing the bundle also re-checks the fingerprint against the registry and stops if the tag has moved. Dependency updates for this image still require review.

Part of #3515. The remaining half is a guard that rejects floating image tags across every rendered workload, tracked as its own follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)