### PR TITLE
fix(storage): require baseline workers for Coroot and vault snapshot volumes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,6 +296,8 @@ jobs:
               # gate that proves the rule actually fires are one contract.
               - 'tests/label-baseline-workers/**'
               - 'scripts/tests/test-label-baseline-workers.sh'
+              # The hcloud consumers that require that label (#3287).
+              - 'scripts/tests/test-hcloud-baseline-worker-affinity.sh'
               - 'tests/audit-privileged-rbac/**'
               - 'tests/auto-vpa/**'
               - 'scripts/tests/test-audit-privileged-rbac.sh'
@@ -1125,6 +1127,8 @@ jobs:
           bash scripts/tests/test-add-baseline-context.sh
           shellcheck scripts/tests/test-label-baseline-workers.sh
           bash scripts/tests/test-label-baseline-workers.sh
+          shellcheck scripts/tests/test-hcloud-baseline-worker-affinity.sh
+          bash scripts/tests/test-hcloud-baseline-worker-affinity.sh
           shellcheck scripts/guard-longhorn-ui-baseline-context.sh scripts/tests/test-guard-longhorn-ui-baseline-context.sh scripts/tests/test-longhorn-ui-baseline-context.sh
           bash scripts/tests/test-guard-longhorn-ui-baseline-context.sh
           bash scripts/tests/test-longhorn-ui-baseline-context.sh

--- a/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
@@ -44,16 +44,13 @@
 # podAntiAffinity verbatim rather than merging into it — dropping it would put
 # two raft peers on one host and lose the anti-affinity the HA setup depends on.
 #
-# WHY A POSITIVE LABEL (#3287): the rule REQUIRES
-# `platform.devantler.tech/baseline-worker=true`, which the
-# label-baseline-workers policies stamp on exactly the static `prod-worker-*`
-# nodes. A negative `ksail.io/autoscaled DoesNotExist` rule fails open: an
-# autoscaler node that boots without that marker (ksail#7013 — measured on every
-# autoscaler node on 2026-09-13) matches it and is treated as baseline. A missing
-# positive label fails closed instead — the pod goes Pending rather than landing
-# on a node that can be reclaimed. Node affinity supports no name wildcard, so
-# the name-based `autoscale-*` discriminator the Longhorn policies use is not
-# expressible here; the label is how that name match reaches the scheduler.
+# RESIDUAL (shared with prefer-baseline-nodes, tracked in #3178): the
+# discriminator is `DoesNotExist`, so an autoscaler node created before KSail
+# began stamping `ksail.io/autoscaled` (ksail#5113) carries no label and is
+# still treated as baseline. Node affinity matches label values and supports no
+# wildcard, so the name-based `autoscale-*` discriminator the Longhorn policies
+# use is not expressible here. Every autoscaler node currently in the pool is
+# labelled; the durable fix is to not leave stranded nodes running.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -75,7 +72,5 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: platform.devantler.tech/baseline-worker
-                    operator: In
-                    values:
-                      - "true"
+                  - key: ksail.io/autoscaled
+                    operator: DoesNotExist

--- a/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/openbao/patches/keep-off-autoscale-nodes.yaml
@@ -44,13 +44,16 @@
 # podAntiAffinity verbatim rather than merging into it — dropping it would put
 # two raft peers on one host and lose the anti-affinity the HA setup depends on.
 #
