### PR TITLE
fix(security): supply the C-0211 baseline context to cert-manager

### DIFF
--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -41,13 +41,17 @@ spec:
     dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53,9.9.9.9:53"
     dns01RecursiveNameserversOnly: true
     # C-0211 baseline context, supplied through the chart's own values because
-    # cert-manager is excluded from the add-security-context mutation (#3239).
-    # Helm merges these maps into the chart defaults, so runAsNonRoot and the
-    # RuntimeDefault seccomp profile are kept. Both fields are inert here: none
-    # of the three Deployments sets fsGroup or mounts a volume that ownership
-    # policy governs, and the empty seLinuxOptions object leaves SELinux type and
-    # MCS category selection to the runtime. The webhook and cainjector blocks
-    # below carry the same two fields.
+    # cert-manager is excluded from add-security-context's pod and container
+    # rules, and the scan reads the stored Deployment template rather than the
+    # mutated pod (#3239). Helm merges these maps into the chart defaults, so
+    # runAsNonRoot and the RuntimeDefault seccomp profile are kept. Both fields
+    # are inert here: the Deployment templates set no fsGroup, and although
+    # Kyverno's add-imageuid-pod-security-context rule adds fsGroup 1000 with
+    # this same OnRootMismatch policy when each pod is created, none of the
+    # three pods mounts a volume whose ownership that governs. The empty
+    # seLinuxOptions object leaves SELinux type and MCS category selection to
+    # the runtime. The webhook and cainjector blocks below carry the same two
+    # fields.
     securityContext:
       fsGroupChangePolicy: OnRootMismatch
     # Restricted PSS baseline: add runAsNonRoot to container SCs (chart leaves it unset, which fails validate-container-security).

--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -40,6 +40,16 @@ spec:
     # authoritative CA-side validation, and is fully reversible.
     dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53,9.9.9.9:53"
     dns01RecursiveNameserversOnly: true
+    # C-0211 baseline context, supplied through the chart's own values because
+    # cert-manager is excluded from the add-security-context mutation (#3239).
+    # Helm merges these maps into the chart defaults, so runAsNonRoot and the
+    # RuntimeDefault seccomp profile are kept. Both fields are inert here: none
+    # of the three Deployments sets fsGroup or mounts a volume that ownership
+    # policy governs, and the empty seLinuxOptions object leaves SELinux type and
+    # MCS category selection to the runtime. The webhook and cainjector blocks
+    # below carry the same two fields.
+    securityContext:
+      fsGroupChangePolicy: OnRootMismatch
     # Restricted PSS baseline: add runAsNonRoot to container SCs (chart leaves it unset, which fails validate-container-security).
     containerSecurityContext:
       allowPrivilegeEscalation: false
@@ -48,6 +58,7 @@ spec:
           - ALL
       readOnlyRootFilesystem: true
       runAsNonRoot: true
+      seLinuxOptions: {}
     replicaCount: ${cert_manager_replicas:=2}
     podDisruptionBudget:
       enabled: true
@@ -73,6 +84,8 @@ spec:
             app.kubernetes.io/instance: cert-manager
     webhook:
       replicaCount: ${cert_manager_replicas:=2}
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -80,6 +93,7 @@ spec:
             - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
+        seLinuxOptions: {}
       podDisruptionBudget:
         enabled: true
         # Stays minAvailable: 1 -- ksail bootstrap-installs cert-manager before
@@ -101,6 +115,8 @@ spec:
               app.kubernetes.io/instance: cert-manager
     cainjector:
       replicaCount: ${cert_manager_replicas:=2}
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -108,6 +124,7 @@ spec:
             - ALL
         readOnlyRootFilesystem: true
         runAsNonRoot: true
