### PR TITLE
fix(security): reject EKS surface re-approvals computed against a stale base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -752,6 +752,10 @@ jobs:
         # tree without the other's delta, and a resolved conflict in that constant
         # looks correct (#3740). Compare the record with the approval on the base
         # so a stale one fails naming the aggregate to re-derive against.
+        # HEAD^1 is that base because the PR merge ref's first parent is main and
+        # the merge queue SQUASHes each entry onto a single parent. Switching the
+        # queue to REBASE would make HEAD^1 the PR's own previous commit; revisit
+        # this step if the queue's merge method changes.
         run: |
           set -euo pipefail
           base_source="$RUNNER_TEMP/approval-base-main.go"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -736,12 +736,28 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # The approval-base step reads the validator on the first parent, which
+          # is the commit this PR merge ref or merge-group commit merges onto.
+          fetch-depth: 2
 
       - name: ⚙️ Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: 🔐 Validate authorization approval base
+        # A re-approval of the rendered-surface fingerprint records the aggregate
+        # it supersedes. Two concurrent re-approvals from one base each describe a
+        # tree without the other's delta, and a resolved conflict in that constant
+        # looks correct (#3740). Compare the record with the approval on the base
+        # so a stale one fails naming the aggregate to re-derive against.
+        run: |
+          set -euo pipefail
+          base_source="$RUNNER_TEMP/approval-base-main.go"
+          git show HEAD^1:scripts/validate-eks-ci-role-policy/main.go > "$base_source"
+          go run ./scripts/validate-eks-ci-role-policy approval-base \
+            "$base_source" scripts/validate-eks-ci-role-policy/main.go
 
       - name: ⚙️ Install pinned kubectl renderer
         shell: bash