-# RESIDUAL (shared with prefer-baseline-nodes, tracked in #3178): the
-# discriminator is `DoesNotExist`, so an autoscaler node created before KSail
-# began stamping `ksail.io/autoscaled` (ksail#5113) carries no label and is
-# still treated as baseline. Node affinity matches label values and supports no
-# wildcard, so the name-based `autoscale-*` discriminator the Longhorn policies
-# use is not expressible here. Every autoscaler node currently in the pool is
-# labelled; the durable fix is to not leave stranded nodes running.
+# WHY A POSITIVE LABEL (#3287): the rule REQUIRES
+# `platform.devantler.tech/baseline-worker=true`, which the
+# label-baseline-workers policies stamp on exactly the static `prod-worker-*`
+# nodes. A negative `ksail.io/autoscaled DoesNotExist` rule fails open: an
+# autoscaler node that boots without that marker (ksail#7013 — measured on every
+# autoscaler node on 2026-09-13) matches it and is treated as baseline. A missing
+# positive label fails closed instead — the pod goes Pending rather than landing
+# on a node that can be reclaimed. Node affinity supports no name wildcard, so
+# the name-based `autoscale-*` discriminator the Longhorn policies use is not
+# expressible here; the label is how that name match reaches the scheduler.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -72,5 +75,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: ksail.io/autoscaled
-                    operator: DoesNotExist
+                  - key: platform.devantler.tech/baseline-worker
+                    operator: In
+                    values:
+                      - "true"

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/enable-ha.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/enable-ha.yaml
@@ -41,7 +41,28 @@ spec:
   # node and a single node loss would take Coroot down despite replicas: 2.
   # Preferred (not required) so scheduling still succeeds if only one eligible
   # node is available — the platform house pattern (spread-pods).
+  #
+  # The REQUIRED node affinity is a different concern (#3287): every Coroot
+  # component with `className: hcloud` storage below must run on a static
+  # baseline worker. An hcloud volume attaches to one node and is not
+  # force-detached when that node departs, so a pod that bursts onto an
+  # autoscaler node strands its volume when the node is reclaimed. The rule
+  # requires the positive `platform.devantler.tech/baseline-worker=true` label
+  # (stamped by the label-baseline-workers policies on `prod-worker-*` only), so
+  # an unlabelled node fails closed. The same block is repeated on prometheus,
+  # clickhouse and keeper: each is a separate StatefulSet with its own affinity.
+  # This is a JSON merge patch on a custom resource, so the added `nodeAffinity`
+  # key merges beside the base's clickhouse/keeper `podAntiAffinity` instead of
+  # replacing it.
   affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: platform.devantler.tech/baseline-worker
+                operator: In
+                values:
+                  - "true"
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
@@ -94,6 +115,17 @@ spec:
       limits:
         cpu: "2"
         memory: 2Gi
+    # hcloud storage below: required baseline-worker node affinity (see the
+    # server `affinity` above for why).
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: platform.devantler.tech/baseline-worker
+                  operator: In
+                  values:
+                    - "true"
     # 14d metrics retention (matches the old kube-prometheus-stack posture).
     retention: 14d
     storage:
@@ -120,7 +152,30 @@ spec:
     storage:
       className: hcloud
       size: 15Gi
+    # hcloud storage above: required baseline-worker node affinity (see the
+    # server `affinity` for why). Merges beside the base podAntiAffinity.
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: platform.devantler.tech/baseline-worker
+                  operator: In
+                  values:
+                    - "true"
     keeper:
+      # The three keeper replicas already require distinct hosts, so they need
+      # all three baseline workers; with one down the third goes Pending and
+      # Keeper keeps its 2-of-3 Raft quorum.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: platform.devantler.tech/baseline-worker
+                    operator: In
+                    values:
+                      - "true"
       storage:
         className: hcloud
         size: 2Gi

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/enable-ha.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/enable-ha.yaml
@@ -50,7 +50,8 @@ spec:
   # requires the positive `platform.devantler.tech/baseline-worker=true` label
   # (stamped by the label-baseline-workers policies on `prod-worker-*` only), so
   # an unlabelled node fails closed. The same block is repeated on prometheus,
-  # clickhouse and keeper: each is a separate StatefulSet with its own affinity.
+  # clickhouse and keeper: each is a separate workload (Prometheus a Deployment,
+  # the others StatefulSets) with its own affinity.
   # This is a JSON merge patch on a custom resource, so the added `nodeAffinity`
   # key merges beside the base's clickhouse/keeper `podAntiAffinity` instead of
   # replacing it.

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -197,9 +197,22 @@ patches:
   - path: patches/store-vault-snapshots-on-hcloud.yaml
   - path: patches/recover-vault-snapshot.yaml
   # Prod-only: the vault-snapshot CronJob and Job mount that hcloud volume, so