+        seLinuxOptions: {}
       podDisruptionBudget:
         enabled: true
         # Stays minAvailable: 1 -- ksail bootstrap-installs cert-manager before

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2097,8 +2097,9 @@ const (
 //
 // Moved again by the cert-manager C-0211 baseline context (#3239), derived on
 // main 1576b21c, whose approved aggregate is 59f51f17 above. cert-manager is
-// excluded from the add-security-context mutation, so the two inert fields are
-// supplied through the chart's own values. A HelmRelease is a controller-RBAC
+// excluded from add-security-context's pod and container rules, and the scan
+// reads the stored Deployment template rather than the mutated pod, so the two
+// inert fields are supplied through the chart's own values. A HelmRelease is a controller-RBAC
 // emitter, so a pure VALUES change moves this aggregate even though nothing is
 // granted.
 //

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -2090,7 +2090,39 @@ const (
 // aggregate. This host's renderer is unapproved, so no local digest is claimed.
 //
 // Previous aggregate: e36a3db7047b2b45855f6e3f2b25087dd4e56f74775bd08a5ba94efd3b86d300.
-const expectedRenderedSurfaceSHA = "59f51f1775bcded62ab018a6389ef11420b696a3b00357fc4424c4ab83935dba"
+//
+// That alert established aggregate:
+//
+//	59f51f1775bcded62ab018a6389ef11420b696a3b00357fc4424c4ab83935dba
+//
+// Moved again by the cert-manager C-0211 baseline context (#3239), derived on
+// main 1576b21c, whose approved aggregate is 59f51f17 above. cert-manager is
+// excluded from the add-security-context mutation, so the two inert fields are
+// supplied through the chart's own values. A HelmRelease is a controller-RBAC
+// emitter, so a pure VALUES change moves this aggregate even though nothing is
+// granted.
+//
+// CONSERVATION: exactly one existing document changes: the cert-manager/
+// cert-manager HelmRelease gains securityContext.fsGroupChangePolicy:
+// OnRootMismatch and containerSecurityContext.seLinuxOptions: {} for the
+// controller, webhook and cainjector. Rendering
+// k8s/providers/hetzner/infrastructure/controllers on this branch and on main
+// 1576b21c differs only in those nine value lines, and the grant-bearing
+// identity set (ClusterRole, Role, ClusterRoleBinding, RoleBinding,
+// ServiceAccount) is identical at 41 per side. Injecting one synthetic
+// ClusterRole into the branch render makes that comparison report it, so the
+// identical result is a finding rather than a blind read. No identity, binding,
+// ServiceAccount, verb, wildcard, AWS identity or permission changes; only the
+// cert-manager HelmRelease's unresolved-substitution fingerprint moves.
+//
+// RENDERER PROVENANCE: the value below was read from CI's own failure on job
+// 103698254744 at 7e970822, which renders under the approved SHA256-verified
+// kubectl v1.36.2 and reported ZERO missing and ZERO duplicate rendered
+// resources; its single unapproved entry was this aggregate. This host's
+// renderer is unapproved, so no local digest is claimed.
+//
+// Previous aggregate: 59f51f1775bcded62ab018a6389ef11420b696a3b00357fc4424c4ab83935dba.
+const expectedRenderedSurfaceSHA = "779dc0a75257fed54f4bc75cf1e1ebb5e4d47281fc900316e000b83ecd641aa0"
 
 // previousRenderedSurfaceSHA is the aggregate the approval above supersedes, in
 // machine-readable form. It is the base the approval was computed against.
@@ -2103,7 +2135,7 @@ const expectedRenderedSurfaceSHA = "59f51f1775bcded62ab018a6389ef11420b696a3b003
 // review as a plausible-looking constant. A change that does not move the
 // surface leaves both constants untouched. Reverting a re-approval is itself a
 // re-approval: restore the older aggregate and record the current one here.
-const previousRenderedSurfaceSHA = "e36a3db7047b2b45855f6e3f2b25087dd4e56f74775bd08a5ba94efd3b86d300"
+const previousRenderedSurfaceSHA = "59f51f1775bcded62ab018a6389ef11420b696a3b00357fc4424c4ab83935dba"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

cert-manager is exempt from the cluster's automatic security-context defaults, so its three workloads still miss two harmless C-0211 settings. Those gaps keep the security posture control failing for no benefit.

### What

Sets the two fields through cert-manager's own chart values for the controller, webhook and cainjector. Nothing about their privileges or identity changes. This is the next workload after the descheduler in the staged rollout.

⚠️ **Merge order:** CI will report a new approved authorization fingerprint, because any chart-values change moves it. That re-pin lands in this PR before it is promoted.

Part of #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
