### PR TITLE
feat(dr): add a parity evaluator for the Wedding backup catalogue mirror

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,13 @@ jobs:
           go test ./scripts/validate-merge-group-heal
           go run ./scripts/validate-merge-group-heal .github/workflows/ci.yaml
 
+      # The Wedding backup catalogue must be proven complete before the database
+      # switches to its dedicated bucket. The evaluator's refusals (credential
+      # reuse, wrong destination, partial copy, source changed mid-run) are the
+      # only thing standing between a bad mirror and a cutover with no history.
+      - name: 💒 Validate Wedding backup mirror evaluator
+        run: go test ./scripts/mirror-wedding-backup-catalogue
+
       - name: 💾 Validate two-stage PVC retirement
         # A merge-group artifact is speculative, but a PVC deletion is not: its
         # deletionTimestamp survives queue eviction and main cannot undo it.

--- a/scripts/mirror-wedding-backup-catalogue/main.go
+++ b/scripts/mirror-wedding-backup-catalogue/main.go
@@ -22,21 +22,27 @@
 //
 // Usage:
 //
-//	mirror-wedding-backup-catalogue validate-plan <source-bucket>
-//	mirror-wedding-backup-catalogue evaluate <run-start> <source-before> <source-after> <destination>
+//	mirror-wedding-backup-catalogue validate-plan <source-bucket> <source-prefix> <source-secret> <destination-bucket> <destination-prefix> <destination-secret>
+//	mirror-wedding-backup-catalogue evaluate <run-start> <source-bucket> <source-before> <source-after> <destination>
+//
+// validate-plan takes the exact values the mirror job will use, so a typo in
+// any of them is refused rather than replaced by the reviewed value.
 //
 // <run-start> is an RFC 3339 timestamp taken before the starting listing. Each
 // listing is the `mc ls --json --recursive` output for the catalogue prefix,
 // with keys starting at the server directory, optionally carrying a "sha256"
 // field (64 lowercase hex characters) per object.
 //
-// Raw `mc ls` output has no terminal record, so a listing cut short is
-// indistinguishable from a complete one. The caller must therefore append one
-// completion record as the last line, and only after `mc ls` exits successfully:
+// Raw `mc ls` output has no terminal record and its keys carry no bucket, so a
+// listing cut short, or taken from the wrong bucket, is indistinguishable from
+// the right one. The caller must therefore append one completion record as the
+// last line, only after `mc ls` exits successfully, naming the bucket and
+// prefix it listed:
 //
-//	{"status":"success","type":"listing-complete","files":<number of file entries>}
+//	{"status":"success","type":"listing-complete","location":"<bucket>/<prefix>","files":<number of file entries>}
 //
-// A listing without that record, or whose count does not match, is refused.
+// A listing without that record, whose count does not match, or whose location
+// is not the one being evaluated, is refused.
 //
 // The result is a single non-secret JSON line: counts, the newest base backup,
 // and the newest WAL segment on each side.
@@ -76,7 +82,9 @@ var (
 	ErrIncompleteListing = errors.New("incomplete listing")
 	ErrEmptySource       = errors.New("empty source")
 	ErrNoBaseBackup      = errors.New("no base backup")
+	ErrNoArchivedWAL     = errors.New("no archived WAL")
 	ErrMalformedListing  = errors.New("malformed listing")
+	ErrListingLocation   = errors.New("listing from an unexpected location")
 )
 
 // Location is one side of the mirror: a bucket, the catalogue prefix inside it,
@@ -192,13 +200,19 @@ func EvaluateParity(runStart time.Time, before, after, destination []Object) (Su
 	if sourceBackup == "" {
 		return Summary{}, ErrNoBaseBackup
 	}
+	// A base backup only restores to a consistent state by replaying the WAL
+	// archived with it, so a catalogue without any is not recoverable history.
+	sourceWAL := newestWAL(beforeIndex)
+	if sourceWAL == "" {
+		return Summary{}, ErrNoArchivedWAL
+	}
 	return Summary{
 		SourceObjects:               len(beforeIndex),
 		MatchedObjects:              matched,
 		ExtraDestinationObjects:     len(destinationIndex) - matched,
 		SourceNewestBaseBackup:      sourceBackup,
 		DestinationNewestBaseBackup: newestBaseBackup(destinationIndex),
-		SourceNewestWAL:             newestWAL(beforeIndex),
+		SourceNewestWAL:             sourceWAL,
 		DestinationNewestWAL:        newestWAL(destinationIndex),
 	}, nil
 }
@@ -286,6 +300,7 @@ type listingEntry struct {
 	SHA256       string `json:"sha256"`
 	LastModified string `json:"lastModified"`
 	Files        *int   `json:"files"`
+	Location     string `json:"location"`
 }
 
 // ParseListing reads `mc ls --json --recursive` output ending in a completion