-  # both require a static baseline worker (#3287). Each self-identifies.
+  # both require a static baseline worker (#3287). JSON patches don't
+  # self-identify, so each names its target.
   - path: patches/keep-vault-snapshot-on-baseline-workers.yaml
+    target:
+      group: batch
+      version: v1
+      kind: CronJob
+      name: vault-snapshot
+      namespace: openbao
   - path: patches/keep-vault-snapshot-init-on-baseline-workers.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: vault-snapshot-init
+      namespace: openbao
   # Prod-only: add a generous memory `default` to the kube-system / kyverno
   # LimitRanges (which are CPU-only in the base). This seeds the memory limit the
   # vertical-pod-autoscalers/ VPAs scale ratio-preserving, so VPA right-sizes the memory

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -196,6 +196,10 @@ patches:
   # vault-snapshots, so no explicit target is needed.
   - path: patches/store-vault-snapshots-on-hcloud.yaml
   - path: patches/recover-vault-snapshot.yaml
+  # Prod-only: the vault-snapshot CronJob and Job mount that hcloud volume, so
+  # both require a static baseline worker (#3287). Each self-identifies.
+  - path: patches/keep-vault-snapshot-on-baseline-workers.yaml
+  - path: patches/keep-vault-snapshot-init-on-baseline-workers.yaml
   # Prod-only: add a generous memory `default` to the kube-system / kyverno
   # LimitRanges (which are CPU-only in the base). This seeds the memory limit the
   # vertical-pod-autoscalers/ VPAs scale ratio-preserving, so VPA right-sizes the memory

--- a/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
@@ -4,28 +4,23 @@
 # The Job mounts the same hcloud-backed `vault-snapshots` PVC as the daily
 # CronJob, so it carries the same required node affinity (see
 # keep-vault-snapshot-on-baseline-workers.yaml for the stranded-volume
-# rationale). The positive `platform.devantler.tech/baseline-worker=true` label
-# fails closed on a node the label-baseline-workers policies did not stamp.
+# rationale, the layer ordering, and why this is a JSON patch). The positive
+# `platform.devantler.tech/baseline-worker=true` label fails closed on a node
+# the label-baseline-workers policies did not stamp.
 #
 # The Job is immutable and force-enabled, so adding this affinity makes Flux
 # replace it once. The re-run skips the snapshot when one from the same day
 # already exists, which is the Job's normal behaviour on a spec change; the
 # completed Job is still retained afterwards, so it does not re-run on later
 # reconciles.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: vault-snapshot-init
-  namespace: openbao
-spec:
-  template:
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: platform.devantler.tech/baseline-worker
-                    operator: In
-                    values:
-                      - "true"
+- op: add
+  path: /spec/template/spec/affinity
+  value:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: platform.devantler.tech/baseline-worker
+                operator: In
+                values:
+                  - "true"

--- a/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
@@ -8,9 +8,10 @@
 # fails closed on a node the label-baseline-workers policies did not stamp.
 #
 # The Job is immutable and force-enabled, so adding this affinity makes Flux
-# replace it once and take one fresh baseline snapshot. That is the Job's
-# intended behaviour on a spec change; the completed Job is still retained
-# afterwards, so it does not re-run on later reconciles.
+# replace it once. The re-run skips the snapshot when one from the same day
+# already exists, which is the Job's normal behaviour on a spec change; the
+# completed Job is still retained afterwards, so it does not re-run on later
+# reconciles.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-init-on-baseline-workers.yaml
@@ -1,0 +1,30 @@
+# Prod-only: run the one-shot vault-snapshot-init Job on static baseline
+# workers only (#3287).
+#
+# The Job mounts the same hcloud-backed `vault-snapshots` PVC as the daily
+# CronJob, so it carries the same required node affinity (see
+# keep-vault-snapshot-on-baseline-workers.yaml for the stranded-volume
+# rationale). The positive `platform.devantler.tech/baseline-worker=true` label
+# fails closed on a node the label-baseline-workers policies did not stamp.
+#
+# The Job is immutable and force-enabled, so adding this affinity makes Flux
+# replace it once and take one fresh baseline snapshot. That is the Job's
+# intended behaviour on a spec change; the completed Job is still retained
+# afterwards, so it does not re-run on later reconciles.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-snapshot-init
+  namespace: openbao
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: platform.devantler.tech/baseline-worker
+                    operator: In
+                    values:
+                      - "true"

