### PR TITLE
fix(kubescape): drop wedding-app from the C-0017 read-only root exception

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/readonly-rootfs-pending.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/readonly-rootfs-pending.yaml
@@ -12,10 +12,6 @@
 #     mount). Upstream fix needed: opencost/opencost#2655. The MAIN opencost
 #     container already runs readOnlyRootFilesystem: true — only the UI is exempt,
 #     but Kubescape scopes exceptions by namespace, so the namespace is listed.
-#   - wedding-app: the container securityContext lives in the wedding-app app repo's
-#     env-agnostic OCI artifact (deploy/deployment.yaml), not this platform repo.
-#     It is hardened there (readOnlyRootFilesystem + a /tmp emptyDir) in a follow-up
-#     app release; once that ships, remove wedding-app from this list.
 apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
@@ -23,10 +19,9 @@ metadata:
 spec:
   reason: >-
     opencost-UI (nginx) rewrites its baked /var/www assets in place at boot so it
-    cannot run a read-only root (upstream opencost/opencost#2655); wedding-app's
-    container securityContext lives in its own OCI artifact and is hardened in a
-    follow-up app release. Every other non-privileged workload sets
-    readOnlyRootFilesystem in-spec, so C-0017 genuinely passes for them.
+    cannot run a read-only root (upstream opencost/opencost#2655). Every other
+    non-privileged workload sets readOnlyRootFilesystem in-spec, so C-0017
+    genuinely passes for them.
   posture:
     - controlID: C-0017
       action: ignore
@@ -37,4 +32,3 @@ spec:
           operator: In
           values:
             - opencost
-            - wedding-app

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -724,7 +724,7 @@ data:
           {
             "designatorType": "Attributes",
             "attributes": {
-              "namespace": "^(opencost|wedding-app)$"
+              "namespace": "^(opencost)$"
             }
           }
         ],
@@ -733,7 +733,7 @@ data:
             "controlID": "^C-0017$"
           }
         ],
-        "reason": "opencost-UI (nginx) rewrites its baked /var/www assets in place at boot so it cannot run a read-only root (upstream opencost/opencost#2655); wedding-app's container securityContext lives in its own OCI artifact and is hardened in a follow-up app release. Every other non-privileged workload sets readOnlyRootFilesystem in-spec, so C-0017 genuinely passes for them."
+        "reason": "opencost-UI (nginx) rewrites its baked /var/www assets in place at boot so it cannot run a read-only root (upstream opencost/opencost#2655). Every other non-privileged workload sets readOnlyRootFilesystem in-spec, so C-0017 genuinely passes for them."
       },
       {
         "name": "secret-reader-rbac",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why
Since July the cluster has been skipping its read-only filesystem check for the wedding app. That exception was only meant to last until the app locked down its own filesystem. The app now does, and it's running that way in production, so the exception only stops a future regression from being noticed.

### What
The check applies to the wedding app again. The exception now covers only the cost dashboard, which still waits on an upstream fix. The cluster dashboard's copy of the exception list is regenerated to match.

Fixes #3756

🤖 Generated with [Claude Code](https://claude.com/claude-code)