### PR TITLE
fix(kyverno): let the reports controller read HTTPRoutes and CiliumNetworkPolicies

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/cluster-role-reports-controller-read-network-routes.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/cluster-role-reports-controller-read-network-routes.yaml
@@ -1,0 +1,39 @@
+# Read access for Kyverno's reports controller to the Gateway API and Cilium
+# kinds that background-scanned policies match.
+#
+# Kyverno aggregates any ClusterRole carrying the
+# rbac.kyverno.io/aggregate-to-reports-controller label into the reports
+# controller's ClusterRole (kyverno:reports-controller). For background scanning
+# the controller starts a watch on every resource kind a background policy
+# matches, and creating a report requires get, list and watch on that kind.
+#
+# restrict-homepage-service-groups matches HTTPRoutes and add-default-deny
+# matches CiliumNetworkPolicies. Without this grant the resource report
+# controller fails to list and watch both kinds ("httproutes.gateway.networking.k8s.io
+# is forbidden", "ciliumnetworkpolicies.cilium.io is forbidden") on every
+# resync, and no PolicyReport has been refreshed since the 3.9.0 upgrade (#3760).
+# Like the KEDA grant, it ships in infrastructure-controllers, one layer before
+# the policies that need it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:reports-controller:read-network-routes
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
@@ -14,5 +14,6 @@ resources:
   - role.yaml
   - role-binding.yaml
   - cluster-role-reports-controller-read-keda.yaml
+  - cluster-role-reports-controller-read-network-routes.yaml
   - cluster-role-read-github-teams.yaml
   - cluster-role-read-rbac.yaml


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

No Kyverno policy report in production has been refreshed since the 2026-08-27 chart upgrade, so the compliance dashboard has been showing 17-day-old results. New violations can't appear and fixed ones never clear. The reports controller keeps failing to read two kinds that our background-scanned policies check: Gateway API routes and Cilium network policies.

### What

Grants the reports controller read-only access to those two kinds, using the same aggregated-role pattern the platform already uses for KEDA. It is live one layer before the policies that need it. The issue stays open until a live read-back shows reports refreshing again.

Part of #3760

🤖 Generated with [Claude Code](https://claude.com/claude-code)