--- a/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-on-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-on-baseline-workers.yaml
@@ -10,28 +10,29 @@
 #
 # The rule requires the positive `platform.devantler.tech/baseline-worker=true`
 # label, stamped by the label-baseline-workers policies on `prod-worker-*` only.
-# A missing label fails closed: the pod goes Pending instead of attaching the
-# volume to an unlabelled autoscaler node. The Job-level activeDeadlineSeconds
-# still bounds a run that cannot schedule.
+# Those policies apply in this same `infrastructure` layer, so a rebuilt
+# cluster labels its workers before this pod can wait on them. A missing label
+# fails closed: the pod goes Pending instead of attaching the volume to an
+# unlabelled autoscaler node. The Job-level activeDeadlineSeconds still bounds a
+# run that cannot schedule.
+#
+# JSON patch (not strategic merge), with the target in kustomization.yaml: a
+# partial CronJob manifest is scanned by Kubescape as if it were a workload, and
+# its missing `automountServiceAccountToken` raises C-0034 on this file even
+# though the rendered CronJob is unchanged in that respect. An operation list is
+# not a workload manifest. The base pod spec has no `affinity`, so `add` creates
+# it.
 #
 # Hetzner overlay only: the label and the hcloud StorageClass exist only on this
 # provider, so the local Docker cluster keeps the unconstrained base.
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: vault-snapshot
-  namespace: openbao
-spec:
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: platform.devantler.tech/baseline-worker
-                        operator: In
-                        values:
-                          - "true"
+- op: add
+  path: /spec/jobTemplate/spec/template/spec/affinity
+  value:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: platform.devantler.tech/baseline-worker
+                operator: In
+                values:
+                  - "true"

--- a/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-on-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/patches/keep-vault-snapshot-on-baseline-workers.yaml
@@ -1,0 +1,37 @@
+# Prod-only: run the daily vault-snapshot CronJob's pods on static baseline
+# workers only (#3287).
+#
+# Each run mounts the `vault-snapshots` PVC, which store-vault-snapshots-on-hcloud
+# puts on an hcloud block volume. An hcloud volume attaches to one node and is
+# not force-detached when that node departs. Measured on prod 2026-09-13: the
+# last three runs all completed on an autoscaler node, so every run left the
+# volume attached to a node the autoscaler may reclaim. The next run — or the
+# vault-snapshot-init Job — then waits on a stranded attachment.
+#
+# The rule requires the positive `platform.devantler.tech/baseline-worker=true`
+# label, stamped by the label-baseline-workers policies on `prod-worker-*` only.
+# A missing label fails closed: the pod goes Pending instead of attaching the
+# volume to an unlabelled autoscaler node. The Job-level activeDeadlineSeconds
+# still bounds a run that cannot schedule.
+#
+# Hetzner overlay only: the label and the hcloud StorageClass exist only on this
+# provider, so the local Docker cluster keeps the unconstrained base.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vault-snapshot
+  namespace: openbao
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: platform.devantler.tech/baseline-worker
+                        operator: In
+                        values:
+                          - "true"

