### PR TITLE
fix(skills): hide vendored development skills from npx skills discovery

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -22,9 +22,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@a147ead8b8bc937fbfb1974e3698c7e32f95517d # v13.5.1
+    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@759ff9b2526cd1b142b49c5dc1616118a1ef44d9 # v13.6.0
     with:
       dir: .agents/skills
+      # These are development skills our own agents use, not skills the platform publishes.
+      # Marking them internal after every update keeps `npx skills add devantler-tech/platform`
+      # from offering them (devantler-tech/ksail#6221).
+      mark-internal: true
       # Create the update PR with a GitHub App token so it triggers this
       # repo's required CI (a PR opened with GITHUB_TOKEN does not), instead
       # of landing permanently blocked on missing required checks.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The platform keeps 13 third-party skills in its repository for our own agents. Tools that list a repository's skills, such as `npx skills add devantler-tech/platform`, offer them as if the platform published them.

### What

Turns on the skill updater's new option to mark those vendored skills as internal, which hides them from that listing. The updater re-applies the mark on every run, so it survives upstream changes, and our agents keep using the skills as before.

This changes only the daily skill-update workflow, not anything deployed to the cluster. The effect shows up in the next skill-update PR, which should add one `internal: true` line to each vendored skill.

Part of devantler-tech/ksail#6221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