--- a/scripts/validate-eks-ci-role-policy/approval_base_test.go
+++ b/scripts/validate-eks-ci-role-policy/approval_base_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	digestZ = strings.Repeat("0", 64)
+	digestX = strings.Repeat("1", 64)
+	digestA = strings.Repeat("a", 64)
+	digestB = strings.Repeat("b", 64)
+	digestC = strings.Repeat("c", 64)
+)
+
+// approvalSource renders a minimal validator source carrying the approval
+// record. An empty previous omits that constant, as on a base that predates it.
+func approvalSource(expected string, previous string) []byte {
+	var source bytes.Buffer
+	source.WriteString("package main\n\n")
+	source.WriteString("const expectedRenderedSurfaceSHA = \"" + expected + "\"\n")
+	if previous != "" {
+		source.WriteString("const previousRenderedSurfaceSHA = \"" + previous + "\"\n")
+	}
+	return source.Bytes()
+}
+
+// The #3740 scenario: two branches re-approve from base X. Branch A merges and
+// the base now approves A. Branch B still declares X as the aggregate it
+// supersedes, so its approval describes a tree without A's delta.
+func TestValidateApprovalBaseRejectsReapprovalAgainstStaleBase(t *testing.T) {
+	base := approvalSource(digestA, digestX)
+	head := approvalSource(digestB, digestX)
+
+	err := validateApprovalBase(head, base)
+	if err == nil {
+		t.Fatal("expected a re-approval computed against a stale base to be rejected")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"stale rendered authorization surface approval",
+		"supersedes " + digestX,
+		"approves " + digestA,
+		"re-derive the aggregate against the current base",
+		"set previousRenderedSurfaceSHA to " + digestA,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("rejection is missing %q, so it is not failing for the stale base: %v", want, err)
+		}
+	}
+}
+
+// The same approval re-derived against the current base passes.
+func TestValidateApprovalBaseAcceptsReapprovalAgainstCurrentBase(t *testing.T) {
+	base := approvalSource(digestA, digestX)
+	head := approvalSource(digestB, digestA)
+
+	if err := validateApprovalBase(head, base); err != nil {
+		t.Fatalf("expected a re-approval against the current base to pass: %v", err)
+	}
+}
+
+// Negative control: a change that moves nothing inherits both constants from
+// its base and must not start failing.
+func TestValidateApprovalBaseAcceptsUnmovedSurface(t *testing.T) {
+	base := approvalSource(digestA, digestX)
+
+	if err := validateApprovalBase(base, base); err != nil {
+		t.Fatalf("expected an unmoved approval to pass: %v", err)
+	}
+}
+
+// The first change carrying the record merges onto a base without it, and must
+// not fail merely because the base predates the constant.
+func TestValidateApprovalBaseAcceptsBaseWithoutRecord(t *testing.T) {
+	base := approvalSource(digestA, "")
+
+	if err := validateApprovalBase(approvalSource(digestA, digestX), base); err != nil {
+		t.Fatalf("expected an unmoved approval over a pre-record base to pass: %v", err)
+	}
+	if err := validateApprovalBase(approvalSource(digestB, digestA), base); err != nil {
+		t.Fatalf("expected a re-approval over a pre-record base to pass: %v", err)
+	}
+	err := validateApprovalBase(approvalSource(digestB, digestX), base)
+	if err == nil || !strings.Contains(err.Error(), "stale rendered authorization surface approval") {
+		t.Fatalf("expected a stale re-approval over a pre-record base to be rejected as stale, got: %v", err)
+	}
+}
+
+// A conflict resolved by keeping the base's aggregate but this branch's
+// superseded value leaves a record that describes no approval at all.
+func TestValidateApprovalBaseRejectsRecordChangedWithoutMove(t *testing.T) {
+	base := approvalSource(digestA, digestX)
+	head := approvalSource(digestA, digestC)
+
+	err := validateApprovalBase(head, base)
+	if err == nil || !strings.Contains(err.Error(), "changed without moving expectedRenderedSurfaceSHA") {
+		t.Fatalf("expected an orphaned previousRenderedSurfaceSHA change to be rejected, got: %v", err)
+	}
+}
+
+func TestValidateApprovalBaseRejectsMalformedRecords(t *testing.T) {
+	valid := approvalSource(digestA, digestX)
+	for name, test := range map[string]struct {
+		head []byte
+		base []byte
+		want string
+	}{
+		"head without record": {
+			head: approvalSource(digestB, ""),
+			base: valid,
+			want: "previousRenderedSurfaceSHA is missing",
+		},
+		"record supersedes itself": {
+			head: approvalSource(digestB, digestB),
+			base: valid,
+			want: "equals expectedRenderedSurfaceSHA",
+		},
+		"uppercase digest": {
+			head: approvalSource(strings.ToUpper(digestB), digestA),
+			base: valid,
+			want: "expectedRenderedSurfaceSHA is not a lowercase SHA-256 digest",
+		},
+		"short previous": {
+			head: approvalSource(digestB, digestA[:63]),
+			base: valid,
+			want: "previousRenderedSurfaceSHA is not a lowercase SHA-256 digest",
+		},
+		"base without aggregate": {
+			head: valid,
+			base: []byte("package main\n"),
+			want: "base validator source: expectedRenderedSurfaceSHA is missing",
+		},
+		"non-literal aggregate": {
+			head: []byte("package main\n\nconst expectedRenderedSurfaceSHA = other\n" +
+				"const previousRenderedSurfaceSHA = \"" + digestA + "\"\n"),
+			base: valid,
+			want: "must be a string literal",
+		},
+		"unparseable source": {
+			head: []byte("package main\nconst ("),
+			base: valid,
+			want: "parse head validator source",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateApprovalBase(test.head, test.base)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected rejection containing %q, got: %v", test.want, err)
+			}
+		})
+	}
+}
+
+// The committed record must be well-formed, and the parser must read the real
+// validator source the way CI will, not only the synthetic fixtures above.
+func TestCommittedApprovalRecordMatchesSource(t *testing.T) {
+	if err := validateApprovalRecord(expectedRenderedSurfaceSHA, previousRenderedSurfaceSHA); err != nil {
+		t.Fatalf("committed approval record is invalid: %v", err)
+	}
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read validator source: %v", err)
+	}
+	approval, err := parseSurfaceApproval(source, "validator source")
+	if err != nil {
+		t.Fatalf("parse validator source: %v", err)
+	}
+	if approval.expected != expectedRenderedSurfaceSHA || approval.previous != previousRenderedSurfaceSHA {
+		t.Fatalf("parsed record %+v does not match the compiled constants", approval)
+	}
+	if err := validateApprovalBase(source, source); err != nil {
+		t.Fatalf("validator source must pass against itself: %v", err)
+	}
+}
+
+func TestRunCLIApprovalBase(t *testing.T) {
+	directory := t.TempDir()
+	write := func(name string, contents []byte) string {
+		path := filepath.Join(directory, name)
+		if err := os.WriteFile(path, contents, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return path
+	}
+	base := write("base.go", approvalSource(digestA, digestX))
+	current := write("current.go", approvalSource(digestB, digestA))
+	stale := write("stale.go", approvalSource(digestB, digestX))
+
+	var stdout, stderr bytes.Buffer
+	if code := runCLI([]string{"approval-base", base, current}, &stdout, &stderr); code != 0 {
+		t.Fatalf("current approval exit %d, stderr: %s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runCLI([]string{"approval-base", base, stale}, &stdout, &stderr); code != 1 {
+		t.Fatalf("stale approval exit %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "re-derive the aggregate against the current base") {
+		t.Fatalf("stale approval stderr lacks the fix: %s", stderr.String())
+	}
+
+	stderr.Reset()
+	if code := runCLI([]string{"approval-base", filepath.Join(directory, "absent.go"), current}, &stdout, &stderr); code != 1 {
+		t.Fatalf("unreadable base exit %d, want 1", code)
+	}
+
+	stderr.Reset()
+	if code := runCLI([]string{"approval-base", base}, &stdout, &stderr); code != 2 {
+		t.Fatalf("incomplete approval-base arguments exit %d, want 2", code)
+	}
+}

--- a/scripts/validate-eks-ci-role-policy/approval_base_test.go
+++ b/scripts/validate-eks-ci-role-policy/approval_base_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	digestZ = strings.Repeat("0", 64)
 	digestX = strings.Repeat("1", 64)
 	digestA = strings.Repeat("a", 64)
 	digestB = strings.Repeat("b", 64)
@@ -133,6 +132,17 @@ func TestValidateApprovalBaseRejectsMalformedRecords(t *testing.T) {
 			head: valid,
 			base: []byte("package main\n"),
 			want: "base validator source: expectedRenderedSurfaceSHA is missing",
+		},
+		"malformed base aggregate": {
+			head: approvalSource(digestB, digestA),
+			base: approvalSource(digestA[:63], digestX),
+			want: "base validator source: expectedRenderedSurfaceSHA is not a lowercase SHA-256 digest",
+		},
+		"implicit iota value": {
+			head: []byte("package main\n\nconst (\n\tfirst = iota\n\texpectedRenderedSurfaceSHA\n)\n" +
+				"const previousRenderedSurfaceSHA = \"" + digestA + "\"\n"),
+			base: valid,
+			want: "expectedRenderedSurfaceSHA must be a string literal",
 		},
 		"non-literal aggregate": {
 			head: []byte("package main\n\nconst expectedRenderedSurfaceSHA = other\n" +

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -17,12 +17,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1953,6 +1957,7 @@ const (
 // The previous aggregate remains recorded here:
 //
 //	bc95f7ee1b1d9a29819844f5dfac84f256aa4caadac8eb39b43fed59992b85ea
+//
 // Moved again by the trusted tenant semantic-version rollout (#3677). Exactly
 // two existing source objects change: the ascoachingogvaner and wedding-app
 // OCIRepositories replace one fixed ref.tag with ref.semver >=1.0.0. Their
@@ -2086,6 +2091,18 @@ const (
 //
 // Previous aggregate: e36a3db7047b2b45855f6e3f2b25087dd4e56f74775bd08a5ba94efd3b86d300.
 const expectedRenderedSurfaceSHA = "59f51f1775bcded62ab018a6389ef11420b696a3b00357fc4424c4ab83935dba"
+
+// previousRenderedSurfaceSHA is the aggregate the approval above supersedes, in
+// machine-readable form. It is the base the approval was computed against.
+//
+// Every change that re-approves expectedRenderedSurfaceSHA must set this to the
+// expectedRenderedSurfaceSHA of the commit it merges onto. CI compares the two
+// ("approval-base" mode) against the first parent of the PR merge ref or the
+// merge-group commit, so an approval derived on a base that another re-approval
+// has since moved fails with the value to re-derive against, instead of reaching
+// review as a plausible-looking constant. A change that does not move the
+// surface leaves both constants untouched.
+const previousRenderedSurfaceSHA = "e36a3db7047b2b45855f6e3f2b25087dd4e56f74775bd08a5ba94efd3b86d300"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.
@@ -3561,12 +3578,167 @@ func run(repoRoot string, stdout io.Writer, stderr io.Writer) int {
 	return 0
 }
 
+// approvalBaseCommand selects the mode that compares this tree's approval record
+// with the approval on the commit it merges onto.
+const approvalBaseCommand = "approval-base"
+
+var exactSurfaceDigest = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// surfaceApproval is the rendered-surface approval record declared in a
+// validator source file. previous is empty when the source predates the record.
+type surfaceApproval struct {
+	expected string
+	previous string
+}
+
+// validateApprovalRecord checks one tree's record: both aggregates are exact
+// digests and the approval does not claim to supersede itself.
+func validateApprovalRecord(expected string, previous string) error {
+	if !exactSurfaceDigest.MatchString(expected) {
+		return fmt.Errorf("expectedRenderedSurfaceSHA is not a lowercase SHA-256 digest: %q", expected)
+	}
+	if !exactSurfaceDigest.MatchString(previous) {
+		return fmt.Errorf("previousRenderedSurfaceSHA is not a lowercase SHA-256 digest: %q", previous)
+	}
+	if expected == previous {
+		return errors.New(
+			"previousRenderedSurfaceSHA equals expectedRenderedSurfaceSHA: " +
+				"record the aggregate this approval supersedes, not the one it asserts",
+		)
+	}
+	return nil
+}
+
+// parseSurfaceApproval reads the approval constants from Go source without
+// compiling it, so CI can read the base commit's validator from Git.
+func parseSurfaceApproval(source []byte, description string) (surfaceApproval, error) {
+	file, err := parser.ParseFile(token.NewFileSet(), description, source, parser.SkipObjectResolution)
+	if err != nil {
+		return surfaceApproval{}, fmt.Errorf("parse %s: %w", description, err)
+	}
+	values := map[string]string{}
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for index, name := range valueSpec.Names {
+				if name.Name != "expectedRenderedSurfaceSHA" && name.Name != "previousRenderedSurfaceSHA" {
+					continue
+				}
+				if _, duplicate := values[name.Name]; duplicate {
+					return surfaceApproval{}, fmt.Errorf("%s: %s is declared more than once", description, name.Name)
+				}
+				if index >= len(valueSpec.Values) {
+					return surfaceApproval{}, fmt.Errorf("%s: %s must be a string literal", description, name.Name)
+				}
+				literal, ok := valueSpec.Values[index].(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					return surfaceApproval{}, fmt.Errorf("%s: %s must be a string literal", description, name.Name)
+				}
+				value, unquoteErr := strconv.Unquote(literal.Value)
+				if unquoteErr != nil {
+					return surfaceApproval{}, fmt.Errorf("%s: unquote %s: %w", description, name.Name, unquoteErr)
+				}
+				values[name.Name] = value
+			}
+		}
+	}
+	expected, ok := values["expectedRenderedSurfaceSHA"]
+	if !ok {
+		return surfaceApproval{}, fmt.Errorf("%s: expectedRenderedSurfaceSHA is missing", description)
+	}
+	return surfaceApproval{expected: expected, previous: values["previousRenderedSurfaceSHA"]}, nil
+}
+
+// validateApprovalBase fails when this tree re-approves the rendered surface
+// against a base other than the commit it merges onto. Concurrent re-approvals
+// from one base otherwise each describe a tree missing the other's delta (#3740).
+func validateApprovalBase(headSource []byte, baseSource []byte) error {
+	head, err := parseSurfaceApproval(headSource, "head validator source")
+	if err != nil {
+		return err
+	}
+	if head.previous == "" {
+		return errors.New(
+			"head validator source: previousRenderedSurfaceSHA is missing: " +
+				"record the aggregate each approval supersedes next to expectedRenderedSurfaceSHA",
+		)
+	}
+	if recordErr := validateApprovalRecord(head.expected, head.previous); recordErr != nil {
+		return fmt.Errorf("head validator source: %w", recordErr)
+	}
+	base, err := parseSurfaceApproval(baseSource, "base validator source")
+	if err != nil {
+		return err
+	}
+	if !exactSurfaceDigest.MatchString(base.expected) {
+		return fmt.Errorf("base validator source: expectedRenderedSurfaceSHA is not a lowercase SHA-256 digest: %q", base.expected)
+	}
+	if head.expected == base.expected {
+		if base.previous != "" && head.previous != base.previous {
+			return fmt.Errorf(
+				"previousRenderedSurfaceSHA changed without moving expectedRenderedSurfaceSHA: "+
+					"restore it to %s, or re-approve the aggregate against the current base",
+				base.previous,
+			)
+		}
+		return nil
+	}
+	if head.previous != base.expected {
+		return fmt.Errorf(
+			"stale rendered authorization surface approval: it supersedes %s, but the base it merges onto approves %s; "+
+				"re-derive the aggregate against the current base and set previousRenderedSurfaceSHA to %s",
+			head.previous,
+			base.expected,
+			base.expected,
+		)
+	}
+	return nil
+}
+
+// runApprovalBase compares a head validator source with its base commit's copy.
+func runApprovalBase(basePath string, headPath string, stdout io.Writer, stderr io.Writer) int {
+	baseSource, err := os.ReadFile(basePath) //nolint:gosec // CI-supplied path to the base commit's validator.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "EKS CI role policy: read base validator source: %v\n", err)
+		return 1
+	}
+	headSource, err := os.ReadFile(headPath) //nolint:gosec // CI-supplied path to this tree's validator.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "EKS CI role policy: read head validator source: %v\n", err)
+		return 1
+	}
+	if err := validateApprovalBase(headSource, baseSource); err != nil {
+		_, _ = fmt.Fprintf(stderr, "EKS CI role policy: %v\n", err)
+		return 1
+	}
+	_, _ = fmt.Fprintln(stdout, "EKS CI role authorization approval base passed.")
+	return 0
+}
+
 // runCLI enforces the single explicit repository-root argument before invoking
 // validation, preventing ambient working-directory assumptions.
 func runCLI(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == approvalBaseCommand {
+		if len(args) != 3 {
+			_, _ = fmt.Fprintln(stderr, "usage: validate-eks-ci-role-policy approval-base <base-validator-source> <head-validator-source>")
+			return 2
+		}
+		return runApprovalBase(args[1], args[2], stdout, stderr)
+	}
 	if len(args) != 1 {
 		_, _ = fmt.Fprintln(stderr, "usage: validate-eks-ci-role-policy <repository-root>")
 		return 2
+	}
+	if err := validateApprovalRecord(expectedRenderedSurfaceSHA, previousRenderedSurfaceSHA); err != nil {
+		_, _ = fmt.Fprintf(stderr, "EKS CI role policy: %v\n", err)
+		return 1
 	}
 	return run(args[0], stdout, stderr)
 }

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2101,7 +2101,8 @@ const expectedRenderedSurfaceSHA = "59f51f1775bcded62ab018a6389ef11420b696a3b003
 // merge-group commit, so an approval derived on a base that another re-approval
 // has since moved fails with the value to re-derive against, instead of reaching
 // review as a plausible-looking constant. A change that does not move the
-// surface leaves both constants untouched.
+// surface leaves both constants untouched. Reverting a re-approval is itself a
+// re-approval: restore the older aggregate and record the current one here.
 const previousRenderedSurfaceSHA = "e36a3db7047b2b45855f6e3f2b25087dd4e56f74775bd08a5ba94efd3b86d300"
 
 // authorizationOverlayPaths lists every independently reconciled production


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The EKS authorization fingerprint only means "this exact surface was reviewed" if each re-approval describes the tree it merges into. When two branches re-approve from the same base, whichever merges second carries a value that silently omits the other's change, and the conflict looks like any ordinary resolved constant. Today only CI's re-render catches it, with an unexplained digest mismatch.

### What

Each re-approval now records, in machine-readable form, the aggregate it supersedes. A new CI step compares that record with the approval on the commit being merged onto and fails with the exact value to re-derive against. Changes that do not move the surface are unaffected.

**Merge-order note:** open PRs that re-approve the fingerprint (for example #3758) will need to set the new `previousRenderedSurfaceSHA` when they rebase after this lands — the new check tells them the value.

Fixes #3740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