--- a/scripts/tests/test-hcloud-baseline-worker-affinity.sh
+++ b/scripts/tests/test-hcloud-baseline-worker-affinity.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Positive gate for the hcloud block-storage guards (#3287).
+#
+# An hcloud volume attaches to one node and is not force-detached when that
+# node departs, so every workload that mounts one must require a static
+# baseline worker. This renders the prod (hetzner) overlays and asserts, for
+# each such workload, that EVERY required nodeSelectorTerm carries
+# `platform.devantler.tech/baseline-worker In ["true"]`. Terms are ORed, so a
+# single term without it would fail open.
+#
+# Coroot is checked generically: every object in the Coroot CR spec whose
+# `storage.className` is hcloud must carry the rule in its sibling `affinity`,
+# so a component that gains hcloud storage later fails here until it is
+# guarded. The base's clickhouse/keeper podAntiAffinity must survive the merge.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+infra="${repo_root}/k8s/providers/hetzner/infrastructure"
+controllers="${infra}/controllers"
+label='platform.devantler.tech/baseline-worker'
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+kubectl kustomize "${infra}" >"${work}/infra.yaml"
+kubectl kustomize "${controllers}" >"${work}/controllers.yaml"
+[ -s "${work}/infra.yaml" ] || { echo "::error::infrastructure overlay rendered nothing"; exit 1; }
+[ -s "${work}/controllers.yaml" ] || { echo "::error::controllers overlay rendered nothing"; exit 1; }
+
+fail=0
+checked=0
+
+# check_affinity <what> <file holding one affinity document as YAML>
+# Passes only when the required terms are non-empty and every term requires the
+# label with exactly the value "true".
+check_affinity() {
+  local what="$1" file="$2" terms bad
+  terms="$(yq '.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [] | length' "${file}")"
+  if [ "${terms}" -eq 0 ]; then
+    echo "::error::${what}: no required nodeSelectorTerms"
+    fail=1
+    return
+  fi
+  bad="$(yq "[.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[]
+          | select(([.matchExpressions // [] | .[]
+                     | select(.key == \"${label}\" and .operator == \"In\"
+                              and (.values | length) == 1 and .values[0] == \"true\")]
+                    | length) == 0)] | length" "${file}")"
+  if [ "${bad}" -ne 0 ]; then
+    echo "::error::${what}: ${bad} of ${terms} required nodeSelectorTerm(s) do not require ${label}=true"
+    fail=1
+    return
+  fi
+  checked=$((checked + 1))
+}
+
+# extract <rendered file> <yq selector for the document> <yq path to affinity> <out>
+extract() {
+  local src="$1" doc="$2" path="$3" out="$4"
+  yq ea "select(${doc}) | ${path} // {}" "${src}" >"${out}"
+}
+
+# OpenBao: `server.affinity` is a templated string — parse it as YAML. The
+# template expressions sit in quoted/label positions, so the YAML still parses.
+yq ea 'select(.kind == "HelmRelease" and .metadata.name == "openbao") | .spec.values.server.affinity // ""' \
+  "${work}/controllers.yaml" | sed -e 's/{{[^}]*}}/tmpl/g' >"${work}/openbao.yaml"
+if [ ! -s "${work}/openbao.yaml" ]; then
+  echo "::error::openbao HelmRelease server.affinity did not render"
+  fail=1
+else
+  check_affinity "openbao server" "${work}/openbao.yaml"
+  anti="$(yq '.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution // [] | length' "${work}/openbao.yaml")"
+  [ "${anti}" -ge 1 ] || { echo "::error::openbao server lost its required podAntiAffinity"; fail=1; }
+fi
+
+# Vault snapshot workloads: both mount the hcloud-backed vault-snapshots PVC.
+extract "${work}/infra.yaml" '.kind == "CronJob" and .metadata.name == "vault-snapshot"' \
+  '.spec.jobTemplate.spec.template.spec.affinity' "${work}/cron.yaml"
+check_affinity "vault-snapshot CronJob" "${work}/cron.yaml"
+extract "${work}/infra.yaml" '.kind == "Job" and .metadata.name == "vault-snapshot-init"' \
+  '.spec.template.spec.affinity' "${work}/init.yaml"
+check_affinity "vault-snapshot-init Job" "${work}/init.yaml"
+
+# Coroot: every spec object with hcloud storage, found by walking the CR.
+yq ea 'select(.kind == "Coroot" and .metadata.name == "coroot") | .spec' "${work}/infra.yaml" >"${work}/coroot.yaml"
+[ -s "${work}/coroot.yaml" ] || { echo "::error::Coroot CR did not render"; fail=1; }
+coroot_paths=()
+# The root spec itself has no path segment; yq prints an empty line for it.
+while IFS= read -r p; do
+  coroot_paths+=("${p}")
+done < <(yq '[.. | select(tag == "!!map" and .storage.className == "hcloud") | path | join(".")] | .[]' "${work}/coroot.yaml")
+if [ "${#coroot_paths[@]}" -lt 4 ]; then
+  echo "::error::expected >=4 Coroot components with hcloud storage (server, prometheus, clickhouse, keeper), found ${#coroot_paths[@]}"
+  fail=1
+fi
+for p in "${coroot_paths[@]}"; do
+  if [ -z "${p}" ]; then
+    name="server"
+    sel='.affinity // {}'
+  else
+    name="${p}"
+    sel=".${p}.affinity // {}"
+  fi
+  yq "${sel}" "${work}/coroot.yaml" >"${work}/coroot-affinity.yaml"
+  check_affinity "coroot ${name}" "${work}/coroot-affinity.yaml"
+done
+for c in clickhouse clickhouse.keeper; do
+  anti="$(yq ".${c}.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution // [] | length" "${work}/coroot.yaml")"
+  [ "${anti}" -ge 1 ] || { echo "::error::coroot ${c} lost the base's required podAntiAffinity"; fail=1; }
+done
+
+if [ "${fail}" -ne 0 ]; then
+  exit 1
+fi
+echo "hcloud-baseline-worker-affinity: ${checked} hcloud consumers require ${label}=true in every term"

--- a/scripts/tests/test-hcloud-baseline-worker-affinity.sh
+++ b/scripts/tests/test-hcloud-baseline-worker-affinity.sh
@@ -4,11 +4,19 @@ set -euo pipefail
 # Positive gate for the hcloud block-storage guards (#3287).
 #
 # An hcloud volume attaches to one node and is not force-detached when that
-# node departs, so every workload that mounts one must require a static
-# baseline worker. This renders the prod (hetzner) overlays and asserts, for
-# each such workload, that EVERY required nodeSelectorTerm carries
+# node departs, so a workload that mounts one must require a static baseline
+# worker. This renders the prod (hetzner) `infrastructure` overlay and asserts,
+# for each guarded workload, that EVERY required nodeSelectorTerm carries
 # `platform.devantler.tech/baseline-worker In ["true"]`. Terms are ORed, so a
 # single term without it would fail open.
+#
+# Scope is the `infrastructure` layer only, because the label-baseline-workers
+# policies that stamp the label are applied in that same layer. OpenBao is NOT
+# covered: it deploys in `infrastructure-controllers`, which must converge
+# before `infrastructure` applies, so requiring the label there would deadlock
+# a rebuilt cluster whose nodes are not labelled yet. It keeps its
+# `ksail.io/autoscaled DoesNotExist` rule until a label source that exists
+# before Flux is in place (tracked on #3287).
 #
 # Coroot is checked generically: every object in the Coroot CR spec whose
 # `storage.className` is hcloud must carry the rule in its sibling `affinity`,
@@ -18,15 +26,12 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 infra="${repo_root}/k8s/providers/hetzner/infrastructure"
-controllers="${infra}/controllers"
 label='platform.devantler.tech/baseline-worker'
 work="$(mktemp -d)"
 trap 'rm -rf "${work}"' EXIT
 
 kubectl kustomize "${infra}" >"${work}/infra.yaml"
-kubectl kustomize "${controllers}" >"${work}/controllers.yaml"
 [ -s "${work}/infra.yaml" ] || { echo "::error::infrastructure overlay rendered nothing"; exit 1; }
-[ -s "${work}/controllers.yaml" ] || { echo "::error::controllers overlay rendered nothing"; exit 1; }
 
 fail=0
 checked=0
@@ -35,8 +40,23 @@ checked=0
 # Passes only when the required terms are non-empty and every term requires the
 # label with exactly the value "true".
 check_affinity() {
-  local what="$1" file="$2" terms bad
+  local what="$1" file="$2" terms bad docs
+  # Exactly one document: a selector matching two resources would make yq print
+  # one number per document, and a non-integer must never pass the checks below.
+  docs="$(yq ea '[.] | length' "${file}")"
+  if [ "${docs}" != "1" ]; then
+    echo "::error::${what}: expected exactly one rendered document, got '${docs}'"
+    fail=1
+    return
+  fi
   terms="$(yq '.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms // [] | length' "${file}")"
+  case "${terms}" in
+    '' | *[!0-9]*)
+      echo "::error::${what}: unreadable nodeSelectorTerms count '${terms}'"
+      fail=1
+      return
+      ;;
+  esac
   if [ "${terms}" -eq 0 ]; then
     echo "::error::${what}: no required nodeSelectorTerms"
     fail=1
@@ -61,24 +81,11 @@ extract() {
   yq ea "select(${doc}) | ${path} // {}" "${src}" >"${out}"
 }
 
-# OpenBao: `server.affinity` is a templated string — parse it as YAML. The
-# template expressions sit in quoted/label positions, so the YAML still parses.
-yq ea 'select(.kind == "HelmRelease" and .metadata.name == "openbao") | .spec.values.server.affinity // ""' \
-  "${work}/controllers.yaml" | sed -e 's/{{[^}]*}}/tmpl/g' >"${work}/openbao.yaml"
-if [ ! -s "${work}/openbao.yaml" ]; then
-  echo "::error::openbao HelmRelease server.affinity did not render"
-  fail=1
-else
-  check_affinity "openbao server" "${work}/openbao.yaml"
-  anti="$(yq '.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution // [] | length' "${work}/openbao.yaml")"
-  [ "${anti}" -ge 1 ] || { echo "::error::openbao server lost its required podAntiAffinity"; fail=1; }
-fi
-
 # Vault snapshot workloads: both mount the hcloud-backed vault-snapshots PVC.
-extract "${work}/infra.yaml" '.kind == "CronJob" and .metadata.name == "vault-snapshot"' \
+extract "${work}/infra.yaml" '.kind == "CronJob" and .metadata.name == "vault-snapshot" and .metadata.namespace == "openbao"' \
   '.spec.jobTemplate.spec.template.spec.affinity' "${work}/cron.yaml"
 check_affinity "vault-snapshot CronJob" "${work}/cron.yaml"
-extract "${work}/infra.yaml" '.kind == "Job" and .metadata.name == "vault-snapshot-init"' \
+extract "${work}/infra.yaml" '.kind == "Job" and .metadata.name == "vault-snapshot-init" and .metadata.namespace == "openbao"' \
   '.spec.template.spec.affinity' "${work}/init.yaml"
 check_affinity "vault-snapshot-init Job" "${work}/init.yaml"
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

Storage that attaches to a single node (Hetzner block volumes) gets stranded when the autoscaler removes the node it is attached to. That is how an OpenBao volume once wedged every prod deploy for about 9 hours. Coroot and the nightly vault snapshot job have no rule keeping them off autoscaler nodes. One Coroot database pod runs on one right now, and the snapshot job has run there every night.

### What

Coroot (server, metrics, log store and its coordinator) and the vault snapshot jobs now run only on the three permanent workers, using the node label added in #3758. A node without the label is refused rather than allowed. A new CI check fails if any of these workloads loses the rule.

OpenBao is deliberately **not** switched here. It deploys one Flux layer before the policies that stamp the label, so on a cluster rebuild it would wait for a label that never arrives. It needs a label source that exists before Flux runs, which #3287 now tracks.

**Operational note:** the deploy restarts the Coroot pods one at a time, and the Coroot database pod now on an autoscaler node moves to a permanent worker. Coroot keeps its second database copy while that happens. The vault-snapshot-init job runs once more but skips the snapshot if one from today already exists. Memory requests on the permanent workers are 70–82% today, so they can absorb the pods that move.

Part of #3287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