@@ -294,7 +309,7 @@ type listingEntry struct {
 // must start at the Barman server directory, so a listing rooted one level too
 // high or too low is reported as malformed rather than as a catalogue with no
 // backups.
-func ParseListing(r io.Reader) ([]Object, error) {
+func ParseListing(r io.Reader, location string) ([]Object, error) {
 	var objects []Object
 	complete := false
 	scanner := bufio.NewScanner(r)
@@ -320,6 +335,9 @@ func ParseListing(r io.Reader) ([]Object, error) {
 		case "listing-complete":
 			if entry.Files == nil {
 				return nil, fmt.Errorf("%w: completion record without a file count", ErrIncompleteListing)
+			}
+			if location == "" || entry.Location != location {
+				return nil, fmt.Errorf("%w: listed %q, want %q", ErrListingLocation, entry.Location, location)
 			}
 			if *entry.Files < 0 {
 				return nil, fmt.Errorf("%w: negative completion count", ErrMalformedListing)
@@ -365,12 +383,12 @@ func catalogueKey(key string) bool {
 }
 
 // readListing parses one listing file named on the command line.
-func readListing(name string) ([]Object, error) {
+func readListing(name, location string) ([]Object, error) {
 	file, err := os.Open(name)
 	if err != nil {
 		return nil, err
 	}
-	objects, parseErr := ParseListing(file)
+	objects, parseErr := ParseListing(file, location)
 	if closeErr := file.Close(); closeErr != nil && parseErr == nil {
 		return nil, closeErr
 	}
@@ -379,20 +397,28 @@ func readListing(name string) ([]Object, error) {
 
 // run dispatches the command line and writes the summary for a passing evaluation.
 func run(args []string, stdout io.Writer) error {
-	if len(args) == 2 && args[0] == "validate-plan" {
+	if len(args) == 7 && args[0] == "validate-plan" {
 		return ValidatePlan(Plan{
-			Source:      Location{Bucket: args[1], Prefix: sourcePrefix, Secret: sourceSecret},
-			Destination: Location{Bucket: destinationBucket, Prefix: destinationPrefix, Secret: destinationSecret},
+			Source:      Location{Bucket: args[1], Prefix: args[2], Secret: args[3]},
+			Destination: Location{Bucket: args[4], Prefix: args[5], Secret: args[6]},
 		})
 	}
-	if len(args) == 5 && args[0] == "evaluate" {
+	if len(args) == 6 && args[0] == "evaluate" {
 		runStart, err := time.Parse(time.RFC3339Nano, args[1])
 		if err != nil {
 			return fmt.Errorf("%w: run start: %w", ErrMalformedListing, err)
 		}
+		if args[2] == "" || args[2] == destinationBucket {
+			return fmt.Errorf("%w: source bucket %q", ErrWrongSource, args[2])
+		}
+		locations := []string{
+			args[2] + "/" + sourcePrefix,
+			args[2] + "/" + sourcePrefix,
+			destinationBucket + "/" + destinationPrefix,
+		}
 		listings := make([][]Object, 0, 3)
-		for _, name := range args[2:] {
-			objects, err := readListing(name)
+		for i, name := range args[3:] {
+			objects, err := readListing(name, locations[i])
 			if err != nil {
 				return fmt.Errorf("%s: %w", name, err)
 			}
@@ -404,7 +430,7 @@ func run(args []string, stdout io.Writer) error {
 		}
 		return json.NewEncoder(stdout).Encode(summary)
 	}
-	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> | evaluate <run-start> <source-before> <source-after> <destination>")
+	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> <source-prefix> <source-secret> <destination-bucket> <destination-prefix> <destination-secret> | evaluate <run-start> <source-bucket> <source-before> <source-after> <destination>")
 }
 
 // main exits non-zero with the refusal reason when a plan or mirror is not trusted.

--- a/scripts/mirror-wedding-backup-catalogue/main.go
+++ b/scripts/mirror-wedding-backup-catalogue/main.go
@@ -10,8 +10,9 @@
 //
 //   - the plan reads with the shared credential and writes with the dedicated
 //     one, to exactly the reviewed destination;
-//   - the listing taken when the run started is complete, and every object in
-//     it is unchanged when the run ends; and
+//   - every listing is proven complete, the listing taken when the run started
+//     misses nothing that already existed, and every object in it is unchanged
+//     when the run ends; and
 //   - every one of those objects exists in the destination with a matching size
 //     and content checksum.
 //
@@ -27,8 +28,18 @@
 // <run-start> is an RFC 3339 timestamp taken before the starting listing. Each
 // listing is the `mc ls --json --recursive` output for the catalogue prefix,
 // with keys starting at the server directory, optionally carrying a "sha256"
-// field per object. The result is a single non-secret JSON line: counts, the
-// newest base backup, and the newest WAL segment on each side.
+// field (64 lowercase hex characters) per object.
+//
+// Raw `mc ls` output has no terminal record, so a listing cut short is
+// indistinguishable from a complete one. The caller must therefore append one
+// completion record as the last line, and only after `mc ls` exits successfully:
+//
+//	{"status":"success","type":"listing-complete","files":<number of file entries>}
+//
+// A listing without that record, or whose count does not match, is refused.
+//
+// The result is a single non-secret JSON line: counts, the newest base backup,
+// and the newest WAL segment on each side.
 package main
 
 import (
@@ -44,6 +55,8 @@ import (
 	"time"
 )
 
+// These name the reviewed locations. The Secret values are Kubernetes Secret
+// names, not credentials.
 const (
 	sourcePrefix      = "cnpg/wedding-db"
 	sourceSecret      = "wedding-db-backup-r2"
@@ -60,7 +73,7 @@ var (
 	ErrChecksumMismatch  = errors.New("checksum mismatch")
 	ErrUnverifiable      = errors.New("unverifiable object")
 	ErrSourceChanged     = errors.New("source changed during the run")
-	ErrIncompleteListing = errors.New("incomplete starting listing")
+	ErrIncompleteListing = errors.New("incomplete listing")
 	ErrEmptySource       = errors.New("empty source")
 	ErrNoBaseBackup      = errors.New("no base backup")
 	ErrMalformedListing  = errors.New("malformed listing")
@@ -125,6 +138,7 @@ func ValidatePlan(plan Plan) error {
 var (
 	walSegment = regexp.MustCompile(`^[0-9A-F]{24}$`)
 	backupID   = regexp.MustCompile(`^[0-9]{8}T[0-9]{6}$`)
+	sha256Hex  = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 
 // EvaluateParity proves that the starting listing was complete, that every
@@ -210,10 +224,12 @@ func sameContent(source, copied Object) error {
 	return nil
 }
 
+// isMultipart reports whether an ETag has the "<hash>-<parts>" multipart form.
 func isMultipart(etag string) bool {
 	return strings.Contains(etag, "-")
 }
 
+// index keys objects by name and refuses a listing that names an object twice.
 func index(objects []Object) (map[string]Object, error) {
 	result := make(map[string]Object, len(objects))
 	for _, object := range objects {
@@ -259,6 +275,8 @@ func newestWAL(objects map[string]Object) string {
 	return newest
 }
 
+// listingEntry is one line of a listing: an mc object or folder record, or the
+// caller's completion record.
 type listingEntry struct {
 	Status       string `json:"status"`
 	Type         string `json:"type"`
@@ -267,15 +285,18 @@ type listingEntry struct {
 	ETag         string `json:"etag"`
 	SHA256       string `json:"sha256"`
 	LastModified string `json:"lastModified"`
+	Files        *int   `json:"files"`
 }
 
-// ParseListing reads `mc ls --json --recursive` output. Any entry that is not a
-// clean success is refused, because a silently skipped object would make a
-// partial listing look like a complete one. Keys must start at the Barman
-// server directory, so a listing rooted one level too high or too low is
-// reported as malformed rather than as a catalogue with no backups.
+// ParseListing reads `mc ls --json --recursive` output ending in a completion
+// record. Any entry that is not a clean success is refused, because a silently
+// skipped object would make a partial listing look like a complete one. Keys
+// must start at the Barman server directory, so a listing rooted one level too
+// high or too low is reported as malformed rather than as a catalogue with no
+// backups.
 func ParseListing(r io.Reader) ([]Object, error) {
 	var objects []Object
+	complete := false
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
@@ -283,19 +304,37 @@ func ParseListing(r io.Reader) ([]Object, error) {
 		if line == "" {
 			continue
 		}
+		if complete {
+			return nil, fmt.Errorf("%w: record after the completion record", ErrMalformedListing)
+		}
 		var entry listingEntry
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrMalformedListing, err)
+			return nil, fmt.Errorf("%w: %w", ErrMalformedListing, err)
 		}
 		if entry.Status != "success" {
 			return nil, fmt.Errorf("%w: status %q", ErrMalformedListing, entry.Status)
 		}
-		if entry.Type == "folder" {
+		switch entry.Type {
+		case "folder":
+			continue
+		case "listing-complete":
+			if entry.Files == nil {
+				return nil, fmt.Errorf("%w: completion record without a file count", ErrIncompleteListing)
+			}
+			if *entry.Files < 0 {
+				return nil, fmt.Errorf("%w: negative completion count", ErrMalformedListing)
+			}
+			if *entry.Files != len(objects) {
+				return nil, fmt.Errorf("%w: completion record counts %d files, listing has %d",
+					ErrIncompleteListing, *entry.Files, len(objects))
+			}
+			complete = true
 			continue
 		}
 		modified, err := time.Parse(time.RFC3339Nano, entry.LastModified)
 		if entry.Type != "file" || entry.Size == nil || *entry.Size < 0 || entry.ETag == "" ||
-			err != nil || !catalogueKey(entry.Key) {
+			err != nil || !catalogueKey(entry.Key) ||
+			(entry.SHA256 != "" && !sha256Hex.MatchString(entry.SHA256)) {
 			return nil, fmt.Errorf("%w: entry %q", ErrMalformedListing, entry.Key)
 		}
 		objects = append(objects, Object{
@@ -307,7 +346,10 @@ func ParseListing(r io.Reader) ([]Object, error) {
 		})
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrMalformedListing, err)
+		return nil, fmt.Errorf("%w: %w", ErrMalformedListing, err)
+	}
+	if !complete {
+		return nil, fmt.Errorf("%w: no completion record", ErrIncompleteListing)
 	}
 	return objects, nil
 }
@@ -322,15 +364,20 @@ func catalogueKey(key string) bool {
 	return len(parts) >= 3 && parts[0] != "" && (parts[1] == "base" || parts[1] == "wals")
 }
 
+// readListing parses one listing file named on the command line.
 func readListing(name string) ([]Object, error) {
 	file, err := os.Open(name)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
-	return ParseListing(file)
+	objects, parseErr := ParseListing(file)
+	if closeErr := file.Close(); closeErr != nil && parseErr == nil {
+		return nil, closeErr
+	}
+	return objects, parseErr
 }
 
+// run dispatches the command line and writes the summary for a passing evaluation.
 func run(args []string, stdout io.Writer) error {
 	if len(args) == 2 && args[0] == "validate-plan" {
 		return ValidatePlan(Plan{
@@ -341,13 +388,13 @@ func run(args []string, stdout io.Writer) error {
 	if len(args) == 5 && args[0] == "evaluate" {
 		runStart, err := time.Parse(time.RFC3339Nano, args[1])
 		if err != nil {
-			return fmt.Errorf("%w: run start: %v", ErrMalformedListing, err)
+			return fmt.Errorf("%w: run start: %w", ErrMalformedListing, err)
 		}
 		listings := make([][]Object, 0, 3)
 		for _, name := range args[2:] {
 			objects, err := readListing(name)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", name, err)
 			}
 			listings = append(listings, objects)
 		}
@@ -360,6 +407,7 @@ func run(args []string, stdout io.Writer) error {
 	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> | evaluate <run-start> <source-before> <source-after> <destination>")
 }
 
+// main exits non-zero with the refusal reason when a plan or mirror is not trusted.
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, "mirror-wedding-backup-catalogue:", err)

--- a/scripts/mirror-wedding-backup-catalogue/main.go
+++ b/scripts/mirror-wedding-backup-catalogue/main.go
@@ -10,21 +10,25 @@
 //
 //   - the plan reads with the shared credential and writes with the dedicated
 //     one, to exactly the reviewed destination;
-//   - every object present when the run started is unchanged when it ends; and
+//   - the listing taken when the run started is complete, and every object in
+//     it is unchanged when the run ends; and
 //   - every one of those objects exists in the destination with a matching size
 //     and content checksum.
 //
-// Objects archived during the run are expected and left to the next pass.
+// Objects archived after the run started are expected and left to the next
+// pass. An object that is missing from the starting listing but was written
+// before the run started proves that listing was incomplete, so it is refused.
 //
 // Usage:
 //
 //	mirror-wedding-backup-catalogue validate-plan <source-bucket>
-//	mirror-wedding-backup-catalogue evaluate <source-before> <source-after> <destination>
+//	mirror-wedding-backup-catalogue evaluate <run-start> <source-before> <source-after> <destination>
 //
-// Each listing is the `mc ls --json --recursive` output for the catalogue
-// prefix, optionally carrying a "sha256" field per object. The result is a
-// single non-secret JSON line: counts, the newest base backup, and the newest
-// WAL segment on each side.
+// <run-start> is an RFC 3339 timestamp taken before the starting listing. Each
+// listing is the `mc ls --json --recursive` output for the catalogue prefix,
+// with keys starting at the server directory, optionally carrying a "sha256"
+// field per object. The result is a single non-secret JSON line: counts, the
+// newest base backup, and the newest WAL segment on each side.
 package main
 
 import (
@@ -37,6 +41,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
@@ -48,16 +53,17 @@ const (
 )
 
 var (
-	ErrCredentialReuse  = errors.New("credential reuse")
-	ErrWrongDestination = errors.New("wrong destination")
-	ErrWrongSource      = errors.New("wrong source")
-	ErrPartialCopy      = errors.New("partial copy")
-	ErrChecksumMismatch = errors.New("checksum mismatch")
-	ErrUnverifiable     = errors.New("unverifiable object")
-	ErrSourceChanged    = errors.New("source changed during the run")
-	ErrEmptySource      = errors.New("empty source")
-	ErrNoBaseBackup     = errors.New("no base backup")
-	ErrMalformedListing = errors.New("malformed listing")
+	ErrCredentialReuse   = errors.New("credential reuse")
+	ErrWrongDestination  = errors.New("wrong destination")
+	ErrWrongSource       = errors.New("wrong source")
+	ErrPartialCopy       = errors.New("partial copy")
+	ErrChecksumMismatch  = errors.New("checksum mismatch")
+	ErrUnverifiable      = errors.New("unverifiable object")
+	ErrSourceChanged     = errors.New("source changed during the run")
+	ErrIncompleteListing = errors.New("incomplete starting listing")
+	ErrEmptySource       = errors.New("empty source")
+	ErrNoBaseBackup      = errors.New("no base backup")
+	ErrMalformedListing  = errors.New("malformed listing")
 )
 
 // Location is one side of the mirror: a bucket, the catalogue prefix inside it,
@@ -76,10 +82,11 @@ type Plan struct {
 
 // Object is one listed catalogue object, keyed relative to the catalogue prefix.
 type Object struct {
-	Key    string
-	Size   int64
-	ETag   string
-	SHA256 string
+	Key          string
+	Size         int64
+	ETag         string
+	SHA256       string
+	LastModified time.Time
 }
 
 // Summary is the non-secret evidence a successful evaluation reports.
@@ -120,9 +127,12 @@ var (
 	backupID   = regexp.MustCompile(`^[0-9]{8}T[0-9]{6}$`)
 )
 
-// EvaluateParity proves that every object present when the run started is
-// unchanged at the end and was copied intact.
-func EvaluateParity(before, after, destination []Object) (Summary, error) {
+// EvaluateParity proves that the starting listing was complete, that every
+// object in it is unchanged at the end, and that each was copied intact.
+func EvaluateParity(runStart time.Time, before, after, destination []Object) (Summary, error) {
+	if runStart.IsZero() {
+		return Summary{}, fmt.Errorf("%w: no run start", ErrMalformedListing)
+	}
 	beforeIndex, err := index(before)
 	if err != nil {
 		return Summary{}, err
@@ -142,8 +152,13 @@ func EvaluateParity(before, after, destination []Object) (Summary, error) {
 	for key, source := range beforeIndex {
 		current, ok := afterIndex[key]
 		if !ok || current.Size != source.Size || current.ETag != source.ETag ||
-			current.SHA256 != source.SHA256 {
+			(current.SHA256 != "" && source.SHA256 != "" && current.SHA256 != source.SHA256) {
 			return Summary{}, fmt.Errorf("%w: %s", ErrSourceChanged, key)
+		}
+	}
+	for key, current := range afterIndex {
+		if _, ok := beforeIndex[key]; !ok && !current.LastModified.After(runStart) {
+			return Summary{}, fmt.Errorf("%w: %s predates the run", ErrIncompleteListing, key)
 		}
 	}
 
@@ -245,17 +260,20 @@ func newestWAL(objects map[string]Object) string {
 }
 
 type listingEntry struct {
-	Status string `json:"status"`
-	Type   string `json:"type"`
-	Size   *int64 `json:"size"`
-	Key    string `json:"key"`
-	ETag   string `json:"etag"`
-	SHA256 string `json:"sha256"`
+	Status       string `json:"status"`
+	Type         string `json:"type"`
+	Size         *int64 `json:"size"`
+	Key          string `json:"key"`
+	ETag         string `json:"etag"`
+	SHA256       string `json:"sha256"`
+	LastModified string `json:"lastModified"`
 }
 
 // ParseListing reads `mc ls --json --recursive` output. Any entry that is not a
 // clean success is refused, because a silently skipped object would make a
-// partial listing look like a complete one.
+// partial listing look like a complete one. Keys must start at the Barman
+// server directory, so a listing rooted one level too high or too low is
+// reported as malformed rather than as a catalogue with no backups.
 func ParseListing(r io.Reader) ([]Object, error) {
 	var objects []Object
 	scanner := bufio.NewScanner(r)
@@ -275,11 +293,18 @@ func ParseListing(r io.Reader) ([]Object, error) {
 		if entry.Type == "folder" {
 			continue
 		}
+		modified, err := time.Parse(time.RFC3339Nano, entry.LastModified)
 		if entry.Type != "file" || entry.Size == nil || *entry.Size < 0 || entry.ETag == "" ||
-			!cleanKey(entry.Key) {
+			err != nil || !catalogueKey(entry.Key) {
 			return nil, fmt.Errorf("%w: entry %q", ErrMalformedListing, entry.Key)
 		}
-		objects = append(objects, Object{Key: entry.Key, Size: *entry.Size, ETag: entry.ETag, SHA256: entry.SHA256})
+		objects = append(objects, Object{
+			Key:          entry.Key,
+			Size:         *entry.Size,
+			ETag:         entry.ETag,
+			SHA256:       entry.SHA256,
+			LastModified: modified,
+		})
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrMalformedListing, err)
@@ -287,8 +312,14 @@ func ParseListing(r io.Reader) ([]Object, error) {
 	return objects, nil
 }
 
-func cleanKey(key string) bool {
-	return key != "" && !strings.HasPrefix(key, "/") && path.Clean(key) == key
+// catalogueKey accepts a clean relative key of the form
+// <server>/base/... or <server>/wals/..., the only trees Barman Cloud writes.
+func catalogueKey(key string) bool {
+	if key == "" || strings.HasPrefix(key, "/") || path.Clean(key) != key {
+		return false
+	}
+	parts := strings.Split(key, "/")
+	return len(parts) >= 3 && parts[0] != "" && (parts[1] == "base" || parts[1] == "wals")
 }
 
 func readListing(name string) ([]Object, error) {
@@ -307,22 +338,26 @@ func run(args []string, stdout io.Writer) error {
 			Destination: Location{Bucket: destinationBucket, Prefix: destinationPrefix, Secret: destinationSecret},
 		})
 	}
-	if len(args) == 4 && args[0] == "evaluate" {
+	if len(args) == 5 && args[0] == "evaluate" {
+		runStart, err := time.Parse(time.RFC3339Nano, args[1])
+		if err != nil {
+			return fmt.Errorf("%w: run start: %v", ErrMalformedListing, err)
+		}
 		listings := make([][]Object, 0, 3)
-		for _, name := range args[1:] {
+		for _, name := range args[2:] {
 			objects, err := readListing(name)
 			if err != nil {
 				return err
 			}
 			listings = append(listings, objects)
 		}
-		summary, err := EvaluateParity(listings[0], listings[1], listings[2])
+		summary, err := EvaluateParity(runStart, listings[0], listings[1], listings[2])
 		if err != nil {
 			return err
 		}
 		return json.NewEncoder(stdout).Encode(summary)
 	}
-	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> | evaluate <source-before> <source-after> <destination>")
+	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> | evaluate <run-start> <source-before> <source-after> <destination>")
 }
 
 func main() {

--- a/scripts/mirror-wedding-backup-catalogue/main.go
+++ b/scripts/mirror-wedding-backup-catalogue/main.go
@@ -1,0 +1,333 @@
+// Command mirror-wedding-backup-catalogue decides whether a mirror of the
+// shared Wedding backup catalogue into its dedicated bucket can be trusted.
+//
+// The dedicated bucket must hold the full recoverable history before the
+// wedding-db Cluster switches its archive reference, or the new archive starts
+// with no base backup to restore from. Copying needs two identities, because
+// each R2 credential is scoped to its own bucket, and the shared catalogue keeps
+// receiving WAL until the switch. Every part of that is easy to get silently
+// wrong, so the mirror is only accepted when:
+//
+//   - the plan reads with the shared credential and writes with the dedicated
+//     one, to exactly the reviewed destination;
+//   - every object present when the run started is unchanged when it ends; and
+//   - every one of those objects exists in the destination with a matching size
+//     and content checksum.
+//
+// Objects archived during the run are expected and left to the next pass.
+//
+// Usage:
+//
+//	mirror-wedding-backup-catalogue validate-plan <source-bucket>
+//	mirror-wedding-backup-catalogue evaluate <source-before> <source-after> <destination>
+//
+// Each listing is the `mc ls --json --recursive` output for the catalogue
+// prefix, optionally carrying a "sha256" field per object. The result is a
+// single non-secret JSON line: counts, the newest base backup, and the newest
+// WAL segment on each side.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const (
+	sourcePrefix      = "cnpg/wedding-db"
+	sourceSecret      = "wedding-db-backup-r2"
+	destinationBucket = "wedding-db-backups"
+	destinationPrefix = "cnpg/wedding-db"
+	destinationSecret = "wedding-db-backup-r2-dedicated"
+)
+
+var (
+	ErrCredentialReuse  = errors.New("credential reuse")
+	ErrWrongDestination = errors.New("wrong destination")
+	ErrWrongSource      = errors.New("wrong source")
+	ErrPartialCopy      = errors.New("partial copy")
+	ErrChecksumMismatch = errors.New("checksum mismatch")
+	ErrUnverifiable     = errors.New("unverifiable object")
+	ErrSourceChanged    = errors.New("source changed during the run")
+	ErrEmptySource      = errors.New("empty source")
+	ErrNoBaseBackup     = errors.New("no base backup")
+	ErrMalformedListing = errors.New("malformed listing")
+)
+
+// Location is one side of the mirror: a bucket, the catalogue prefix inside it,
+// and the name of the namespace Secret holding the credential for that bucket.
+type Location struct {
+	Bucket string
+	Prefix string
+	Secret string
+}
+
+// Plan is the pair of locations a mirror run reads from and writes to.
+type Plan struct {
+	Source      Location
+	Destination Location
+}
+
+// Object is one listed catalogue object, keyed relative to the catalogue prefix.
+type Object struct {
+	Key    string
+	Size   int64
+	ETag   string
+	SHA256 string
+}
+
+// Summary is the non-secret evidence a successful evaluation reports.
+type Summary struct {
+	SourceObjects               int    `json:"sourceObjects"`
+	MatchedObjects              int    `json:"matchedObjects"`
+	ExtraDestinationObjects     int    `json:"extraDestinationObjects"`
+	SourceNewestBaseBackup      string `json:"sourceNewestBaseBackup"`
+	DestinationNewestBaseBackup string `json:"destinationNewestBaseBackup"`
+	SourceNewestWAL             string `json:"sourceNewestWal"`
+	DestinationNewestWAL        string `json:"destinationNewestWal"`
+}
+
+// ValidatePlan refuses any plan other than the reviewed one. The source bucket
+// is the only free value, because the shared bucket name is a cluster variable.
+func ValidatePlan(plan Plan) error {
+	if plan.Source.Secret == plan.Destination.Secret ||
+		plan.Source.Secret == destinationSecret ||
+		plan.Destination.Secret == sourceSecret {
+		return ErrCredentialReuse
+	}
+	if plan.Destination.Bucket != destinationBucket ||
+		plan.Destination.Prefix != destinationPrefix ||
+		plan.Destination.Secret != destinationSecret ||
+		plan.Source.Bucket == plan.Destination.Bucket {
+		return ErrWrongDestination
+	}
+	if plan.Source.Bucket == "" ||
+		plan.Source.Prefix != sourcePrefix ||
+		plan.Source.Secret != sourceSecret {
+		return ErrWrongSource
+	}
+	return nil
+}
+
+var (
+	walSegment = regexp.MustCompile(`^[0-9A-F]{24}$`)
+	backupID   = regexp.MustCompile(`^[0-9]{8}T[0-9]{6}$`)
+)
+
+// EvaluateParity proves that every object present when the run started is
+// unchanged at the end and was copied intact.
+func EvaluateParity(before, after, destination []Object) (Summary, error) {
+	beforeIndex, err := index(before)
+	if err != nil {
+		return Summary{}, err
+	}
+	afterIndex, err := index(after)
+	if err != nil {
+		return Summary{}, err
+	}
+	destinationIndex, err := index(destination)
+	if err != nil {
+		return Summary{}, err
+	}
+	if len(beforeIndex) == 0 {
+		return Summary{}, ErrEmptySource
+	}
+
+	for key, source := range beforeIndex {
+		current, ok := afterIndex[key]
+		if !ok || current.Size != source.Size || current.ETag != source.ETag ||
+			current.SHA256 != source.SHA256 {
+			return Summary{}, fmt.Errorf("%w: %s", ErrSourceChanged, key)
+		}
+	}
+
+	matched := 0
+	for key, source := range beforeIndex {
+		copied, ok := destinationIndex[key]
+		if !ok || copied.Size != source.Size {
+			return Summary{}, fmt.Errorf("%w: %s", ErrPartialCopy, key)
+		}
+		if err := sameContent(source, copied); err != nil {
+			return Summary{}, fmt.Errorf("%w: %s", err, key)
+		}
+		matched++
+	}
+
+	sourceBackup := newestBaseBackup(beforeIndex)
+	if sourceBackup == "" {
+		return Summary{}, ErrNoBaseBackup
+	}
+	return Summary{
+		SourceObjects:               len(beforeIndex),
+		MatchedObjects:              matched,
+		ExtraDestinationObjects:     len(destinationIndex) - matched,
+		SourceNewestBaseBackup:      sourceBackup,
+		DestinationNewestBaseBackup: newestBaseBackup(destinationIndex),
+		SourceNewestWAL:             newestWAL(beforeIndex),
+		DestinationNewestWAL:        newestWAL(destinationIndex),
+	}, nil
+}
+
+// sameContent compares a content digest when both sides carry one. Otherwise
+// it falls back to the ETag, which is a content MD5 only for a single-part
+// upload: a multipart ETag depends on how the object was split, so identical
+// bytes can differ and different bytes cannot be told apart. That case is
+// refused rather than accepted on size alone.
+func sameContent(source, copied Object) error {
+	if source.SHA256 != "" && copied.SHA256 != "" {
+		if source.SHA256 != copied.SHA256 {
+			return ErrChecksumMismatch
+		}
+		return nil
+	}
+	if isMultipart(source.ETag) || isMultipart(copied.ETag) {
+		return ErrUnverifiable
+	}
+	if source.ETag != copied.ETag {
+		return ErrChecksumMismatch
+	}
+	return nil
+}
+
+func isMultipart(etag string) bool {
+	return strings.Contains(etag, "-")
+}
+
+func index(objects []Object) (map[string]Object, error) {
+	result := make(map[string]Object, len(objects))
+	for _, object := range objects {
+		if _, seen := result[object.Key]; seen {
+			return nil, fmt.Errorf("%w: duplicate key %s", ErrMalformedListing, object.Key)
+		}
+		result[object.Key] = object
+	}
+	return result, nil
+}
+
+// newestBaseBackup returns "<server>/<backup ID>" for the latest base backup,
+// identified by its backup.info file in the Barman Cloud layout.
+func newestBaseBackup(objects map[string]Object) string {
+	newest, newestID := "", ""
+	for key := range objects {
+		parts := strings.Split(key, "/")
+		if len(parts) != 4 || parts[1] != "base" || parts[3] != "backup.info" ||
+			!backupID.MatchString(parts[2]) {
+			continue
+		}
+		if parts[2] > newestID || (parts[2] == newestID && parts[0]+"/"+parts[2] > newest) {
+			newest, newestID = parts[0]+"/"+parts[2], parts[2]
+		}
+	}
+	return newest
+}
+
+// newestWAL returns the highest WAL segment name. Segment names order by
+// timeline and then position, so the lexical maximum is the newest segment.
+func newestWAL(objects map[string]Object) string {
+	newest := ""
+	for key := range objects {
+		parts := strings.Split(key, "/")
+		if len(parts) != 4 || parts[1] != "wals" {
+			continue
+		}
+		segment := strings.TrimSuffix(parts[3], ".gz")
+		if walSegment.MatchString(segment) && segment > newest {
+			newest = segment
+		}
+	}
+	return newest
+}
+
+type listingEntry struct {
+	Status string `json:"status"`
+	Type   string `json:"type"`
+	Size   *int64 `json:"size"`
+	Key    string `json:"key"`
+	ETag   string `json:"etag"`
+	SHA256 string `json:"sha256"`
+}
+
+// ParseListing reads `mc ls --json --recursive` output. Any entry that is not a
+// clean success is refused, because a silently skipped object would make a
+// partial listing look like a complete one.
+func ParseListing(r io.Reader) ([]Object, error) {
+	var objects []Object
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry listingEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrMalformedListing, err)
+		}
+		if entry.Status != "success" {
+			return nil, fmt.Errorf("%w: status %q", ErrMalformedListing, entry.Status)
+		}
+		if entry.Type == "folder" {
+			continue
+		}
+		if entry.Type != "file" || entry.Size == nil || *entry.Size < 0 || entry.ETag == "" ||
+			!cleanKey(entry.Key) {
+			return nil, fmt.Errorf("%w: entry %q", ErrMalformedListing, entry.Key)
+		}
+		objects = append(objects, Object{Key: entry.Key, Size: *entry.Size, ETag: entry.ETag, SHA256: entry.SHA256})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrMalformedListing, err)
+	}
+	return objects, nil
+}
+
+func cleanKey(key string) bool {
+	return key != "" && !strings.HasPrefix(key, "/") && path.Clean(key) == key
+}
+
+func readListing(name string) ([]Object, error) {
+	file, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return ParseListing(file)
+}
+
+func run(args []string, stdout io.Writer) error {
+	if len(args) == 2 && args[0] == "validate-plan" {
+		return ValidatePlan(Plan{
+			Source:      Location{Bucket: args[1], Prefix: sourcePrefix, Secret: sourceSecret},
+			Destination: Location{Bucket: destinationBucket, Prefix: destinationPrefix, Secret: destinationSecret},
+		})
+	}
+	if len(args) == 4 && args[0] == "evaluate" {
+		listings := make([][]Object, 0, 3)
+		for _, name := range args[1:] {
+			objects, err := readListing(name)
+			if err != nil {
+				return err
+			}
+			listings = append(listings, objects)
+		}
+		summary, err := EvaluateParity(listings[0], listings[1], listings[2])
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(stdout).Encode(summary)
+	}
+	return errors.New("usage: mirror-wedding-backup-catalogue validate-plan <source-bucket> | evaluate <source-before> <source-after> <destination>")
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "mirror-wedding-backup-catalogue:", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/mirror-wedding-backup-catalogue/main_test.go
+++ b/scripts/mirror-wedding-backup-catalogue/main_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func validPlan() Plan {
@@ -59,14 +60,21 @@ const (
 	baseData = "wedding-db-20260909/base/20260908T030000/data.tar.gz"
 	olderWAL = "wedding-db-20260909/wals/0000000200000001/000000020000000100000003.gz"
 	newerWAL = "wedding-db-20260909/wals/0000000300000001/000000030000000100000001.gz"
+	lateWAL  = "wedding-db-20260909/wals/0000000300000001/000000030000000100000002.gz"
+)
+
+var (
+	runStart     = time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
+	beforeRun    = runStart.Add(-24 * time.Hour)
+	duringTheRun = runStart.Add(5 * time.Minute)
 )
 
 func sourceListing() []Object {
 	return []Object{
-		{Key: baseInfo, Size: 1200, ETag: "a1"},
-		{Key: baseData, Size: 90_000_000, ETag: "b2-6", SHA256: "sha-data"},
-		{Key: olderWAL, Size: 4000, ETag: "c3"},
-		{Key: newerWAL, Size: 4100, ETag: "d4"},
+		{Key: baseInfo, Size: 1200, ETag: "a1", LastModified: beforeRun},
+		{Key: baseData, Size: 90_000_000, ETag: "b2-6", SHA256: "sha-data", LastModified: beforeRun},
+		{Key: olderWAL, Size: 4000, ETag: "c3", LastModified: beforeRun},
+		{Key: newerWAL, Size: 4100, ETag: "d4", LastModified: beforeRun},
 	}
 }
 
@@ -74,15 +82,15 @@ func sourceListing() []Object {
 // destination carries a different multipart ETag for identical bytes.
 func destinationListing() []Object {
 	return []Object{
-		{Key: baseInfo, Size: 1200, ETag: "a1"},
-		{Key: baseData, Size: 90_000_000, ETag: "ff-4", SHA256: "sha-data"},
-		{Key: olderWAL, Size: 4000, ETag: "c3"},
-		{Key: newerWAL, Size: 4100, ETag: "d4"},
+		{Key: baseInfo, Size: 1200, ETag: "a1", LastModified: duringTheRun},
+		{Key: baseData, Size: 90_000_000, ETag: "ff-4", SHA256: "sha-data", LastModified: duringTheRun},
+		{Key: olderWAL, Size: 4000, ETag: "c3", LastModified: duringTheRun},
+		{Key: newerWAL, Size: 4100, ETag: "d4", LastModified: duringTheRun},
 	}
 }
 
 func TestEvaluateParityProvesAFullCopy(t *testing.T) {
-	summary, err := EvaluateParity(sourceListing(), sourceListing(), destinationListing())
+	summary, err := EvaluateParity(runStart, sourceListing(), sourceListing(), destinationListing())
 	if err != nil {
 		t.Fatalf("EvaluateParity() = %v, want nil", err)
 	}
@@ -103,8 +111,8 @@ func TestEvaluateParityProvesAFullCopy(t *testing.T) {
 // WAL keeps archiving to the shared store until the cutover, so objects that
 // appear during the run are expected and only need to be copied by a later pass.
 func TestEvaluateParityAllowsObjectsArchivedDuringTheRun(t *testing.T) {
-	after := append(sourceListing(), Object{Key: "wedding-db-20260909/wals/0000000300000001/000000030000000100000002.gz", Size: 4200, ETag: "e5"})
-	summary, err := EvaluateParity(sourceListing(), after, destinationListing())
+	after := append(sourceListing(), Object{Key: lateWAL, Size: 4200, ETag: "e5", LastModified: duringTheRun})
+	summary, err := EvaluateParity(runStart, sourceListing(), after, destinationListing())
 	if err != nil {
 		t.Fatalf("EvaluateParity() = %v, want nil", err)
 	}
@@ -113,9 +121,20 @@ func TestEvaluateParityAllowsObjectsArchivedDuringTheRun(t *testing.T) {
 	}
 }
 
+// A digest computed on only one of the two source listings says nothing about
+// whether the object changed; size and ETag still do.
+func TestEvaluateParityIgnoresADigestPresentOnOneSourceListing(t *testing.T) {
+	after := sourceListing()
+	after[0].SHA256 = "sha-info"
+	if _, err := EvaluateParity(runStart, sourceListing(), after, destinationListing()); err != nil {
+		t.Fatalf("EvaluateParity() = %v, want nil", err)
+	}
+}
+
 func TestEvaluateParityRefusals(t *testing.T) {
 	tests := []struct {
 		name        string
+		start       time.Time
 		before      func() []Object
 		after       func() []Object
 		destination func() []Object
@@ -191,6 +210,34 @@ func TestEvaluateParityRefusals(t *testing.T) {
 			want:        ErrSourceChanged,
 		},
 		{
+			name:   "source digests disagree",
+			before: sourceListing,
+			after: func() []Object {
+				s := sourceListing()
+				s[1].SHA256 = "sha-rewritten"
+				return s
+			},
+			destination: destinationListing,
+			want:        ErrSourceChanged,
+		},
+		{
+			// The starting listing stopped part-way: the base backup existed
+			// before the run but was never listed, so it was never checked.
+			name:        "truncated starting listing",
+			before:      func() []Object { return sourceListing()[2:] },
+			after:       sourceListing,
+			destination: func() []Object { return destinationListing()[2:] },
+			want:        ErrIncompleteListing,
+		},
+		{
+			name:        "missing run start",
+			start:       time.Time{},
+			before:      sourceListing,
+			after:       sourceListing,
+			destination: destinationListing,
+			want:        ErrMalformedListing,
+		},
+		{
 			name:        "empty source",
 			before:      func() []Object { return nil },
 			after:       func() []Object { return nil },
@@ -198,13 +245,11 @@ func TestEvaluateParityRefusals(t *testing.T) {
 			want:        ErrEmptySource,
 		},
 		{
-			name:   "source without a base backup",
-			before: func() []Object { return sourceListing()[2:] },
-			after:  func() []Object { return sourceListing()[2:] },
-			destination: func() []Object {
-				return destinationListing()[2:]
-			},
-			want: ErrNoBaseBackup,
+			name:        "source without a base backup",
+			before:      func() []Object { return sourceListing()[2:] },
+			after:       func() []Object { return sourceListing()[2:] },
+			destination: func() []Object { return destinationListing()[2:] },
+			want:        ErrNoBaseBackup,
 		},
 		{
 			name: "duplicate key in a listing",
@@ -218,7 +263,11 @@ func TestEvaluateParityRefusals(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := EvaluateParity(tt.before(), tt.after(), tt.destination())
+			start := runStart
+			if tt.name == "missing run start" {
+				start = tt.start
+			}
+			_, err := EvaluateParity(start, tt.before(), tt.after(), tt.destination())
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("EvaluateParity() = %v, want %v", err, tt.want)
 			}
@@ -228,9 +277,9 @@ func TestEvaluateParityRefusals(t *testing.T) {
 
 func TestParseListingReadsMcJSONLines(t *testing.T) {
 	input := strings.Join([]string{
-		`{"status":"success","type":"file","size":1200,"key":"` + baseInfo + `","etag":"a1"}`,
+		`{"status":"success","type":"file","lastModified":"2026-09-12T10:00:00.123Z","size":1200,"key":"` + baseInfo + `","etag":"a1"}`,
 		`{"status":"success","type":"folder","size":0,"key":"wedding-db-20260909/base/"}`,
-		`{"status":"success","type":"file","size":4000,"key":"` + olderWAL + `","etag":"c3","sha256":"abc"}`,
+		`{"status":"success","type":"file","lastModified":"2026-09-12T10:00:00Z","size":4000,"key":"` + olderWAL + `","etag":"c3","sha256":"abc"}`,
 		``,
 	}, "\n")
 	objects, err := ParseListing(strings.NewReader(input))
@@ -240,19 +289,24 @@ func TestParseListingReadsMcJSONLines(t *testing.T) {
 	if len(objects) != 2 {
 		t.Fatalf("len(objects) = %d, want 2 files and no folders", len(objects))
 	}
-	if objects[1] != (Object{Key: olderWAL, Size: 4000, ETag: "c3", SHA256: "abc"}) {
-		t.Fatalf("objects[1] = %+v", objects[1])
+	want := Object{Key: olderWAL, Size: 4000, ETag: "c3", SHA256: "abc", LastModified: time.Date(2026, 9, 12, 10, 0, 0, 0, time.UTC)}
+	if objects[1] != want {
+		t.Fatalf("objects[1] = %+v, want %+v", objects[1], want)
 	}
 }
 
 func TestParseListingRefusesFailedEntries(t *testing.T) {
+	const modified = `"lastModified":"2026-09-12T10:00:00Z",`
 	tests := map[string]string{
-		"error status":  `{"status":"error","type":"file","size":1,"key":"x","etag":"a"}`,
-		"not json":      `not json`,
-		"absolute key":  `{"status":"success","type":"file","size":1,"key":"/x","etag":"a"}`,
-		"parent key":    `{"status":"success","type":"file","size":1,"key":"a/../x","etag":"a"}`,
-		"negative size": `{"status":"success","type":"file","size":-1,"key":"x","etag":"a"}`,
-		"missing etag":  `{"status":"success","type":"file","size":1,"key":"x"}`,
+		"error status":            `{"status":"error","type":"file",` + modified + `"size":1,"key":"` + baseInfo + `","etag":"a"}`,
+		"not json":                `not json`,
+		"absolute key":            `{"status":"success","type":"file",` + modified + `"size":1,"key":"/` + baseInfo + `","etag":"a"}`,
+		"parent key":              `{"status":"success","type":"file",` + modified + `"size":1,"key":"wedding-db-20260909/base/../x","etag":"a"}`,
+		"negative size":           `{"status":"success","type":"file",` + modified + `"size":-1,"key":"` + baseInfo + `","etag":"a"}`,
+		"missing etag":            `{"status":"success","type":"file",` + modified + `"size":1,"key":"` + baseInfo + `"}`,
+		"missing last modified":   `{"status":"success","type":"file","size":1,"key":"` + baseInfo + `","etag":"a"}`,
+		"listing rooted too high": `{"status":"success","type":"file",` + modified + `"size":1,"key":"wedding-db/` + baseInfo + `","etag":"a"}`,
+		"listing rooted too low":  `{"status":"success","type":"file",` + modified + `"size":1,"key":"base/20260908T030000/backup.info","etag":"a"}`,
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/scripts/mirror-wedding-backup-catalogue/main_test.go
+++ b/scripts/mirror-wedding-backup-catalogue/main_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func validPlan() Plan {
+	return Plan{
+		Source: Location{
+			Bucket: "platform-backups",
+			Prefix: sourcePrefix,
+			Secret: sourceSecret,
+		},
+		Destination: Location{
+			Bucket: destinationBucket,
+			Prefix: destinationPrefix,
+			Secret: destinationSecret,
+		},
+	}
+}
+
+func TestValidatePlanAcceptsTheReviewedPlan(t *testing.T) {
+	if err := ValidatePlan(validPlan()); err != nil {
+		t.Fatalf("ValidatePlan() = %v, want nil", err)
+	}
+}
+
+func TestValidatePlanRefusals(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Plan)
+		want   error
+	}{
+		{"credential reuse", func(p *Plan) { p.Destination.Secret = sourceSecret }, ErrCredentialReuse},
+		{"source uses the dedicated credential", func(p *Plan) { p.Source.Secret = destinationSecret }, ErrCredentialReuse},
+		{"wrong destination bucket", func(p *Plan) { p.Destination.Bucket = "platform-backups-copy" }, ErrWrongDestination},
+		{"wrong destination prefix", func(p *Plan) { p.Destination.Prefix = "cnpg/wedding-db/restore" }, ErrWrongDestination},
+		{"destination is the source", func(p *Plan) { p.Source.Bucket = destinationBucket }, ErrWrongDestination},
+		{"unexpected destination credential", func(p *Plan) { p.Destination.Secret = "other-r2" }, ErrWrongDestination},
+		{"unexpected source prefix", func(p *Plan) { p.Source.Prefix = "cnpg" }, ErrWrongSource},
+		{"unexpected source credential", func(p *Plan) { p.Source.Secret = "other-r2" }, ErrWrongSource},
+		{"empty source bucket", func(p *Plan) { p.Source.Bucket = "" }, ErrWrongSource},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := validPlan()
+			tt.mutate(&plan)
+			if err := ValidatePlan(plan); !errors.Is(err, tt.want) {
+				t.Fatalf("ValidatePlan() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+const (
+	baseInfo = "wedding-db-20260909/base/20260908T030000/backup.info"
+	baseData = "wedding-db-20260909/base/20260908T030000/data.tar.gz"
+	olderWAL = "wedding-db-20260909/wals/0000000200000001/000000020000000100000003.gz"
+	newerWAL = "wedding-db-20260909/wals/0000000300000001/000000030000000100000001.gz"
+)
+
+func sourceListing() []Object {
+	return []Object{
+		{Key: baseInfo, Size: 1200, ETag: "a1"},
+		{Key: baseData, Size: 90_000_000, ETag: "b2-6", SHA256: "sha-data"},
+		{Key: olderWAL, Size: 4000, ETag: "c3"},
+		{Key: newerWAL, Size: 4100, ETag: "d4"},
+	}
+}
+
+// A mirror uploads large objects in a different number of parts, so the
+// destination carries a different multipart ETag for identical bytes.
+func destinationListing() []Object {
+	return []Object{
+		{Key: baseInfo, Size: 1200, ETag: "a1"},
+		{Key: baseData, Size: 90_000_000, ETag: "ff-4", SHA256: "sha-data"},
+		{Key: olderWAL, Size: 4000, ETag: "c3"},
+		{Key: newerWAL, Size: 4100, ETag: "d4"},
+	}
+}
+
+func TestEvaluateParityProvesAFullCopy(t *testing.T) {
+	summary, err := EvaluateParity(sourceListing(), sourceListing(), destinationListing())
+	if err != nil {
+		t.Fatalf("EvaluateParity() = %v, want nil", err)
+	}
+	if summary.SourceObjects != 4 || summary.MatchedObjects != 4 || summary.ExtraDestinationObjects != 0 {
+		t.Fatalf("summary counts = %+v, want 4 source, 4 matched, 0 extra", summary)
+	}
+	if summary.SourceNewestBaseBackup != "wedding-db-20260909/20260908T030000" {
+		t.Fatalf("SourceNewestBaseBackup = %q", summary.SourceNewestBaseBackup)
+	}
+	if summary.DestinationNewestBaseBackup != summary.SourceNewestBaseBackup {
+		t.Fatalf("DestinationNewestBaseBackup = %q, want %q", summary.DestinationNewestBaseBackup, summary.SourceNewestBaseBackup)
+	}
+	if summary.SourceNewestWAL != "000000030000000100000001" || summary.DestinationNewestWAL != "000000030000000100000001" {
+		t.Fatalf("newest WAL = %q / %q", summary.SourceNewestWAL, summary.DestinationNewestWAL)
+	}
+}
+
+// WAL keeps archiving to the shared store until the cutover, so objects that
+// appear during the run are expected and only need to be copied by a later pass.
+func TestEvaluateParityAllowsObjectsArchivedDuringTheRun(t *testing.T) {
+	after := append(sourceListing(), Object{Key: "wedding-db-20260909/wals/0000000300000001/000000030000000100000002.gz", Size: 4200, ETag: "e5"})
+	summary, err := EvaluateParity(sourceListing(), after, destinationListing())
+	if err != nil {
+		t.Fatalf("EvaluateParity() = %v, want nil", err)
+	}
+	if summary.SourceObjects != 4 {
+		t.Fatalf("SourceObjects = %d, want the 4 objects present when the run started", summary.SourceObjects)
+	}
+}
+
+func TestEvaluateParityRefusals(t *testing.T) {
+	tests := []struct {
+		name        string
+		before      func() []Object
+		after       func() []Object
+		destination func() []Object
+		want        error
+	}{
+		{
+			name:        "partial copy",
+			before:      sourceListing,
+			after:       sourceListing,
+			destination: func() []Object { return destinationListing()[:3] },
+			want:        ErrPartialCopy,
+		},
+		{
+			name:   "truncated object",
+			before: sourceListing,
+			after:  sourceListing,
+			destination: func() []Object {
+				d := destinationListing()
+				d[2].Size = 10
+				return d
+			},
+			want: ErrPartialCopy,
+		},
+		{
+			name:   "same size different content",
+			before: sourceListing,
+			after:  sourceListing,
+			destination: func() []Object {
+				d := destinationListing()
+				d[1].SHA256 = "sha-other"
+				return d
+			},
+			want: ErrChecksumMismatch,
+		},
+		{
+			name:   "single-part etag differs",
+			before: sourceListing,
+			after:  sourceListing,
+			destination: func() []Object {
+				d := destinationListing()
+				d[0].ETag = "zz"
+				return d
+			},
+			want: ErrChecksumMismatch,
+		},
+		{
+			name:   "multipart object without a digest",
+			before: sourceListing,
+			after:  sourceListing,
+			destination: func() []Object {
+				d := destinationListing()
+				d[1].SHA256 = ""
+				return d
+			},
+			want: ErrUnverifiable,
+		},
+		{
+			name:        "source object removed during the run",
+			before:      sourceListing,
+			after:       func() []Object { return sourceListing()[1:] },
+			destination: destinationListing,
+			want:        ErrSourceChanged,
+		},
+		{
+			name:   "source object rewritten during the run",
+			before: sourceListing,
+			after: func() []Object {
+				s := sourceListing()
+				s[0].ETag = "rewritten"
+				return s
+			},
+			destination: destinationListing,
+			want:        ErrSourceChanged,
+		},
+		{
+			name:        "empty source",
+			before:      func() []Object { return nil },
+			after:       func() []Object { return nil },
+			destination: destinationListing,
+			want:        ErrEmptySource,
+		},
+		{
+			name:   "source without a base backup",
+			before: func() []Object { return sourceListing()[2:] },
+			after:  func() []Object { return sourceListing()[2:] },
+			destination: func() []Object {
+				return destinationListing()[2:]
+			},
+			want: ErrNoBaseBackup,
+		},
+		{
+			name: "duplicate key in a listing",
+			before: func() []Object {
+				return append(sourceListing(), sourceListing()[0])
+			},
+			after:       sourceListing,
+			destination: destinationListing,
+			want:        ErrMalformedListing,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := EvaluateParity(tt.before(), tt.after(), tt.destination())
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("EvaluateParity() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseListingReadsMcJSONLines(t *testing.T) {
+	input := strings.Join([]string{
+		`{"status":"success","type":"file","size":1200,"key":"` + baseInfo + `","etag":"a1"}`,
+		`{"status":"success","type":"folder","size":0,"key":"wedding-db-20260909/base/"}`,
+		`{"status":"success","type":"file","size":4000,"key":"` + olderWAL + `","etag":"c3","sha256":"abc"}`,
+		``,
+	}, "\n")
+	objects, err := ParseListing(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseListing() = %v, want nil", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("len(objects) = %d, want 2 files and no folders", len(objects))
+	}
+	if objects[1] != (Object{Key: olderWAL, Size: 4000, ETag: "c3", SHA256: "abc"}) {
+		t.Fatalf("objects[1] = %+v", objects[1])
+	}
+}
+
+func TestParseListingRefusesFailedEntries(t *testing.T) {
+	tests := map[string]string{
+		"error status":  `{"status":"error","type":"file","size":1,"key":"x","etag":"a"}`,
+		"not json":      `not json`,
+		"absolute key":  `{"status":"success","type":"file","size":1,"key":"/x","etag":"a"}`,
+		"parent key":    `{"status":"success","type":"file","size":1,"key":"a/../x","etag":"a"}`,
+		"negative size": `{"status":"success","type":"file","size":-1,"key":"x","etag":"a"}`,
+		"missing etag":  `{"status":"success","type":"file","size":1,"key":"x"}`,
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseListing(strings.NewReader(input)); !errors.Is(err, ErrMalformedListing) {
+				t.Fatalf("ParseListing() = %v, want %v", err, ErrMalformedListing)
+			}
+		})
+	}
+}

--- a/scripts/mirror-wedding-backup-catalogue/main_test.go
+++ b/scripts/mirror-wedding-backup-catalogue/main_test.go
@@ -67,12 +67,16 @@ var (
 	runStart     = time.Date(2026, 9, 13, 10, 0, 0, 0, time.UTC)
 	beforeRun    = runStart.Add(-24 * time.Hour)
 	duringTheRun = runStart.Add(5 * time.Minute)
+
+	dataDigest  = strings.Repeat("a", 64)
+	infoDigest  = strings.Repeat("b", 64)
+	otherDigest = strings.Repeat("c", 64)
 )
 
 func sourceListing() []Object {
 	return []Object{
 		{Key: baseInfo, Size: 1200, ETag: "a1", LastModified: beforeRun},
-		{Key: baseData, Size: 90_000_000, ETag: "b2-6", SHA256: "sha-data", LastModified: beforeRun},
+		{Key: baseData, Size: 90_000_000, ETag: "b2-6", SHA256: dataDigest, LastModified: beforeRun},
 		{Key: olderWAL, Size: 4000, ETag: "c3", LastModified: beforeRun},
 		{Key: newerWAL, Size: 4100, ETag: "d4", LastModified: beforeRun},
 	}
@@ -83,7 +87,7 @@ func sourceListing() []Object {
 func destinationListing() []Object {
 	return []Object{
 		{Key: baseInfo, Size: 1200, ETag: "a1", LastModified: duringTheRun},
-		{Key: baseData, Size: 90_000_000, ETag: "ff-4", SHA256: "sha-data", LastModified: duringTheRun},
+		{Key: baseData, Size: 90_000_000, ETag: "ff-4", SHA256: dataDigest, LastModified: duringTheRun},
 		{Key: olderWAL, Size: 4000, ETag: "c3", LastModified: duringTheRun},
 		{Key: newerWAL, Size: 4100, ETag: "d4", LastModified: duringTheRun},
 	}
@@ -125,7 +129,7 @@ func TestEvaluateParityAllowsObjectsArchivedDuringTheRun(t *testing.T) {
 // whether the object changed; size and ETag still do.
 func TestEvaluateParityIgnoresADigestPresentOnOneSourceListing(t *testing.T) {
 	after := sourceListing()
-	after[0].SHA256 = "sha-info"
+	after[0].SHA256 = infoDigest
 	if _, err := EvaluateParity(runStart, sourceListing(), after, destinationListing()); err != nil {
 		t.Fatalf("EvaluateParity() = %v, want nil", err)
 	}
@@ -164,7 +168,7 @@ func TestEvaluateParityRefusals(t *testing.T) {
 			after:  sourceListing,
 			destination: func() []Object {
 				d := destinationListing()
-				d[1].SHA256 = "sha-other"
+				d[1].SHA256 = otherDigest
 				return d
 			},
 			want: ErrChecksumMismatch,
@@ -214,7 +218,7 @@ func TestEvaluateParityRefusals(t *testing.T) {
 			before: sourceListing,
 			after: func() []Object {
 				s := sourceListing()
-				s[1].SHA256 = "sha-rewritten"
+				s[1].SHA256 = otherDigest
 				return s
 			},
 			destination: destinationListing,
@@ -275,11 +279,33 @@ func TestEvaluateParityRefusals(t *testing.T) {
 	}
 }
 
+const modified = `"lastModified":"2026-09-12T10:00:00Z",`
+
+func fileLine(key, extra string) string {
+	return `{"status":"success","type":"file",` + modified + `"size":1,"key":"` + key + `","etag":"a"` + extra + `}`
+}
+
+func completeLine(files int) string {
+	return `{"status":"success","type":"listing-complete","files":` + itoa(files) + `}`
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for ; n > 0; n /= 10 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+	}
+	return string(digits)
+}
+
 func TestParseListingReadsMcJSONLines(t *testing.T) {
 	input := strings.Join([]string{
 		`{"status":"success","type":"file","lastModified":"2026-09-12T10:00:00.123Z","size":1200,"key":"` + baseInfo + `","etag":"a1"}`,
 		`{"status":"success","type":"folder","size":0,"key":"wedding-db-20260909/base/"}`,
-		`{"status":"success","type":"file","lastModified":"2026-09-12T10:00:00Z","size":4000,"key":"` + olderWAL + `","etag":"c3","sha256":"abc"}`,
+		`{"status":"success","type":"file","lastModified":"2026-09-12T10:00:00Z","size":4000,"key":"` + olderWAL + `","etag":"c3","sha256":"` + dataDigest + `"}`,
+		completeLine(2),
 		``,
 	}, "\n")
 	objects, err := ParseListing(strings.NewReader(input))
@@ -289,29 +315,65 @@ func TestParseListingReadsMcJSONLines(t *testing.T) {
 	if len(objects) != 2 {
 		t.Fatalf("len(objects) = %d, want 2 files and no folders", len(objects))
 	}
-	want := Object{Key: olderWAL, Size: 4000, ETag: "c3", SHA256: "abc", LastModified: time.Date(2026, 9, 12, 10, 0, 0, 0, time.UTC)}
+	want := Object{Key: olderWAL, Size: 4000, ETag: "c3", SHA256: dataDigest, LastModified: time.Date(2026, 9, 12, 10, 0, 0, 0, time.UTC)}
 	if objects[1] != want {
 		t.Fatalf("objects[1] = %+v, want %+v", objects[1], want)
 	}
 }
 
+// An empty catalogue still needs the completion record, and then parses as
+// empty rather than as malformed; EvaluateParity refuses an empty source.
+func TestParseListingAcceptsACompletedEmptyListing(t *testing.T) {
+	objects, err := ParseListing(strings.NewReader(completeLine(0) + "\n"))
+	if err != nil || len(objects) != 0 {
+		t.Fatalf("ParseListing() = %v, %v, want no objects and nil", objects, err)
+	}
+}
+
 func TestParseListingRefusesFailedEntries(t *testing.T) {
-	const modified = `"lastModified":"2026-09-12T10:00:00Z",`
 	tests := map[string]string{
 		"error status":            `{"status":"error","type":"file",` + modified + `"size":1,"key":"` + baseInfo + `","etag":"a"}`,
 		"not json":                `not json`,
-		"absolute key":            `{"status":"success","type":"file",` + modified + `"size":1,"key":"/` + baseInfo + `","etag":"a"}`,
-		"parent key":              `{"status":"success","type":"file",` + modified + `"size":1,"key":"wedding-db-20260909/base/../x","etag":"a"}`,
+		"absolute key":            fileLine("/"+baseInfo, ""),
+		"parent key":              fileLine("wedding-db-20260909/base/../x", ""),
 		"negative size":           `{"status":"success","type":"file",` + modified + `"size":-1,"key":"` + baseInfo + `","etag":"a"}`,
 		"missing etag":            `{"status":"success","type":"file",` + modified + `"size":1,"key":"` + baseInfo + `"}`,
 		"missing last modified":   `{"status":"success","type":"file","size":1,"key":"` + baseInfo + `","etag":"a"}`,
-		"listing rooted too high": `{"status":"success","type":"file",` + modified + `"size":1,"key":"wedding-db/` + baseInfo + `","etag":"a"}`,
-		"listing rooted too low":  `{"status":"success","type":"file",` + modified + `"size":1,"key":"base/20260908T030000/backup.info","etag":"a"}`,
+		"listing rooted too high": fileLine("wedding-db/"+baseInfo, ""),
+		"listing rooted too low":  fileLine("base/20260908T030000/backup.info", ""),
+		"placeholder sha256":      fileLine(baseInfo, `,"sha256":"sha-data"`),
+		"short sha256":            fileLine(baseInfo, `,"sha256":"`+strings.Repeat("a", 63)+`"`),
+		"uppercase sha256":        fileLine(baseInfo, `,"sha256":"`+strings.Repeat("A", 64)+`"`),
+		"record after completion": completeLine(0) + "\n" + fileLine(baseInfo, ""),
+		"negative completion":     `{"status":"success","type":"listing-complete","files":-1}`,
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
+			if name != "record after completion" && name != "negative completion" && !strings.HasPrefix(input, "not json") {
+				input += "\n" + completeLine(1)
+			}
 			if _, err := ParseListing(strings.NewReader(input)); !errors.Is(err, ErrMalformedListing) {
 				t.Fatalf("ParseListing() = %v, want %v", err, ErrMalformedListing)
+			}
+		})
+	}
+}
+
+// Raw `mc ls` output has no terminal record, so a listing cut short looks like
+// a complete one. Only the wrapper's completion record, written after mc exits
+// successfully, proves the listing ran to the end.
+func TestParseListingRequiresCompletionProof(t *testing.T) {
+	tests := map[string]string{
+		"no completion record":          fileLine(baseInfo, "") + "\n" + fileLine(olderWAL, ""),
+		"completion count too high":     fileLine(baseInfo, "") + "\n" + completeLine(2),
+		"completion count too low":      fileLine(baseInfo, "") + "\n" + fileLine(olderWAL, "") + "\n" + completeLine(1),
+		"empty input":                   "",
+		"completion without file count": fileLine(baseInfo, "") + "\n" + `{"status":"success","type":"listing-complete"}`,
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseListing(strings.NewReader(input)); !errors.Is(err, ErrIncompleteListing) {
+				t.Fatalf("ParseListing() = %v, want %v", err, ErrIncompleteListing)
 			}
 		})
 	}

--- a/scripts/mirror-wedding-backup-catalogue/main_test.go
+++ b/scripts/mirror-wedding-backup-catalogue/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -55,12 +58,48 @@ func TestValidatePlanRefusals(t *testing.T) {
 	}
 }
 
+// The command checks the locations and credentials the caller will actually
+// use, so a typo in the mirror job is refused instead of silently replaced by
+// the reviewed values.
+func TestRunValidatePlanChecksTheCallersActualValues(t *testing.T) {
+	valid := []string{"validate-plan",
+		"platform-backups", sourcePrefix, sourceSecret,
+		destinationBucket, destinationPrefix, destinationSecret}
+	if err := run(valid, io.Discard); err != nil {
+		t.Fatalf("run(valid plan) = %v, want nil", err)
+	}
+	tests := []struct {
+		name  string
+		index int
+		value string
+		want  error
+	}{
+		{"typo in the destination bucket", 4, "wedding-db-backup", ErrWrongDestination},
+		{"typo in the destination credential", 6, "wedding-db-backup-r2-dedicate", ErrWrongDestination},
+		{"typo in the destination prefix", 5, "cnpg/wedding", ErrWrongDestination},
+		{"wrong source credential", 3, "other-r2", ErrWrongSource},
+		{"wrong source prefix", 2, "cnpg", ErrWrongSource},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string(nil), valid...)
+			args[tt.index] = tt.value
+			if err := run(args, io.Discard); !errors.Is(err, tt.want) {
+				t.Fatalf("run() = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
 const (
 	baseInfo = "wedding-db-20260909/base/20260908T030000/backup.info"
 	baseData = "wedding-db-20260909/base/20260908T030000/data.tar.gz"
 	olderWAL = "wedding-db-20260909/wals/0000000200000001/000000020000000100000003.gz"
 	newerWAL = "wedding-db-20260909/wals/0000000300000001/000000030000000100000001.gz"
 	lateWAL  = "wedding-db-20260909/wals/0000000300000001/000000030000000100000002.gz"
+
+	sourceLocation      = "platform-backups/" + sourcePrefix
+	destinationLocation = destinationBucket + "/" + destinationPrefix
 )
 
 var (
@@ -256,6 +295,16 @@ func TestEvaluateParityRefusals(t *testing.T) {
 			want:        ErrNoBaseBackup,
 		},
 		{
+			// A base backup cannot be restored to a consistent state without the
+			// WAL archived alongside it, so a catalogue with none is not a
+			// recoverable history however faithfully it was copied.
+			name:        "source without archived WAL",
+			before:      func() []Object { return sourceListing()[:2] },
+			after:       func() []Object { return sourceListing()[:2] },
+			destination: func() []Object { return destinationListing()[:2] },
+			want:        ErrNoArchivedWAL,
+		},
+		{
 			name: "duplicate key in a listing",
 			before: func() []Object {
 				return append(sourceListing(), sourceListing()[0])
@@ -285,8 +334,12 @@ func fileLine(key, extra string) string {
 	return `{"status":"success","type":"file",` + modified + `"size":1,"key":"` + key + `","etag":"a"` + extra + `}`
 }
 
+func completeLineAt(location string, files int) string {
+	return `{"status":"success","type":"listing-complete","location":"` + location + `","files":` + itoa(files) + `}`
+}
+
 func completeLine(files int) string {
-	return `{"status":"success","type":"listing-complete","files":` + itoa(files) + `}`
+	return completeLineAt(sourceLocation, files)
 }
 
 func itoa(n int) string {
@@ -308,7 +361,7 @@ func TestParseListingReadsMcJSONLines(t *testing.T) {
 		completeLine(2),
 		``,
 	}, "\n")
-	objects, err := ParseListing(strings.NewReader(input))
+	objects, err := ParseListing(strings.NewReader(input), sourceLocation)
 	if err != nil {
 		t.Fatalf("ParseListing() = %v, want nil", err)
 	}
@@ -324,7 +377,7 @@ func TestParseListingReadsMcJSONLines(t *testing.T) {
 // An empty catalogue still needs the completion record, and then parses as
 // empty rather than as malformed; EvaluateParity refuses an empty source.
 func TestParseListingAcceptsACompletedEmptyListing(t *testing.T) {
-	objects, err := ParseListing(strings.NewReader(completeLine(0) + "\n"))
+	objects, err := ParseListing(strings.NewReader(completeLine(0)+"\n"), sourceLocation)
 	if err != nil || len(objects) != 0 {
 		t.Fatalf("ParseListing() = %v, %v, want no objects and nil", objects, err)
 	}
@@ -345,14 +398,14 @@ func TestParseListingRefusesFailedEntries(t *testing.T) {
 		"short sha256":            fileLine(baseInfo, `,"sha256":"`+strings.Repeat("a", 63)+`"`),
 		"uppercase sha256":        fileLine(baseInfo, `,"sha256":"`+strings.Repeat("A", 64)+`"`),
 		"record after completion": completeLine(0) + "\n" + fileLine(baseInfo, ""),
-		"negative completion":     `{"status":"success","type":"listing-complete","files":-1}`,
+		"negative completion":     `{"status":"success","type":"listing-complete","location":"` + sourceLocation + `","files":-1}`,
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
 			if name != "record after completion" && name != "negative completion" && !strings.HasPrefix(input, "not json") {
 				input += "\n" + completeLine(1)
 			}
-			if _, err := ParseListing(strings.NewReader(input)); !errors.Is(err, ErrMalformedListing) {
+			if _, err := ParseListing(strings.NewReader(input), sourceLocation); !errors.Is(err, ErrMalformedListing) {
 				t.Fatalf("ParseListing() = %v, want %v", err, ErrMalformedListing)
 			}
 		})
@@ -368,13 +421,65 @@ func TestParseListingRequiresCompletionProof(t *testing.T) {
 		"completion count too high":     fileLine(baseInfo, "") + "\n" + completeLine(2),
 		"completion count too low":      fileLine(baseInfo, "") + "\n" + fileLine(olderWAL, "") + "\n" + completeLine(1),
 		"empty input":                   "",
-		"completion without file count": fileLine(baseInfo, "") + "\n" + `{"status":"success","type":"listing-complete"}`,
+		"completion without file count": fileLine(baseInfo, "") + "\n" + `{"status":"success","type":"listing-complete","location":"` + sourceLocation + `"}`,
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
-			if _, err := ParseListing(strings.NewReader(input)); !errors.Is(err, ErrIncompleteListing) {
+			if _, err := ParseListing(strings.NewReader(input), sourceLocation); !errors.Is(err, ErrIncompleteListing) {
 				t.Fatalf("ParseListing() = %v, want %v", err, ErrIncompleteListing)
 			}
 		})
+	}
+}
+
+// Raw `mc ls` keys carry no bucket, so a complete listing of the wrong bucket
+// is indistinguishable from the right one. The completion record names the
+// location the wrapper listed, and it must be the one being evaluated.
+func TestParseListingBindsTheListingToItsLocation(t *testing.T) {
+	tests := map[string]string{
+		"listing of another bucket":     fileLine(baseInfo, "") + "\n" + completeLineAt("platform-backups-copy/"+sourcePrefix, 1),
+		"listing of another prefix":     fileLine(baseInfo, "") + "\n" + completeLineAt("platform-backups/cnpg", 1),
+		"completion without a location": fileLine(baseInfo, "") + "\n" + `{"status":"success","type":"listing-complete","files":1}`,
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseListing(strings.NewReader(input), sourceLocation); !errors.Is(err, ErrListingLocation) {
+				t.Fatalf("ParseListing() = %v, want %v", err, ErrListingLocation)
+			}
+		})
+	}
+}
+
+func writeListing(t *testing.T, name, location string, keys ...string) string {
+	t.Helper()
+	lines := make([]string, 0, len(keys)+1)
+	for _, key := range keys {
+		lines = append(lines, fileLine(key, ""))
+	}
+	lines = append(lines, completeLineAt(location, len(keys)))
+	file := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(file, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return file
+}
+
+// A copy that landed in the wrong bucket produces matching listings there, so
+// the destination listing must be proven to come from the reviewed bucket.
+func TestRunEvaluateRefusesListingsFromTheWrongLocation(t *testing.T) {
+	keys := []string{baseInfo, olderWAL}
+	before := writeListing(t, "before", sourceLocation, keys...)
+	after := writeListing(t, "after", sourceLocation, keys...)
+	good := writeListing(t, "destination", destinationLocation, keys...)
+	if err := run([]string{"evaluate", "2026-09-13T10:00:00Z", "platform-backups", before, after, good}, io.Discard); err != nil {
+		t.Fatalf("run(evaluate) = %v, want nil", err)
+	}
+	wrongBucket := writeListing(t, "wrong", "platform-backups-copy/"+destinationPrefix, keys...)
+	if err := run([]string{"evaluate", "2026-09-13T10:00:00Z", "platform-backups", before, after, wrongBucket}, io.Discard); !errors.Is(err, ErrListingLocation) {
+		t.Fatalf("run(evaluate, wrong destination) = %v, want %v", err, ErrListingLocation)
+	}
+	swapped := writeListing(t, "swapped", destinationLocation, keys...)
+	if err := run([]string{"evaluate", "2026-09-13T10:00:00Z", "platform-backups", swapped, after, good}, io.Discard); !errors.Is(err, ErrListingLocation) {
+		t.Fatalf("run(evaluate, source listed from destination) = %v, want %v", err, ErrListingLocation)
 	}
 }


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

### Why

The Wedding database still archives its backups to the shared bucket. Before it can switch to its own dedicated bucket, the full backup history has to be copied there and proven complete. Switching without that history would leave the new archive with nothing to restore from, and the September recovery showed how much that history matters.

### What

This adds the check that decides whether a copy can be trusted, before any copy runs. It accepts a copy only when all of these hold:

- the source was read with the shared credential and the destination written with the dedicated one;
- the destination is the reviewed dedicated bucket;
- the copy's start time belongs to this pass, not an earlier one, and the destination was read no earlier than the source's final read, so an old destination reading cannot vouch for a copy;
- nothing in the source changed while the copy ran;
- every source object arrived with a matching size and content checksum;
- the newest base backup includes its data, not just its description;
- nothing unexpected sits in the destination.

A partial or unprovable copy is refused. Backups written during the copy are checked if they already arrived; otherwise the result says the copy has not caught up, and only a caught-up copy counts as proof for the switch. The check runs in CI.

The dispatch-only production workflow that performs the copy and records the proof is the next step on the same issue.

Part of #3767
